### PR TITLE
fix(http): make sure we set the media to json if encoder is not found

### DIFF
--- a/health/transport/http/http_test.go
+++ b/health/transport/http/http_test.go
@@ -138,12 +138,12 @@ func TestReadinessNoop(t *testing.T) {
 			req.Header.Add("User-Agent", "test-user-agent")
 			req.Header.Set("Content-Type", "application/json")
 
-			resp, err := client.Do(req)
+			res, err := client.Do(req)
 			So(err, ShouldBeNil)
 
-			defer resp.Body.Close()
+			defer res.Body.Close()
 
-			body, err := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(res.Body)
 			So(err, ShouldBeNil)
 
 			actual := strings.TrimSpace(string(body))
@@ -152,6 +152,8 @@ func TestReadinessNoop(t *testing.T) {
 
 			Convey("Then I should have a healthy response", func() {
 				So(actual, ShouldEqual, "{\"status\":\"SERVING\"}")
+				So(res.StatusCode, ShouldEqual, 200)
+				So(res.Header.Get("Content-Type"), ShouldEqual, "application/json")
 			})
 		})
 	})
@@ -190,12 +192,12 @@ func TestInvalidHealth(t *testing.T) {
 			req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf("http://%s/healthz", cfg.HTTP.Address), http.NoBody)
 			So(err, ShouldBeNil)
 
-			resp, err := client.Do(req)
+			res, err := client.Do(req)
 			So(err, ShouldBeNil)
 
-			defer resp.Body.Close()
+			defer res.Body.Close()
 
-			body, err := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(res.Body)
 			So(err, ShouldBeNil)
 
 			actual := strings.TrimSpace(string(body))
@@ -204,6 +206,8 @@ func TestInvalidHealth(t *testing.T) {
 
 			Convey("Then I should have an unhealthy response", func() {
 				So(actual, ShouldEqual, "{\"errors\":{\"http\":\"invalid status code\"},\"status\":\"NOT_SERVING\"}")
+				So(res.StatusCode, ShouldEqual, 503)
+				So(res.Header.Get("Content-Type"), ShouldEqual, "application/json")
 			})
 		})
 	})

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -10,48 +10,50 @@ import (
 const (
 	jsonMediaType = "application/json"
 	jsonKind      = "json"
+
+	// TypeKey for HTTP headers.
+	TypeKey = "Content-Type"
 )
 
-// TypeKey for HTTP headers.
-var TypeKey = "Content-Type"
-
 // NewFromRequest for content.
-func NewFromRequest(req *http.Request) *Type {
+func NewFromRequest(req *http.Request, enc *encoding.Map) *Type {
 	t, err := ct.GetMediaType(req)
-	if err != nil {
-		return &Type{Media: jsonMediaType, Kind: jsonKind}
-	}
 
-	return &Type{Media: t.String(), Kind: t.Subtype}
+	return newType(t, err, enc)
 }
 
 // NewFromMedia for content.
-func NewFromMedia(mediaType string) *Type {
+func NewFromMedia(mediaType string, enc *encoding.Map) *Type {
 	t, err := ct.ParseMediaType(mediaType)
-	if err != nil {
-		return &Type{Media: jsonMediaType, Kind: jsonKind}
-	}
 
-	return &Type{Media: t.String(), Kind: t.Subtype}
+	return newType(t, err, enc)
 }
 
 // Type for content.
 type Type struct {
-	Media string
-	Kind  string
-}
-
-// Marshaller for type.
-func (t *Type) Encoder(enc *encoding.Map) encoding.Encoder {
-	m := enc.Get(t.Kind)
-	if m == nil {
-		m = enc.Get(jsonKind)
-	}
-
-	return m
+	Encoder encoding.Encoder
+	Media   string
+	Kind    string
 }
 
 // IsText for type.
 func (t *Type) IsText() bool {
 	return t.Kind == "plain"
+}
+
+func newType(t ct.MediaType, err error, enc *encoding.Map) *Type {
+	if err != nil {
+		return &Type{Media: jsonMediaType, Kind: jsonKind, Encoder: enc.Get(jsonKind)}
+	}
+
+	if t.Subtype == "plain" {
+		return &Type{Media: t.String(), Kind: t.Subtype}
+	}
+
+	e := enc.Get(t.Subtype)
+	if e == nil {
+		return &Type{Media: jsonMediaType, Kind: jsonKind, Encoder: enc.Get(jsonKind)}
+	}
+
+	return &Type{Media: t.String(), Kind: t.Subtype, Encoder: e}
 }

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -29,13 +29,12 @@ func NewHandler(prefix string, enc *encoding.Map, handler Handler) func(res http
 			}
 		}()
 
-		ct := NewFromRequest(req)
+		ct := NewFromRequest(req, enc)
 		res.Header().Add(TypeKey, ct.Media)
 
-		e := ct.Encoder(enc)
 		data := handler(ctx)
 
-		err := e.Encode(res, data)
+		err := ct.Encoder.Encode(res, data)
 		runtime.Must(err)
 	}
 

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -29,21 +29,19 @@ func Route[Req any, Res any](path string, handler Handler[Req, Res]) {
 			}
 		}()
 
-		ct := content.NewFromRequest(req)
+		ct := content.NewFromRequest(req, enc)
 		res.Header().Add(content.TypeKey, ct.Media)
-
-		e := ct.Encoder(enc)
 
 		var rq Req
 		ptr := &rq
 
-		err := e.Decode(req.Body, ptr)
+		err := ct.Encoder.Decode(req.Body, ptr)
 		runtime.Must(err)
 
 		rs, err := handler(ctx, ptr)
 		runtime.Must(err)
 
-		err = e.Encode(res, rs)
+		err = ct.Encoder.Encode(res, rs)
 		runtime.Must(err)
 	}
 


### PR DESCRIPTION
When an encoder could not be found the original content type was left and we defaulted to JSON.