### PR TITLE
fix(cmd): pass variable with StringVarP

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -23,5 +23,5 @@ func NewInputConfig(enc *encoding.Map, fs os.FileSystem) *InputConfig {
 
 // RegisterInput for cmd.
 func (c *Command) RegisterInput(flags *flags.FlagSet, value string) {
-	InputFlag = flags.StringP("input", "i", value, "input config location (format kind:location)")
+	flags.StringVarP(InputFlag, "input", "i", value, "input config location (format kind:location)")
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -23,5 +23,5 @@ func NewOutputConfig(enc *encoding.Map, fs os.FileSystem) *OutputConfig {
 
 // RegisterInput for cmd.
 func (c *Command) RegisterOutput(flags *flags.FlagSet, value string) {
-	OutputFlag = flags.StringP("output", "o", value, "output config location (format kind:location)")
+	flags.StringVarP(OutputFlag, "output", "o", value, "output config location (format kind:location)")
 }


### PR DESCRIPTION
We accidentaly override the var.
