### PR TITLE
feat(tracer): reader should be nil if disabled

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/alexfalkowski/go-service/runtime"
 	"github.com/alexfalkowski/go-service/security/token"
 	"github.com/alexfalkowski/go-service/telemetry"
-	"github.com/alexfalkowski/go-service/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/test"
 	st "github.com/alexfalkowski/go-service/time"
 	"github.com/alexfalkowski/go-service/transport"
@@ -278,7 +277,7 @@ func opts() []fx.Option {
 	return []fx.Option{
 		fx.NopLogger, env.Module,
 		runtime.Module, cmd.Module, config.Module, debug.Module, feature.Module, st.Module,
-		transport.Module, telemetry.Module, metrics.Module, health.Module,
+		transport.Module, telemetry.Module, health.Module,
 		sql.Module, hooks.Module, token.Module, cache.Module,
 		compress.Module, encoding.Module, crypto.Module,
 		fx.Provide(registrations), fx.Provide(healthObserver), fx.Provide(livenessObserver),

--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -71,18 +71,16 @@ type MeterParams struct {
 }
 
 // NewMeter for metrics.
-func NewMeter(params MeterParams) om.Meter {
-	if !IsEnabled(params.Config) {
-		return noop.Meter{}
-	}
-
-	return params.Provider.Meter(string(params.Name))
+func NewMeter(provider om.MeterProvider, name env.Name) om.Meter {
+	return provider.Meter(string(name))
 }
 
-// NewReader for metrics.
+// NewReader for metrics. A nil reader means disabled.
+//
+//nolint:nilnil
 func NewReader(cfg *Config) (sm.Reader, error) {
 	if !IsEnabled(cfg) {
-		return prom()
+		return nil, nil
 	}
 
 	if cfg.IsOTLP() {
@@ -102,10 +100,6 @@ func NewReader(cfg *Config) (sm.Reader, error) {
 		return sm.NewPeriodicReader(r), se.Prefix("new otlp", err)
 	}
 
-	return prom()
-}
-
-func prom() (*prometheus.Exporter, error) {
 	e, err := prometheus.New()
 
 	return e, se.Prefix("new prometheus", err)

--- a/telemetry/module.go
+++ b/telemetry/module.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"github.com/alexfalkowski/go-service/telemetry/logger"
+	"github.com/alexfalkowski/go-service/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/telemetry/tracer"
 	"go.uber.org/fx"
 )
@@ -9,5 +10,6 @@ import (
 // Module for fx.
 var Module = fx.Options(
 	logger.Module,
+	metrics.Module,
 	tracer.Module,
 )

--- a/test/metrics.go
+++ b/test/metrics.go
@@ -19,13 +19,7 @@ func NewPrometheusMeter(lc fx.Lifecycle) metric.Meter {
 
 // NewMeter for test.
 func NewMeter(lc fx.Lifecycle, c *metrics.Config) metric.Meter {
-	p := metrics.MeterParams{
-		Config:   c,
-		Provider: NewMeterProvider(lc, c),
-		Name:     Name,
-	}
-
-	return metrics.NewMeter(p)
+	return metrics.NewMeter(NewMeterProvider(lc, c), Name)
 }
 
 // NewOTLPMeterProvider for test.


### PR DESCRIPTION
A nil eader will not perform any work, so we should not return the prom reader.