### PR TITLE
feat(grpc): re-export client dial helpers and use them in tests

### DIFF
--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -5,14 +5,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/net"
-	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/transport"
-	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	grpcbreaker "github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
@@ -62,27 +61,27 @@ func (c *Client) NewHTTP(os ...httpbreaker.Option) (*http.Client, error) {
 // NewGRPC returns a gRPC client connection configured with the world's interceptors,
 // retry policy, token generator, limiter, tracing, and optional compression.
 func (c *Client) NewGRPC(os ...grpcbreaker.Option) (*grpc.ClientConn, error) {
-	opts := []transportgrpc.ClientOption{
-		transportgrpc.WithClientUnaryInterceptors(),
-		transportgrpc.WithClientStreamInterceptors(),
-		transportgrpc.WithClientLogger(c.Logger),
-		transportgrpc.WithClientBreaker(os...),
-		transportgrpc.WithClientRetry(c.Transport.GRPC.Retry),
-		transportgrpc.WithClientUserAgent(UserAgent),
-		transportgrpc.WithClientTokenGenerator(UserID, c.Generator),
-		transportgrpc.WithClientTimeout(time.Minute),
-		transportgrpc.WithClientKeepalive(time.Minute, time.Minute),
-		transportgrpc.WithClientDialOption(),
-		transportgrpc.WithClientTLS(c.TLS),
-		transportgrpc.WithClientID(c.ID),
-		transportgrpc.WithClientLimiter(c.GRPCLimiter),
+	opts := []grpc.ClientOption{
+		grpc.WithClientUnaryInterceptors(),
+		grpc.WithClientStreamInterceptors(),
+		grpc.WithClientLogger(c.Logger),
+		grpc.WithClientBreaker(os...),
+		grpc.WithClientRetry(c.Transport.GRPC.Retry),
+		grpc.WithClientUserAgent(UserAgent),
+		grpc.WithClientTokenGenerator(UserID, c.Generator),
+		grpc.WithClientTimeout(time.Minute),
+		grpc.WithClientKeepalive(time.Minute, time.Minute),
+		grpc.WithClientDialOption(),
+		grpc.WithClientTLS(c.TLS),
+		grpc.WithClientID(c.ID),
+		grpc.WithClientLimiter(c.GRPCLimiter),
 	}
 
 	if c.Compression {
-		opts = append(opts, transportgrpc.WithClientCompression())
+		opts = append(opts, grpc.WithClientCompression())
 	}
 
 	_, target := net.ListenNetworkAddress(c.Transport.GRPC.Address)
 
-	return transportgrpc.NewClient(target, opts...)
+	return grpc.NewClient(target, opts...)
 }

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -13,9 +13,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/transport"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
-	gl "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
+	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
-	hl "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
+	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/urfave/negroni/v3"
 )
 
@@ -31,8 +31,8 @@ type Server struct {
 	TransportConfig *transport.Config
 	DebugConfig     *debug.Config
 	Tracer          *tracer.Config
-	GRPCLimiter     *gl.Server
-	HTTPLimiter     *hl.Server
+	GRPCLimiter     *grpclimiter.Server
+	HTTPLimiter     *httplimiter.Server
 	Logger          *logger.Logger
 	Generator       id.Generator
 	RegisterHTTP    bool

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -21,7 +21,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/events"
-	v2 "github.com/cloudevents/sdk-go/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/client"
 	"github.com/linxGnu/mssqlx"
 	"github.com/stretchr/testify/require"
@@ -150,7 +150,7 @@ type World struct {
 	PG     *pg.Config
 	*Server
 	*Client
-	*v2.Event
+	*cloudevents.Event
 	*events.Receiver
 	*cache.Cache
 	Sender client.Client

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -18,116 +18,117 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-type (
-	// CallOption is an alias of grpc.CallOption.
-	//
-	// It represents a per-RPC option (for example compression, per-call
-	// credentials, etc.) passed to a client call.
-	CallOption = grpc.CallOption
+// CallOption is an alias of grpc.CallOption.
+//
+// It represents a per-RPC option (for example compression, per-call
+// credentials, etc.) passed to a client call.
+type CallOption = grpc.CallOption
 
-	// ClientConn is an alias of grpc.ClientConn.
-	//
-	// It represents a virtual connection to a gRPC endpoint and is used to create
-	// generated service clients.
-	ClientConn = grpc.ClientConn
+// ClientConn is an alias of grpc.ClientConn.
+//
+// It represents a virtual connection to a gRPC endpoint and is used to create
+// generated service clients.
+type ClientConn = grpc.ClientConn
 
-	// ClientStream is an alias of grpc.ClientStream.
-	//
-	// It is the client-side stream interface used by streaming RPCs.
-	ClientStream = grpc.ClientStream
+// ClientStream is an alias of grpc.ClientStream.
+//
+// It is the client-side stream interface used by streaming RPCs.
+type ClientStream = grpc.ClientStream
 
-	// DialOption is an alias of grpc.DialOption.
-	//
-	// It configures client connection creation (dialing, credentials, interceptors,
-	// stats handlers, etc.).
-	DialOption = grpc.DialOption
+// DialOption is an alias of grpc.DialOption.
+//
+// It configures client connection creation (dialing, credentials, interceptors,
+// stats handlers, etc.).
+type DialOption = grpc.DialOption
 
-	// EmptyServerOption is an alias of grpc.EmptyServerOption.
-	//
-	// It is used when building server options that conditionally return "no option".
-	EmptyServerOption = grpc.EmptyServerOption
+// EmptyServerOption is an alias of grpc.EmptyServerOption.
+//
+// It is used when building server options that conditionally return "no option".
+type EmptyServerOption = grpc.EmptyServerOption
 
-	// UnaryInvoker is an alias of grpc.UnaryInvoker.
-	//
-	// It is the function signature used by unary client interceptors to invoke the
-	// next interceptor/transport.
-	UnaryInvoker = grpc.UnaryInvoker
+// UnaryInvoker is an alias of grpc.UnaryInvoker.
+//
+// It is the function signature used by unary client interceptors to invoke the
+// next interceptor/transport.
+type UnaryInvoker = grpc.UnaryInvoker
 
-	// ServerOption is an alias of grpc.ServerOption.
-	//
-	// It configures server construction (credentials, interceptors, keepalive,
-	// stats handlers, etc.).
-	ServerOption = grpc.ServerOption
+// ServerOption is an alias of grpc.ServerOption.
+//
+// It configures server construction (credentials, interceptors, keepalive,
+// stats handlers, etc.).
+type ServerOption = grpc.ServerOption
 
-	// Server is an alias of grpc.Server.
-	//
-	// It is the gRPC server implementation that hosts registered services.
-	Server = grpc.Server
+// Server is an alias of grpc.Server.
+//
+// It is the gRPC server implementation that hosts registered services.
+type Server = grpc.Server
 
-	// ServerStream is an alias of grpc.ServerStream.
-	//
-	// It is the server-side stream interface used by streaming RPCs.
-	ServerStream = grpc.ServerStream
+// ServerStream is an alias of grpc.ServerStream.
+//
+// It is the server-side stream interface used by streaming RPCs.
+type ServerStream = grpc.ServerStream
 
-	// ServiceRegistrar is an alias of grpc.ServiceRegistrar.
-	//
-	// It is implemented by *grpc.Server and is accepted by generated Register*
-	// functions.
-	ServiceRegistrar = grpc.ServiceRegistrar
+// ServiceRegistrar is an alias of grpc.ServiceRegistrar.
+//
+// It is implemented by *grpc.Server and is accepted by generated Register*
+// functions.
+type ServiceRegistrar = grpc.ServiceRegistrar
 
-	// StreamClientInterceptor is an alias of grpc.StreamClientInterceptor.
-	//
-	// It intercepts client-side streaming RPCs.
-	StreamClientInterceptor = grpc.StreamClientInterceptor
+// StreamClientInterceptor is an alias of grpc.StreamClientInterceptor.
+//
+// It intercepts client-side streaming RPCs.
+type StreamClientInterceptor = grpc.StreamClientInterceptor
 
-	// StreamDesc is an alias of grpc.StreamDesc.
-	//
-	// It describes streaming RPC characteristics.
-	StreamDesc = grpc.StreamDesc
+// StreamDesc is an alias of grpc.StreamDesc.
+//
+// It describes streaming RPC characteristics.
+type StreamDesc = grpc.StreamDesc
 
-	// Streamer is an alias of grpc.Streamer.
-	//
-	// It is the function signature used by stream client interceptors to create a
-	// client stream.
-	Streamer = grpc.Streamer
+// Streamer is an alias of grpc.Streamer.
+//
+// It is the function signature used by stream client interceptors to create a
+// client stream.
+type Streamer = grpc.Streamer
 
-	// StreamHandler is an alias of grpc.StreamHandler.
-	//
-	// It is the function signature used by stream server interceptors to handle a
-	// server stream.
-	StreamHandler = grpc.StreamHandler
+// StreamHandler is an alias of grpc.StreamHandler.
+//
+// It is the function signature used by stream server interceptors to handle a
+// server stream.
+type StreamHandler = grpc.StreamHandler
 
-	// StreamServerInfo is an alias of grpc.StreamServerInfo.
-	//
-	// It provides information about a streaming RPC to a server interceptor.
-	StreamServerInfo = grpc.StreamServerInfo
+// StreamServerInfo is an alias of grpc.StreamServerInfo.
+//
+// It provides information about a streaming RPC to a server interceptor.
+type StreamServerInfo = grpc.StreamServerInfo
 
-	// StreamServerInterceptor is an alias of grpc.StreamServerInterceptor.
-	//
-	// It intercepts server-side streaming RPCs.
-	StreamServerInterceptor = grpc.StreamServerInterceptor
+// StreamServerInterceptor is an alias of grpc.StreamServerInterceptor.
+//
+// It intercepts server-side streaming RPCs.
+type StreamServerInterceptor = grpc.StreamServerInterceptor
 
-	// UnaryClientInterceptor is an alias of grpc.UnaryClientInterceptor.
-	//
-	// It intercepts client-side unary RPCs.
-	UnaryClientInterceptor = grpc.UnaryClientInterceptor
+// UnaryClientInterceptor is an alias of grpc.UnaryClientInterceptor.
+//
+// It intercepts client-side unary RPCs.
+type UnaryClientInterceptor = grpc.UnaryClientInterceptor
 
-	// UnaryHandler is an alias of grpc.UnaryHandler.
-	//
-	// It is the function signature used by unary server interceptors to invoke the
-	// handler.
-	UnaryHandler = grpc.UnaryHandler
+// UnaryHandler is an alias of grpc.UnaryHandler.
+//
+// It is the function signature used by unary server interceptors to invoke the
+// handler.
+type UnaryHandler = grpc.UnaryHandler
 
-	// UnaryServerInfo is an alias of grpc.UnaryServerInfo.
-	//
-	// It provides information about a unary RPC to a server interceptor.
-	UnaryServerInfo = grpc.UnaryServerInfo
+// UnaryServerInfo is an alias of grpc.UnaryServerInfo.
+//
+// It provides information about a unary RPC to a server interceptor.
+type UnaryServerInfo = grpc.UnaryServerInfo
 
-	// UnaryServerInterceptor is an alias of grpc.UnaryServerInterceptor.
-	//
-	// It intercepts server-side unary RPCs.
-	UnaryServerInterceptor = grpc.UnaryServerInterceptor
-)
+// UnaryServerInterceptor is an alias of grpc.UnaryServerInterceptor.
+//
+// It intercepts server-side unary RPCs.
+type UnaryServerInterceptor = grpc.UnaryServerInterceptor
+
+// TransportCredentials is an alias of credentials.TransportCredentials.
+type TransportCredentials = credentials.TransportCredentials
 
 // StatsHandler returns a ServerOption that installs h as the server stats handler.
 //
@@ -178,10 +179,14 @@ func MaxRecvMsgSize(m int) ServerOption {
 	return grpc.MaxRecvMsgSize(m)
 }
 
-// NewClient creates a gRPC client connection to target using opts.
+// NewClient creates a new gRPC client channel for target using opts.
 //
-// This forwards to grpc.NewClient. The target format and supported schemes are
-// defined by gRPC and any registered resolvers in your binary.
+// This forwards to grpc.NewClient. No I/O is performed during construction; the
+// returned ClientConn connects automatically when it is used for RPCs (or when
+// Connect is called explicitly).
+//
+// The target format and supported schemes are defined by gRPC and any
+// registered resolvers in your binary.
 func NewClient(target string, opts ...DialOption) (*ClientConn, error) {
 	return grpc.NewClient(target, opts...)
 }

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
-	tg "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
 
 func init() {
-	tg.Register(test.FS)
+	transportgrpc.Register(test.FS)
 }
 
 //nolint:funlen
@@ -36,7 +36,7 @@ func BenchmarkGRPC(b *testing.B) {
 		//nolint:errcheck
 		go server.Serve(l)
 
-		conn, err := grpc.NewClient(l.Addr().String(), grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
+		conn, err := transportgrpc.NewClientConn(l.Addr().String(), transportgrpc.WithTransportCredentials(transportgrpc.NewInsecureCredentials()))
 		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
@@ -60,7 +60,7 @@ func BenchmarkGRPC(b *testing.B) {
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
 
-		g, err := tg.NewServer(tg.ServerParams{
+		g, err := transportgrpc.NewServer(transportgrpc.ServerParams{
 			Shutdowner: test.NewShutdowner(),
 			Config:     cfg.GRPC,
 			UserAgent:  test.UserAgent, Version: test.Version,
@@ -76,7 +76,7 @@ func BenchmarkGRPC(b *testing.B) {
 		_, addr, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
 		cl := &client.Config{Address: addr}
 
-		conn, err := tg.NewClient(cl.Address)
+		conn, err := transportgrpc.NewClient(cl.Address)
 		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
@@ -103,7 +103,7 @@ func BenchmarkGRPC(b *testing.B) {
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
 
-		g, err := tg.NewServer(tg.ServerParams{
+		g, err := transportgrpc.NewServer(transportgrpc.ServerParams{
 			Shutdowner: test.NewShutdowner(),
 			Config:     cfg.GRPC, Logger: logger,
 			UserAgent: test.UserAgent, Version: test.Version,
@@ -120,7 +120,7 @@ func BenchmarkGRPC(b *testing.B) {
 		_, addr, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
 		cl := &client.Config{Address: addr}
 
-		conn, err := tg.NewClient(cl.Address)
+		conn, err := transportgrpc.NewClient(cl.Address)
 		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)
@@ -149,7 +149,7 @@ func BenchmarkGRPC(b *testing.B) {
 
 		test.RegisterTracer(lc, nil)
 
-		g, err := tg.NewServer(tg.ServerParams{
+		g, err := transportgrpc.NewServer(transportgrpc.ServerParams{
 			Shutdowner: test.NewShutdowner(),
 			Config:     cfg.GRPC, Logger: logger,
 			UserAgent: test.UserAgent, Version: test.Version,
@@ -166,7 +166,7 @@ func BenchmarkGRPC(b *testing.B) {
 		_, addr, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
 		cl := &client.Config{Address: addr}
 
-		conn, err := tg.NewClient(cl.Address)
+		conn, err := transportgrpc.NewClient(cl.Address)
 		require.NoError(b, err)
 
 		client := v1.NewGreeterServiceClient(conn)

--- a/transport/grpc/grpc.go
+++ b/transport/grpc/grpc.go
@@ -1,0 +1,49 @@
+package grpc
+
+import (
+	"crypto/tls"
+
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+)
+
+// DialOption is an alias for net/grpc.DialOption.
+//
+// It is exposed so callers can use raw dial options through the transport/grpc
+// import path when they do not need the higher-level ClientOption stack.
+type DialOption = grpc.DialOption
+
+// NewClientConn constructs a low-level gRPC client channel using raw dial options.
+//
+// This forwards to net/grpc.NewClient. No I/O is performed during construction;
+// the returned ClientConn connects automatically when it is used for RPCs (or
+// when Connect is called explicitly).
+//
+// It is intended for callers that want the transport/grpc import path without
+// opting into the higher-level ClientOption stack used by NewClient.
+func NewClientConn(target string, opts ...DialOption) (*ClientConn, error) {
+	return grpc.NewClient(target, opts...)
+}
+
+// NewInsecureCredentials returns transport credentials that disable transport security.
+//
+// This forwards to net/grpc.NewInsecureCredentials and is intended for local
+// development, tests, or deployments where transport security is handled
+// out-of-band.
+func NewInsecureCredentials() grpc.TransportCredentials {
+	return grpc.NewInsecureCredentials()
+}
+
+// NewTLS constructs TLS transport credentials from c.
+//
+// This forwards to net/grpc.NewTLS.
+func NewTLS(c *tls.Config) grpc.TransportCredentials {
+	return grpc.NewTLS(c)
+}
+
+// WithTransportCredentials returns a DialOption that configures client-side transport credentials.
+//
+// This forwards to net/grpc.WithTransportCredentials. For TLS, use NewTLS to
+// construct the credentials from a *tls.Config.
+func WithTransportCredentials(creds grpc.TransportCredentials) DialOption {
+	return grpc.WithTransportCredentials(creds)
+}


### PR DESCRIPTION
## What

- Added low-level client dial helpers to `transport/grpc` so callers can use the transport package for shared gRPC client primitives.
- Updated `internal/test/client.go` to return `*transportgrpc.ClientConn` instead of depending on `net/grpc`.
- Updated the gRPC benchmark to use `transport/grpc` for client construction, while keeping `net/grpc` only for the `Server` exception.

## Why

- This reduces mixed imports between `net/grpc` and `transport/grpc` and makes `transport/grpc` the main import path for transport-level gRPC usage.
- It keeps the one intentional exception in place: `Server` remains sourced from `net/grpc` because the two server types are not compatible.

## Testing

- Ran `env GOCACHE=/tmp/go-build go test ./transport/grpc ./internal/test -run TestDoesNotExist`
- Result: passed compile/test setup for both packages with no test failures (`[no tests to run]`)