### PR TITLE
feat(http): use context from the context package

### DIFF
--- a/net/http/rpc/context.go
+++ b/net/http/rpc/context.go
@@ -5,36 +5,24 @@ import (
 	"net/http"
 )
 
-type (
-	// Context for HTTP.
-	Context interface {
-		// Request of the context.
-		Request() *http.Request
+type contextKey string
 
-		// Response of the context.
-		Response() http.ResponseWriter
-
-		context.Context
-	}
-
-	//nolint:containedctx
-	handlerContext struct {
-		req *http.Request
-		res http.ResponseWriter
-
-		context.Context
-	}
-)
-
-// NewContext for HTTP.
-func NewContext(ctx context.Context, req *http.Request, res http.ResponseWriter) Context {
-	return &handlerContext{req: req, res: res, Context: ctx}
+// WithRequest for rpc.
+func WithRequest(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, contextKey("request"), r)
 }
 
-func (c *handlerContext) Request() *http.Request {
-	return c.req
+// Request for rpc.
+func Request(ctx context.Context) *http.Request {
+	return ctx.Value(contextKey("request")).(*http.Request)
 }
 
-func (c *handlerContext) Response() http.ResponseWriter {
-	return c.res
+// WithResponse for rpc.
+func WithResponse(ctx context.Context, r http.ResponseWriter) context.Context {
+	return context.WithValue(ctx, contextKey("response"), r)
+}
+
+// Response for rpc.
+func Response(ctx context.Context) http.ResponseWriter {
+	return ctx.Value(contextKey("response")).(http.ResponseWriter)
 }

--- a/net/http/rpc/error.go
+++ b/net/http/rpc/error.go
@@ -1,10 +1,11 @@
 package rpc
 
 import (
+	"context"
 	"net/http"
 )
 
-// WriteError for HTTP.
-func WriteError(ctx Context, err error) {
-	http.Error(ctx.Response(), err.Error(), Code(err))
+// WriteError for rpc.
+func WriteError(ctx context.Context, err error) {
+	http.Error(Response(ctx), err.Error(), Code(err))
 }

--- a/net/http/rpc/rpc.go
+++ b/net/http/rpc/rpc.go
@@ -1,0 +1,17 @@
+package rpc
+
+import (
+	"net/http"
+
+	"github.com/alexfalkowski/go-service/encoding"
+)
+
+var (
+	mux *http.ServeMux
+	enc *encoding.Map
+)
+
+// Register for HTTP.
+func Register(mu *http.ServeMux, en *encoding.Map) {
+	mux, enc = mu, en
+}

--- a/net/http/rpc/status.go
+++ b/net/http/rpc/status.go
@@ -17,7 +17,7 @@ func IsError(err error) bool {
 	return errors.As(err, &e)
 }
 
-// Code from the error, otherwise 500.
+// Code from the error. If nil 200, otherwise 500.
 func Code(err error) int {
 	if err == nil {
 		return http.StatusOK

--- a/net/http/rpc/unary.go
+++ b/net/http/rpc/unary.go
@@ -2,34 +2,26 @@ package rpc
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 
-	"github.com/alexfalkowski/go-service/encoding"
 	"github.com/alexfalkowski/go-service/errors"
 	"github.com/alexfalkowski/go-service/net/http/content"
 )
 
-var (
-	mux *http.ServeMux
-	enc *encoding.Map
-)
-
-// Register for HTTP.
-func Register(mu *http.ServeMux, en *encoding.Map) {
-	mux, enc = mu, en
-}
-
-// Handler for HTTP.
-type Handler[Req any, Res any] interface {
+// UnaryHandler for rpc.
+type UnaryHandler[Req any, Res any] interface {
 	// Handle the request/response.
-	Handle(ctx Context, req *Req) (*Res, error)
+	Handle(ctx context.Context, req *Req) (*Res, error)
 }
 
-// Handler for HTTP.
-func Handle[Req any, Res any](path string, handler Handler[Req, Res]) {
+// Unary for rpc.
+func Unary[Req any, Res any](path string, handler UnaryHandler[Req, Res]) {
 	h := func(res http.ResponseWriter, req *http.Request) {
-		ctx := NewContext(req.Context(), req, res)
+		ctx := req.Context()
+		ctx = WithRequest(ctx, req)
+		ctx = WithResponse(ctx, res)
 		ct := content.NewFromRequest(req)
 
 		m, err := ct.Marshaller(enc)

--- a/test/rpc.go
+++ b/test/rpc.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/alexfalkowski/go-service/meta"
@@ -19,8 +20,10 @@ type Response struct {
 
 type SuccessHandler struct{}
 
-func (*SuccessHandler) Handle(ctx rpc.Context, r *Request) (*Response, error) {
-	name := ctx.Request().URL.Query().Get("name")
+func (*SuccessHandler) Handle(ctx context.Context, r *Request) (*Response, error) {
+	req := rpc.Request(ctx)
+
+	name := req.URL.Query().Get("name")
 	if name == "" {
 		name = r.Name
 	}
@@ -32,16 +35,16 @@ func (*SuccessHandler) Handle(ctx rpc.Context, r *Request) (*Response, error) {
 
 type ProtobufHandler struct{}
 
-func (*ProtobufHandler) Handle(_ rpc.Context, r *v1.SayHelloRequest) (*v1.SayHelloResponse, error) {
+func (*ProtobufHandler) Handle(_ context.Context, r *v1.SayHelloRequest) (*v1.SayHelloResponse, error) {
 	return &v1.SayHelloResponse{Message: "Hello " + r.GetName()}, nil
 }
 
-func (*ProtobufHandler) Error(_ rpc.Context, err error) *v1.SayHelloResponse {
+func (*ProtobufHandler) Error(_ context.Context, err error) *v1.SayHelloResponse {
 	return &v1.SayHelloResponse{Message: err.Error()}
 }
 
 type ErrorHandler struct{}
 
-func (*ErrorHandler) Handle(_ rpc.Context, _ *Request) (*Response, error) {
+func (*ErrorHandler) Handle(_ context.Context, _ *Request) (*Response, error) {
 	return nil, rpc.Error(http.StatusServiceUnavailable, "ohh no")
 }

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -45,7 +45,7 @@ func TestValidAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Handle("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", &test.SuccessHandler{})
 
 		Convey("When I query for an authenticated greet", func() {
 			client := cl.NewHTTP()
@@ -103,7 +103,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Handle("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", &test.SuccessHandler{})
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -159,7 +159,7 @@ func TestMissingAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Handle("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", &test.SuccessHandler{})
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -216,7 +216,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Handle("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", &test.SuccessHandler{})
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -266,7 +266,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Handle("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", &test.SuccessHandler{})
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -323,7 +323,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Handle("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", &test.SuccessHandler{})
 
 		Convey("When I query for a greet that will generate a token error", func() {
 			client := cl.NewHTTP()

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -42,7 +42,7 @@ func TestRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Compression: true, H2C: true}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Handle("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", &test.SuccessHandler{})
 
 			lc.RequireStart()
 
@@ -82,7 +82,7 @@ func TestProtobufRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Handle("/hello", &test.ProtobufHandler{})
+			rpc.Unary("/hello", &test.ProtobufHandler{})
 
 			lc.RequireStart()
 
@@ -122,7 +122,7 @@ func TestBadUnmarshalRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Handle("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", &test.SuccessHandler{})
 
 			lc.RequireStart()
 
@@ -174,7 +174,7 @@ func TestErrorRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Handle("/hello", &test.ErrorHandler{})
+			rpc.Unary("/hello", &test.ErrorHandler{})
 
 			lc.RequireStart()
 
@@ -227,7 +227,7 @@ func TestAllowedRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("test", nil)}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Handle("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", &test.SuccessHandler{})
 
 			lc.RequireStart()
 
@@ -265,7 +265,7 @@ func TestDisallowedRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("bob", nil)}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Handle("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", &test.SuccessHandler{})
 
 			lc.RequireStart()
 


### PR DESCRIPTION
Use the https://pkg.go.dev/context rather than create our own.