### PR TITLE
fix(transport): geolocation can only be read from headers

### DIFF
--- a/transport/grpc/meta/meta.go
+++ b/transport/grpc/meta/meta.go
@@ -37,7 +37,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version) grpc.U
 		ctx = m.WithIPAddr(ctx, ip)
 		ctx = m.WithIPAddrKind(ctx, kind)
 
-		ctx = m.WithGeolocation(ctx, extractGeolocation(ctx, md))
+		ctx = m.WithGeolocation(ctx, extractGeolocation(md))
 		ctx = m.WithAuthorization(ctx, extractAuthorization(ctx, md))
 
 		_ = grpc.SetHeader(ctx, metadata.Pairs("service-version", version.String(), "request-id", requestID.Value()))
@@ -71,7 +71,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version) grpc.
 		ctx = m.WithIPAddr(ctx, ip)
 		ctx = m.WithIPAddrKind(ctx, kind)
 
-		ctx = m.WithGeolocation(ctx, extractGeolocation(ctx, md))
+		ctx = m.WithGeolocation(ctx, extractGeolocation(md))
 		ctx = m.WithAuthorization(ctx, extractAuthorization(ctx, md))
 
 		wrappedStream := middleware.WrapServerStream(stream)
@@ -194,11 +194,7 @@ func authorization(md metadata.MD) string {
 	return ""
 }
 
-func extractGeolocation(ctx context.Context, md metadata.MD) meta.Valuer {
-	if gl := m.Geolocation(ctx); gl != nil {
-		return gl
-	}
-
+func extractGeolocation(md metadata.MD) meta.Valuer {
 	if id := md.Get("geolocation"); len(id) > 0 {
 		return meta.String(id[0])
 	}

--- a/transport/http/meta/meta.go
+++ b/transport/http/meta/meta.go
@@ -47,7 +47,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	ctx = m.WithIPAddr(ctx, ip)
 	ctx = m.WithIPAddrKind(ctx, kind)
 
-	ctx = m.WithGeolocation(ctx, extractGeolocation(ctx, req))
+	ctx = m.WithGeolocation(ctx, extractGeolocation(req))
 	ctx = m.WithAuthorization(ctx, extractAuthorization(ctx, req))
 
 	next(res, req.WithContext(ctx))
@@ -141,10 +141,6 @@ func extractAuthorization(ctx context.Context, req *http.Request) meta.Valuer {
 	return meta.Ignored(value)
 }
 
-func extractGeolocation(ctx context.Context, req *http.Request) meta.Valuer {
-	if gl := m.Geolocation(ctx); gl != nil {
-		return gl
-	}
-
+func extractGeolocation(req *http.Request) meta.Valuer {
 	return meta.String(req.Header.Get("Geolocation"))
 }


### PR DESCRIPTION
We do not passthis from client to server like we do request-id.
