### PR TITLE
feat(http): shorten options for rpc client

### DIFF
--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -9,10 +9,8 @@ import (
 )
 
 const (
-	// JSONMediaType for content.
-	JSONMediaType = "application/json"
-
-	jsonKind = "json"
+	jsonMediaType = "application/json"
+	jsonKind      = "json"
 )
 
 var (
@@ -25,14 +23,14 @@ var (
 
 // AddJSONHeader for content.
 func AddJSONHeader(header http.Header) {
-	header.Set(TypeKey, JSONMediaType)
+	header.Set(TypeKey, jsonMediaType)
 }
 
 // NewFromRequest for content.
 func NewFromRequest(req *http.Request) *Type {
 	t, err := ct.GetMediaType(req)
 	if err != nil {
-		return &Type{Media: JSONMediaType, Kind: jsonKind}
+		return &Type{Media: jsonMediaType, Kind: jsonKind}
 	}
 
 	return &Type{Media: t.String(), Kind: t.Subtype}
@@ -42,7 +40,7 @@ func NewFromRequest(req *http.Request) *Type {
 func NewFromMedia(mediaType string) *Type {
 	t, err := ct.ParseMediaType(mediaType)
 	if err != nil {
-		return &Type{Media: JSONMediaType, Kind: jsonKind}
+		return &Type{Media: jsonMediaType, Kind: jsonKind}
 	}
 
 	return &Type{Media: t.String(), Kind: t.Subtype}

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -33,8 +33,8 @@ func WithClient(client *http.Client) ClientOption {
 	})
 }
 
-// WithClientContentType for rpc.
-func WithClientContentType(ct string) ClientOption {
+// WithContentType for rpc.
+func WithContentType(ct string) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.contentType = ct
 	})
@@ -42,7 +42,7 @@ func WithClientContentType(ct string) ClientOption {
 
 // NewClient for rpc.
 func NewClient[Req any, Res any](url string, opts ...ClientOption) *Client[Req, Res] {
-	os := &clientOpts{contentType: content.JSONMediaType}
+	os := &clientOpts{}
 	for _, o := range opts {
 		o.apply(os)
 	}

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -48,9 +48,8 @@ func TestRPC(t *testing.T) {
 			lc.RequireStart()
 
 			Convey("When I post data", func() {
-				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port),
-					rpc.WithClientContentType("application/"+mt),
-					rpc.WithClient(cl.NewHTTP()))
+				url := fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port)
+				client := rpc.NewClient[test.Request, test.Response](url, rpc.WithContentType("application/"+mt), rpc.WithClient(cl.NewHTTP()))
 
 				resp, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
 				So(err, ShouldBeNil)
@@ -88,8 +87,8 @@ func TestProtobufRPC(t *testing.T) {
 			lc.RequireStart()
 
 			Convey("When I post data", func() {
-				client := rpc.NewClient[v1.SayHelloRequest, v1.SayHelloResponse](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port),
-					rpc.WithClientContentType("application/"+mt))
+				url := fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port)
+				client := rpc.NewClient[v1.SayHelloRequest, v1.SayHelloResponse](url, rpc.WithContentType("application/"+mt))
 
 				resp, err := client.Invoke(context.Background(), &v1.SayHelloRequest{Name: "Bob"})
 				So(err, ShouldBeNil)
@@ -234,9 +233,8 @@ func TestAllowedRPC(t *testing.T) {
 			lc.RequireStart()
 
 			Convey("When I post authenticated data", func() {
-				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port),
-					rpc.WithClientContentType("application/"+mt),
-					rpc.WithClient(cl.NewHTTP()))
+				url := fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port)
+				client := rpc.NewClient[test.Request, test.Response](url, rpc.WithContentType("application/"+mt), rpc.WithClient(cl.NewHTTP()))
 
 				resp, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
 				So(err, ShouldBeNil)
@@ -274,9 +272,8 @@ func TestDisallowedRPC(t *testing.T) {
 			lc.RequireStart()
 
 			Convey("When I post authenticated data", func() {
-				client := rpc.NewClient[test.Request, test.Response](fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port),
-					rpc.WithClientContentType("application/"+mt),
-					rpc.WithClient(cl.NewHTTP()))
+				url := fmt.Sprintf("http://localhost:%s/hello", cfg.HTTP.Port)
+				client := rpc.NewClient[test.Request, test.Response](url, rpc.WithContentType("application/"+mt), rpc.WithClient(cl.NewHTTP()))
 
 				_, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
 


### PR DESCRIPTION
We don't have other options, so no need to prefix.