### PR TITLE
fix(health): gRPC observer should be optional

### DIFF
--- a/health/transport/grpc/grpc.go
+++ b/health/transport/grpc/grpc.go
@@ -2,10 +2,22 @@ package grpc
 
 import (
 	"github.com/alexfalkowski/go-service/transport/grpc"
+	"go.uber.org/fx"
 	health "google.golang.org/grpc/health/grpc_health_v1"
 )
 
+// RegisterParams for gRPC.
+type RegisterParams struct {
+	fx.In
+
+	Server   *grpc.Server
+	Observer *Observer `optional:"true"`
+}
+
 // Register health for gRPC.
-func Register(srv *grpc.Server, ob *Observer) {
-	health.RegisterHealthServer(srv.Server(), &server{ob: ob})
+func Register(params RegisterParams) {
+	ob := params.Observer
+	if ob != nil {
+		health.RegisterHealthServer(params.Server.Server(), &server{ob: ob})
+	}
 }

--- a/health/transport/grpc/grpc_test.go
+++ b/health/transport/grpc/grpc_test.go
@@ -49,7 +49,7 @@ func TestUnary(t *testing.T) {
 		}
 		s.Register()
 
-		shg.Register(s.GRPC, &shg.Observer{Observer: o})
+		shg.Register(shg.RegisterParams{Server: s.GRPC, Observer: &shg.Observer{Observer: o}})
 		lc.RequireStart()
 		time.Sleep(1 * time.Second)
 
@@ -90,7 +90,7 @@ func TestInvalidUnary(t *testing.T) {
 		s := &test.Server{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Mux: test.GatewayMux}
 		s.Register()
 
-		shg.Register(s.GRPC, &shg.Observer{Observer: o})
+		shg.Register(shg.RegisterParams{Server: s.GRPC, Observer: &shg.Observer{Observer: o}})
 		lc.RequireStart()
 		time.Sleep(1 * time.Second)
 
@@ -136,7 +136,7 @@ func TestIgnoreAuthUnary(t *testing.T) {
 		}
 		s.Register()
 
-		shg.Register(s.GRPC, &shg.Observer{Observer: o})
+		shg.Register(shg.RegisterParams{Server: s.GRPC, Observer: &shg.Observer{Observer: o}})
 		lc.RequireStart()
 		time.Sleep(1 * time.Second)
 
@@ -182,7 +182,7 @@ func TestStream(t *testing.T) {
 		}
 		s.Register()
 
-		shg.Register(s.GRPC, &shg.Observer{Observer: o})
+		shg.Register(shg.RegisterParams{Server: s.GRPC, Observer: &shg.Observer{Observer: o}})
 		lc.RequireStart()
 		time.Sleep(1 * time.Second)
 
@@ -224,7 +224,7 @@ func TestInvalidStream(t *testing.T) {
 		s := &test.Server{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Mux: test.GatewayMux}
 		s.Register()
 
-		shg.Register(s.GRPC, &shg.Observer{Observer: o})
+		shg.Register(shg.RegisterParams{Server: s.GRPC, Observer: &shg.Observer{Observer: o}})
 		lc.RequireStart()
 		time.Sleep(1 * time.Second)
 
@@ -270,7 +270,7 @@ func TestIgnoreAuthStream(t *testing.T) {
 		}
 		s.Register()
 
-		shg.Register(s.GRPC, &shg.Observer{Observer: o})
+		shg.Register(shg.RegisterParams{Server: s.GRPC, Observer: &shg.Observer{Observer: o}})
 		lc.RequireStart()
 		time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
This API https://github.com/alexfalkowski/cded will purely use HTTP.