### PR TITLE
feat(transport): client options should not return errors

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -177,7 +177,7 @@ func registrations(logger *zap.Logger, cfg *http.Config, ua env.UserAgent, trace
 	t := 5 * time.Second
 	nc := checker.NewNoopChecker()
 	nr := server.NewRegistration("noop", t, nc)
-	rt := http.NewRoundTripper(http.WithClientLogger(logger), http.WithClientTracer(tracer), http.WithClientUserAgent(ua))
+	rt, _ := http.NewRoundTripper(http.WithClientLogger(logger), http.WithClientTracer(tracer), http.WithClientUserAgent(ua))
 	hc := checker.NewHTTPChecker("https://google.com", rt, t)
 	hr := server.NewRegistration("http", t, hc)
 

--- a/transport/events/http/http_test.go
+++ b/transport/events/http/http_test.go
@@ -42,7 +42,9 @@ func TestSendReceiveWithRoundTripper(t *testing.T) {
 
 		Convey("When I send an event", func() {
 			tracer := test.NewTracer(lc, tc, logger)
-			rt := sh.NewRoundTripper(sh.WithClientLogger(logger), sh.WithClientTracer(tracer), sh.WithClientMetrics(m))
+
+			rt, err := sh.NewRoundTripper(sh.WithClientLogger(logger), sh.WithClientTracer(tracer), sh.WithClientMetrics(m))
+			So(err, ShouldBeNil)
 
 			c, err := eh.NewSender(h, eh.WithSenderRoundTripper(rt))
 			So(err, ShouldBeNil)
@@ -141,7 +143,10 @@ func TestSendNotReceive(t *testing.T) {
 
 		Convey("When I send an event", func() {
 			tracer := test.NewTracer(lc, tc, logger)
-			rt := sh.NewRoundTripper(sh.WithClientLogger(logger), sh.WithClientTracer(tracer), sh.WithClientMetrics(m))
+
+			rt, err := sh.NewRoundTripper(sh.WithClientLogger(logger), sh.WithClientTracer(tracer), sh.WithClientMetrics(m))
+			So(err, ShouldBeNil)
+
 			rt = &delRoundTripper{rt: rt}
 
 			c, err := eh.NewSender(h, eh.WithSenderRoundTripper(rt))

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -1,10 +1,10 @@
-package grpc_test
+package http_test
 
 import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/crypto/tls"
-	"github.com/alexfalkowski/go-service/transport/grpc"
+	"github.com/alexfalkowski/go-service/transport/http"
 	. "github.com/smartystreets/goconvey/convey" //nolint:revive
 )
 
@@ -13,7 +13,7 @@ func TestClient(t *testing.T) {
 		c := &tls.Config{Cert: "bob", Key: "bob"}
 
 		Convey("When I create a client", func() {
-			_, err := grpc.NewClient("none", grpc.WithClientTLS(c))
+			_, err := http.NewClient(http.WithClientTLS(c))
 
 			Convey("Then I should have an error", func() {
 				So(err, ShouldBeError)
@@ -25,7 +25,7 @@ func TestClient(t *testing.T) {
 		c := &tls.Config{}
 
 		Convey("When I create a client", func() {
-			_, err := grpc.NewClient("none", grpc.WithClientTLS(c))
+			_, err := http.NewClient(http.WithClientTLS(c))
 
 			Convey("Then I should not have an error", func() {
 				So(err, ShouldBeNil)


### PR DESCRIPTION
This mirrors http and grpc when creating clients.
