### PR TITLE
feat(security): add ability to configure token kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ host = "localhost:4318"
 secure = false
 ```
 
+## Token
+
+The framework allows you to define different token generators and verifiers. We provide the config, how these are defined are up to you.
+
+### Configuration
+
+To configure, please specify the following:
+
+```yaml
+token:
+  Kind: none
+```
+
+```toml
+[token]
+kind = "none"
+```
+
 ## Transport
 
 The transport layer provides ways to abstract communication for in/out of the service. So we have the following integrations:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	hgrpc "github.com/alexfalkowski/go-service/health/transport/grpc"
 	hhttp "github.com/alexfalkowski/go-service/health/transport/http"
 	"github.com/alexfalkowski/go-service/runtime"
+	"github.com/alexfalkowski/go-service/security/token"
 	"github.com/alexfalkowski/go-service/telemetry"
 	"github.com/alexfalkowski/go-service/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/test"
@@ -160,7 +161,7 @@ func redisCache(c *rcache.Cache) error {
 	return c.Delete(context.Background(), "test")
 }
 
-func configs(_ *redis.Config, _ *ristretto.Config, _ *pg.Config, _ *nsq.Config) {
+func configs(_ *redis.Config, _ *ristretto.Config, _ *pg.Config, _ *nsq.Config, _ *token.Config) {
 }
 
 func meter(_ metric.Meter) {

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/database/sql/pg"
 	"github.com/alexfalkowski/go-service/debug"
 	"github.com/alexfalkowski/go-service/env"
+	"github.com/alexfalkowski/go-service/security/token"
 	"github.com/alexfalkowski/go-service/telemetry"
 	"github.com/alexfalkowski/go-service/telemetry/logger/zap"
 	"github.com/alexfalkowski/go-service/telemetry/tracer"
@@ -24,6 +25,7 @@ type Config struct {
 	Cache       cache.Config     `yaml:"cache" json:"cache" toml:"cache"`
 	SQL         sql.Config       `yaml:"sql" json:"sql" toml:"sql"`
 	Telemetry   telemetry.Config `yaml:"telemetry" json:"telemetry" toml:"telemetry"`
+	Token       token.Config     `yaml:"token" json:"token" toml:"token"`
 	Transport   transport.Config `yaml:"transport" json:"transport" toml:"transport"`
 }
 
@@ -57,6 +59,10 @@ func (cfg *Config) LoggerConfig() *zap.Config {
 
 func (cfg *Config) TransportConfig() *transport.Config {
 	return &cfg.Transport
+}
+
+func (cfg *Config) TokenConfig() *token.Config {
+	return &cfg.Token
 }
 
 func (cfg *Config) GRPCConfig() *grpc.Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,6 +89,7 @@ func verifyConfig(cfg config.Configurator) {
 	So(cfg.PGConfig().MaxIdleConns, ShouldEqual, 5)
 	So(cfg.PGConfig().MaxOpenConns, ShouldEqual, 5)
 	So(cfg.PGConfig().ConnMaxLifetime, ShouldEqual, time.Hour)
+	So(cfg.TokenConfig().Kind, ShouldEqual, "none")
 	So(cfg.TracerConfig().Host, ShouldEqual, "localhost:4318")
 	So(cfg.GRPCConfig().Enabled, ShouldEqual, true)
 	So(cfg.GRPCConfig().Port, ShouldEqual, "9090")

--- a/config/configurator.go
+++ b/config/configurator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/database/sql/pg"
 	"github.com/alexfalkowski/go-service/debug"
 	"github.com/alexfalkowski/go-service/env"
+	"github.com/alexfalkowski/go-service/security/token"
 	"github.com/alexfalkowski/go-service/telemetry/logger/zap"
 	"github.com/alexfalkowski/go-service/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/transport"
@@ -30,6 +31,7 @@ type Configurator interface {
 	RistrettoConfig() *ristretto.Config
 	PGConfig() *pg.Config
 	LoggerConfig() *zap.Config
+	TokenConfig() *token.Config
 	TracerConfig() *tracer.Config
 	TransportConfig() *transport.Config
 	GRPCConfig() *grpc.Config
@@ -59,6 +61,10 @@ func pgConfig(cfg Configurator) *pg.Config {
 
 func loggerConfig(cfg Configurator) *zap.Config {
 	return cfg.LoggerConfig()
+}
+
+func tokenConfig(cfg Configurator) *token.Config {
+	return cfg.TokenConfig()
 }
 
 func tracerConfig(cfg Configurator) *tracer.Config {

--- a/config/module.go
+++ b/config/module.go
@@ -20,9 +20,8 @@ var (
 	ConfigModule = fx.Options(
 		fx.Provide(environmentConfig), fx.Provide(debugConfig),
 		fx.Provide(redisConfig), fx.Provide(ristrettoConfig),
-		fx.Provide(pgConfig),
+		fx.Provide(pgConfig), fx.Provide(tokenConfig),
 		fx.Provide(loggerConfig), fx.Provide(tracerConfig),
-		fx.Provide(transportConfig),
-		fx.Provide(grpcConfig), fx.Provide(httpConfig), fx.Provide(nsqConfig),
+		fx.Provide(transportConfig), fx.Provide(grpcConfig), fx.Provide(httpConfig), fx.Provide(nsqConfig),
 	)
 )

--- a/security/token/config.go
+++ b/security/token/config.go
@@ -1,0 +1,6 @@
+package token
+
+// Config for token.
+type Config struct {
+	Kind string `yaml:"kind" json:"kind" toml:"kind"`
+}

--- a/test/config.toml
+++ b/test/config.toml
@@ -28,6 +28,9 @@ level = "info"
 [telemetry.tracer]
 host = "localhost:4318"
 
+[token]
+kind = "none"
+
 [transport.http]
 port = "8080"
 user_agent = "Service http/1.0"

--- a/test/config.yml
+++ b/test/config.yml
@@ -23,6 +23,8 @@ telemetry:
     level: info
   tracer:
     host: localhost:4318
+token:
+  kind: none
 transport:
   http:
     port: 8080


### PR DESCRIPTION
This is mostly used for other services to be able to configure their own security.