### PR TITLE
test(world): validate world transport addresses before building server and debug urls

### DIFF
--- a/internal/test/connect.go
+++ b/internal/test/connect.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-// Connect retries dialing address until it succeeds or the test timeout expires.
+// Connect retries dialing address for up to one second until it succeeds.
 //
 // The address may be a raw host:port or a go-service "<network>://<address>" string.
 func Connect(ctx context.Context, address string) (net.Conn, error) {

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -273,23 +273,25 @@ func (w *World) ResponseWithNoBody(ctx context.Context, url, method string, head
 
 func (w *World) namedURL(host, path string) string {
 	w.t.Helper()
+
 	url, err := url.JoinPath(host, Name.String(), path)
 	require.NoError(w.t, err)
-
 	return url
 }
 
 func (w *World) pathURL(host, path string) string {
 	w.t.Helper()
+
 	url, err := url.JoinPath(host, path)
 	require.NoError(w.t, err)
-
 	return url
 }
 
 func (w *World) url(protocol, address string) string {
-	_, host, _ := net.SplitNetworkAddress(address)
+	w.t.Helper()
 
+	_, host, ok := net.SplitNetworkAddress(address)
+	require.True(w.t, ok, "invalid network address: %s", address)
 	return strings.Concat(protocol, "://", host)
 }
 


### PR DESCRIPTION
## What

- updated [`internal/test/world.go`](/Users/alejandro/code/go-service/internal/test/world.go) so `World.url(...)` now validates the transport address before building the final server/debug URL
- changed that helper to fail through the test handle when `net.SplitNetworkAddress(...)` cannot parse the configured address

## Why

- keeps malformed transport addresses in normal test-failure space instead of silently producing a broken URL
- makes `World.url(...)` consistent with the other world URL helpers that already validate and fail through `testing.TB`

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./internal/test -count=1
make lint
```