### PR TITLE
feat(http): move to a content struct

### DIFF
--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -29,7 +29,7 @@ func TestInsecureDebug(t *testing.T) {
 
 		debug.RegisterPprof(server)
 		debug.RegisterFgprof(server)
-		debug.RegisterPsutil(server, test.Encoder)
+		debug.RegisterPsutil(server, test.Content)
 		debug.RegisterStatsviz(server)
 
 		transport.Register(transport.RegisterParams{Lifecycle: lc, Servers: []transport.Server{server}})
@@ -83,7 +83,7 @@ func TestSecureDebug(t *testing.T) {
 
 		debug.RegisterPprof(server)
 		debug.RegisterFgprof(server)
-		debug.RegisterPsutil(server, test.Encoder)
+		debug.RegisterPsutil(server, test.Content)
 		debug.RegisterStatsviz(server)
 
 		transport.Register(transport.RegisterParams{Lifecycle: lc, Servers: []transport.Server{server}})

--- a/debug/psutil.go
+++ b/debug/psutil.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"context"
 
-	"github.com/alexfalkowski/go-service/encoding"
 	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/runtime"
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -11,9 +10,9 @@ import (
 )
 
 // RegisterPprof for debug.
-func RegisterPsutil(srv *Server, enc *encoding.Map) {
+func RegisterPsutil(srv *Server, content *content.Content) {
 	mux := srv.ServeMux()
-	h := content.NewHandler("debug", enc, func(ctx context.Context) any {
+	h := content.NewHandler("debug", func(ctx context.Context) any {
 		data := make(map[string]any)
 
 		i, err := cpu.InfoWithContext(ctx)

--- a/health/transport/http/http.go
+++ b/health/transport/http/http.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/alexfalkowski/go-health/subscriber"
-	"github.com/alexfalkowski/go-service/encoding"
 	"github.com/alexfalkowski/go-service/net/http/content"
 	hc "github.com/alexfalkowski/go-service/net/http/context"
 	"go.uber.org/fx"
@@ -24,22 +23,22 @@ type RegisterParams struct {
 	Health    *HealthObserver
 	Liveness  *LivenessObserver
 	Readiness *ReadinessObserver
-	Encoder   *encoding.Map
+	Content   *content.Content
 }
 
 // Register health for HTTP.
 func Register(params RegisterParams) error {
 	mux := params.Mux
 
-	resister("/healthz", mux, params.Health.Observer, params.Encoder, true)
-	resister("/livez", mux, params.Liveness.Observer, params.Encoder, false)
-	resister("/readyz", mux, params.Readiness.Observer, params.Encoder, false)
+	resister("/healthz", mux, params.Health.Observer, params.Content, true)
+	resister("/livez", mux, params.Liveness.Observer, params.Content, false)
+	resister("/readyz", mux, params.Readiness.Observer, params.Content, false)
 
 	return nil
 }
 
-func resister(path string, mux *http.ServeMux, ob *subscriber.Observer, enc *encoding.Map, withErrors bool) {
-	h := content.NewHandler("health", enc, func(ctx context.Context) any {
+func resister(path string, mux *http.ServeMux, ob *subscriber.Observer, ct *content.Content, withErrors bool) {
+	h := ct.NewHandler("health", func(ctx context.Context) any {
 		var (
 			status   int
 			response string

--- a/health/transport/http/http_test.go
+++ b/health/transport/http/http_test.go
@@ -64,7 +64,7 @@ func TestHealth(t *testing.T) {
 			params := shh.RegisterParams{
 				Mux: mux, Health: &shh.HealthObserver{Observer: o},
 				Liveness: &shh.LivenessObserver{Observer: o}, Readiness: &shh.ReadinessObserver{Observer: o},
-				Encoder: test.Encoder,
+				Content: test.Content,
 			}
 			err = shh.Register(params)
 			So(err, ShouldBeNil)
@@ -123,7 +123,7 @@ func TestReadinessNoop(t *testing.T) {
 		params := shh.RegisterParams{
 			Mux: mux, Health: &shh.HealthObserver{Observer: o},
 			Liveness: &shh.LivenessObserver{Observer: o}, Readiness: &shh.ReadinessObserver{Observer: so.Observe("noop")},
-			Encoder: test.Encoder,
+			Content: test.Content,
 		}
 		err = shh.Register(params)
 		So(err, ShouldBeNil)
@@ -181,7 +181,7 @@ func TestInvalidHealth(t *testing.T) {
 		params := shh.RegisterParams{
 			Mux: mux, Health: &shh.HealthObserver{Observer: o},
 			Liveness: &shh.LivenessObserver{Observer: o}, Readiness: &shh.ReadinessObserver{Observer: o},
-			Encoder: test.Encoder,
+			Content: test.Content,
 		}
 		err = shh.Register(params)
 		So(err, ShouldBeNil)

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -15,18 +15,28 @@ const (
 	TypeKey = "Content-Type"
 )
 
+// Content creates types from media types.
+type Content struct {
+	enc *encoding.Map
+}
+
+// NewContent with an encoding.
+func NewContent(enc *encoding.Map) *Content {
+	return &Content{enc: enc}
+}
+
 // NewFromRequest for content.
-func NewFromRequest(req *http.Request, enc *encoding.Map) *Type {
+func (c *Content) NewFromRequest(req *http.Request) *Type {
 	t, err := ct.GetMediaType(req)
 
-	return newType(t, err, enc)
+	return newType(t, err, c.enc)
 }
 
 // NewFromMedia for content.
-func NewFromMedia(mediaType string, enc *encoding.Map) *Type {
+func (c *Content) NewFromMedia(mediaType string) *Type {
 	t, err := ct.ParseMediaType(mediaType)
 
-	return newType(t, err, enc)
+	return newType(t, err, c.enc)
 }
 
 // Type for content.

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/alexfalkowski/go-service/encoding"
 	"github.com/alexfalkowski/go-service/errors"
 	nh "github.com/alexfalkowski/go-service/net/http"
 	hc "github.com/alexfalkowski/go-service/net/http/context"
@@ -16,7 +15,7 @@ import (
 type Handler func(ctx context.Context) any
 
 // NewHandler for content.
-func NewHandler(prefix string, enc *encoding.Map, handler Handler) func(res http.ResponseWriter, req *http.Request) {
+func (c *Content) NewHandler(prefix string, handler Handler) func(res http.ResponseWriter, req *http.Request) {
 	h := func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		ctx = hc.WithRequest(ctx, req)
@@ -29,7 +28,7 @@ func NewHandler(prefix string, enc *encoding.Map, handler Handler) func(res http
 			}
 		}()
 
-		ct := NewFromRequest(req, enc)
+		ct := c.NewFromRequest(req)
 
 		ctx = hc.WithEncoder(ctx, ct.Encoder)
 		res.Header().Add(TypeKey, ct.Media)

--- a/net/http/rpc/rpc.go
+++ b/net/http/rpc/rpc.go
@@ -3,17 +3,17 @@ package rpc
 import (
 	"net/http"
 
-	"github.com/alexfalkowski/go-service/encoding"
+	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/sync"
 )
 
 var (
 	mux  *http.ServeMux
-	enc  *encoding.Map
+	cont *content.Content
 	pool *sync.BufferPool
 )
 
 // Register for rpc.
-func Register(mu *http.ServeMux, en *encoding.Map, p *sync.BufferPool) {
-	mux, enc, pool = mu, en, p
+func Register(mu *http.ServeMux, ct *content.Content, p *sync.BufferPool) {
+	mux, cont, pool = mu, ct, p
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"context"
 
-	"github.com/alexfalkowski/go-service/net/http/content"
 	hc "github.com/alexfalkowski/go-service/net/http/context"
 	"github.com/alexfalkowski/go-service/runtime"
 )
@@ -13,7 +12,7 @@ type Handler[Req any, Res any] func(ctx context.Context, req *Req) (*Res, error)
 
 // Route for rpc.
 func Route[Req any, Res any](path string, handler Handler[Req, Res]) {
-	h := content.NewHandler("rpc", enc, func(ctx context.Context) any {
+	h := cont.NewHandler("rpc", func(ctx context.Context) any {
 		e := hc.Encoder(ctx)
 		req := hc.Request(ctx)
 

--- a/test/encoding.go
+++ b/test/encoding.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/alexfalkowski/go-service/encoding"
+	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/sync"
 )
 
@@ -12,6 +13,9 @@ var Pool = sync.NewBufferPool()
 
 // Encoder for tests.
 var Encoder = encoding.NewMap()
+
+// Content for tests.
+var Content = content.NewContent(Encoder)
 
 // NewEncoder for test.
 func NewEncoder(err error) encoding.Encoder {

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -41,7 +41,7 @@ func TestValidAuthUnary(t *testing.T) {
 			Generator: test.NewGenerator("test", nil),
 		}
 
-		rpc.Register(mux, test.Encoder, test.Pool)
+		rpc.Register(mux, test.Content, test.Pool)
 		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for an authenticated greet", func() {
@@ -96,7 +96,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 			Generator: test.NewGenerator("bob", nil),
 		}
 
-		rpc.Register(mux, test.Encoder, test.Pool)
+		rpc.Register(mux, test.Content, test.Pool)
 		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
@@ -149,7 +149,7 @@ func TestMissingAuthUnary(t *testing.T) {
 		ctx := context.Background()
 		cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-		rpc.Register(mux, test.Encoder, test.Pool)
+		rpc.Register(mux, test.Content, test.Pool)
 		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
@@ -203,7 +203,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 			RoundTripper: ht.NewRoundTripper(test.NewGenerator("", nil), http.DefaultTransport),
 		}
 
-		rpc.Register(mux, test.Encoder, test.Pool)
+		rpc.Register(mux, test.Content, test.Pool)
 		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
@@ -250,7 +250,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 		ctx := context.Background()
 		cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-		rpc.Register(mux, test.Encoder, test.Pool)
+		rpc.Register(mux, test.Content, test.Pool)
 		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a unauthenticated greet", func() {
@@ -304,7 +304,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 			Generator: test.NewGenerator("", errors.New("token error")),
 		}
 
-		rpc.Register(mux, test.Encoder, test.Pool)
+		rpc.Register(mux, test.Content, test.Pool)
 		rpc.Route("/hello", test.SuccessSayHello)
 
 		Convey("When I query for a greet that will generate a token error", func() {

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 
+	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/net/http/mvc"
 	"github.com/alexfalkowski/go-service/net/http/rpc"
 	"go.uber.org/fx"
@@ -11,6 +12,7 @@ import (
 // Module for fx.
 var Module = fx.Options(
 	fx.Provide(http.NewServeMux),
+	fx.Provide(content.NewContent),
 	fx.Provide(mvc.NewViews),
 	fx.Provide(mvc.NewRouter),
 	fx.Invoke(rpc.Register),

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -43,7 +43,7 @@ func TestRPC(t *testing.T) {
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Compression: true, H2C: true}
 
-			rpc.Register(mux, test.Encoder, test.Pool)
+			rpc.Register(mux, test.Content, test.Pool)
 			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
@@ -84,7 +84,7 @@ func TestProtobufRPC(t *testing.T) {
 			s := &test.Server{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Limiter: l, Key: k, Mux: mux}
 			s.Register()
 
-			rpc.Register(mux, test.Encoder, test.Pool)
+			rpc.Register(mux, test.Content, test.Pool)
 			rpc.Route("/hello", test.ProtobufSayHello)
 
 			lc.RequireStart()
@@ -125,7 +125,7 @@ func TestBadUnmarshalRPC(t *testing.T) {
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-			rpc.Register(mux, test.Encoder, test.Pool)
+			rpc.Register(mux, test.Content, test.Pool)
 			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
@@ -177,7 +177,7 @@ func TestErrorRPC(t *testing.T) {
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 
-			rpc.Register(mux, test.Encoder, test.Pool)
+			rpc.Register(mux, test.Content, test.Pool)
 			rpc.Route("/hello", test.ErrorSayHello)
 
 			lc.RequireStart()
@@ -233,7 +233,7 @@ func TestAllowedRPC(t *testing.T) {
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("test", nil)}
 
-			rpc.Register(mux, test.Encoder, test.Pool)
+			rpc.Register(mux, test.Content, test.Pool)
 			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
@@ -274,7 +274,7 @@ func TestDisallowedRPC(t *testing.T) {
 
 			cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m, Generator: test.NewGenerator("bob", nil)}
 
-			rpc.Register(mux, test.Encoder, test.Pool)
+			rpc.Register(mux, test.Content, test.Pool)
 			rpc.Route("/hello", test.SuccessSayHello)
 
 			lc.RequireStart()
@@ -316,7 +316,7 @@ func BenchmarkRPC(b *testing.B) {
 	cl := &test.Client{Lifecycle: lc, Logger: logger, Tracer: tc, Transport: cfg, Meter: m}
 	t := cl.NewHTTP().Transport
 
-	rpc.Register(mux, test.Encoder, test.Pool)
+	rpc.Register(mux, test.Content, test.Pool)
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	url := fmt.Sprintf("http://%s/hello", cfg.HTTP.Address)


### PR DESCRIPTION
This way we can pass some parameters to the constructor and simplify passing parameters.