### PR TITLE
fix(http): remove version header as we have it in grpc gateway

### DIFF
--- a/transport/http/meta/meta.go
+++ b/transport/http/meta/meta.go
@@ -37,8 +37,6 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx = tmeta.WithRequestID(ctx, requestID)
 	ctx = tmeta.WithRemoteAddress(ctx, extractRemoteAddress(ctx, req))
 
-	resp.Header().Add("Version", string(h.version))
-
 	h.Handler.ServeHTTP(resp, req.WithContext(ctx))
 }
 


### PR DESCRIPTION
Remove version header as it it already present for gRPC Gateway.