### PR TITLE
fix(telemetry): ignore stop error as there is little we can do about it

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -2,9 +2,7 @@ package net
 
 import (
 	"context"
-	"errors"
 	"net"
-	"syscall"
 	"time"
 )
 
@@ -16,9 +14,4 @@ func Listener(port string) (net.Listener, error) {
 // DialContext for net.
 func DialContext(_ context.Context, network, address string) (net.Conn, error) {
 	return net.DialTimeout(network, address, time.Minute)
-}
-
-// IsConnectionRefused returns a boolean indicating whether the error is known to report connection is refused.
-func IsConnectionRefused(err error) bool {
-	return errors.Is(err, syscall.ECONNREFUSED)
 }

--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/alexfalkowski/go-service/env"
 	"github.com/alexfalkowski/go-service/errors"
-	"github.com/alexfalkowski/go-service/net"
 	otlp "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	m "go.opentelemetry.io/otel/metric"
@@ -52,12 +51,9 @@ func NewMeter(params MeterParams) m.Meter {
 
 	params.Lifecycle.Append(fx.Hook{
 		OnStop: func(ctx context.Context) error {
-			err := provider.Shutdown(ctx)
-			if net.IsConnectionRefused(err) {
-				return nil
-			}
+			_ = provider.Shutdown(ctx)
 
-			return errors.Prefix("stop metrics", err)
+			return nil
 		},
 	})
 

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -2,11 +2,9 @@ package tracer
 
 import (
 	"context"
-	"errors"
 
 	"github.com/alexfalkowski/go-service/env"
 	se "github.com/alexfalkowski/go-service/errors"
-	"github.com/alexfalkowski/go-service/net"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	otlp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -71,7 +69,10 @@ func newTracer(lc fx.Lifecycle, env env.Environment, ver env.Version, name env.N
 			return se.Prefix("start tracer", exporter.Start(ctx))
 		},
 		OnStop: func(ctx context.Context) error {
-			return se.Prefix("stop tracer", errors.Join(p.Shutdown(ctx), exporter.Shutdown(ctx)))
+			_ = p.Shutdown(ctx)
+			_ = exporter.Shutdown(ctx)
+
+			return nil
 		},
 	})
 
@@ -83,9 +84,5 @@ type errorHandler struct {
 }
 
 func (e *errorHandler) Handle(err error) {
-	if net.IsConnectionRefused(err) {
-		return
-	}
-
 	e.logger.Error("trace: global error", zap.Error(err))
 }


### PR DESCRIPTION
We get 
```
stop metrics: failed to upload metrics: failed to send metrics to http://localhost:9009/otlp/v1/metrics: 400 Bad Request
```

The reason being:
```
ts=2024-05-30T05:18:46.117481253Z caller=push.go:171 level=error user=anonymous msg="push error" err="failed pushing to ingester 5dd03b12fb86: user=anonymous: the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed (err-mimir-sample-out-of-order). The affected sample has timestamp 2024-05-30T05:18:46.11Z and is from series target_info{deployment_environment=\"dev\", service_version=\"1.0.0\"}"

This instance we need to setup https://grafana.com/docs/mimir/latest/configure/configure-out-of-order-samples-ingestion/ though this is out of our control.
```