### PR TITLE
fix(logger): enable annotaions and stack trace

### DIFF
--- a/telemetry/logger/zap/config.go
+++ b/telemetry/logger/zap/config.go
@@ -38,8 +38,6 @@ func NewConfig(env env.Environment, config *Config) (zap.Config, error) {
 	}
 
 	cfg.Level = l
-	cfg.DisableCaller = true
-	cfg.DisableStacktrace = true
 	cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		enc.AppendString(t.Format(time.RFC3339))
 	})


### PR DESCRIPTION
We are getting some logs and are not sure why they are happening, we are hoping that adding this will help us diagnose this better.

```json
{
  "level": "error",
  "ts": "2024-08-04T11:28:03Z",
  "msg": "http: get https://api.github.com/repos/alexfalkowski/app-config/contents/web/production?ref=web%2Fv1.1.0",
  "name": "konfig",
  "environment": "production",
  "version": "v1.221.0",
  "duration": "26.702µs",
  "service": "http",
  "path": "/repos/alexfalkowski/app-config/contents/web/production",
  "method": "get",
  "ipAddr": "10.244.1.89",
  "ipAddrKind": "peer",
  "traceId": "e6346bfbc1ccc16fc89b8160d90b4b2b",
  "userAgent": "konfig/1.221.0 grpc-go/1.65.0",
  "requestId": "ad885d0c-7be6-4cda-b976-d5ba750be0ec",
  "error": "context deadline exceeded"
}
```