### PR TITLE
feat(http): move to a func

### DIFF
--- a/net/http/rpc/unary.go
+++ b/net/http/rpc/unary.go
@@ -11,10 +11,7 @@ import (
 )
 
 // UnaryHandler for rpc.
-type UnaryHandler[Req any, Res any] interface {
-	// Handle the request/response.
-	Handle(ctx context.Context, req *Req) (*Res, error)
-}
+type UnaryHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res, error)
 
 // Unary for rpc.
 func Unary[Req any, Res any](path string, handler UnaryHandler[Req, Res]) {
@@ -51,7 +48,7 @@ func Unary[Req any, Res any](path string, handler UnaryHandler[Req, Res]) {
 			return
 		}
 
-		rs, err := handler.Handle(ctx, ptr)
+		rs, err := handler(ctx, ptr)
 		if err != nil {
 			WriteError(ctx, errors.Prefix("rpc handle", err))
 

--- a/test/rpc.go
+++ b/test/rpc.go
@@ -18,9 +18,7 @@ type Response struct {
 	Greeting *string
 }
 
-type SuccessHandler struct{}
-
-func (*SuccessHandler) Handle(ctx context.Context, r *Request) (*Response, error) {
+func SuccessSayHello(ctx context.Context, r *Request) (*Response, error) {
 	req := rpc.Request(ctx)
 
 	name := req.URL.Query().Get("name")
@@ -33,18 +31,10 @@ func (*SuccessHandler) Handle(ctx context.Context, r *Request) (*Response, error
 	return &Response{Greeting: &s}, nil
 }
 
-type ProtobufHandler struct{}
-
-func (*ProtobufHandler) Handle(_ context.Context, r *v1.SayHelloRequest) (*v1.SayHelloResponse, error) {
+func ProtobufSayHello(_ context.Context, r *v1.SayHelloRequest) (*v1.SayHelloResponse, error) {
 	return &v1.SayHelloResponse{Message: "Hello " + r.GetName()}, nil
 }
 
-func (*ProtobufHandler) Error(_ context.Context, err error) *v1.SayHelloResponse {
-	return &v1.SayHelloResponse{Message: err.Error()}
-}
-
-type ErrorHandler struct{}
-
-func (*ErrorHandler) Handle(_ context.Context, _ *Request) (*Response, error) {
+func ErrorSayHello(_ context.Context, _ *Request) (*Response, error) {
 	return nil, rpc.Error(http.StatusServiceUnavailable, "ohh no")
 }

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -45,7 +45,7 @@ func TestValidAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", test.SuccessSayHello)
 
 		Convey("When I query for an authenticated greet", func() {
 			client := cl.NewHTTP()
@@ -103,7 +103,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -159,7 +159,7 @@ func TestMissingAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -216,7 +216,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -266,7 +266,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -323,7 +323,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 		defer conn.Close()
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", &test.SuccessHandler{})
+		rpc.Unary("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a greet that will generate a token error", func() {
 			client := cl.NewHTTP()

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -42,7 +42,7 @@ func TestRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Compression: true, H2C: true}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
@@ -82,7 +82,7 @@ func TestProtobufRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", &test.ProtobufHandler{})
+			rpc.Unary("/hello", test.ProtobufSayHello)
 
 			lc.RequireStart()
 
@@ -122,7 +122,7 @@ func TestBadUnmarshalRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
@@ -174,7 +174,7 @@ func TestErrorRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", &test.ErrorHandler{})
+			rpc.Unary("/hello", test.ErrorSayHello)
 
 			lc.RequireStart()
 
@@ -227,7 +227,7 @@ func TestAllowedRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("test", nil)}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
@@ -265,7 +265,7 @@ func TestDisallowedRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("bob", nil)}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", &test.SuccessHandler{})
+			rpc.Unary("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 


### PR DESCRIPTION
We don't need an interface, use a func to simplify.