### PR TITLE
fix(http): use stable errors and add the error to meta

### DIFF
--- a/transport/http/sync_test.go
+++ b/transport/http/sync_test.go
@@ -165,7 +165,7 @@ func TestBadSync(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("Then I should have response", func() {
-					So(r.Error.Message, ShouldEqual, "ohh no")
+					So(r.Error.Message, ShouldEqual, "invalid handle")
 					So(resp.Header.Get("Content-Type"), ShouldEqual, "application/"+mt)
 					So(resp.StatusCode, ShouldEqual, 500)
 				})


### PR DESCRIPTION
This way we can log the errors instead, of needing to inspect the body.