### PR TITLE
feat(http): remove gzip from server

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	_ "google.golang.org/grpc/encoding/gzip" // Install the gzip compressor
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 )

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/alexfalkowski/go-service/transport/http/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/transport/http/telemetry/tracer"
 	ht "github.com/alexfalkowski/go-service/transport/http/token"
-	"github.com/klauspost/compress/gzhttp"
 	"github.com/sethvargo/go-limiter"
 	"github.com/urfave/negroni/v3"
 	"go.opentelemetry.io/otel/metric"
@@ -82,8 +81,6 @@ func NewServer(params ServerParams) (*Server, error) {
 	if params.Limiter != nil {
 		n.Use(hl.NewHandler(params.Limiter, params.Key))
 	}
-
-	n.UseHandler(gzhttp.GzipHandler(params.Mux))
 
 	s := &http.Server{
 		Handler:     h2c.NewHandler(n, &http2.Server{}),


### PR DESCRIPTION
gzip is doubling the number of allocations.

with:
```
BenchmarkDefaultHTTP/std-4         	    2570	    657821 ns/op	   22049 B/op	      61 allocs/op
BenchmarkHTTP/none-4               	    1333	    806057 ns/op	   49736 B/op	     217 allocs/op
BenchmarkLogHTTP/log-4             	    1602	    762080 ns/op	   51936 B/op	     254 allocs/op
BenchmarkTraceHTTP/trace-4         	    1408	    926716 ns/op	   59161 B/op	     354 allocs/op
BenchmarkRoute/html-4              	     733	   1630073 ns/op	   67578 B/op	     650 allocs/op
BenchmarkRPC/json-4                	     801	   1479908 ns/op	   73762 B/op	     605 allocs/op
BenchmarkRPC/yaml-4                	     613	   2254152 ns/op	  116196 B/op	     908 allocs/op
BenchmarkRPC/yml-4                 	     609	   2129621 ns/op	  114772 B/op	     864 allocs/op
BenchmarkRPC/toml-4                	     717	   1867858 ns/op	   93077 B/op	     876 allocs/op
BenchmarkRPC/gob-4                 	     607	   1917436 ns/op	   93915 B/op	    1023 allocs/op
```

without:
```
BenchmarkDefaultHTTP/std-4         	    3136	    834997 ns/op	   22347 B/op	      61 allocs/op
BenchmarkHTTP/none-4               	    1706	    675197 ns/op	   25075 B/op	     108 allocs/op
BenchmarkLogHTTP/log-4             	    2402	    707533 ns/op	   26829 B/op	     134 allocs/op
BenchmarkTraceHTTP/trace-4         	    1321	    910076 ns/op	   33854 B/op	     223 allocs/op
BenchmarkRoute/html-4              	     852	   1623592 ns/op	   49312 B/op	     405 allocs/op
BenchmarkRPC/json-4                	     818	   1903368 ns/op	   54927 B/op	     445 allocs/op
BenchmarkRPC/yaml-4                	     662	   2059265 ns/op	   64353 B/op	     515 allocs/op
BenchmarkRPC/yml-4                 	     835	   1743033 ns/op	   63400 B/op	     497 allocs/op
BenchmarkRPC/toml-4                	    1165	   1888891 ns/op	   59327 B/op	     475 allocs/op
BenchmarkRPC/gob-4                 	    1078	   2430627 ns/op	   57070 B/op	     479 allocs/op
```