### PR TITLE
fix(cmd): do not pass context

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 // New command with serve and worker.
-func New(ctx context.Context, timeout time.Duration, serverOpts []fx.Option, workerOpts []fx.Option) (*cobra.Command, error) {
+func New(timeout time.Duration, serverOpts []fx.Option, workerOpts []fx.Option) (*cobra.Command, error) {
 	cfg, err := NewConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -1,7 +1,6 @@
 package cmd_test
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -35,7 +34,7 @@ func TestShutdown(t *testing.T) {
 				fx.Provide(httpObserver), fx.Provide(grpcObserver), fx.Invoke(shutdown),
 			}
 
-			c, err := cmd.New(context.Background(), 10*time.Second, opts, opts)
+			c, err := cmd.New(10*time.Second, opts, opts)
 			So(err, ShouldBeNil)
 
 			c.SetArgs([]string{"worker"})
@@ -69,7 +68,7 @@ func TestInvalidHTTP(t *testing.T) {
 				fx.Provide(httpObserver), fx.Provide(grpcObserver),
 			}
 
-			c, err := cmd.New(context.Background(), 10*time.Second, opts, opts)
+			c, err := cmd.New(10*time.Second, opts, opts)
 			So(err, ShouldBeNil)
 
 			c.SetArgs([]string{"serve"})
@@ -103,7 +102,7 @@ func TestInvalidGRPC(t *testing.T) {
 				fx.Provide(httpObserver), fx.Provide(grpcObserver),
 			}
 
-			c, err := cmd.New(context.Background(), 10*time.Second, opts, opts)
+			c, err := cmd.New(10*time.Second, opts, opts)
 			So(err, ShouldBeNil)
 
 			c.SetArgs([]string{"serve"})


### PR DESCRIPTION
Do not pass context as it's not needed.