### PR TITLE
fix(cmd): error on decode with no encoder

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -180,13 +180,13 @@ func TestInvalidKindConfig(t *testing.T) {
 
 func TestInvalidConfig(t *testing.T) {
 	Convey("Given I have invalid kind configuration file", t, func() {
-		So(os.Setenv("CONFIG_FILE", "../test/greet/v1/service.proto"), ShouldBeNil)
+		So(os.Setenv("CONFIG_FILE", "../test/config.go"), ShouldBeNil)
 
 		Convey("When I try to parse the configuration file", func() {
-			c := test.NewInputConfig("test:test")
+			c := test.NewInputConfig("env:CONFIG_FILE")
 
-			Convey("Then I should have a valid configuration", func() {
-				So(c, ShouldNotBeNil)
+			Convey("Then I should have an error when decoding", func() {
+				So(c.Decode(nil), ShouldBeError)
 			})
 
 			So(os.Unsetenv("CONFIG_FILE"), ShouldBeNil)

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -10,21 +10,23 @@ import (
 	"github.com/alexfalkowski/go-service/encoding/yaml"
 )
 
-// Encoder allows different types of encoding/decoding.
-type Encoder interface {
-	// Encode any to a writer.
-	Encode(w io.Writer, e any) error
+type (
+	// Encoder allows different types of encoding/decoding.
+	Encoder interface {
+		// Encode any to a writer.
+		Encode(w io.Writer, e any) error
 
-	// Decode any from a reader.
-	Decode(r io.Reader, e any) error
-}
+		// Decode any from a reader.
+		Decode(r io.Reader, e any) error
+	}
 
-type encoders map[string]Encoder
+	encoders map[string]Encoder
 
-// Map of encoding.
-type Map struct {
-	encoders encoders
-}
+	// Map of encoding.
+	Map struct {
+		encoders encoders
+	}
+)
 
 // NewMap for encoding.
 func NewMap() *Map {


### PR DESCRIPTION
We need to error when there is no encoder.
