### PR TITLE
feat(http): rpc to follow mvc

### DIFF
--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/alexfalkowski/go-service/encoding"
 	"github.com/alexfalkowski/go-service/errors"
 	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/net/http/status"
@@ -15,16 +14,14 @@ import (
 )
 
 // NewClient for HTTP.
-func NewClient[Req any, Res any](url, contentType string, client *http.Client, enc *encoding.Map) *Client[Req, Res] {
+func NewClient[Req any, Res any](url, ct string, client *http.Client) *Client[Req, Res] {
 	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
-	ct := content.NewFromMedia(contentType)
 
-	return &Client[Req, Res]{client: client, enc: enc, url: url, ct: ct}
+	return &Client[Req, Res]{client: client, url: url, ct: content.NewFromMedia(ct)}
 }
 
 // Client for HTTP.
 type Client[Req any, Res any] struct {
-	enc    *encoding.Map
 	client *http.Client
 	ct     *content.Type
 	url    string

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -25,11 +25,11 @@ func Register(mu *http.ServeMux, en *encoding.Map) {
 	mux, enc = mu, en
 }
 
-// UnaryHandler for rpc.
-type UnaryHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res, error)
+// Handler for rpc.
+type Handler[Req any, Res any] func(ctx context.Context, req *Req) (*Res, error)
 
-// Unary for rpc.
-func Unary[Req any, Res any](path string, handler UnaryHandler[Req, Res]) {
+// Route for rpc.
+func Route[Req any, Res any](path string, handler Handler[Req, Res]) {
 	h := func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		ctx = hc.WithRequest(ctx, req)

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -42,7 +42,7 @@ func TestValidAuthUnary(t *testing.T) {
 		}
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", test.SuccessSayHello)
+		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for an authenticated greet", func() {
 			client := cl.NewHTTP()
@@ -97,7 +97,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 		}
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", test.SuccessSayHello)
+		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -150,7 +150,7 @@ func TestMissingAuthUnary(t *testing.T) {
 		cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", test.SuccessSayHello)
+		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -204,7 +204,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 		}
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", test.SuccessSayHello)
+		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -251,7 +251,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 		cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", test.SuccessSayHello)
+		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
 			client := cl.NewHTTP()
@@ -305,7 +305,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 		}
 
 		rpc.Register(mux, test.Marshaller)
-		rpc.Unary("/hello", test.SuccessSayHello)
+		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a greet that will generate a token error", func() {
 			client := cl.NewHTTP()

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -43,12 +43,12 @@ func TestRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Compression: true, H2C: true}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", test.SuccessSayHello)
+			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
 			Convey("When I post data", func() {
-				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP(), test.Marshaller)
+				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP())
 
 				resp, err := client.Call(context.Background(), &test.Request{Name: "Bob"})
 				So(err, ShouldBeNil)
@@ -83,12 +83,12 @@ func TestProtobufRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", test.ProtobufSayHello)
+			rpc.Route("/hello", test.ProtobufSayHello)
 
 			lc.RequireStart()
 
 			Convey("When I post data", func() {
-				client := rpc.NewClient[v1.SayHelloRequest, v1.SayHelloResponse](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP(), test.Marshaller)
+				client := rpc.NewClient[v1.SayHelloRequest, v1.SayHelloResponse](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP())
 
 				resp, err := client.Call(context.Background(), &v1.SayHelloRequest{Name: "Bob"})
 				So(err, ShouldBeNil)
@@ -123,7 +123,7 @@ func TestBadUnmarshalRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", test.SuccessSayHello)
+			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
@@ -175,7 +175,7 @@ func TestErrorRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", test.ErrorSayHello)
+			rpc.Route("/hello", test.ErrorSayHello)
 
 			lc.RequireStart()
 
@@ -228,12 +228,12 @@ func TestAllowedRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("test", nil)}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", test.SuccessSayHello)
+			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
 			Convey("When I post authenticated data", func() {
-				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP(), test.Marshaller)
+				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP())
 
 				resp, err := client.Call(context.Background(), &test.Request{Name: "Bob"})
 				So(err, ShouldBeNil)
@@ -266,12 +266,12 @@ func TestDisallowedRPC(t *testing.T) {
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("bob", nil)}
 
 			rpc.Register(mux, test.Marshaller)
-			rpc.Unary("/hello", test.SuccessSayHello)
+			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
 
 			Convey("When I post authenticated data", func() {
-				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP(), test.Marshaller)
+				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port), "application/"+mt, cl.NewHTTP())
 
 				_, err := client.Call(context.Background(), &test.Request{Name: "Bob"})
 


### PR DESCRIPTION
As we don't have any stream API, we just follow what the MVC package has.