### PR TITLE
feat(http): simplify handler

### DIFF
--- a/health/transport/grpc/grpc_test.go
+++ b/health/transport/grpc/grpc_test.go
@@ -31,7 +31,7 @@ func init() {
 
 func TestUnary(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -80,7 +80,7 @@ func TestUnary(t *testing.T) {
 
 func TestInvalidUnary(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()
@@ -123,7 +123,7 @@ func TestInvalidUnary(t *testing.T) {
 
 func TestIgnoreAuthUnary(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()
@@ -167,7 +167,7 @@ func TestIgnoreAuthUnary(t *testing.T) {
 
 func TestStream(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -217,7 +217,7 @@ func TestStream(t *testing.T) {
 
 func TestInvalidStream(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()
@@ -260,7 +260,7 @@ func TestInvalidStream(t *testing.T) {
 
 func TestIgnoreAuthStream(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()

--- a/health/transport/http/http.go
+++ b/health/transport/http/http.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alexfalkowski/go-health/subscriber"
 	"github.com/alexfalkowski/go-service/env"
 	"github.com/alexfalkowski/go-service/marshaller"
-	sh "github.com/alexfalkowski/go-service/net/http"
 	"go.uber.org/fx"
 )
 
@@ -19,7 +18,7 @@ const (
 type RegisterParams struct {
 	fx.In
 
-	Mux       sh.ServeMux
+	Mux       *http.ServeMux
 	Health    *HealthObserver
 	Liveness  *LivenessObserver
 	Readiness *ReadinessObserver
@@ -38,8 +37,8 @@ func Register(params RegisterParams) error {
 	return nil
 }
 
-func resister(path string, mux sh.ServeMux, ob *subscriber.Observer, version env.Version, json *marshaller.JSON, withErrors bool) {
-	mux.Handle("GET", path, func(resp http.ResponseWriter, _ *http.Request) {
+func resister(path string, mux *http.ServeMux, ob *subscriber.Observer, version env.Version, json *marshaller.JSON, withErrors bool) {
+	mux.HandleFunc("GET "+path, func(resp http.ResponseWriter, _ *http.Request) {
 		resp.Header().Set("Content-Type", "application/json")
 		resp.Header().Set("Version", string(version))
 

--- a/health/transport/http/http_test.go
+++ b/health/transport/http/http_test.go
@@ -38,7 +38,7 @@ func TestHealth(t *testing.T) {
 
 	for _, check := range checks {
 		Convey("Given I register the health handler", t, func() {
-			mux := nh.NewServeMux(nh.NewStandardServeMux())
+			mux := nh.NewServeMux()
 			lc := fxtest.NewLifecycle(t)
 			logger := test.NewLogger(lc)
 
@@ -103,7 +103,7 @@ func TestHealth(t *testing.T) {
 
 func TestReadinessNoop(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()
@@ -159,7 +159,7 @@ func TestReadinessNoop(t *testing.T) {
 
 func TestInvalidHealth(t *testing.T) {
 	Convey("Given I register the health handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()

--- a/net/http/mux.go
+++ b/net/http/mux.go
@@ -1,40 +1,10 @@
 package http
 
 import (
-	"fmt"
 	"net/http"
 )
 
-// NewServeMux for HTTP.
-func NewServeMux(s *http.ServeMux) ServeMux {
-	return &StandardServeMux{s}
-}
-
-// ServeMux for HTTP.
-type ServeMux interface {
-	// Handle a verb, pattern with the func.
-	Handle(verb, pattern string, fn http.HandlerFunc) error
-
-	// Handler from the mux.
-	Handler() http.Handler
-}
-
 // NewServeMux for http.
-func NewStandardServeMux() *http.ServeMux {
+func NewServeMux() *http.ServeMux {
 	return http.NewServeMux()
-}
-
-// StandardServeMux for HTTP.
-type StandardServeMux struct {
-	*http.ServeMux
-}
-
-func (s *StandardServeMux) Handle(verb, pattern string, fn http.HandlerFunc) error {
-	s.HandleFunc(fmt.Sprintf("%s %s", verb, pattern), fn)
-
-	return nil
-}
-
-func (s *StandardServeMux) Handler() http.Handler {
-	return s.ServeMux
 }

--- a/test/server.go
+++ b/test/server.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	lm "github.com/alexfalkowski/go-service/limiter"
-	nh "github.com/alexfalkowski/go-service/net/http"
 	"github.com/alexfalkowski/go-service/runtime"
 	"github.com/alexfalkowski/go-service/security/token"
 	"github.com/alexfalkowski/go-service/telemetry/tracer"
@@ -24,7 +23,7 @@ type Server struct {
 	Lifecycle  fx.Lifecycle
 	Meter      metric.Meter
 	Verifier   token.Verifier
-	Mux        nh.ServeMux
+	Mux        *http.ServeMux
 	HTTP       *th.Server
 	GRPC       *tg.Server
 	Transport  *transport.Config

--- a/transport/events/http/http_test.go
+++ b/transport/events/http/http_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestSendReceive(t *testing.T) {
 	Convey("Given I have a http event receiver", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()
@@ -73,7 +73,7 @@ func TestSendReceive(t *testing.T) {
 
 func TestSendNotReceive(t *testing.T) {
 	Convey("Given I have a http event receiver", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()

--- a/transport/events/http/receiver.go
+++ b/transport/events/http/receiver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	sh "github.com/alexfalkowski/go-service/net/http"
 	h "github.com/alexfalkowski/go-service/transport/events/http/hooks"
 	events "github.com/cloudevents/sdk-go/v2"
 	hooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
@@ -15,12 +14,12 @@ type ReceiverFunc func(ctx context.Context, e events.Event)
 
 // Receiver for HTTP.
 type Receiver struct {
-	mux  sh.ServeMux
+	mux  *http.ServeMux
 	hook *hooks.Webhook
 }
 
 // NewReceiver for HTTP.
-func NewReceiver(mux sh.ServeMux, hook *hooks.Webhook) *Receiver {
+func NewReceiver(mux *http.ServeMux, hook *hooks.Webhook) *Receiver {
 	return &Receiver{mux: mux, hook: hook}
 }
 
@@ -41,7 +40,9 @@ func (r *Receiver) Register(ctx context.Context, path string, fn ReceiverFunc) e
 
 	handler = h.NewHandler(r.hook, handler)
 
-	return r.mux.Handle("POST", path, func(w http.ResponseWriter, r *http.Request) {
+	r.mux.HandleFunc("POST "+path, func(w http.ResponseWriter, r *http.Request) {
 		handler.ServeHTTP(w, r)
 	})
+
+	return nil
 }

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestTokenErrorAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -60,7 +60,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 
 func TestEmptyAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -103,7 +103,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 
 func TestMissingClientAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -143,7 +143,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 
 func TestInvalidAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -187,7 +187,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 
 func TestValidAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -231,7 +231,7 @@ func TestValidAuthUnary(t *testing.T) {
 
 func TestBreakerAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -278,7 +278,7 @@ func TestBreakerAuthUnary(t *testing.T) {
 
 func TestValidAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -327,7 +327,7 @@ func TestValidAuthStream(t *testing.T) {
 
 func TestInvalidAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -375,7 +375,7 @@ func TestInvalidAuthStream(t *testing.T) {
 
 func TestEmptyAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -417,7 +417,7 @@ func TestEmptyAuthStream(t *testing.T) {
 
 func TestMissingClientAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -462,7 +462,7 @@ func TestMissingClientAuthStream(t *testing.T) {
 
 func TestTokenErrorAuthStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestInsecureUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()
@@ -54,7 +54,7 @@ func TestInsecureUnary(t *testing.T) {
 
 func TestSecureUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewSecureTransportConfig()
@@ -91,7 +91,7 @@ func TestSecureUnary(t *testing.T) {
 
 func TestStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		cfg := test.NewInsecureTransportConfig()

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -21,7 +21,7 @@ func init() {
 
 func TestLimiterLimitedUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -65,7 +65,7 @@ func TestLimiterLimitedUnary(t *testing.T) {
 
 func TestLimiterUnlimitedUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -108,7 +108,7 @@ func TestLimiterUnlimitedUnary(t *testing.T) {
 
 func TestLimiterLimitedStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -158,7 +158,7 @@ func TestLimiterLimitedStream(t *testing.T) {
 
 func TestLimiterUnlimitedStream(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -207,7 +207,7 @@ func TestLimiterUnlimitedStream(t *testing.T) {
 
 func TestLimiterAuthUnary(t *testing.T) {
 	Convey("Given I have a gRPC server", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("bob")

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -31,7 +31,7 @@ func TestServer(t *testing.T) {
 	})
 
 	Convey("Given I have secure creds", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -20,7 +20,7 @@ import (
 //nolint:funlen
 func TestValidAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -45,14 +45,12 @@ func TestValidAuthUnary(t *testing.T) {
 		conn := cl.NewGRPC()
 		defer conn.Close()
 
-		h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
-
-		err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+		nh.RegisterHandler(mux, test.Marshaller)
+		nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 			s := "Hello " + r.Name
 
 			return &Response{Greeting: &s}, nil
 		})
-		So(err, ShouldBeNil)
 
 		Convey("When I query for an authenticated greet", func() {
 			client := cl.NewHTTP()
@@ -87,7 +85,7 @@ func TestValidAuthUnary(t *testing.T) {
 //nolint:funlen
 func TestInvalidAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -112,14 +110,12 @@ func TestInvalidAuthUnary(t *testing.T) {
 		conn := cl.NewGRPC()
 		defer conn.Close()
 
-		h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
-
-		err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+		nh.RegisterHandler(mux, test.Marshaller)
+		nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 			s := "Hello " + r.Name
 
 			return &Response{Greeting: &s}, nil
 		})
-		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -154,7 +150,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 //nolint:dupl
 func TestMissingAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -176,14 +172,12 @@ func TestMissingAuthUnary(t *testing.T) {
 		conn := cl.NewGRPC()
 		defer conn.Close()
 
-		h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
-
-		err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+		nh.RegisterHandler(mux, test.Marshaller)
+		nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 			s := "Hello " + r.Name
 
 			return &Response{Greeting: &s}, nil
 		})
-		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -216,7 +210,7 @@ func TestMissingAuthUnary(t *testing.T) {
 
 func TestEmptyAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -241,14 +235,12 @@ func TestEmptyAuthUnary(t *testing.T) {
 		conn := cl.NewGRPC()
 		defer conn.Close()
 
-		h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
-
-		err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+		nh.RegisterHandler(mux, test.Marshaller)
+		nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 			s := "Hello " + r.Name
 
 			return &Response{Greeting: &s}, nil
 		})
-		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -275,7 +267,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 //nolint:dupl
 func TestMissingClientAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -297,14 +289,12 @@ func TestMissingClientAuthUnary(t *testing.T) {
 		conn := cl.NewGRPC()
 		defer conn.Close()
 
-		h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
-
-		err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+		nh.RegisterHandler(mux, test.Marshaller)
+		nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 			s := "Hello " + r.Name
 
 			return &Response{Greeting: &s}, nil
 		})
-		So(err, ShouldBeNil)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -337,7 +327,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 
 func TestTokenErrorAuthUnary(t *testing.T) {
 	Convey("Given I have a all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		verifier := test.NewVerifier("test")
@@ -362,14 +352,12 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 		conn := cl.NewGRPC()
 		defer conn.Close()
 
-		h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
-
-		err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+		nh.RegisterHandler(mux, test.Marshaller)
+		nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 			s := "Hello " + r.Name
 
 			return &Response{Greeting: &s}, nil
 		})
-		So(err, ShouldBeNil)
 
 		Convey("When I query for a greet that will generate a token error", func() {
 			client := cl.NewHTTP()

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -51,7 +51,7 @@ func (*Errorer) Status(error) int {
 func TestSync(t *testing.T) {
 	for _, mt := range []string{"json", "yaml", "yml", "toml", "gob"} {
 		Convey("Given I have all the servers", t, func() {
-			mux := nh.NewServeMux(nh.NewStandardServeMux())
+			mux := nh.NewServeMux()
 			lc := fxtest.NewLifecycle(t)
 			logger := test.NewLogger(lc)
 
@@ -66,14 +66,13 @@ func TestSync(t *testing.T) {
 			s.Register()
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
-			h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
 
-			err = h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+			nh.RegisterHandler(mux, test.Marshaller)
+			nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 				s := "Hello " + r.Name
 
 				return &Response{Greeting: &s}, nil
 			})
-			So(err, ShouldBeNil)
 
 			lc.RequireStart()
 
@@ -116,7 +115,7 @@ func TestSync(t *testing.T) {
 func TestBadSync(t *testing.T) {
 	for _, mt := range []string{"json", "yaml", "yml", "toml", "gob"} {
 		Convey("Given I have all the servers", t, func() {
-			mux := nh.NewServeMux(nh.NewStandardServeMux())
+			mux := nh.NewServeMux()
 			lc := fxtest.NewLifecycle(t)
 			logger := test.NewLogger(lc)
 
@@ -131,12 +130,11 @@ func TestBadSync(t *testing.T) {
 			s.Register()
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
-			h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
 
-			err = h.Handle("POST", "/hello", func(_ context.Context, _ *Request) (*Response, error) {
+			nh.RegisterHandler(mux, test.Marshaller)
+			nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, _ *Request) (*Response, error) {
 				return nil, errors.New("ohh no")
 			})
-			So(err, ShouldBeNil)
 
 			lc.RequireStart()
 
@@ -180,7 +178,7 @@ func TestBadSync(t *testing.T) {
 func TestAllowedSync(t *testing.T) {
 	for _, mt := range []string{"json", "yaml", "yml", "toml", "gob"} {
 		Convey("Given I have all the servers", t, func() {
-			mux := nh.NewServeMux(nh.NewStandardServeMux())
+			mux := nh.NewServeMux()
 			verifier := test.NewVerifier("test")
 			lc := fxtest.NewLifecycle(t)
 			logger := test.NewLogger(lc)
@@ -193,14 +191,13 @@ func TestAllowedSync(t *testing.T) {
 			s.Register()
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("test", nil)}
-			h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
 
-			err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+			nh.RegisterHandler(mux, test.Marshaller)
+			nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 				s := "Hello " + r.Name
 
 				return &Response{Greeting: &s}, nil
 			})
-			So(err, ShouldBeNil)
 
 			lc.RequireStart()
 
@@ -243,7 +240,7 @@ func TestAllowedSync(t *testing.T) {
 func TestDisallowedSync(t *testing.T) {
 	for _, mt := range []string{"json", "yaml", "yml", "toml", "gob"} {
 		Convey("Given I have all the servers", t, func() {
-			mux := nh.NewServeMux(nh.NewStandardServeMux())
+			mux := nh.NewServeMux()
 			verifier := test.NewVerifier("test")
 			lc := fxtest.NewLifecycle(t)
 			logger := test.NewLogger(lc)
@@ -256,14 +253,13 @@ func TestDisallowedSync(t *testing.T) {
 			s.Register()
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("bob", nil)}
-			h := nh.NewHandler[Request, Response](mux, test.Marshaller, &Errorer{})
 
-			err := h.Handle("POST", "/hello", func(_ context.Context, r *Request) (*Response, error) {
+			nh.RegisterHandler(mux, test.Marshaller)
+			nh.Handler("POST /hello", &Errorer{}, func(_ context.Context, r *Request) (*Response, error) {
 				s := "Hello " + r.Name
 
 				return &Response{Greeting: &s}, nil
 			})
-			So(err, ShouldBeNil)
 
 			lc.RequireStart()
 
@@ -300,7 +296,7 @@ func TestDisallowedSync(t *testing.T) {
 
 func TestSecure(t *testing.T) {
 	Convey("Given I a secure client", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		tc := test.NewOTLPTracerConfig()

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -22,7 +22,7 @@ func init() {
 
 func TestGet(t *testing.T) {
 	Convey("Given I have all the servers", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 
@@ -41,10 +41,9 @@ func TestGet(t *testing.T) {
 
 		cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-		err = mux.Handle("GET", "/hello", func(w http.ResponseWriter, _ *http.Request) {
+		mux.HandleFunc("GET /hello", func(w http.ResponseWriter, _ *http.Request) {
 			w.Write([]byte("hello!"))
 		})
-		So(err, ShouldBeNil)
 
 		lc.RequireStart()
 
@@ -76,7 +75,7 @@ func TestGet(t *testing.T) {
 func TestLimiter(t *testing.T) {
 	for _, f := range []string{"user-agent", "ip"} {
 		Convey("Given I have a all the servers", t, func() {
-			mux := nh.NewServeMux(nh.NewStandardServeMux())
+			mux := nh.NewServeMux()
 			lc := fxtest.NewLifecycle(t)
 			logger := test.NewLogger(lc)
 
@@ -95,10 +94,9 @@ func TestLimiter(t *testing.T) {
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-			err = mux.Handle("GET", "/hello", func(w http.ResponseWriter, _ *http.Request) {
+			mux.HandleFunc("GET /hello", func(w http.ResponseWriter, _ *http.Request) {
 				w.Write([]byte("hello!"))
 			})
-			So(err, ShouldBeNil)
 
 			lc.RequireStart()
 

--- a/transport/http/metrics.go
+++ b/transport/http/metrics.go
@@ -3,20 +3,19 @@ package http
 import (
 	"net/http"
 
-	sh "github.com/alexfalkowski/go-service/net/http"
 	"github.com/alexfalkowski/go-service/telemetry/metrics"
 	prom "github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // RegisterMetrics for HTTP.
-func RegisterMetrics(cfg *metrics.Config, mux sh.ServeMux) error {
+func RegisterMetrics(cfg *metrics.Config, mux *http.ServeMux) {
 	if !metrics.IsEnabled(cfg) || !cfg.IsPrometheus() {
-		return nil
+		return
 	}
 
 	handler := prom.Handler()
 
-	return mux.Handle("GET", "/metrics", func(res http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("GET /metrics", func(res http.ResponseWriter, req *http.Request) {
 		handler.ServeHTTP(res, req)
 	})
 }

--- a/transport/http/metrics_test.go
+++ b/transport/http/metrics_test.go
@@ -18,10 +18,9 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-//nolint:funlen
 func TestPrometheusInsecureHTTP(t *testing.T) {
 	Convey("Given I register the metrics handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		tc := test.NewOTLPTracerConfig()
@@ -48,9 +47,7 @@ func TestPrometheusInsecureHTTP(t *testing.T) {
 
 		cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-		err = ht.RegisterMetrics(mc, mux)
-		So(err, ShouldBeNil)
-
+		ht.RegisterMetrics(mc, mux)
 		lc.RequireStart()
 
 		Convey("When I query metrics", func() {
@@ -87,7 +84,7 @@ func TestPrometheusInsecureHTTP(t *testing.T) {
 //nolint:funlen
 func TestPrometheusSecureHTTP(t *testing.T) {
 	Convey("Given I register the metrics handler", t, func() {
-		mux := nh.NewServeMux(nh.NewStandardServeMux())
+		mux := nh.NewServeMux()
 		lc := fxtest.NewLifecycle(t)
 		logger := test.NewLogger(lc)
 		tc := test.NewOTLPTracerConfig()
@@ -117,9 +114,7 @@ func TestPrometheusSecureHTTP(t *testing.T) {
 			TLS: test.NewTLSClientConfig(),
 		}
 
-		err = ht.RegisterMetrics(mc, mux)
-		So(err, ShouldBeNil)
-
+		ht.RegisterMetrics(mc, mux)
 		lc.RequireStart()
 
 		Convey("When I query metrics", func() {

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -7,8 +7,8 @@ import (
 
 // Module for fx.
 var Module = fx.Options(
-	fx.Provide(http.NewStandardServeMux),
 	fx.Provide(http.NewServeMux),
+	fx.Invoke(http.RegisterHandler),
 	fx.Provide(NewServer),
 	fx.Invoke(RegisterMetrics),
 )

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -32,7 +32,7 @@ type ServerParams struct {
 	fx.In
 
 	Shutdowner fx.Shutdowner
-	Mux        sh.ServeMux
+	Mux        *http.ServeMux
 	Config     *Config
 	Logger     *zap.Logger
 	Tracer     trace.Tracer
@@ -72,7 +72,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	}
 
 	n.Use(cors.New())
-	n.UseHandler(params.Mux.Handler())
+	n.UseHandler(params.Mux)
 
 	s := &http.Server{
 		Handler:     n,


### PR DESCRIPTION
A generic struct can have generic methods. This is by design, so we move the handler to be in the package. We also remove the serve mux abstraction.