### PR TITLE
test(transport): propagate test option setup errors and make benchmark error handling consistent

### DIFF
--- a/internal/test/opts.go
+++ b/internal/test/opts.go
@@ -52,19 +52,23 @@ func Options() []di.Option {
 	}
 }
 
-func registrations(logger *logger.Logger, cfg *http.Config, ua env.UserAgent, _ env.Version) health.Registrations {
+func registrations(logger *logger.Logger, cfg *http.Config, ua env.UserAgent, _ env.Version) (health.Registrations, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil
 	}
 
 	timeout := 5 * time.Second
 	nc := checker.NewNoopChecker()
 	nr := server.NewRegistration("noop", timeout, nc)
-	rt, _ := http.NewRoundTripper(http.WithClientLogger(logger), http.WithClientUserAgent(ua))
+	rt, err := http.NewRoundTripper(http.WithClientLogger(logger), http.WithClientUserAgent(ua))
+	if err != nil {
+		return nil, err
+	}
+
 	hc := checker.NewHTTPChecker(StatusURL("200"), timeout, checker.WithRoundTripper(rt))
 	hr := server.NewRegistration("http", timeout, hc)
 
-	return health.Registrations{nr, hr, server.NewOnlineRegistration(timeout, timeout)}
+	return health.Registrations{nr, hr, server.NewOnlineRegistration(timeout, timeout)}, nil
 }
 
 func healthRegister(cfg *http.Config, name env.Name, server *server.Server, regs health.Registrations) {

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/server"
-	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	tg "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -28,7 +28,7 @@ func BenchmarkGRPC(b *testing.B) {
 		n, a, _ := net.SplitNetworkAddress(test.RandomAddress())
 
 		l, err := net.Listen(b.Context(), n, a)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		server := grpc.NewServer(test.ConfigOptions, test.DefaultTimeout)
 		defer server.GracefulStop()
@@ -39,7 +39,7 @@ func BenchmarkGRPC(b *testing.B) {
 		go server.Serve(l)
 
 		conn, err := grpc.NewClient(l.Addr().String(), grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
 		req := &v1.SayHelloRequest{Name: "test"}
@@ -48,7 +48,9 @@ func BenchmarkGRPC(b *testing.B) {
 
 		for b.Loop() {
 			_, err := client.SayHello(b.Context(), req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -65,7 +67,7 @@ func BenchmarkGRPC(b *testing.B) {
 			Config:     cfg.GRPC,
 			UserAgent:  test.UserAgent, Version: test.Version,
 		})
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(lc, []*server.Service{g.GetService()})
@@ -76,7 +78,7 @@ func BenchmarkGRPC(b *testing.B) {
 		cl := &client.Config{Address: addr}
 
 		conn, err := tg.NewClient(cl.Address)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
 		req := &v1.SayHelloRequest{Name: "test"}
@@ -85,7 +87,9 @@ func BenchmarkGRPC(b *testing.B) {
 
 		for b.Loop() {
 			_, err := client.SayHello(b.Context(), req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -95,7 +99,8 @@ func BenchmarkGRPC(b *testing.B) {
 	b.Run("log", func(b *testing.B) {
 		b.ReportAllocs()
 
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
 
@@ -104,7 +109,7 @@ func BenchmarkGRPC(b *testing.B) {
 			Config:     cfg.GRPC, Logger: logger,
 			UserAgent: test.UserAgent, Version: test.Version,
 		})
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(lc, []*server.Service{g.GetService()})
@@ -116,7 +121,7 @@ func BenchmarkGRPC(b *testing.B) {
 		cl := &client.Config{Address: addr}
 
 		conn, err := tg.NewClient(cl.Address)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
 		req := &v1.SayHelloRequest{Name: "test"}
@@ -125,7 +130,9 @@ func BenchmarkGRPC(b *testing.B) {
 
 		for b.Loop() {
 			_, err := client.SayHello(b.Context(), req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -135,7 +142,8 @@ func BenchmarkGRPC(b *testing.B) {
 	b.Run("trace", func(b *testing.B) {
 		b.ReportAllocs()
 
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
 
@@ -146,7 +154,7 @@ func BenchmarkGRPC(b *testing.B) {
 			Config:     cfg.GRPC, Logger: logger,
 			UserAgent: test.UserAgent, Version: test.Version,
 		})
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(lc, []*server.Service{g.GetService()})
@@ -158,7 +166,7 @@ func BenchmarkGRPC(b *testing.B) {
 		cl := &client.Config{Address: addr}
 
 		conn, err := tg.NewClient(cl.Address)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
 		req := &v1.SayHelloRequest{Name: "test"}
@@ -167,7 +175,9 @@ func BenchmarkGRPC(b *testing.B) {
 
 		for b.Loop() {
 			_, err := client.SayHello(b.Context(), req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-service/v2/net/server"
-	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -51,11 +50,13 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ResetTimer()
 
 		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		for b.Loop() {
 			_, err = client.Do(req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -76,7 +77,7 @@ func BenchmarkHTTP(b *testing.B) {
 			Version:    test.Version,
 			ID:         uuid.NewGenerator(),
 		})
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		server.Register(lc, []*server.Service{h.GetService()})
 
@@ -89,11 +90,13 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ResetTimer()
 
 		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		for b.Loop() {
 			_, err = client.Do(req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -105,7 +108,8 @@ func BenchmarkHTTP(b *testing.B) {
 
 		mux := http.NewServeMux()
 		lc := fxtest.NewLifecycle(b)
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 		cfg := test.NewInsecureTransportConfig()
 
 		h, err := transporthttp.NewServer(transporthttp.ServerParams{
@@ -117,7 +121,7 @@ func BenchmarkHTTP(b *testing.B) {
 			Version:    test.Version,
 			ID:         uuid.NewGenerator(),
 		})
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		server.Register(lc, []*server.Service{h.GetService()})
 		errors.Register(errors.NewHandler(logger))
@@ -131,11 +135,13 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ResetTimer()
 
 		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		for b.Loop() {
 			_, err = client.Do(req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -147,7 +153,8 @@ func BenchmarkHTTP(b *testing.B) {
 
 		mux := http.NewServeMux()
 		lc := fxtest.NewLifecycle(b)
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 		cfg := test.NewInsecureTransportConfig()
 
 		test.RegisterTracer(lc, nil)
@@ -161,7 +168,7 @@ func BenchmarkHTTP(b *testing.B) {
 			Version:    test.Version,
 			ID:         uuid.NewGenerator(),
 		})
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		server.Register(lc, []*server.Service{h.GetService()})
 		errors.Register(errors.NewHandler(logger))
@@ -175,11 +182,13 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ResetTimer()
 
 		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		for b.Loop() {
 			_, err = client.Do(req)
-			runtime.Must(err)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 
 		b.StopTimer()
@@ -190,7 +199,8 @@ func BenchmarkHTTP(b *testing.B) {
 func BenchmarkMVC(b *testing.B) {
 	b.ReportAllocs()
 
-	logger, _ := logger.NewLogger(logger.LoggerParams{})
+	logger, err := logger.NewLogger(logger.LoggerParams{})
+	require.NoError(b, err)
 
 	world := test.NewStartedWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(logger))
 
@@ -208,13 +218,15 @@ func BenchmarkMVC(b *testing.B) {
 		url := world.PathServerURL("http", "hello")
 
 		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
-		runtime.Must(err)
+		require.NoError(b, err)
 
 		req.Header.Set(content.TypeKey, mime.HTMLMediaType)
 
 		for b.Loop() {
-			_, err := client.Do(req)
-			runtime.Must(err)
+			_, err = client.Do(req)
+			if err != nil {
+				require.NoError(b, err)
+			}
 		}
 	})
 
@@ -226,7 +238,8 @@ func BenchmarkRPC(b *testing.B) {
 	b.Run("text", func(b *testing.B) {
 		b.ReportAllocs()
 
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 
 		world := test.NewStartedWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(logger))
 
@@ -248,7 +261,9 @@ func BenchmarkRPC(b *testing.B) {
 					res := &test.Response{}
 
 					err := client.Post(b.Context(), "/hello", req, res)
-					runtime.Must(err)
+					if err != nil {
+						require.NoError(b, err)
+					}
 				}
 			})
 		}
@@ -259,7 +274,8 @@ func BenchmarkRPC(b *testing.B) {
 	b.Run("proto", func(b *testing.B) {
 		b.ReportAllocs()
 
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 
 		world := test.NewStartedWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(logger))
 
@@ -280,7 +296,9 @@ func BenchmarkRPC(b *testing.B) {
 					res := &v1.SayHelloResponse{}
 
 					err := client.Post(b.Context(), "/hello", req, res)
-					runtime.Must(err)
+					if err != nil {
+						require.NoError(b, err)
+					}
 				}
 			})
 		}
@@ -294,7 +312,8 @@ func BenchmarkRest(b *testing.B) {
 	b.Run("text", func(b *testing.B) {
 		b.ReportAllocs()
 
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 
 		world := test.NewStartedWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(logger))
 
@@ -320,7 +339,9 @@ func BenchmarkRest(b *testing.B) {
 					}
 
 					err := client.Post(b.Context(), url, opts)
-					runtime.Must(err)
+					if err != nil {
+						require.NoError(b, err)
+					}
 				}
 			})
 		}
@@ -339,7 +360,9 @@ func BenchmarkRest(b *testing.B) {
 				}
 
 				err := client.Get(b.Context(), url, opts)
-				runtime.Must(err)
+				if err != nil {
+					require.NoError(b, err)
+				}
 
 				test.Pool.Put(buffer)
 			}
@@ -351,7 +374,8 @@ func BenchmarkRest(b *testing.B) {
 	b.Run("proto", func(b *testing.B) {
 		b.ReportAllocs()
 
-		logger, _ := logger.NewLogger(logger.LoggerParams{})
+		logger, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
 
 		world := test.NewStartedWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(logger))
 
@@ -376,7 +400,9 @@ func BenchmarkRest(b *testing.B) {
 					}
 
 					err := client.Post(b.Context(), url, opts)
-					runtime.Must(err)
+					if err != nil {
+						require.NoError(b, err)
+					}
 				}
 			})
 		}


### PR DESCRIPTION
## What

- updated [`internal/test/opts.go`](/Users/alejandro/code/go-service/internal/test/opts.go) so `registrations(...)` now returns an error and propagates failures from `http.NewRoundTripper(...)` instead of ignoring them
- cleaned up benchmark setup in:
  - [transport/http/benchmark_test.go](/Users/alejandro/code/go-service/transport/http/benchmark_test.go)
  - [transport/grpc/benchmark_test.go](/Users/alejandro/code/go-service/transport/grpc/benchmark_test.go)
- replaced setup-time `runtime.Must(err)` and ignored constructor errors in benchmarks with `require.NoError(...)`
- kept the benchmark hot paths lightweight by only asserting on the error path inside loops

## Why

- avoids silently hiding setup failures in the shared test wiring
- makes benchmark error handling consistent with the newer error-returning helper style used across `internal/test`
- improves readability by separating setup validation from the benchmarked code path

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./cli ./internal/test -count=1
env GOCACHE=/tmp/go-build go test ./transport/http ./transport/grpc -run '^$' -bench 'Benchmark(HTTP|MVC|RPC|Rest|GRPC)$' -benchtime=1x -count=1
make lint
```