### PR TITLE
build(lint): remove execinquery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
     - errname
     - errorlint
     - exportloopref
-    - execinquery
     - exhaustive
     - exportloopref
     - forbidigo

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -307,7 +307,6 @@ func TestStatementQuery(t *testing.T) {
 
 			defer stmt.Close()
 
-			//nolint:execinquery
 			rows, err := stmt.QueryContext(ctx, "public")
 
 			Convey("Then I should have valid data", func() {
@@ -464,7 +463,6 @@ func TestInvalidStatementQuery(t *testing.T) {
 
 			defer stmt.Close()
 
-			//nolint:execinquery
 			_, err = stmt.QueryContext(ctx, 1)
 
 			Convey("Then I should have an error", func() {


### PR DESCRIPTION
WARN The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner. 