### PR TITLE
test(port): keep bound address rewriting in internal test helpers instead of production packages

### DIFF
--- a/debug/server.go
+++ b/debug/server.go
@@ -52,6 +52,8 @@ type ServerParams struct {
 //   - underlying service construction errors are returned.
 //
 // Errors are prefixed with "debug" for easier attribution.
+// If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
+// to the actual bound listener address after construction.
 func NewServer(params ServerParams) (*Server, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -165,7 +165,7 @@ func NewTLSConfig(c, k string) *tls.Config {
 	return tc
 }
 
-// NewInsecureTransportConfig returns HTTP and gRPC transport configs that listen on random local addresses without TLS.
+// NewInsecureTransportConfig returns HTTP and gRPC transport configs that listen on ephemeral local addresses without TLS.
 func NewInsecureTransportConfig() *transport.Config {
 	return &transport.Config{
 		HTTP: &http.Config{
@@ -195,7 +195,7 @@ func NewGRPCTransportConfig() *grpc.Config {
 	return &grpc.Config{Config: &server.Config{}}
 }
 
-// NewSecureTransportConfig returns HTTP and gRPC transport configs wired with the shared TLS server fixtures.
+// NewSecureTransportConfig returns HTTP and gRPC transport configs wired with the shared TLS server fixtures on ephemeral local addresses.
 func NewSecureTransportConfig() *transport.Config {
 	config := NewTLSServerConfig()
 	retry := NewRetry()
@@ -298,7 +298,7 @@ func NewPGConfig() *pg.Config {
 	}
 }
 
-// NewInsecureDebugConfig returns a debug server config bound to a random local address without TLS.
+// NewInsecureDebugConfig returns a debug server config bound to an ephemeral local address without TLS.
 func NewInsecureDebugConfig() *debug.Config {
 	return &debug.Config{
 		Config: &server.Config{
@@ -309,7 +309,7 @@ func NewInsecureDebugConfig() *debug.Config {
 	}
 }
 
-// NewSecureDebugConfig returns a debug server config bound to a random local address with the shared TLS fixture.
+// NewSecureDebugConfig returns a debug server config bound to an ephemeral local address with the shared TLS fixture.
 func NewSecureDebugConfig() *debug.Config {
 	return &debug.Config{
 		Config: &server.Config{

--- a/internal/test/port.go
+++ b/internal/test/port.go
@@ -1,36 +1,39 @@
 package test
 
-import (
-	"context"
+import "github.com/alexfalkowski/go-service/v2/net"
 
-	"github.com/alexfalkowski/go-service/v2/net"
-	"github.com/alexfalkowski/go-service/v2/runtime"
-	"github.com/alexfalkowski/go-service/v2/strings"
+const (
+	localNetwork = "tcp"
+	localAddress = "localhost:0"
 )
 
-// RandomAddress returns a transport address in `<network>://<host:port>` form backed by a free local port.
+// RandomAddress returns a local transport address in `<network>://<host:port>` form that lets the server pick an ephemeral port.
 func RandomAddress() string {
-	network, address := RandomNetworkHost()
-
-	return strings.Concat(network, "://", address)
+	return net.NetworkAddress(localNetwork, localAddress)
 }
 
-// RandomHost returns a free local `host:port` pair.
+// RandomHost returns a local `host:port` listen address that lets the server pick an ephemeral port.
 func RandomHost() string {
-	_, address := RandomNetworkHost()
-
-	return address
+	return localAddress
 }
 
-// RandomNetworkHost returns a network name and free local address discovered by binding to `localhost:0`.
+// RandomNetworkHost returns the local network name and listen address that let the server pick an ephemeral port.
 func RandomNetworkHost() (string, string) {
-	l, err := net.Listen(context.Background(), "tcp", "localhost:0")
-	runtime.Must(err)
+	return localNetwork, localAddress
+}
 
-	defer l.Close()
+// BoundAddress rewrites configured to the bound listener address while preserving the configured network and host when possible.
+func BoundAddress(configured, actual string) string {
+	network, address := net.ListenNetworkAddress(configured)
+	host, _, err := net.SplitHostPort(address)
+	if err != nil || host == "" {
+		return net.NetworkAddress(network, actual)
+	}
 
-	addr := l.Addr().String()
-	addr = strings.ReplaceAll(addr, "127.0.0.1", "localhost")
+	_, port, err := net.SplitHostPort(actual)
+	if err != nil {
+		return net.NetworkAddress(network, actual)
+	}
 
-	return l.Addr().Network(), addr
+	return net.NetworkAddress(network, net.JoinHostPort(host, port))
 }

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -46,6 +46,8 @@ type Server struct {
 // HTTP, gRPC, and debug servers are created only when their corresponding
 // Register* flag is set. The method also wires the shared tracer registration
 // and attaches common middleware, token handling, and test service handlers.
+//
+//nolint:funlen
 func (s *Server) Register() error {
 	RegisterTracer(s.Lifecycle, s.Tracer)
 
@@ -69,6 +71,7 @@ func (s *Server) Register() error {
 		}
 
 		s.HTTPServer = httpServer
+		s.TransportConfig.HTTP.Address = BoundAddress(s.TransportConfig.HTTP.Address, httpServer.GetService().String())
 		servers = append(servers, httpServer.GetService())
 	}
 
@@ -88,6 +91,7 @@ func (s *Server) Register() error {
 		}
 
 		s.GRPCServer = grpcServer
+		s.TransportConfig.GRPC.Address = BoundAddress(s.TransportConfig.GRPC.Address, grpcServer.GetService().String())
 		v1.RegisterGreeterServiceServer(grpcServer.ServiceRegistrar(), NewService())
 		servers = append(servers, grpcServer.GetService())
 	}
@@ -99,6 +103,7 @@ func (s *Server) Register() error {
 		}
 
 		s.DebugServer = debugServer
+		s.DebugConfig.Address = BoundAddress(s.DebugConfig.Address, debugServer.GetService().String())
 		servers = append(servers, debugServer.GetService())
 	}
 

--- a/net/net.go
+++ b/net/net.go
@@ -58,6 +58,11 @@ func ListenNetworkAddress(address string) (string, string) {
 	return "tcp", address
 }
 
+// NetworkAddress returns an address in the "<network>://<address>" form used by go-service.
+func NetworkAddress(network, address string) string {
+	return strings.Concat(network, "://", address)
+}
+
 // Host returns the host portion of addr if it is in host:port form.
 //
 // If addr cannot be parsed by net.SplitHostPort (for example it has no port, or it is malformed),
@@ -70,9 +75,19 @@ func Host(addr string) string {
 	return host
 }
 
+// SplitHostPort splits addr into host and port using the standard host:port rules.
+func SplitHostPort(addr string) (string, string, error) {
+	return net.SplitHostPort(addr)
+}
+
+// JoinHostPort combines host and port into a network address.
+func JoinHostPort(host, port string) string {
+	return net.JoinHostPort(host, port)
+}
+
 // DefaultAddress returns a go-service server address in the form "tcp://:<port>".
 //
 // This is commonly used as a default bind address when only a port is configured.
 func DefaultAddress(port string) string {
-	return "tcp://:" + port
+	return NetworkAddress("tcp", ":"+port)
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -11,8 +11,20 @@ func TestDefaultAddress(t *testing.T) {
 	require.Equal(t, "tcp://:9000", net.DefaultAddress("9000"))
 }
 
+func TestNetworkAddressValue(t *testing.T) {
+	require.Equal(t, "tcp://localhost:9000", net.NetworkAddress("tcp", "localhost:9000"))
+}
+
 func TestHost(t *testing.T) {
 	require.Equal(t, "none", net.Host("none"))
+}
+
+func TestSplitAndJoinHostPort(t *testing.T) {
+	host, port, err := net.SplitHostPort("localhost:9000")
+	require.NoError(t, err)
+	require.Equal(t, "localhost", host)
+	require.Equal(t, "9000", port)
+	require.Equal(t, "localhost:9000", net.JoinHostPort(host, port))
 }
 
 func TestNetworkAddress(t *testing.T) {

--- a/net/server/service.go
+++ b/net/server/service.go
@@ -76,10 +76,14 @@ func (s *Service) Stop(ctx context.Context) error {
 	return nil
 }
 
+// String returns the underlying server identifier or bound address.
+func (s *Service) String() string {
+	return s.server.String()
+}
+
 func (s *Service) log(fn func(l *logger.Logger)) {
 	if s.logger == nil {
 		return
 	}
-
 	fn(s.logger)
 }

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -25,9 +25,7 @@ func BenchmarkGRPC(b *testing.B) {
 	b.Run("std", func(b *testing.B) {
 		b.ReportAllocs()
 
-		n, a, _ := net.SplitNetworkAddress(test.RandomAddress())
-
-		l, err := net.Listen(b.Context(), n, a)
+		l, err := net.Listen(b.Context(), "tcp", "localhost:0")
 		require.NoError(b, err)
 
 		server := grpc.NewServer(test.ConfigOptions, test.DefaultTimeout)
@@ -68,6 +66,7 @@ func BenchmarkGRPC(b *testing.B) {
 			UserAgent:  test.UserAgent, Version: test.Version,
 		})
 		require.NoError(b, err)
+		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(lc, []*server.Service{g.GetService()})
@@ -110,6 +109,7 @@ func BenchmarkGRPC(b *testing.B) {
 			UserAgent: test.UserAgent, Version: test.Version,
 		})
 		require.NoError(b, err)
+		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(lc, []*server.Service{g.GetService()})
@@ -155,6 +155,7 @@ func BenchmarkGRPC(b *testing.B) {
 			UserAgent: test.UserAgent, Version: test.Version,
 		})
 		require.NoError(b, err)
+		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(lc, []*server.Service{g.GetService()})

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -83,6 +83,9 @@ type ServerParams struct {
 // TLS:
 // If TLS is enabled in config, server credentials are built from `params.Config.TLS`. Certificate/key
 // sources may be resolved via the package-registered filesystem (see `Register` in this package).
+//
+// If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
+// to the actual bound listener address after construction.
 func NewServer(params ServerParams) (*Server, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -32,20 +32,21 @@ func BenchmarkHTTP(b *testing.B) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
 
-		addr := test.RandomHost()
+		listener, err := net.Listen(b.Context(), "tcp", "localhost:0")
+		require.NoError(b, err)
+		defer listener.Close()
 
 		server := &http.Server{
 			Handler:           mux,
-			Addr:              addr,
 			ReadHeaderTimeout: time.Second,
 		}
 		defer server.Close()
 
 		//nolint:errcheck
-		go server.ListenAndServe()
+		go server.Serve(listener)
 
 		client := &http.Client{Transport: http.DefaultTransport}
-		url := fmt.Sprintf("http://%s/hello", addr)
+		url := fmt.Sprintf("http://%s/hello", listener.Addr().String())
 
 		b.ResetTimer()
 
@@ -78,6 +79,7 @@ func BenchmarkHTTP(b *testing.B) {
 			ID:         uuid.NewGenerator(),
 		})
 		require.NoError(b, err)
+		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(lc, []*server.Service{h.GetService()})
 
@@ -122,6 +124,7 @@ func BenchmarkHTTP(b *testing.B) {
 			ID:         uuid.NewGenerator(),
 		})
 		require.NoError(b, err)
+		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(lc, []*server.Service{h.GetService()})
 		errors.Register(errors.NewHandler(logger))
@@ -169,6 +172,7 @@ func BenchmarkHTTP(b *testing.B) {
 			ID:         uuid.NewGenerator(),
 		})
 		require.NoError(b, err)
+		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(lc, []*server.Service{h.GetService()})
 		errors.Register(errors.NewHandler(logger))

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -93,6 +93,9 @@ type ServerParams struct {
 //
 // If TLS is enabled, TLS configuration is constructed using the package-registered filesystem dependency
 // (see `Register` in this package) to resolve certificate/key "source strings" (for example `file:` or `env:`).
+//
+// If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
+// to the actual bound listener address after construction.
 func NewServer(params ServerParams) (*Server, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil


### PR DESCRIPTION
## What

- moved the bound-address rewrite helper back into [`internal/test/port.go`](/Users/alejandro/code/go-service/internal/test/port.go) as test-only behavior
- removed the address-rewrite logic from the production HTTP, gRPC, and debug server constructors
- updated [`internal/test/server.go`](/Users/alejandro/code/go-service/internal/test/server.go) to rewrite the world’s HTTP, gRPC, and debug config addresses after the test servers are constructed
- updated the HTTP and gRPC benchmark setup to use the test-side bound-address helper
- removed the production-package address-rewrite tests and added focused coverage for the helper in [`internal/test/port_test.go`](/Users/alejandro/code/go-service/internal/test/port_test.go)

## Why

- keeps this ephemeral-port fix in test code instead of pushing test-driven behavior into production packages
- preserves the cleaner production server constructors
- keeps the world and benchmark helpers working with real bound addresses after switching to `localhost:0`

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./internal/test ./debug ./transport/http ./transport/grpc ./net -count=1
env GOCACHE=/tmp/go-build go test ./transport/http ./transport/grpc -run '^$' -bench 'Benchmark(HTTP|GRPC)$' -benchtime=1x -count=1
make lint
```