### PR TITLE
fix(cmd): allow shortform flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The supported configuration kinds are as follows:
 - [TOML](https://github.com/BurntSushi/toml)
 - [YAML](https://github.com/go-yaml/yaml)
 
-The configuration can be read from multiple sources by specifying a flag called `--input`. As per the following:
+The configuration can be read from multiple sources by specifying a flag called `--input` or `-i`. As per the following:
 - `env:CONFIG_FILE` - Read from an env variable called `CONFIG_FILE`. This is the default if nothing is passed. The env variable can be file path or the configuration. If it is the config, we expect the format of `extension:ENV_VARIABLE`, where extension is the supported kinds and `ENV_VARIABLE` contains the contents of the config that are *base64 encoded*.
 - `file:path` - Read from the path.
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,7 +26,7 @@ func New(version string) *Command {
 		Version:      version,
 	}
 
-	root.PersistentFlags().StringVar(&inputFlag, "input", "env:CONFIG_FILE", "input config location (format kind:location, default env:CONFIG_FILE)")
+	root.PersistentFlags().StringVarP(&inputFlag, "input", "i", "env:CONFIG_FILE", "input config location (format kind:location, default env:CONFIG_FILE)")
 
 	return &Command{root: root}
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -97,7 +97,7 @@ func TestDisabled(t *testing.T) {
 			c.AddServer(opts()...)
 
 			Convey("Then I should see an error", func() {
-				err := c.RunWithArgs([]string{"server", "--input", "file:../test/disabled.config.yml"})
+				err := c.RunWithArgs([]string{"server", "-i", "file:../test/disabled.config.yml"})
 
 				So(err, ShouldBeNil)
 			})


### PR DESCRIPTION
Allow shorthand of flag.

https://stackoverflow.com/questions/63341006/what-is-the-difference-between-stringvar-vs-stringvarp-or-string-vs-stringp-when