### PR TITLE
feat(http): allow query parameters to be parsed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: alexfalkowski/go:1.23
+      - image: alexfalkowski/go:1.3
       - image: postgres:16-bullseye
         environment:
           POSTGRES_DB: test
@@ -61,7 +61,7 @@ jobs:
     resource_class: large
   release:
     docker:
-      - image: alexfalkowski/release:3.1
+      - image: alexfalkowski/release:3.4
     working_directory: ~/go-service
     steps:
       - checkout

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -7,11 +7,16 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/debug"
+	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/test"
 	"github.com/alexfalkowski/go-service/transport"
 	. "github.com/smartystreets/goconvey/convey" //nolint:revive
 	"go.uber.org/fx/fxtest"
 )
+
+func init() {
+	content.Register(test.Pool)
+}
 
 func TestInsecureDebug(t *testing.T) {
 	Convey("When I have a all the servers", t, func() {

--- a/debug/psutil.go
+++ b/debug/psutil.go
@@ -9,6 +9,9 @@ import (
 )
 
 type (
+	// Request for debug.
+	Request struct{}
+
 	// CPU for debug.
 	CPU struct {
 		Info  []cpu.InfoStat  `yaml:"info,omitempty" json:"info,omitempty" toml:"info,omitempty"`
@@ -32,7 +35,7 @@ type (
 // RegisterPprof for debug.
 func RegisterPsutil(srv *Server, cont *content.Content) {
 	mux := srv.ServeMux()
-	h := content.NewHandler(cont, "debug", func(ctx context.Context) (*Response, error) {
+	h := content.NewQueryHandler(cont, "debug", func(ctx context.Context, _ *Request) (*Response, error) {
 		res := &Response{}
 
 		i, err := cpu.InfoWithContext(ctx)

--- a/health/transport/http/http.go
+++ b/health/transport/http/http.go
@@ -21,10 +21,13 @@ type (
 		Readiness *ReadinessObserver
 	}
 
+	// Request for health.
+	Request struct{}
+
 	// Response for health.
 	Response struct {
-		Meta   map[string]string `json:"meta,omitempty"`
-		Status string            `yaml:"status,omitempty" json:"status,omitempty" toml:"status,omitempty"`
+		Meta   meta.Map `yaml:"meta,omitempty" json:"meta,omitempty" toml:"meta,omitempty"`
+		Status string   `yaml:"status,omitempty" json:"status,omitempty" toml:"status,omitempty"`
 	}
 )
 
@@ -36,7 +39,7 @@ func Register(params RegisterParams) {
 }
 
 func resister(path string, ob *subscriber.Observer) {
-	rest.Get(path, func(ctx context.Context) (*Response, error) {
+	rest.Get(path, func(ctx context.Context, _ *Request) (*Response, error) {
 		if err := ob.Error(); err != nil {
 			return nil, status.Error(http.StatusServiceUnavailable, err.Error())
 		}

--- a/health/transport/http/http_test.go
+++ b/health/transport/http/http_test.go
@@ -17,6 +17,7 @@ import (
 	shh "github.com/alexfalkowski/go-service/health/transport/http"
 	"github.com/alexfalkowski/go-service/limiter"
 	"github.com/alexfalkowski/go-service/meta"
+	"github.com/alexfalkowski/go-service/net/http/content"
 	"github.com/alexfalkowski/go-service/net/http/rest"
 	"github.com/alexfalkowski/go-service/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/test"
@@ -31,6 +32,7 @@ import (
 func init() {
 	tracer.Register()
 	tm.RegisterKeys()
+	content.Register(test.Pool)
 }
 
 //nolint:funlen

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -4,6 +4,12 @@ import (
 	"net/http"
 
 	"github.com/alexfalkowski/go-service/encoding"
+	"github.com/alexfalkowski/go-service/errors"
+	nh "github.com/alexfalkowski/go-service/net/http"
+	hc "github.com/alexfalkowski/go-service/net/http/context"
+	"github.com/alexfalkowski/go-service/net/http/status"
+	"github.com/alexfalkowski/go-service/runtime"
+	"github.com/alexfalkowski/go-service/sync"
 	ct "github.com/elnormous/contenttype"
 )
 
@@ -14,6 +20,13 @@ const (
 	// TypeKey for HTTP headers.
 	TypeKey = "Content-Type"
 )
+
+var pool *sync.BufferPool
+
+// Register for content.
+func Register(p *sync.BufferPool) {
+	pool = p
+}
 
 // Content creates types from media types.
 type Content struct {
@@ -37,6 +50,34 @@ func (c *Content) NewFromMedia(mediaType string) *Media {
 	t, err := ct.ParseMediaType(mediaType)
 
 	return newType(t, err, c.enc)
+}
+
+func (c *Content) handler(prefix string, handler handler) http.HandlerFunc {
+	h := func(res http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		ctx = hc.WithRequest(ctx, req)
+		ctx = hc.WithResponse(ctx, res)
+
+		defer func() {
+			if r := recover(); r != nil {
+				err := errors.Prefix(prefix, runtime.ConvertRecover(r))
+				nh.WriteError(ctx, res, err, status.Code(err))
+			}
+		}()
+
+		ct := c.NewFromRequest(req)
+
+		ctx = hc.WithEncoder(ctx, ct.Encoder)
+		res.Header().Add(TypeKey, ct.Type)
+
+		data, err := handler(ctx)
+		runtime.Must(err)
+
+		err = ct.Encoder.Encode(res, data)
+		runtime.Must(err)
+	}
+
+	return h
 }
 
 // Media for content.

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -8,36 +8,36 @@ import (
 )
 
 // Delete for rest.
-func Delete[Res any](path string, handler content.Handler[Res]) {
-	Route(fmt.Sprintf("%s %s", http.MethodDelete, path), handler)
+func Delete[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	RouteQuery(fmt.Sprintf("%s %s", http.MethodDelete, path), handler)
 }
 
 // Get for rest.
-func Get[Res any](path string, handler content.Handler[Res]) {
-	Route(fmt.Sprintf("%s %s", http.MethodGet, path), handler)
+func Get[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	RouteQuery(fmt.Sprintf("%s %s", http.MethodGet, path), handler)
 }
 
 // Post for rest.
-func Post[Req any, Res any](path string, handler content.RequestHandler[Req, Res]) {
-	RouteRequest(fmt.Sprintf("%s %s", http.MethodPost, path), handler)
+func Post[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	RouteBody(fmt.Sprintf("%s %s", http.MethodPost, path), handler)
 }
 
 // Put for rest.
-func Put[Req any, Res any](path string, handler content.RequestHandler[Req, Res]) {
-	RouteRequest(fmt.Sprintf("%s %s", http.MethodPut, path), handler)
+func Put[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	RouteBody(fmt.Sprintf("%s %s", http.MethodPut, path), handler)
 }
 
 // Patch for rest.
-func Patch[Req any, Res any](path string, handler content.RequestHandler[Req, Res]) {
-	RouteRequest(fmt.Sprintf("%s %s", http.MethodPatch, path), handler)
+func Patch[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	RouteBody(fmt.Sprintf("%s %s", http.MethodPatch, path), handler)
 }
 
-// RouteRequest for rest.
-func RouteRequest[Req any, Res any](path string, handler content.RequestHandler[Req, Res]) {
-	mux.HandleFunc(path, content.NewRequestHandler(cont, "rest", handler))
+// RouteBody for rest.
+func RouteBody[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	mux.HandleFunc(path, content.NewBodyHandler(cont, "rest", handler))
 }
 
-// Route for rest.
-func Route[Res any](path string, handler content.Handler[Res]) {
-	mux.HandleFunc(path, content.NewHandler(cont, "rest", handler))
+// RouteQuery for rest.
+func RouteQuery[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	mux.HandleFunc(path, content.NewQueryHandler(cont, "rest", handler))
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -5,6 +5,6 @@ import (
 )
 
 // Route for rpc.
-func Route[Req any, Res any](path string, handler content.RequestHandler[Req, Res]) {
-	mux.HandleFunc("POST "+path, content.NewRequestHandler(cont, "rpc", handler))
+func Route[Req any, Res any](path string, handler content.Handler[Req, Res]) {
+	mux.HandleFunc("POST "+path, content.NewBodyHandler(cont, "rpc", handler))
 }

--- a/test/rest.go
+++ b/test/rest.go
@@ -5,34 +5,17 @@ import (
 	"context"
 
 	"github.com/alexfalkowski/go-service/meta"
-	nc "github.com/alexfalkowski/go-service/net/http/context"
 )
 
 // RestNoContent for test.
 //
 //nolint:nilnil
-func RestNoContent(_ context.Context) (*Response, error) {
+func RestNoContent(_ context.Context, _ *Request) (*Response, error) {
 	return nil, nil
 }
 
-// RestRequestNoContent for test.
-//
-//nolint:nilnil
-func RestRequestNoContent(_ context.Context, _ *Request) (*Response, error) {
-	return nil, nil
-}
-
-// RestNoContent for test.
-func RestContent(ctx context.Context) (*Response, error) {
-	req := nc.Request(ctx)
-	name := cmp.Or(req.URL.Query().Get("name"), "Bob")
-	s := "Hello " + name
-
-	return &Response{Meta: meta.CamelStrings(ctx, ""), Greeting: s}, nil
-}
-
-// RestRequestContent for test.
-func RestRequestContent(ctx context.Context, req *Request) (*Response, error) {
+// RestContent for test.
+func RestContent(ctx context.Context, req *Request) (*Response, error) {
 	name := cmp.Or(req.Name, "Bob")
 	s := "Hello " + name
 
@@ -40,11 +23,6 @@ func RestRequestContent(ctx context.Context, req *Request) (*Response, error) {
 }
 
 // RestError for test.
-func RestError(_ context.Context) (*Response, error) {
-	return nil, ErrInvalid
-}
-
-// RestRequestError for test.
-func RestRequestError(_ context.Context, _ *Request) (*Response, error) {
+func RestError(_ context.Context, _ *Request) (*Response, error) {
 	return nil, ErrInvalid
 }

--- a/test/rpc.go
+++ b/test/rpc.go
@@ -11,16 +11,18 @@ import (
 	v1 "github.com/alexfalkowski/go-service/test/greet/v1"
 )
 
-// Request for test.
-type Request struct {
-	Name string
-}
+type (
+	// Request for test.
+	Request struct {
+		Name string `yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty"`
+	}
 
-// Response for test.
-type Response struct {
-	Meta     meta.Map
-	Greeting string
-}
+	// Response for test.
+	Response struct {
+		Meta     meta.Map `yaml:"meta,omitempty" json:"meta,omitempty" toml:"meta,omitempty"`
+		Greeting string   `yaml:"greeting,omitempty" json:"greeting,omitempty" toml:"greeting,omitempty"`
+	}
+)
 
 // NoContent for test.
 //

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -13,6 +13,7 @@ import (
 // Module for fx.
 var Module = fx.Options(
 	fx.Provide(http.NewServeMux),
+	fx.Invoke(content.Register),
 	fx.Provide(content.NewContent),
 	fx.Provide(mvc.NewViews),
 	fx.Provide(mvc.NewRouter),

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -56,7 +56,8 @@ func TestRPCNoContent(t *testing.T) {
 					rpc.WithClientTimeout("10s"),
 				)
 
-				_, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
+				req := &test.Request{Name: "test"}
+				_, err := client.Invoke(context.Background(), req)
 
 				Convey("Then I should have no error", func() {
 					So(err, ShouldBeNil)
@@ -100,11 +101,13 @@ func TestRPCWithContent(t *testing.T) {
 					rpc.WithClientTimeout("10s"),
 				)
 
-				resp, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
+				req := &test.Request{Name: "test"}
+
+				resp, err := client.Invoke(context.Background(), req)
 				So(err, ShouldBeNil)
 
 				Convey("Then I should have response", func() {
-					So(resp.Greeting, ShouldEqual, "Hello Bob")
+					So(resp.Greeting, ShouldEqual, "Hello test")
 				})
 
 				lc.RequireStop()
@@ -235,7 +238,9 @@ func TestErrorRPC(t *testing.T) {
 				b := test.Pool.Get()
 				defer test.Pool.Put(b)
 
-				err := enc.Encode(b, test.Request{Name: "Bob"})
+				r := &test.Request{Name: "test"}
+
+				err := enc.Encode(b, r)
 				So(err, ShouldBeNil)
 
 				req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, fmt.Sprintf("http://%s/hello", cfg.HTTP.Address), b)
@@ -290,11 +295,13 @@ func TestAllowedRPC(t *testing.T) {
 					rpc.WithClientContentType("application/"+mt),
 					rpc.WithClientRoundTripper(cl.NewHTTP().Transport))
 
-				resp, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
+				req := &test.Request{Name: "test"}
+
+				resp, err := client.Invoke(context.Background(), req)
 				So(err, ShouldBeNil)
 
 				Convey("Then I should have response", func() {
-					So(resp.Greeting, ShouldEqual, "Hello Bob")
+					So(resp.Greeting, ShouldEqual, "Hello test")
 				})
 
 				lc.RequireStop()
@@ -331,7 +338,9 @@ func TestDisallowedRPC(t *testing.T) {
 					rpc.WithClientContentType(mt),
 					rpc.WithClientRoundTripper(cl.NewHTTP().Transport))
 
-				_, err := client.Invoke(context.Background(), &test.Request{Name: "Bob"})
+				req := &test.Request{Name: "test"}
+
+				_, err := client.Invoke(context.Background(), req)
 
 				Convey("Then I should have an error", func() {
 					So(status.IsError(err), ShouldBeTrue)
@@ -377,7 +386,9 @@ func BenchmarkRPC(b *testing.B) {
 					rpc.WithClientContentType("application/"+mt),
 					rpc.WithClientRoundTripper(t))
 
-				_, _ = client.Invoke(context.Background(), &test.Request{Name: "Bob"})
+				req := &test.Request{Name: "test"}
+
+				_, _ = client.Invoke(context.Background(), req)
 			}
 		})
 	}


### PR DESCRIPTION
We have one handler that can accomodate for body and query.
