### PR TITLE
fix(config): add random wait time to watcher

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,21 +3,20 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alexfalkowski/go-service/os"
+	"github.com/alexfalkowski/go-service/time"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
 
 // Command for application.
 type Command struct {
-	root    *cobra.Command
-	timeout time.Duration
+	root *cobra.Command
 }
 
 // New command.
-func New(timeout time.Duration) *Command {
+func New() *Command {
 	name := os.ExecutableName()
 
 	root := &cobra.Command{
@@ -27,7 +26,7 @@ func New(timeout time.Duration) *Command {
 		SilenceUsage: true,
 	}
 
-	return &Command{root: root, timeout: timeout}
+	return &Command{root: root}
 }
 
 // AddVersion to root.
@@ -72,7 +71,7 @@ func (c *Command) AddServerCommand(name, description string, opts []fx.Option) *
 		Long:         description,
 		SilenceUsage: true,
 		RunE: func(command *cobra.Command, args []string) error {
-			return RunServer(args, c.timeout, opts)
+			return RunServer(args, opts)
 		},
 	}
 
@@ -89,7 +88,7 @@ func (c *Command) AddClientCommand(name, description string, opts []fx.Option) *
 		Long:         description,
 		SilenceUsage: true,
 		RunE: func(command *cobra.Command, args []string) error {
-			return RunClient(args, c.timeout, opts)
+			return RunClient(args, opts)
 		},
 	}
 
@@ -111,11 +110,11 @@ func (c *Command) Run() error {
 }
 
 // RunServer with args and a timeout.
-func RunServer(args []string, timeout time.Duration, opts []fx.Option) error {
+func RunServer(args []string, opts []fx.Option) error {
 	app := fx.New(opts...)
 	done := app.Done()
 
-	startCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	startCtx, cancel := context.WithTimeout(context.Background(), time.Timeout)
 	defer cancel()
 
 	if err := app.Start(startCtx); err != nil {
@@ -124,24 +123,24 @@ func RunServer(args []string, timeout time.Duration, opts []fx.Option) error {
 
 	<-done
 
-	stopCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Timeout)
 	defer cancel()
 
 	return app.Stop(stopCtx)
 }
 
 // RunClient with args and a timeout.
-func RunClient(args []string, timeout time.Duration, opts []fx.Option) error {
+func RunClient(args []string, opts []fx.Option) error {
 	app := fx.New(opts...)
 
-	startCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	startCtx, cancel := context.WithTimeout(context.Background(), time.Timeout)
 	defer cancel()
 
 	if err := app.Start(startCtx); err != nil {
 		return err
 	}
 
-	stopCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Timeout)
 	defer cancel()
 
 	return app.Stop(stopCtx)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -49,7 +49,7 @@ func TestShutdown(t *testing.T) {
 				fx.Provide(readinessObserver), fx.Provide(grpcObserver), fx.Invoke(shutdown), fx.Invoke(configs), fx.Provide(ver),
 			}
 
-			c := cmd.New(10 * time.Second)
+			c := cmd.New()
 			c.AddVersion("1.0.0")
 			c.AddWorker(opts)
 
@@ -79,7 +79,7 @@ func TestRun(t *testing.T) {
 				fx.Provide(readinessObserver), fx.Provide(grpcObserver), fx.Invoke(shutdown), fx.Invoke(configs), fx.Provide(ver),
 			}
 
-			c := cmd.New(10 * time.Second)
+			c := cmd.New()
 			c.AddVersion("1.0.0")
 			c.AddWorker(opts)
 
@@ -110,7 +110,7 @@ func TestInvalidHTTP(t *testing.T) {
 				fx.Provide(readinessObserver), fx.Provide(grpcObserver), fx.Invoke(shutdown), fx.Invoke(configs), fx.Provide(ver),
 			}
 
-			c := cmd.New(10 * time.Second)
+			c := cmd.New()
 			c.AddServer(opts)
 
 			Convey("Then I should see an error", func() {
@@ -143,7 +143,7 @@ func TestInvalidGRPC(t *testing.T) {
 				fx.Provide(readinessObserver), fx.Provide(grpcObserver), fx.Invoke(shutdown), fx.Invoke(configs), fx.Provide(ver),
 			}
 
-			c := cmd.New(10 * time.Second)
+			c := cmd.New()
 			c.AddServer(opts)
 
 			Convey("Then I should see an error", func() {
@@ -163,7 +163,7 @@ func TestClient(t *testing.T) {
 		Convey("When I try to run a client", func() {
 			opts := []fx.Option{fx.NopLogger}
 
-			c := cmd.New(10 * time.Second)
+			c := cmd.New()
 			c.AddClient(opts)
 
 			Convey("Then I should not see an error", func() {
@@ -191,7 +191,7 @@ func TestInvalidClient(t *testing.T) {
 				fx.Provide(readinessObserver), fx.Provide(grpcObserver), fx.Invoke(shutdown), fx.Invoke(configs), fx.Provide(ver),
 			}
 
-			c := cmd.New(10 * time.Second)
+			c := cmd.New()
 			c.AddClient(opts)
 
 			Convey("Then I should see an error", func() {

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 
+	"github.com/alexfalkowski/go-service/time"
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/fx"
 )
@@ -41,22 +42,28 @@ func watch(sh fx.Shutdowner, w *fsnotify.Watcher) {
 		select {
 		case e, ok := <-w.Events:
 			if !ok {
-				sh.Shutdown()
+				shutdown(sh)
 
 				return
 			}
 
 			if e.Op&fsnotify.Write == fsnotify.Write {
-				sh.Shutdown()
+				shutdown(sh)
 
 				return
 			}
 		case _, ok := <-w.Errors:
 			if !ok {
-				sh.Shutdown()
+				shutdown(sh)
 
 				return
 			}
 		}
 	}
+}
+
+func shutdown(sh fx.Shutdowner) error {
+	time.SleepRandomWaitTime()
+
+	return sh.Shutdown()
 }

--- a/time/time.go
+++ b/time/time.go
@@ -1,13 +1,32 @@
 package time
 
 import (
+	"math/rand"
 	"time"
 )
 
-// Timeout as a general guidance of the maximum time any operation should take.
-const Timeout = 5 * time.Second
+const (
+	timeout = 5
+
+	// Timeout as a general guidance of the maximum time any operation should take.
+	Timeout = timeout * time.Second
+)
 
 // ToMilliseconds from the duration.
 func ToMilliseconds(duration time.Duration) int64 {
 	return duration.Nanoseconds() / 1e6 // nolint:gomnd
+}
+
+// RandomWaitTime from the timeout.
+func RandomWaitTime() time.Duration {
+	min := 1
+	max := timeout * 3              // nolint:gomnd
+	num := rand.Intn(max-min) + min // #nosec G404
+
+	return time.Duration(num) * time.Second
+}
+
+// SleepRandomWaitTime from the timeout.
+func SleepRandomWaitTime() {
+	time.Sleep(RandomWaitTime())
 }

--- a/time/time.go
+++ b/time/time.go
@@ -4,6 +4,9 @@ import (
 	"time"
 )
 
+// Timeout as a general guidance of the maximum time any operation should take.
+const Timeout = 5 * time.Second
+
 // ToMilliseconds from the duration.
 func ToMilliseconds(duration time.Duration) int64 {
 	return duration.Nanoseconds() / 1e6 // nolint:gomnd


### PR DESCRIPTION
Make sure we add a delay time when we shutdown from config changes. This will prevent shutting down every process at the same time.