### PR TITLE
feat(grpc): ignore the error for headers

### DIFF
--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -35,9 +35,7 @@ func limit(ctx context.Context, store l.Store, key limiter.KeyFunc) error {
 		return internalError(err)
 	}
 
-	if err := grpc.SetHeader(ctx, metadata.Pairs("ratelimit", info)); err != nil {
-		return internalError(err)
-	}
+	grpc.SetHeader(ctx, metadata.Pairs("ratelimit", info))
 
 	if !ok {
 		return status.Errorf(codes.ResourceExhausted, "limiter: resource exhausted, %s", info)

--- a/transport/grpc/meta/meta.go
+++ b/transport/grpc/meta/meta.go
@@ -26,19 +26,11 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version) grpc.U
 			return handler(ctx, req)
 		}
 
-		if err := grpc.SetHeader(ctx, metadata.Pairs("service-version", version.String())); err != nil {
-			return nil, err
-		}
-
 		md := ExtractIncoming(ctx)
 
 		ctx = m.WithUserAgent(ctx, extractUserAgent(ctx, md, userAgent))
 
 		requestID := extractRequestID(ctx, md)
-		if err := grpc.SetHeader(ctx, metadata.Pairs("request-id", requestID.Value())); err != nil {
-			return nil, err
-		}
-
 		ctx = m.WithRequestID(ctx, requestID)
 
 		kind, ip := extractIPAddr(ctx, md)
@@ -47,6 +39,8 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version) grpc.U
 
 		ctx = m.WithGeolocation(ctx, extractGeolocation(ctx, md))
 		ctx = m.WithAuthorization(ctx, extractAuthorization(ctx, md))
+
+		grpc.SetHeader(ctx, metadata.Pairs("service-version", version.String(), "request-id", requestID.Value()))
 
 		return handler(ctx, req)
 	}


### PR DESCRIPTION
If they get sent great, if not we should not halt the request.