### PR TITLE
fix(os): sanitize args

### DIFF
--- a/cli/application.go
+++ b/cli/application.go
@@ -129,7 +129,7 @@ func (a *Application) Run(ctx context.Context, args ...string) error {
 		AppName:        name,
 		AppDescription: name,
 		Version:        a.version.String(),
-		Args:           args,
+		Args:           os.SanitizeArgs(args),
 		Context:        ctx,
 	})
 

--- a/os/os.go
+++ b/os/os.go
@@ -2,6 +2,9 @@ package os
 
 import (
 	"os"
+	"slices"
+
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // FileInfo is an alias of os.FileInfo.
@@ -39,4 +42,11 @@ func UserHomeDir() string {
 	home, _ := os.UserHomeDir()
 
 	return home
+}
+
+// SanitizeArgs removes all flags that start with -test.
+func SanitizeArgs(args []string) []string {
+	return slices.DeleteFunc(args, func(s string) bool {
+		return strings.HasPrefix(s, "-test")
+	})
 }


### PR DESCRIPTION
no such command -test.cpuprofile=reports/go-service-template-server-9buy-cpu.prof
