### PR TITLE
feat(http): default to json if we can not find encoder

### DIFF
--- a/debug/psutil.go
+++ b/debug/psutil.go
@@ -30,8 +30,7 @@ func RegisterPsutil(srv *Server, enc *encoding.Map) {
 		ct := content.NewFromRequest(req)
 		res.Header().Add(content.TypeKey, ct.Media)
 
-		e, err := ct.Encoder(enc)
-		runtime.Must(err)
+		e := ct.Encoder(enc)
 
 		data := make(map[string]any)
 

--- a/health/transport/http/http.go
+++ b/health/transport/http/http.go
@@ -54,8 +54,7 @@ func resister(path string, mux *http.ServeMux, ob *subscriber.Observer, enc *enc
 		ct := content.NewFromRequest(req)
 		res.Header().Add(content.TypeKey, ct.Media)
 
-		e, err := ct.Encoder(enc)
-		runtime.Must(err)
+		e := ct.Encoder(enc)
 
 		var (
 			status   int
@@ -90,7 +89,7 @@ func resister(path string, mux *http.ServeMux, ob *subscriber.Observer, enc *enc
 			}
 		}
 
-		err = e.Encode(res, data)
+		err := e.Encode(res, data)
 		runtime.Must(err)
 	})
 }

--- a/health/transport/http/http_test.go
+++ b/health/transport/http/http_test.go
@@ -190,8 +190,6 @@ func TestInvalidHealth(t *testing.T) {
 			req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf("http://%s/healthz", cfg.HTTP.Address), http.NoBody)
 			So(err, ShouldBeNil)
 
-			req.Header.Set("Content-Type", "application/json")
-
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
 

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/alexfalkowski/go-service/encoding"
@@ -13,13 +12,8 @@ const (
 	jsonKind      = "json"
 )
 
-var (
-	// TypeKey for HTTP headers.
-	TypeKey = "Content-Type"
-
-	// ErrInvalidEncoder for content.
-	ErrInvalidEncoder = errors.New("invalid encoder")
-)
+// TypeKey for HTTP headers.
+var TypeKey = "Content-Type"
 
 // NewFromRequest for content.
 func NewFromRequest(req *http.Request) *Type {
@@ -48,13 +42,13 @@ type Type struct {
 }
 
 // Marshaller for type.
-func (t *Type) Encoder(enc *encoding.Map) (encoding.Encoder, error) {
+func (t *Type) Encoder(enc *encoding.Map) encoding.Encoder {
 	m := enc.Get(t.Kind)
 	if m == nil {
-		return nil, ErrInvalidEncoder
+		m = enc.Get(jsonKind)
 	}
 
-	return m, nil
+	return m
 }
 
 // IsText for type.

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -84,8 +84,7 @@ func (c *Client[Req, Res]) Invoke(ctx context.Context, req *Req) (res *Res, err 
 		}
 	}()
 
-	e, err := c.ct.Encoder(enc)
-	runtime.Must(err)
+	e := c.ct.Encoder(enc)
 
 	b := pool.Get()
 	defer pool.Put(b)

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -32,13 +32,12 @@ func Route[Req any, Res any](path string, handler Handler[Req, Res]) {
 		ct := content.NewFromRequest(req)
 		res.Header().Add(content.TypeKey, ct.Media)
 
-		e, err := ct.Encoder(enc)
-		runtime.Must(err)
+		e := ct.Encoder(enc)
 
 		var rq Req
 		ptr := &rq
 
-		err = e.Decode(req.Body, ptr)
+		err := e.Decode(req.Body, ptr)
 		runtime.Must(err)
 
 		rs, err := handler(ctx, ptr)


### PR DESCRIPTION
As sometimes content type can be a kind that we don't support.

https://github.com/alexfalkowski/infraops/pull/469