### PR TITLE
feat: error on client with empty token

### DIFF
--- a/pkg/health/transport/http/http_test.go
+++ b/pkg/health/transport/http/http_test.go
@@ -51,7 +51,7 @@ func TestHTTP(t *testing.T) {
 		time.Sleep(2 * time.Second)
 
 		Convey("When I query health", func() {
-			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+			client := pkgHTTP.NewClient(pkgHTTP.NewRoundTripper(logger, http.DefaultTransport))
 
 			req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:10000/health", nil)
 			So(err, ShouldBeNil)
@@ -106,7 +106,7 @@ func TestInvalidHTTP(t *testing.T) {
 		time.Sleep(2 * time.Second)
 
 		Convey("When I query health", func() {
-			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+			client := pkgHTTP.NewClient(pkgHTTP.NewRoundTripper(logger, http.DefaultTransport))
 
 			req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:10001/health", nil)
 			So(err, ShouldBeNil)

--- a/pkg/metrics/transport/http/http_test.go
+++ b/pkg/metrics/transport/http/http_test.go
@@ -33,7 +33,7 @@ func TestHTTP(t *testing.T) {
 		lc.RequireStart()
 
 		Convey("When I query metrics", func() {
-			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+			client := pkgHTTP.NewClient(pkgHTTP.NewRoundTripper(logger, http.DefaultTransport))
 
 			req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:10002/metrics", nil)
 			So(err, ShouldBeNil)

--- a/pkg/security/token/token.go
+++ b/pkg/security/token/token.go
@@ -1,5 +1,14 @@
 package token
 
+import (
+	"errors"
+)
+
+var (
+	// ErrMissingToken for http.
+	ErrMissingToken = errors.New("authorization token is not provided")
+)
+
 // Generator allows the implementation of different types generators.
 type Generator interface {
 	// Generate a new token or error.

--- a/pkg/transport/grpc/grpc_test.go
+++ b/pkg/transport/grpc/grpc_test.go
@@ -94,11 +94,11 @@ func TestValidAuthUnary(t *testing.T) {
 			resp, err := client.SayHello(ctx, req)
 			So(err, ShouldBeNil)
 
-			lc.RequireStop()
-
 			Convey("Then I should have a valid reply", func() {
 				So(resp.GetMessage(), ShouldEqual, "Hello test")
 			})
+
+			lc.RequireStop()
 		})
 	})
 }
@@ -379,7 +379,6 @@ func TestValidAuthStream(t *testing.T) {
 	})
 }
 
-// nolint:dupl
 func TestInvalidAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
 		lc := fxtest.NewLifecycle(t)
@@ -430,7 +429,6 @@ func TestInvalidAuthStream(t *testing.T) {
 	})
 }
 
-// nolint:dupl
 func TestEmptyAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
 		lc := fxtest.NewLifecycle(t)
@@ -465,14 +463,8 @@ func TestEmptyAuthStream(t *testing.T) {
 
 			client := test.NewGreeterClient(conn)
 
-			stream, err := client.SayStreamHello(ctx)
-			So(err, ShouldBeNil)
-
-			err = stream.Send(&test.HelloRequest{Name: "test"})
-			So(err, ShouldBeNil)
-
-			Convey("Then I should have a unauthenticated reply", func() {
-				_, err := stream.Recv()
+			Convey("Then I should have an auth error", func() {
+				_, err := client.SayStreamHello(ctx)
 				So(status.Code(err), ShouldEqual, codes.Unauthenticated)
 			})
 

--- a/pkg/transport/http/client.go
+++ b/pkg/transport/http/client.go
@@ -9,9 +9,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// NewClient for HTTP.
+func NewClient(hrt http.RoundTripper) *http.Client {
+	return &http.Client{Transport: hrt}
+}
+
 // NewRoundTripper for HTTP.
-func NewRoundTripper(logger *zap.Logger) http.RoundTripper {
-	hrt := http.DefaultTransport
+func NewRoundTripper(logger *zap.Logger, hrt http.RoundTripper) http.RoundTripper {
 	hrt = pkgZap.NewRoundTripper(logger, hrt)
 	hrt = opentracing.NewRoundTripper(hrt)
 	hrt = meta.NewRoundTripper(hrt)

--- a/pkg/transport/http/http_test.go
+++ b/pkg/transport/http/http_test.go
@@ -75,8 +75,6 @@ func TestUnary(t *testing.T) {
 
 			actual := strings.TrimSpace(string(body))
 
-			lc.RequireStop()
-
 			Convey("Then I should have a valid reply", func() {
 				So(actual, ShouldEqual, `{"message":"Hello test"}`)
 			})
@@ -86,7 +84,7 @@ func TestUnary(t *testing.T) {
 	})
 }
 
-// nolint:dupl,funlen
+// nolint:dupl
 func TestValidAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
 		sh := test.NewShutdowner()
@@ -141,8 +139,6 @@ func TestValidAuthUnary(t *testing.T) {
 
 			actual := strings.TrimSpace(string(body))
 
-			lc.RequireStop()
-
 			Convey("Then I should have a valid reply", func() {
 				So(actual, ShouldEqual, `{"message":"Hello test"}`)
 			})
@@ -152,7 +148,7 @@ func TestValidAuthUnary(t *testing.T) {
 	})
 }
 
-// nolint:dupl,funlen
+// nolint:dupl
 func TestInvalidAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
 		sh := test.NewShutdowner()
@@ -207,8 +203,6 @@ func TestInvalidAuthUnary(t *testing.T) {
 
 			actual := strings.TrimSpace(string(body))
 
-			lc.RequireStop()
-
 			Convey("Then I should have a unauthenticated reply", func() {
 				So(actual, ShouldContainSubstring, `could not verify token: invalid token`)
 			})
@@ -218,74 +212,8 @@ func TestInvalidAuthUnary(t *testing.T) {
 	})
 }
 
-// nolint:dupl,funlen
-func TestEmptyAuthUnary(t *testing.T) {
-	Convey("Given I have a all the servers", t, func() {
-		sh := test.NewShutdowner()
-		lc := fxtest.NewLifecycle(t)
-
-		logger, err := zap.NewLogger(lc, zap.NewConfig())
-		So(err, ShouldBeNil)
-
-		cfg := &config.Config{GRPCPort: "10013", HTTPPort: "10014"}
-
-		mux := pkgHTTP.NewMux()
-		pkgHTTP.Register(lc, sh, mux, cfg, logger)
-
-		verifier := test.NewVerifier("test")
-		serverUnaryOpt := pkgGRPC.UnaryServerOption(logger, tokenGRPC.UnaryServerInterceptor(verifier))
-		serverStreamOpt := pkgGRPC.StreamServerOption(logger, tokenGRPC.StreamServerInterceptor(verifier))
-		gs := pkgGRPC.NewServer(lc, sh, cfg, logger, serverUnaryOpt, serverStreamOpt)
-
-		test.RegisterGreeterServer(gs, test.NewServer())
-
-		lc.RequireStart()
-
-		ctx := context.Background()
-		clientOpts := []grpc.DialOption{grpc.WithBlock(), grpc.WithInsecure()}
-
-		conn, err := pkgGRPC.NewClient(ctx, fmt.Sprintf("127.0.0.1:%s", cfg.GRPCPort), logger, clientOpts...)
-		So(err, ShouldBeNil)
-
-		defer conn.Close()
-
-		err = test.RegisterGreeterHandler(ctx, mux, conn)
-		So(err, ShouldBeNil)
-
-		Convey("When I query for a unauthenticated greet", func() {
-			transport := tokenHTTP.NewRoundTripper(test.NewGenerator("", nil), pkgHTTP.NewRoundTripper(logger))
-			client := &http.Client{Transport: transport}
-
-			message := []byte(`{"name":"test"}`)
-			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
-			So(err, ShouldBeNil)
-
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Request-ID", "test")
-
-			resp, err := client.Do(req)
-			So(err, ShouldBeNil)
-
-			defer resp.Body.Close()
-
-			body, err := io.ReadAll(resp.Body)
-			So(err, ShouldBeNil)
-
-			actual := strings.TrimSpace(string(body))
-
-			lc.RequireStop()
-
-			Convey("Then I should have a unauthenticated reply", func() {
-				So(actual, ShouldContainSubstring, `authorization token is not provided`)
-			})
-
-			lc.RequireStop()
-		})
-	})
-}
-
-// nolint:funlen
-func TestMissingClientAuthUnary(t *testing.T) {
+// nolint:dupl
+func TestMissingAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
 		sh := test.NewShutdowner()
 		lc := fxtest.NewLifecycle(t)
@@ -338,7 +266,123 @@ func TestMissingClientAuthUnary(t *testing.T) {
 
 			actual := strings.TrimSpace(string(body))
 
+			Convey("Then I should have a unauthenticated reply", func() {
+				So(actual, ShouldContainSubstring, `authorization token is not provided`)
+			})
+
 			lc.RequireStop()
+		})
+	})
+}
+
+func TestEmptyAuthUnary(t *testing.T) {
+	Convey("Given I have a all the servers", t, func() {
+		sh := test.NewShutdowner()
+		lc := fxtest.NewLifecycle(t)
+
+		logger, err := zap.NewLogger(lc, zap.NewConfig())
+		So(err, ShouldBeNil)
+
+		cfg := &config.Config{GRPCPort: "10013", HTTPPort: "10014"}
+
+		mux := pkgHTTP.NewMux()
+		pkgHTTP.Register(lc, sh, mux, cfg, logger)
+
+		verifier := test.NewVerifier("test")
+		serverUnaryOpt := pkgGRPC.UnaryServerOption(logger, tokenGRPC.UnaryServerInterceptor(verifier))
+		serverStreamOpt := pkgGRPC.StreamServerOption(logger, tokenGRPC.StreamServerInterceptor(verifier))
+		gs := pkgGRPC.NewServer(lc, sh, cfg, logger, serverUnaryOpt, serverStreamOpt)
+
+		test.RegisterGreeterServer(gs, test.NewServer())
+
+		lc.RequireStart()
+
+		ctx := context.Background()
+		clientOpts := []grpc.DialOption{grpc.WithBlock(), grpc.WithInsecure()}
+
+		conn, err := pkgGRPC.NewClient(ctx, fmt.Sprintf("127.0.0.1:%s", cfg.GRPCPort), logger, clientOpts...)
+		So(err, ShouldBeNil)
+
+		defer conn.Close()
+
+		err = test.RegisterGreeterHandler(ctx, mux, conn)
+		So(err, ShouldBeNil)
+
+		Convey("When I query for a unauthenticated greet", func() {
+			transport := tokenHTTP.NewRoundTripper(test.NewGenerator("", nil), pkgHTTP.NewRoundTripper(logger))
+			client := &http.Client{Transport: transport}
+
+			message := []byte(`{"name":"test"}`)
+			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
+			So(err, ShouldBeNil)
+
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Request-ID", "test")
+
+			_, err = client.Do(req) // nolint:bodyclose
+
+			Convey("Then I should have an auth error", func() {
+				So(err, ShouldBeError)
+			})
+
+			lc.RequireStop()
+		})
+	})
+}
+
+// nolint:dupl
+func TestMissingClientAuthUnary(t *testing.T) {
+	Convey("Given I have a all the servers", t, func() {
+		sh := test.NewShutdowner()
+		lc := fxtest.NewLifecycle(t)
+
+		logger, err := zap.NewLogger(lc, zap.NewConfig())
+		So(err, ShouldBeNil)
+
+		cfg := &config.Config{GRPCPort: "10013", HTTPPort: "10014"}
+
+		mux := pkgHTTP.NewMux()
+		pkgHTTP.Register(lc, sh, mux, cfg, logger)
+
+		verifier := test.NewVerifier("test")
+		serverUnaryOpt := pkgGRPC.UnaryServerOption(logger, tokenGRPC.UnaryServerInterceptor(verifier))
+		serverStreamOpt := pkgGRPC.StreamServerOption(logger, tokenGRPC.StreamServerInterceptor(verifier))
+		gs := pkgGRPC.NewServer(lc, sh, cfg, logger, serverUnaryOpt, serverStreamOpt)
+
+		test.RegisterGreeterServer(gs, test.NewServer())
+
+		lc.RequireStart()
+
+		ctx := context.Background()
+		clientOpts := []grpc.DialOption{grpc.WithBlock(), grpc.WithInsecure()}
+
+		conn, err := pkgGRPC.NewClient(ctx, fmt.Sprintf("127.0.0.1:%s", cfg.GRPCPort), logger, clientOpts...)
+		So(err, ShouldBeNil)
+
+		defer conn.Close()
+
+		err = test.RegisterGreeterHandler(ctx, mux, conn)
+		So(err, ShouldBeNil)
+
+		Convey("When I query for a unauthenticated greet", func() {
+			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+
+			message := []byte(`{"name":"test"}`)
+			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
+			So(err, ShouldBeNil)
+
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Request-ID", "test")
+
+			resp, err := client.Do(req)
+			So(err, ShouldBeNil)
+
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			So(err, ShouldBeNil)
+
+			actual := strings.TrimSpace(string(body))
 
 			Convey("Then I should have a unauthenticated reply", func() {
 				So(actual, ShouldContainSubstring, `authorization token is not provided`)

--- a/pkg/transport/http/http_test.go
+++ b/pkg/transport/http/http_test.go
@@ -56,7 +56,7 @@ func TestUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for a greet", func() {
-			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+			client := pkgHTTP.NewClient(pkgHTTP.NewRoundTripper(logger, http.DefaultTransport))
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10010/v1/greet/hello", bytes.NewBuffer(message))
@@ -119,8 +119,8 @@ func TestValidAuthUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for an authenticated greet", func() {
-			transport := tokenHTTP.NewRoundTripper(test.NewGenerator("test", nil), pkgHTTP.NewRoundTripper(logger))
-			client := &http.Client{Transport: transport}
+			transport := pkgHTTP.NewRoundTripper(logger, tokenHTTP.NewRoundTripper(test.NewGenerator("test", nil), http.DefaultTransport))
+			client := pkgHTTP.NewClient(transport)
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10012/v1/greet/hello", bytes.NewBuffer(message))
@@ -183,8 +183,8 @@ func TestInvalidAuthUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
-			transport := tokenHTTP.NewRoundTripper(test.NewGenerator("bob", nil), pkgHTTP.NewRoundTripper(logger))
-			client := &http.Client{Transport: transport}
+			transport := pkgHTTP.NewRoundTripper(logger, tokenHTTP.NewRoundTripper(test.NewGenerator("bob", nil), http.DefaultTransport))
+			client := pkgHTTP.NewClient(transport)
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
@@ -247,7 +247,7 @@ func TestMissingAuthUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
-			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+			client := pkgHTTP.NewClient(pkgHTTP.NewRoundTripper(logger, http.DefaultTransport))
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
@@ -309,8 +309,8 @@ func TestEmptyAuthUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
-			transport := tokenHTTP.NewRoundTripper(test.NewGenerator("", nil), pkgHTTP.NewRoundTripper(logger))
-			client := &http.Client{Transport: transport}
+			transport := pkgHTTP.NewRoundTripper(logger, tokenHTTP.NewRoundTripper(test.NewGenerator("", nil), http.DefaultTransport))
+			client := pkgHTTP.NewClient(transport)
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
@@ -365,7 +365,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
-			client := &http.Client{Transport: pkgHTTP.NewRoundTripper(logger)}
+			client := pkgHTTP.NewClient(pkgHTTP.NewRoundTripper(logger, http.DefaultTransport))
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))
@@ -427,8 +427,8 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When I query for a greet that will generate a token error", func() {
-			transport := tokenHTTP.NewRoundTripper(test.NewGenerator("", errors.New("token error")), pkgHTTP.NewRoundTripper(logger))
-			client := &http.Client{Transport: transport}
+			transport := pkgHTTP.NewRoundTripper(logger, tokenHTTP.NewRoundTripper(test.NewGenerator("", errors.New("token error")), http.DefaultTransport))
+			client := pkgHTTP.NewClient(transport)
 
 			message := []byte(`{"name":"test"}`)
 			req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:10014/v1/greet/hello", bytes.NewBuffer(message))

--- a/pkg/transport/http/module.go
+++ b/pkg/transport/http/module.go
@@ -9,7 +9,7 @@ var (
 	ServerModule = fx.Options(fx.Invoke(Register), fx.Provide(NewMux))
 
 	// ClientModule for fx.
-	ClientModule = fx.Options(fx.Provide(NewRoundTripper))
+	ClientModule = fx.Options(fx.Provide(NewClient))
 
 	// Module for fx.
 	Module = fx.Options(ServerModule, ClientModule)

--- a/pkg/transport/http/security/token/token.go
+++ b/pkg/transport/http/security/token/token.go
@@ -20,16 +20,16 @@ type RoundTripper struct {
 }
 
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	token, err := r.gen.Generate()
+	t, err := r.gen.Generate()
 	if err != nil {
 		return nil, err
 	}
 
-	if len(token) == 0 {
-		return r.RoundTripper.RoundTrip(req)
+	if len(t) == 0 {
+		return nil, token.ErrMissingToken
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", string(token)))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", string(t)))
 
 	return r.RoundTripper.RoundTrip(req)
 }


### PR DESCRIPTION
Make sure we return an error on clients if we the generated token is empty.