### PR TITLE
feat(logger): make telemetry logger methods nil-safe

### DIFF
--- a/.gocov
+++ b/.gocov
@@ -1,1 +1,1 @@
-test|.pb|middleware
+test|.pb

--- a/net/server/service.go
+++ b/net/server/service.go
@@ -8,23 +8,36 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 )
 
-// NewService constructs a Service that manages the lifetime of an underlying Server.
+// NewService constructs a [Service] that manages the lifetime of server.
 //
-// name is used for attribution in logs (meta.SystemKey). server is the concrete server implementation
-// (e.g. HTTP or gRPC). logger may be nil to disable logging. sh is used to trigger application shutdown
-// when the underlying Server terminates unexpectedly.
+// name is used for attribution in log attributes under `meta.SystemKey` and as
+// the prefix when [Service.Stop] returns a shutdown error. logger may be nil;
+// the resulting Service relies on the logger package's nil-safe methods and
+// simply skips log emission in that case.
 //
-// NewService does not start the server; call (*Service).Start to begin serving.
+// server is expected to be a non-nil concrete implementation such as an HTTP
+// or gRPC server adapter. sh is expected to be non-nil and is used to trigger
+// application shutdown when server.Serve returns a non-nil error.
+//
+// NewService does not validate its arguments and does not start serving. Call
+// [Service.Start] to launch server.Serve in the background.
 func NewService(name string, server Server, logger *logger.Logger, sh di.Shutdowner) *Service {
 	return &Service{name: name, server: server, logger: logger, sh: sh}
 }
 
-// Service manages starting and stopping a Server with optional logging and shutdown integration.
+// Service manages starting and stopping a [Server] with optional logging and
+// Fx shutdown integration.
 //
-// Concurrency/lifecycle expectations:
-//   - Start launches the server in a new goroutine.
-//   - Stop requests a graceful shutdown and should be called during application shutdown.
-//   - If Server.Serve returns a non-nil error, Service triggers application shutdown via di.Shutdowner.
+// Service is a thin lifecycle adapter. It does not own listener construction or
+// startup readiness checks; it only calls [Server.Serve], [Server.Shutdown], and
+// [Server.String] at the appropriate lifecycle points.
+//
+// Concurrency and lifecycle semantics:
+//   - [Service.Start] launches [Server.Serve] in a new goroutine and returns immediately.
+//   - [Service.Start] does not report Serve errors to its caller. A non-nil Serve error is logged and triggers `di.Shutdowner`.
+//   - A nil Serve return is treated as normal termination and does not trigger shutdown.
+//   - [Service.Stop] calls [Server.Shutdown] synchronously with the provided context.
+//   - Service does not guard against repeated or concurrent Start/Stop calls; callers should coordinate lifecycle transitions.
 type Service struct {
 	server Server
 	sh     di.Shutdowner
@@ -34,56 +47,59 @@ type Service struct {
 
 // Start launches the underlying server asynchronously.
 //
-// Start returns immediately. The underlying Server.Serve runs in a separate goroutine.
+// Start returns immediately after spawning a goroutine that logs the server
+// address and then calls [Server.Serve].
+//
+// If Serve returns a non-nil error, Start requests application shutdown via the
+// configured `di.Shutdowner` and logs the failure. Because Start is
+// asynchronous, it never returns that Serve error directly.
+//
+// Start performs no deduplication or synchronization. Calling it more than once
+// for the same Service will start multiple goroutines and invoke Serve multiple
+// times.
 func (s *Service) Start() {
 	go s.start()
 }
 
 func (s *Service) start() {
 	addr := logger.String("addr", s.server.String())
-
-	s.log(func(l *logger.Logger) {
-		l.Info("starting server", addr, logger.String(meta.SystemKey, s.name))
-	})
+	s.logger.Info("starting server", addr, logger.String(meta.SystemKey, s.name))
 
 	if err := s.server.Serve(); err != nil {
 		// Trigger application shutdown when serving terminates with an error.
 		_ = s.sh.Shutdown()
-
-		s.log(func(l *logger.Logger) {
-			l.Error("could not start server", logger.String(meta.SystemKey, s.name), addr, logger.Error(err))
-		})
+		s.logger.Error("could not start server", logger.String(meta.SystemKey, s.name), addr, logger.Error(err))
 	}
 }
 
 // Stop requests a graceful shutdown of the underlying server.
 //
-// The provided context controls shutdown deadlines/cancellation. If shutdown fails, Stop logs the error and
-// returns it prefixed with the service name for attribution.
+// The provided context controls shutdown deadlines and cancellation for
+// [Server.Shutdown]. Stop logs the shutdown attempt regardless of whether the
+// Service was previously started.
+//
+// If Shutdown returns an error, Stop logs the failure and returns the same
+// error wrapped with [errors.Prefix] using the service name for attribution. A
+// successful shutdown returns nil.
+//
+// Stop does not trigger `di.Shutdowner`; that mechanism is reserved for
+// unexpected Serve failures observed by [Service.Start].
 func (s *Service) Stop(ctx context.Context) error {
-	s.log(func(l *logger.Logger) {
-		l.Info("stopping server", logger.String(meta.SystemKey, s.name))
-	})
+	s.logger.Info("stopping server", logger.String(meta.SystemKey, s.name))
 
 	if err := s.server.Shutdown(ctx); err != nil {
-		s.log(func(l *logger.Logger) {
-			l.Error("could not stop server", logger.String(meta.SystemKey, s.name), logger.Error(err))
-		})
+		s.logger.Error("could not stop server", logger.String(meta.SystemKey, s.name), logger.Error(err))
 
 		return errors.Prefix(s.name, err)
 	}
-
 	return nil
 }
 
-// String returns the underlying server identifier or bound address.
+// String returns [Server.String] unchanged.
+//
+// This is typically the human-readable address or identifier used by the
+// underlying server and matches the value logged under the "addr" attribute
+// during [Service.Start].
 func (s *Service) String() string {
 	return s.server.String()
-}
-
-func (s *Service) log(fn func(l *logger.Logger)) {
-	if s.logger == nil {
-		return
-	}
-	fn(s.logger)
 }

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -29,10 +29,16 @@ const (
 	LevelWarn = slog.LevelWarn
 )
 
-// Attr is a structured logging attribute.
+// Attr is an alias of [slog.Attr].
+//
+// It lets packages expose go-service logging types without importing log/slog
+// directly.
 type Attr = slog.Attr
 
-// Level is the slog logging level type.
+// Level is an alias of [slog.Level].
+//
+// It lets packages refer to slog levels through the go-service logger package
+// when that keeps imports or public APIs simpler.
 type Level = slog.Level
 
 // ErrNotFound is returned when Config.Kind is unknown.
@@ -57,9 +63,10 @@ func Int(key string, value int) Attr {
 
 // LogError logs an error message using the process-wide default slog logger.
 //
-// This is a thin wrapper around slog.ErrorContext and does not change semantics.
-// It is useful in code that prefers importing go-service packages rather than
-// log/slog directly.
+// It is a thin wrapper around [slog.ErrorContext] and does not change
+// semantics. In applications wired with [NewLogger], the default logger is the
+// instance installed by this package. If another package replaces the process
+// default via [slog.SetDefault], LogError uses that logger instead.
 func LogError(ctx context.Context, msg string, args ...any) {
 	slog.ErrorContext(ctx, msg, args...)
 }
@@ -73,39 +80,70 @@ func String(key, value string) Attr {
 
 // LoggerParams declares the dependencies required by NewLogger.
 //
-// It is intended for Fx/Dig injection and includes service identity fields that
-// are attached as static attributes by most logger implementations.
+// It is intended for Fx/Dig injection. Stdout-oriented logger kinds attach the
+// identity fields as static slog attributes, while the OTLP logger kind maps
+// them into OpenTelemetry resource attributes.
 type LoggerParams struct {
 	di.In
 
-	// Lifecycle is used by some logger kinds (for example OTLP) to shut down
-	// exporters/providers on application stop.
+	// Lifecycle is used by logger kinds that need shutdown hooks.
+	//
+	// For example, the OTLP logger appends an OnStop hook that shuts down its
+	// OpenTelemetry logger provider and exporter.
 	Lifecycle di.Lifecycle
 
-	// Config enables logging when non-nil and selects the logger kind.
+	// Config enables logging when non-nil and selects the logger kind and level.
+	//
+	// A nil Config disables logging and causes NewLogger to return (nil, nil).
 	Config *Config
 
-	// ID is the host identifier typically attached as a static attribute (for example "id").
+	// ID identifies the host or instance emitting logs.
+	//
+	// Stdout-oriented logger kinds attach it as an "id" attribute. The OTLP
+	// logger uses it when constructing the OpenTelemetry resource.
 	ID env.ID
 
-	// Name is the service name typically attached as a static attribute (for example "name").
+	// Name identifies the service emitting logs.
+	//
+	// Stdout-oriented logger kinds attach it as a "name" attribute. The OTLP
+	// logger uses it when constructing the OpenTelemetry resource.
 	Name env.Name
 
-	// Version is the service version typically attached as a static attribute (for example "version").
+	// Version identifies the build or release version of the service.
+	//
+	// Stdout-oriented logger kinds attach it as a "version" attribute. The OTLP
+	// logger uses it when constructing the OpenTelemetry resource.
 	Version env.Version
 
-	// Environment is the deployment environment typically attached as a static attribute (for example "environment").
+	// Environment identifies the deployment environment for emitted logs.
+	//
+	// Stdout-oriented logger kinds attach it as an "environment" attribute. The
+	// OTLP logger uses it when constructing the OpenTelemetry resource.
 	Environment env.Environment
 }
 
-// NewLogger constructs the configured slog logger and installs it as the process-wide default.
+// NewLogger constructs the configured slog logger, installs it as the
+// process-wide default, and returns a wrapper with go-service logging helpers.
 //
-// When logging is enabled (params.Config != nil), NewLogger builds the configured logger,
-// installs it as the global default via slog.SetDefault, and returns a *Logger wrapper.
+// When params.Config is nil, logging is disabled and NewLogger returns (nil,
+// nil).
 //
-// If logging is disabled (params.Config == nil), NewLogger returns (nil, nil).
-// If Config.Kind is unknown, NewLogger returns ErrNotFound.
-// If Config.Level is set to an unsupported value, NewLogger returns ErrInvalidLevel.
+// When logging is enabled, NewLogger validates Config.Level, builds the
+// implementation selected by Config.Kind, installs it via [slog.SetDefault],
+// and returns a [Logger].
+//
+// Stdout-oriented logger kinds attach ID, Name, Version, and Environment as
+// static attributes on every log record. The "otlp" logger kind instead maps
+// those values to OpenTelemetry resource attributes, installs a global
+// OpenTelemetry logger provider, and registers shutdown hooks on
+// params.Lifecycle.
+//
+// NewLogger returns [ErrNotFound] when Config.Kind is unknown and
+// [ErrInvalidLevel] when Config.Level is unsupported.
+//
+// NewLogger may panic if the selected logger kind performs mandatory startup
+// wiring that fails. In particular, the "otlp" logger panics if its exporter
+// cannot be created.
 func NewLogger(params LoggerParams) (*Logger, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil
@@ -123,41 +161,97 @@ func NewLogger(params LoggerParams) (*Logger, error) {
 	return &Logger{logger}, nil
 }
 
-// Logger wraps slog.Logger and adds helpers that standardize contextual metadata and errors.
+// Logger wraps [slog.Logger] and adds go-service logging helpers.
 //
-// When logging via Log / LogAttrs, the logger appends:
+// The embedded slog.Logger remains available for native slog APIs. The helper
+// methods on Logger are nil-safe so callers can treat logging as optional when
+// Config is nil and dependency injection provides no logger.
+//
+// When logging via [Logger.Log] or [Logger.LogAttrs], the logger appends:
 //
 //   - metadata attributes extracted from the provided context (via Meta), and
 //   - an "error" attribute when the Message contains a non-nil error (via Error).
 //
-// This keeps log records consistent across handlers/exporters.
+// The pass-through severity helpers [Logger.Info], [Logger.Warn], and
+// [Logger.Error] keep slog semantics unchanged and do not add those extra
+// attributes automatically.
 type Logger struct {
 	*slog.Logger
 }
 
-// Log logs the Message at its derived level and appends context metadata.
+// Info logs at [LevelInfo].
 //
-// The level is derived from `msg.Level()`. Use `LogAttrs` when you need to override
-// the level explicitly.
+// It forwards msg and args to the embedded [slog.Logger] unchanged. It is a
+// no-op when l is nil.
+func (l *Logger) Info(msg string, args ...any) {
+	if l == nil {
+		return
+	}
+
+	l.Logger.Info(msg, args...)
+}
+
+// Error logs at [LevelError].
+//
+// It forwards msg and args to the embedded [slog.Logger] unchanged. It is a
+// no-op when l is nil.
+func (l *Logger) Error(msg string, args ...any) {
+	if l == nil {
+		return
+	}
+
+	l.Logger.Error(msg, args...)
+}
+
+// Warn logs at [LevelWarn].
+//
+// It forwards msg and args to the embedded [slog.Logger] unchanged. It is a
+// no-op when l is nil.
+func (l *Logger) Warn(msg string, args ...any) {
+	if l == nil {
+		return
+	}
+
+	l.Logger.Warn(msg, args...)
+}
+
+// Log logs msg.Text at the level derived from [Message.Level].
+//
+// It preserves the supplied attrs, then appends the output of [Meta] and the
+// standardized error attribute from [Error] before delegating to
+// [Logger.LogAttrs]. It is a no-op when l is nil.
+//
+// Use [Logger.LogAttrs] when you need to override the derived level
+// explicitly.
 func (l *Logger) Log(ctx context.Context, msg Message, attrs ...slog.Attr) {
+	if l == nil {
+		return
+	}
+
 	l.LogAttrs(ctx, msg.Level(), msg, attrs...)
 }
 
-// LogAttrs logs the Message at level and appends context metadata.
+// LogAttrs logs msg.Text at level and enriches the record with go-service
+// logging conventions.
 //
-// It appends `Meta(ctx)` and `Error(msg.Error)` to the provided attrs before
-// delegating to the underlying slog.Logger.
+// It preserves the supplied attrs, then appends the output of [Meta] and the
+// standardized error attribute from [Error] before delegating to the embedded
+// [slog.Logger]. It is a no-op when l is nil.
 func (l *Logger) LogAttrs(ctx context.Context, level slog.Level, msg Message, attrs ...slog.Attr) {
+	if l == nil {
+		return
+	}
+
 	attrs = append(attrs, Meta(ctx)...)
 	attrs = append(attrs, Error(msg.Error))
 
 	l.Logger.LogAttrs(ctx, level, msg.Text, attrs...)
 }
 
-// GetLogger returns the underlying slog.Logger.
+// GetLogger returns the embedded [slog.Logger].
 //
-// It returns nil if the receiver is nil, making it safe to call when logging is
-// disabled and a *Logger dependency was not provided.
+// It returns nil when l is nil, making it safe for adapters that accept an
+// optional [Logger] but need to work with a raw `*slog.Logger`.
 func (l *Logger) GetLogger() *slog.Logger {
 	if l == nil {
 		return nil

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -15,8 +15,14 @@ func TestLogger(t *testing.T) {
 	log, err := test.NewLogger(lc, test.NewTextLoggerConfig())
 	require.NoError(t, err)
 
-	log.Log(t.Context(), logger.NewText("test"), logger.Bool("yes", true))
-	log.Log(t.Context(), logger.NewMessage("test", context.Canceled), logger.Bool("yes", true))
+	require.NotPanics(t, func() {
+		log.Log(t.Context(), logger.NewText("test"), logger.Bool("yes", true))
+		log.Log(t.Context(), logger.NewMessage("test", context.Canceled), logger.Bool("yes", true))
+		log.LogAttrs(t.Context(), logger.LevelInfo, logger.NewMessage("test", context.Canceled), logger.Bool("yes", true))
+		log.Info("hello")
+		log.Warn("hello")
+		log.Error("hello")
+	})
 }
 
 func TestInvalidLogger(t *testing.T) {
@@ -31,13 +37,23 @@ func TestInvalidLogger(t *testing.T) {
 		Environment: test.Environment,
 	}
 
-	_, err := logger.NewLogger(params)
+	log, err := logger.NewLogger(params)
 	require.Error(t, err)
+	require.Nil(t, log)
+
+	require.NotPanics(t, func() {
+		log.Log(t.Context(), logger.NewText("test"), logger.Bool("yes", true))
+		log.Log(t.Context(), logger.NewMessage("test", context.Canceled), logger.Bool("yes", true))
+		log.LogAttrs(t.Context(), logger.LevelInfo, logger.NewMessage("test", context.Canceled), logger.Bool("yes", true))
+		log.Info("hello")
+		log.Warn("hello")
+		log.Error("hello")
+	})
 }
 
 func TestInvalidLevel(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
-	cfg := &logger.Config{Kind: "text", Level: "erorr"}
+	cfg := &logger.Config{Kind: "text", Level: "bob"}
 	params := logger.LoggerParams{
 		Lifecycle:   lc,
 		Config:      cfg,


### PR DESCRIPTION
## What

- Made `telemetry/logger.Logger` methods nil-safe, including `Info`, `Warn`, `Error`, `Log`, `LogAttrs`, and `GetLogger`.
- Simplified [service.go](/Users/alejandro/code/go-service/net/server/service.go) by removing the local logging guard helper and calling the logger directly.
- Updated the GoDoc in [logger.go](/Users/alejandro/code/go-service/telemetry/logger/logger.go) and [service.go](/Users/alejandro/code/go-service/net/server/service.go) so the comments accurately describe the current behavior.

## Why

- `*logger.Logger` is optional in some paths, so nil-safe logger methods make logging safer and easier to use.
- Moving nil handling into the logger keeps server lifecycle code smaller and avoids repeating wrapper logic.
- Clearer docs make the async startup, shutdown, and optional logging behavior easier to understand and maintain.

## Testing

- `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./telemetry/logger`
- `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./net/server`