### PR TITLE
feat(http): new success view

### DIFF
--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -16,6 +16,11 @@ func ParseTemplate(fs fs.FS, pattern string) *template.Template {
 	return t
 }
 
+// NewSuccessView for routes in mvc.
+func NewSuccessView(template *template.Template) *View {
+	return NewView(template, nil)
+}
+
 // NewView for routes in mvc.
 func NewView(success, failure *template.Template) *View {
 	return &View{success: success, failure: failure}

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -35,7 +35,7 @@ func TestRouteSuccess(t *testing.T) {
 
 		mvc.Register(mux)
 
-		t := mvc.NewView(mvc.ParseTemplate(test.Views, "views/hello.tmpl.html"), mvc.ParseTemplate(test.Views, "views/error.tmpl.html"))
+		t := mvc.NewSuccessView(mvc.ParseTemplate(test.Views, "views/hello.tmpl.html"))
 		mvc.Route("GET /hello", t, func(_ context.Context, _ *http.Request, _ http.ResponseWriter) (*test.PageData, error) {
 			return &test.Model, nil
 		})
@@ -139,7 +139,7 @@ func TestRouteError(t *testing.T) {
 
 		mvc.Register(mux)
 
-		t := mvc.NewView(mvc.ParseTemplate(test.Views, "views/hello.tmpl.html"), mvc.ParseTemplate(test.Views, "views/error.tmpl.html"))
+		t := mvc.NewView(nil, mvc.ParseTemplate(test.Views, "views/error.tmpl.html"))
 		mvc.Route("GET /hello", t, func(_ context.Context, _ *http.Request, _ http.ResponseWriter) (*test.PageData, error) {
 			return nil, status.Error(http.StatusServiceUnavailable, "ohh no")
 		})


### PR DESCRIPTION
Most views will have a success and failure part to render, though at times we don't anticipate this.