### PR TITLE
fix(limiter): do not rate limit health checks

### DIFF
--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -2,9 +2,11 @@ package limiter
 
 import (
 	"context"
+	"path"
 
 	"github.com/alexfalkowski/go-service/limiter"
 	"github.com/alexfalkowski/go-service/meta"
+	"github.com/alexfalkowski/go-service/transport/strings"
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	v3 "github.com/ulule/limiter/v3"
 	"google.golang.org/grpc"
@@ -14,7 +16,12 @@ import (
 
 // UnaryServerInterceptor for gRPC.
 func UnaryServerInterceptor(limiter *v3.Limiter, key limiter.KeyFunc) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		p := path.Dir(info.FullMethod)[1:]
+		if limiter == nil || strings.IsHealth(p) {
+			return handler(ctx, req)
+		}
+
 		if err := limit(ctx, limiter, key); err != nil {
 			return nil, err
 		}
@@ -25,7 +32,12 @@ func UnaryServerInterceptor(limiter *v3.Limiter, key limiter.KeyFunc) grpc.Unary
 
 // StreamServerInterceptor for gRPC.
 func StreamServerInterceptor(limiter *v3.Limiter, key limiter.KeyFunc) grpc.StreamServerInterceptor {
-	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		p := path.Dir(info.FullMethod)[1:]
+		if limiter == nil || strings.IsHealth(p) {
+			return handler(srv, stream)
+		}
+
 		ctx := stream.Context()
 		if err := limit(ctx, limiter, key); err != nil {
 			return err
@@ -39,10 +51,6 @@ func StreamServerInterceptor(limiter *v3.Limiter, key limiter.KeyFunc) grpc.Stre
 }
 
 func limit(ctx context.Context, limiter *v3.Limiter, key limiter.KeyFunc) error {
-	if limiter == nil {
-		return nil
-	}
-
 	// Memory stores do not return error.
 	context, _ := limiter.Get(ctx, meta.ValueOrBlank(key(ctx)))
 

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -208,7 +208,7 @@ func TestLimiterAuthUnary(t *testing.T) {
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("bob")
 
-		l, _, err := limiter.New(test.NewLimiterConfig("token", "10-S"))
+		l, k, err := limiter.New(test.NewLimiterConfig("token", "10-S"))
 		So(err, ShouldBeNil)
 
 		cfg := test.NewInsecureTransportConfig()
@@ -217,7 +217,7 @@ func TestLimiterAuthUnary(t *testing.T) {
 
 		s := &test.Server{
 			Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, VerifyAuth: true,
-			Limiter: l, Key: token.Key, Verifier: verifier, Mux: test.GatewayMux,
+			Limiter: l, Key: k, Verifier: verifier, Mux: test.GatewayMux,
 		}
 		s.Register()
 

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/limiter"
 	"github.com/alexfalkowski/go-service/meta"
+	"github.com/alexfalkowski/go-service/transport/strings"
 	l "github.com/ulule/limiter/v3"
 )
 
@@ -22,7 +23,7 @@ type Handler struct {
 
 // ServeHTTP for limiter.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	if h.limiter == nil {
+	if h.limiter == nil || strings.IsHealth(req.URL.Path) {
 		next(res, req)
 
 		return


### PR DESCRIPTION
Rate limiting can be done by token and those endpoints do not require it.