### PR TITLE
feat(timer): add marshalable duration type and migrate typed config timeouts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - nonamedreturns
     - noinlineerr
     - paralleltest
+    - recvcheck
     - revive
     - tagalign
     - tagliatelle

--- a/breaker/breaker.go
+++ b/breaker/breaker.go
@@ -47,8 +47,8 @@ type Settings = breaker.Settings
 //   - Settings.IsSuccessful to classify which errors should count as failures
 var DefaultSettings = Settings{
 	MaxRequests: 3,
-	Interval:    30 * time.Second,
-	Timeout:     10 * time.Second,
+	Interval:    (30 * time.Second).Duration(),
+	Timeout:     (10 * time.Second).Duration(),
 	ReadyToTrip: func(counts breaker.Counts) bool {
 		return counts.ConsecutiveFailures >= 5
 	},

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -127,7 +127,7 @@ func (c *Cache) Persist(_ context.Context, key string, value any, ttl time.Durat
 		return err
 	}
 
-	return c.driver.Save(key, enc, ttl)
+	return c.driver.Save(key, enc, ttl.Duration())
 }
 
 func (c *Cache) encode(value any) (string, error) {

--- a/config/client/config.go
+++ b/config/client/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/limiter"
 	"github.com/alexfalkowski/go-service/v2/retry"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
 )
 
@@ -28,8 +29,10 @@ type Config struct {
 	// Address is the remote address for the client to connect to (for example "host:port").
 	Address string `yaml:"address,omitempty" json:"address,omitempty" toml:"address,omitempty"`
 
-	// Timeout is the client request timeout duration, encoded as a Go duration string (for example "30s", "5m").
-	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	// Timeout is the client request timeout duration.
+	//
+	// In config files it is encoded as a Go duration string (for example "30s", "5m").
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
 }
 
 // IsEnabled reports whether client configuration is present.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -241,7 +242,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "file:../test/secrets/pg", config.SQL.PG.Slaves[0].URL)
 	require.Equal(t, 5, config.SQL.PG.MaxIdleConns)
 	require.Equal(t, 5, config.SQL.PG.MaxOpenConns)
-	require.Equal(t, "1h", config.SQL.PG.ConnMaxLifetime)
+	require.Equal(t, time.Hour, config.SQL.PG.ConnMaxLifetime)
 	require.Equal(t, "text", config.Telemetry.Logger.Kind)
 	require.Equal(t, "info", config.Telemetry.Logger.Level)
 	require.Equal(t, "prometheus", config.Telemetry.Metrics.Kind)
@@ -252,7 +253,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.True(t, config.Transport.GRPC.Token.IsEnabled())
 	require.Equal(t, "../test/configs/rbac.csv", config.Transport.GRPC.Token.Access.Policy)
 	require.Equal(t, "jwt", config.Transport.GRPC.Token.Kind)
-	require.Equal(t, "1h", config.Transport.GRPC.Token.JWT.Expiration)
+	require.Equal(t, time.Hour, config.Transport.GRPC.Token.JWT.Expiration)
 	require.Equal(t, "iss", config.Transport.GRPC.Token.JWT.Issuer)
 	require.Equal(t, "1234567890", config.Transport.GRPC.Token.JWT.KeyID)
 	require.True(t, config.Transport.GRPC.Config.IsEnabled())
@@ -260,7 +261,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, int64(3145728), config.Transport.GRPC.MaxReceiveBytes)
 	require.Equal(t, "user-agent", config.Transport.GRPC.Limiter.Kind)
 	require.Equal(t, 10, int(config.Transport.GRPC.Limiter.Tokens))
-	require.Equal(t, "1s", config.Transport.GRPC.Limiter.Interval)
+	require.Equal(t, time.Second, config.Transport.GRPC.Limiter.Interval)
 	require.Equal(t,
 		options.Map{
 			"keepalive_enforcement_policy_ping_min_time": "10s",
@@ -272,12 +273,12 @@ func verifyConfig(t *testing.T, config *config.Config) {
 		config.Transport.GRPC.Options,
 	)
 	require.Equal(t, 3, int(config.Transport.GRPC.Retry.Attempts))
-	require.Equal(t, "1s", config.Transport.GRPC.Retry.Timeout)
+	require.Equal(t, time.Second, config.Transport.GRPC.Retry.Timeout)
 	require.False(t, config.Transport.GRPC.TLS.IsEnabled())
 	require.True(t, config.Transport.HTTP.Token.IsEnabled())
 	require.Equal(t, "../test/configs/rbac.csv", config.Transport.HTTP.Token.Access.Policy)
 	require.Equal(t, "jwt", config.Transport.HTTP.Token.Kind)
-	require.Equal(t, "1h", config.Transport.HTTP.Token.JWT.Expiration)
+	require.Equal(t, time.Hour, config.Transport.HTTP.Token.JWT.Expiration)
 	require.Equal(t, "iss", config.Transport.HTTP.Token.JWT.Issuer)
 	require.Equal(t, "1234567890", config.Transport.HTTP.Token.JWT.KeyID)
 	require.True(t, config.Transport.HTTP.Config.IsEnabled())
@@ -285,7 +286,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, int64(2097152), config.Transport.HTTP.MaxReceiveBytes)
 	require.Equal(t, "user-agent", config.Transport.HTTP.Limiter.Kind)
 	require.Equal(t, 10, int(config.Transport.HTTP.Limiter.Tokens))
-	require.Equal(t, "1s", config.Transport.HTTP.Limiter.Interval)
+	require.Equal(t, time.Second, config.Transport.HTTP.Limiter.Interval)
 	require.Equal(t,
 		options.Map{
 			"read_timeout":        "10s",
@@ -296,6 +297,6 @@ func verifyConfig(t *testing.T, config *config.Config) {
 		config.Transport.HTTP.Options,
 	)
 	require.Equal(t, 3, int(config.Transport.HTTP.Retry.Attempts))
-	require.Equal(t, "1s", config.Transport.HTTP.Retry.Timeout)
+	require.Equal(t, time.Second, config.Transport.HTTP.Retry.Timeout)
 	require.False(t, config.Transport.HTTP.TLS.IsEnabled())
 }

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/limiter"
 	"github.com/alexfalkowski/go-service/v2/retry"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
 )
 
@@ -28,11 +29,13 @@ type Config struct {
 	// Options provides transport/server-specific options as key-value pairs.
 	Options options.Map `yaml:"options,omitempty" json:"options,omitempty" toml:"options,omitempty"`
 
-	// Timeout is the server request timeout duration, encoded as a Go duration string (for example "30s", "5m").
-	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
-
 	// Address is the bind address for the server (for example ":8080").
 	Address string `yaml:"address,omitempty" json:"address,omitempty" toml:"address,omitempty"`
+
+	// Timeout is the server request timeout duration.
+	//
+	// In config files it is encoded as a Go duration string (for example "30s", "5m").
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
 
 	// MaxReceiveBytes limits inbound request payload size in bytes.
 	//

--- a/context/context.go
+++ b/context/context.go
@@ -65,7 +65,7 @@ func WithDeadline(parent Context, d time.Time) (Context, CancelFunc) {
 // This is a thin wrapper around context.WithTimeout. The returned CancelFunc should be called to release
 // resources associated with the derived context.
 func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
-	return context.WithTimeout(parent, timeout)
+	return context.WithTimeout(parent, timeout.Duration())
 }
 
 // WithoutCancel returns a copy of parent that is not canceled when parent is canceled.

--- a/database/sql/config/config.go
+++ b/database/sql/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/alexfalkowski/go-service/v2/os"
+import (
+	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
 
 // Config contains shared `database/sql` connection pool configuration.
 //
@@ -10,13 +13,6 @@ import "github.com/alexfalkowski/go-service/v2/os"
 // Masters and Slaves contain DSNs (connection strings) expressed as go-service "source strings"
 // (literal values, `file:` paths, or `env:` references) that are resolved by `os.FS.ReadSource`.
 type Config struct {
-	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
-	//
-	// The value is parsed as a Go duration string (for example "30s", "5m", "1h").
-	// Wiring that consumes this field typically parses it using time.ParseDuration semantics and may
-	// treat parsing failures as fatal configuration errors.
-	ConnMaxLifetime string `yaml:"conn_max_lifetime,omitempty" json:"conn_max_lifetime,omitempty" toml:"conn_max_lifetime,omitempty"`
-
 	// Masters is the set of primary (read-write) datasource DSNs.
 	//
 	// Each DSN URL is a "source string" resolved via `os.FS.ReadSource`, so it can be:
@@ -29,6 +25,11 @@ type Config struct {
 	//
 	// Each DSN URL is a "source string" resolved via `os.FS.ReadSource` (see Masters for the supported formats).
 	Slaves []DSN `yaml:"slaves,omitempty" json:"slaves,omitempty" toml:"slaves,omitempty"`
+
+	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
+	//
+	// In config files it is encoded as a Go duration string (for example "30s", "5m", "1h").
+	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime,omitempty" json:"conn_max_lifetime,omitempty" toml:"conn_max_lifetime,omitempty"`
 
 	// MaxOpenConns is the maximum number of open connections to the database.
 	MaxOpenConns int `yaml:"max_open_conns,omitempty" json:"max_open_conns,omitempty" toml:"max_open_conns,omitempty"`

--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/jmoiron/sqlx"
 	"github.com/linxGnu/mssqlx"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -61,8 +60,7 @@ func Register(name string, driver Driver) (err error) {
 //
 // Failure behavior:
 //   - returns errors encountered while resolving DSNs or connecting, and
-//   - returns ErrNoDSNs when neither masters nor slaves are configured, and
-//   - panics if ConnMaxLifetime cannot be parsed, because it uses time.MustParseDuration.
+//   - returns ErrNoDSNs when neither masters nor slaves are configured.
 func Connect(name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 	masters := make([]string, len(cfg.Masters))
 
@@ -91,9 +89,7 @@ func Connect(name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 		return nil, err
 	}
 
-	d := time.MustParseDuration(cfg.ConnMaxLifetime)
-
-	db.SetConnMaxLifetime(d)
+	db.SetConnMaxLifetime(cfg.ConnMaxLifetime.Duration())
 	db.SetMaxIdleConns(cfg.MaxIdleConns)
 	db.SetMaxOpenConns(cfg.MaxOpenConns)
 

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -63,7 +63,7 @@ func TestInvalidOpen(t *testing.T) {
 					Slaves:          []config.DSN{{URL: test.FilePath("secrets/pg")}},
 					MaxOpenConns:    5,
 					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour.String(),
+					ConnMaxLifetime: time.Hour,
 				},
 			},
 			wantErr: fs.ErrNotExist,
@@ -76,7 +76,7 @@ func TestInvalidOpen(t *testing.T) {
 					Slaves:          []config.DSN{{URL: test.FilePath("secrets/none")}},
 					MaxOpenConns:    5,
 					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour.String(),
+					ConnMaxLifetime: time.Hour,
 				},
 			},
 			wantErr: fs.ErrNotExist,
@@ -87,7 +87,7 @@ func TestInvalidOpen(t *testing.T) {
 				Config: &config.Config{
 					MaxOpenConns:    5,
 					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour.String(),
+					ConnMaxLifetime: time.Hour,
 				},
 			},
 			wantErr: driver.ErrNoDSNs,
@@ -335,7 +335,7 @@ func TestInvalidSQLPort(t *testing.T) {
 		Slaves:          []config.DSN{{URL: test.FilePath("secrets/pg_invalid")}},
 		MaxOpenConns:    5,
 		MaxIdleConns:    5,
-		ConnMaxLifetime: time.Hour.String(),
+		ConnMaxLifetime: time.Hour,
 	}}
 
 	lc := fxtest.NewLifecycle(t)

--- a/debug/server.go
+++ b/debug/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
-	"github.com/alexfalkowski/go-service/v2/time"
 )
 
 // ServerParams defines dependencies for constructing the debug server.
@@ -41,13 +40,11 @@ type ServerParams struct {
 // Disabled behavior: if params.Config is nil/disabled, NewServer returns (nil, nil).
 //
 // Enabled behavior:
-//   - parses the configured timeout,
-//   - constructs an HTTP server using the debug mux,
+//   - constructs an HTTP server using the configured timeout and debug mux,
 //   - builds the net/http server config (address and optional TLS), and
 //   - wraps it in a managed service ("debug") that integrates with DI lifecycle/shutdown.
 //
 // Failure behavior:
-//   - invalid timeout configuration panics via time.MustParseDuration,
 //   - TLS configuration errors (when TLS is enabled) are returned, and
 //   - underlying service construction errors are returned.
 //
@@ -59,8 +56,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, nil
 	}
 
-	timeout := time.MustParseDuration(params.Config.Timeout)
-	httpServer := http.NewServer(params.Config.Options, timeout, params.Mux)
+	httpServer := http.NewServer(params.Config.Options, params.Config.Timeout, params.Mux)
 
 	cfg, err := newConfig(params.FS, params.Config)
 	if err != nil {

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/debug"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,7 +53,7 @@ func TestSecureDebug(t *testing.T) {
 func TestInvalidServer(t *testing.T) {
 	cfg := &debug.Config{
 		Config: &server.Config{
-			Timeout: "5s",
+			Timeout: 5 * time.Second,
 			TLS:     test.NewTLSConfig("certs/client-cert.pem", "secrets/none"),
 		},
 	}

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -2,12 +2,12 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alexfalkowski/go-service/v2/cache"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/strings"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"time"
-
 	cache "github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/config"
 	"github.com/alexfalkowski/go-service/v2/config/options"
@@ -23,6 +21,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/token/jwt"
@@ -72,12 +71,12 @@ func NewToken(kind string) *token.Config {
 		Kind: kind,
 		JWT: &jwt.Config{
 			Issuer:     "iss",
-			Expiration: "1h",
+			Expiration: time.Hour,
 			KeyID:      "1234567890",
 		},
 		Paseto: &paseto.Config{
 			Issuer:     "iss",
-			Expiration: "1h",
+			Expiration: time.Hour,
 		},
 		SSH: &ssh.Config{
 			Key: &ssh.Key{
@@ -134,8 +133,8 @@ func NewHook() *hooks.Config {
 // NewRetry returns a short retry policy suitable for deterministic tests.
 func NewRetry() *retry.Config {
 	return &retry.Config{
-		Timeout:  timeout.String(),
-		Backoff:  "100ms",
+		Timeout:  timeout,
+		Backoff:  100 * time.Millisecond,
 		Attempts: 1,
 	}
 }
@@ -170,14 +169,14 @@ func NewInsecureTransportConfig() *transport.Config {
 	return &transport.Config{
 		HTTP: &http.Config{
 			Config: &server.Config{
-				Timeout: timeout.String(),
+				Timeout: timeout,
 				Address: RandomAddress(),
 				Retry:   NewRetry(),
 			},
 		},
 		GRPC: &grpc.Config{
 			Config: &server.Config{
-				Timeout: timeout.String(),
+				Timeout: timeout,
 				Address: RandomAddress(),
 				Retry:   NewRetry(),
 			},
@@ -203,7 +202,7 @@ func NewSecureTransportConfig() *transport.Config {
 	return &transport.Config{
 		HTTP: &http.Config{
 			Config: &server.Config{
-				Timeout: timeout.String(),
+				Timeout: timeout,
 				TLS:     config,
 				Address: RandomAddress(),
 				Retry:   retry,
@@ -211,7 +210,7 @@ func NewSecureTransportConfig() *transport.Config {
 		},
 		GRPC: &grpc.Config{
 			Config: &server.Config{
-				Timeout: timeout.String(),
+				Timeout: timeout,
 				TLS:     config,
 				Address: RandomAddress(),
 				Retry:   retry,
@@ -293,7 +292,7 @@ func NewPGConfig() *pg.Config {
 			Slaves:          []sql.DSN{{URL: FilePath("secrets/pg")}},
 			MaxOpenConns:    5,
 			MaxIdleConns:    5,
-			ConnMaxLifetime: time.Hour.String(),
+			ConnMaxLifetime: time.Hour,
 		},
 	}
 }
@@ -302,7 +301,7 @@ func NewPGConfig() *pg.Config {
 func NewInsecureDebugConfig() *debug.Config {
 	return &debug.Config{
 		Config: &server.Config{
-			Timeout: "5s",
+			Timeout: 5 * time.Second,
 			Address: RandomAddress(),
 			Retry:   NewRetry(),
 		},
@@ -313,7 +312,7 @@ func NewInsecureDebugConfig() *debug.Config {
 func NewSecureDebugConfig() *debug.Config {
 	return &debug.Config{
 		Config: &server.Config{
-			Timeout: "5s",
+			Timeout: 5 * time.Second,
 			TLS:     NewTLSServerConfig(),
 			Address: RandomAddress(),
 			Retry:   NewRetry(),
@@ -336,7 +335,7 @@ func NewCacheConfig(kind, compressor, encoder, secret string) *cache.Config {
 func NewLimiterConfig(kind, interval string, tokens uint64) *limiter.Config {
 	return &limiter.Config{
 		Kind:     kind,
-		Interval: interval,
+		Interval: time.MustParseDuration(interval),
 		Tokens:   tokens,
 	}
 }

--- a/internal/test/connect.go
+++ b/internal/test/connect.go
@@ -12,7 +12,7 @@ import (
 func Connect(ctx context.Context, address string) (net.Conn, error) {
 	network, addr := net.ListenNetworkAddress(address)
 	dialer := &net.Dialer{}
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(time.Second.Duration())
 	var err error
 
 	for time.Now().Before(deadline) {

--- a/internal/test/di.go
+++ b/internal/test/di.go
@@ -59,16 +59,16 @@ func registrations(logger *logger.Logger, cfg *http.Config, ua env.UserAgent, _ 
 
 	timeout := 5 * time.Second
 	nc := checker.NewNoopChecker()
-	nr := server.NewRegistration("noop", timeout, nc)
+	nr := server.NewRegistration("noop", timeout.Duration(), nc)
 	rt, err := http.NewRoundTripper(http.WithClientLogger(logger), http.WithClientUserAgent(ua))
 	if err != nil {
 		return nil, err
 	}
 
-	hc := checker.NewHTTPChecker(StatusURL("200"), timeout, checker.WithRoundTripper(rt))
-	hr := server.NewRegistration("http", timeout, hc)
+	hc := checker.NewHTTPChecker(StatusURL("200"), timeout.Duration(), checker.WithRoundTripper(rt))
+	hr := server.NewRegistration("http", timeout.Duration(), hc)
 
-	return health.Registrations{nr, hr, server.NewOnlineRegistration(timeout, timeout)}, nil
+	return health.Registrations{nr, hr, server.NewOnlineRegistration(timeout.Duration(), timeout.Duration())}, nil
 }
 
 func healthRegister(cfg *http.Config, name env.Name, server *server.Server, regs health.Registrations) {

--- a/internal/test/health.go
+++ b/internal/test/health.go
@@ -63,16 +63,16 @@ func (w *World) RegisterGRPCHealth(name, url string, observations ...HealthObser
 // the server and then hit the generated HTTP health endpoints through RegisterHealth.
 func (w *World) HealthServer(name, url string) *server.Server {
 	t := w.httpClient.Transport
-	cc := checker.NewHTTPChecker(url, 5*time.Second, checker.WithRoundTripper(t))
-	hr := server.NewRegistration("http", 10*time.Millisecond, cc)
+	cc := checker.NewHTTPChecker(url, (5 * time.Second).Duration(), checker.WithRoundTripper(t))
+	hr := server.NewRegistration("http", (10 * time.Millisecond).Duration(), cc)
 
 	no := checker.NewNoopChecker()
-	nr := server.NewRegistration("noop", 10*time.Millisecond, no)
+	nr := server.NewRegistration("noop", (10 * time.Millisecond).Duration(), no)
 
 	regs := health.Registrations{hr, nr}
 	if w.DB != nil {
 		dc := hc.NewDBChecker(w.DB, 1*time.Second)
-		dr := server.NewRegistration("db", 10*time.Millisecond, dc)
+		dr := server.NewRegistration("db", (10 * time.Millisecond).Duration(), dc)
 		regs = append(regs, dr)
 	}
 

--- a/limiter/config.go
+++ b/limiter/config.go
@@ -1,5 +1,7 @@
 package limiter
 
+import "github.com/alexfalkowski/go-service/v2/time"
+
 // Config configures the in-memory rate limiter.
 //
 // The limiter is typically constructed by `NewLimiter`, which interprets these fields as:
@@ -7,8 +9,8 @@ package limiter
 //   - Kind: selects how request keys are derived from context metadata (see NewKeyMap for default kinds).
 //     Examples: "user-agent", "ip", "token".
 //
-//   - Interval: a Go duration string (e.g. "1s", "1m") defining the refill/measurement window used by the
-//     underlying token bucket store.
+//   - Interval: a typed duration encoded as a Go duration string (e.g. "1s", "1m")
+//     defining the refill/measurement window used by the underlying token bucket store.
 //
 //   - Tokens: the maximum number of tokens available per Interval for a given key.
 //
@@ -22,11 +24,10 @@ type Config struct {
 	// If Kind is not present in the KeyMap passed to NewLimiter, NewLimiter returns ErrMissingKey.
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
 
-	// Interval is a Go duration string (for example "1s" or "1m") that defines the refill window.
+	// Interval is a typed duration that defines the refill window.
 	//
-	// NewLimiter parses this value using time.MustParseDuration; invalid values will panic during
-	// limiter construction.
-	Interval string `yaml:"interval,omitempty" json:"interval,omitempty" toml:"interval,omitempty"`
+	// In config files it is encoded as a Go duration string, for example "1s" or "1m".
+	Interval time.Duration `yaml:"interval,omitempty" json:"interval,omitempty" toml:"interval,omitempty"`
 
 	// Tokens is the maximum number of tokens available per interval, per derived key.
 	//

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -57,7 +57,7 @@ var ErrMissingKey = errors.New("limiter: missing key")
 //   - Returns ErrMissingKey when cfg.Kind is not present in keys.
 //
 // Notes:
-//   - cfg.Interval is parsed using time.MustParseDuration and will panic if invalid.
+//   - cfg.Interval is used directly as a typed duration decoded from config.
 //   - The underlying store constructor currently does not return an error (it is ignored).
 func NewLimiter(lc di.Lifecycle, keys KeyMap, cfg *Config) (*Limiter, error) {
 	if !cfg.IsEnabled() {
@@ -69,12 +69,11 @@ func NewLimiter(lc di.Lifecycle, keys KeyMap, cfg *Config) (*Limiter, error) {
 		return nil, ErrMissingKey
 	}
 
-	interval := time.MustParseDuration(cfg.Interval)
 	config := &memorystore.Config{
 		Tokens:        cfg.Tokens,
-		Interval:      interval,
-		SweepMinTTL:   time.Hour,
-		SweepInterval: time.Hour,
+		Interval:      cfg.Interval.Duration(),
+		SweepMinTTL:   time.Hour.Duration(),
+		SweepInterval: time.Hour.Duration(),
 	}
 	store, _ := memorystore.New(config)
 	limiter := &Limiter{store: store, key: k}

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/limiter"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -12,7 +13,7 @@ import (
 func TestValidLimiter(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
-	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: "1s"}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
 
 	limiter, err := limiter.NewLimiter(lc, m, config)
 	require.NoError(t, err)
@@ -24,7 +25,7 @@ func TestValidLimiter(t *testing.T) {
 func TestMissingLimiter(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{}
-	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: "1s"}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
 
 	_, err := limiter.NewLimiter(lc, m, config)
 	require.Error(t, err)
@@ -42,7 +43,7 @@ func TestDisabledLimiter(t *testing.T) {
 func TestClosedLimiter(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
-	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: "1s"}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
 
 	limiter, err := limiter.NewLimiter(lc, m, config)
 	require.NoError(t, err)

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -220,7 +220,7 @@ func SetHeader(ctx context.Context, md metadata.MD) error {
 // This forwards to timeout.UnaryClientInterceptor from go-grpc-middleware.
 // The interceptor typically wraps the outgoing context with a deadline of d.
 func TimeoutUnaryClientInterceptor(d time.Duration) grpc.UnaryClientInterceptor {
-	return timeout.UnaryClientInterceptor(d)
+	return timeout.UnaryClientInterceptor(d.Duration())
 }
 
 // UseCompressor returns a CallOption that requests message compression by name.
@@ -285,8 +285,8 @@ func WithTransportCredentials(creds credentials.TransportCredentials) DialOption
 // so that the client may send pings even when there are no active RPC streams.
 func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 	return grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time:                ping,
-		Timeout:             timeout,
+		Time:                ping.Duration(),
+		Timeout:             timeout.Duration(),
 		PermitWithoutStream: true,
 	})
 }
@@ -312,15 +312,15 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption) *Server {
 	os := make([]ServerOption, 0, 2+len(opts))
 	os = append(os, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-		MinTime:             options.Duration("keepalive_enforcement_policy_ping_min_time", timeout),
+		MinTime:             options.Duration("keepalive_enforcement_policy_ping_min_time", timeout).Duration(),
 		PermitWithoutStream: true,
 	}))
 	os = append(os, grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionIdle:     options.Duration("keepalive_max_connection_idle", timeout),
-		MaxConnectionAge:      options.Duration("keepalive_max_connection_age", timeout),
-		MaxConnectionAgeGrace: options.Duration("keepalive_max_connection_age_grace", timeout),
-		Time:                  options.Duration("keepalive_ping_time", timeout),
-		Timeout:               timeout,
+		MaxConnectionIdle:     options.Duration("keepalive_max_connection_idle", timeout).Duration(),
+		MaxConnectionAge:      options.Duration("keepalive_max_connection_age", timeout).Duration(),
+		MaxConnectionAgeGrace: options.Duration("keepalive_max_connection_age_grace", timeout).Duration(),
+		Time:                  options.Duration("keepalive_ping_time", timeout).Duration(),
+		Timeout:               timeout.Duration(),
 	}))
 	os = append(os, opts...)
 

--- a/net/grpc/health/health_test.go
+++ b/net/grpc/health/health_test.go
@@ -260,7 +260,7 @@ func TestWatchStatusChanges(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, 25*time.Millisecond)
+	}, time.Second.Duration(), (25 * time.Millisecond).Duration())
 
 	cancel()
 
@@ -328,7 +328,7 @@ func requireObservedHealth(t *testing.T, server *server.Server, service string, 
 		}
 
 		return observer.Error() != nil
-	}, time.Second, 10*time.Millisecond)
+	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
 }
 
 func newGRPCHealthWorld(t *testing.T, url string, opts ...test.WorldOption) *test.World {

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -161,7 +161,7 @@ func NewClient(rt http.RoundTripper, timeout time.Duration) *http.Client {
 				return telemetry.NewClientTrace(ctx)
 			}),
 		),
-		Timeout: timeout,
+		Timeout: timeout.Duration(),
 	}
 }
 
@@ -225,10 +225,10 @@ func StatusText(code int) string {
 func NewServer(options options.Map, timeout time.Duration, handler Handler) *Server {
 	return &http.Server{
 		Handler:           handler,
-		ReadTimeout:       options.Duration("read_timeout", timeout),
-		WriteTimeout:      options.Duration("write_timeout", timeout),
-		IdleTimeout:       options.Duration("idle_timeout", timeout),
-		ReadHeaderTimeout: options.Duration("read_header_timeout", timeout),
+		ReadTimeout:       options.Duration("read_timeout", timeout).Duration(),
+		WriteTimeout:      options.Duration("write_timeout", timeout).Duration(),
+		IdleTimeout:       options.Duration("idle_timeout", timeout).Duration(),
+		ReadHeaderTimeout: options.Duration("read_header_timeout", timeout).Duration(),
 		Protocols:         Protocols(),
 	}
 }

--- a/net/http/server/server_test.go
+++ b/net/http/server/server_test.go
@@ -2,13 +2,13 @@ package server_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	server "github.com/alexfalkowski/go-service/v2/net/http/server"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 

--- a/net/http/transport.go
+++ b/net/http/transport.go
@@ -25,16 +25,16 @@ import (
 //   - If cfg is non-nil it is assigned to Transport.TLSClientConfig.
 //   - If cfg is nil, the standard library defaults apply.
 func Transport(cfg *tls.Config) *http.Transport {
-	dialer := &net.Dialer{Timeout: time.Minute, KeepAlive: 30 * time.Second}
+	dialer := &net.Dialer{Timeout: time.Minute.Duration(), KeepAlive: (30 * time.Second).Duration()}
 
 	return &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       (90 * time.Second).Duration(),
+		TLSHandshakeTimeout:   (10 * time.Second).Duration(),
+		ExpectContinueTimeout: time.Second.Duration(),
 		MaxConnsPerHost:       100,
 		MaxIdleConnsPerHost:   100,
 		TLSClientConfig:       cfg,

--- a/retry/config.go
+++ b/retry/config.go
@@ -1,5 +1,7 @@
 package retry
 
+import "github.com/alexfalkowski/go-service/v2/time"
+
 // Config configures retry behavior for an operation.
 //
 // This package defines configuration only; concrete retry behavior is implemented
@@ -8,8 +10,8 @@ package retry
 // whether jitter is applied, etc.) is transport-defined, but these fields are
 // the common knobs most implementations interpret similarly.
 //
-// Timeout and Backoff are encoded as Go duration strings (see time.ParseDuration),
-// such as "250ms", "5s", or "1m".
+// Timeout and Backoff are typed durations encoded as Go duration strings in config
+// (see time.ParseDuration), such as "250ms", "5s", or "1m".
 type Config struct {
 	// Timeout is the per-attempt timeout duration.
 	//
@@ -17,7 +19,7 @@ type Config struct {
 	// independently (for example by deriving a per-attempt context deadline).
 	//
 	// Value encoding: Go duration string (for example "250ms", "5s").
-	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
 
 	// Backoff is the delay between attempts after a failed attempt.
 	//
@@ -26,7 +28,7 @@ type Config struct {
 	// implementation.
 	//
 	// Value encoding: Go duration string (for example "100ms", "1s").
-	Backoff string `yaml:"backoff,omitempty" json:"backoff,omitempty" toml:"backoff,omitempty"`
+	Backoff time.Duration `yaml:"backoff,omitempty" json:"backoff,omitempty" toml:"backoff,omitempty"`
 
 	// Attempts is the maximum number of attempts, including the initial attempt.
 	//

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -14,8 +14,8 @@
 //   - Timeout: a per-attempt timeout. Each attempt is bounded independently.
 //   - Backoff: a delay inserted between failed attempts.
 //
-// Timeout and Backoff are encoded as Go duration strings (see time.ParseDuration),
-// such as "250ms", "5s", or "1m".
+// Timeout and Backoff are typed durations. In config files they are encoded as
+// Go duration strings (see time.ParseDuration), such as "250ms", "5s", or "1m".
 //
 // # Transport interpretation
 //
@@ -40,7 +40,7 @@
 // A common convention is:
 //   - Attempts == 0: retries disabled using the transport's zero-value behavior.
 //   - Attempts == 1: retries disabled.
-//   - Timeout == "" or Backoff == "": treated as "unspecified" and replaced with
+//   - Timeout == 0 or Backoff == 0: treated as "unspecified" and replaced with
 //     transport defaults.
 //
 // # Usage

--- a/time/doc.go
+++ b/time/doc.go
@@ -3,32 +3,34 @@
 //
 // This package serves two purposes:
 //
-//  1. Standard library compatibility via aliases.
+//  1. Standard library compatibility via wrappers and aliases.
 //     It re-exports a small subset of the Go standard library time API so code across
 //     go-service can consistently import go-service packages while still using the
 //     underlying time semantics.
 //
-//     Exported aliases include Time (time.Time), Duration (time.Duration), common
-//     duration constants (Second, Minute, Hour, etc.), and RFC3339.
+//     Exported types include Time (an alias of time.Time), Duration (a named type over
+//     time.Duration), common duration constants (Second, Minute, Hour, etc.), and RFC3339.
 //
 //  2. Optional network time sourcing.
 //     In environments where local wall-clock time may drift or needs stronger
 //     guarantees, this package can construct a Network provider that fetches time
 //     from external services (for example NTP or NTS).
 //
-// # Standard library aliases
+// # Standard library compatibility
 //
-// The following identifiers are thin wrappers/aliases of the standard library and do
-// not change semantics:
+// The following identifiers are thin wrappers around the standard library and do not
+// materially change semantics:
 //
-//   - Time and Duration alias time.Time and time.Duration.
+//   - Time aliases time.Time.
+//   - Duration wraps time.Duration and adds Text/JSON marshaling helpers while preserving
+//     Go duration string semantics.
 //   - Now, Since, Sleep, and ParseDuration forward to time.Now, time.Since,
 //     time.Sleep, and time.ParseDuration respectively.
-//   - Constants such as Second, Minute, Hour, and RFC3339 alias the standard library
+//   - Constants such as Second, Minute, Hour, and RFC3339 mirror the standard library
 //     values.
 //
 // Use these when you want to keep dependencies within the go-service module while
-// remaining fully compatible with the standard library time types.
+// remaining close to the standard library time types.
 //
 // # Strict helpers
 //

--- a/time/time.go
+++ b/time/time.go
@@ -1,6 +1,7 @@
 package time
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/alexfalkowski/go-service/v2/runtime"
@@ -10,32 +11,32 @@ import (
 //
 // It is an alias of time.Hour, provided so callers can depend on go-service
 // packages while using standard library time values.
-const Hour = time.Hour
+const Hour Duration = Duration(time.Hour)
 
 // Microsecond is a duration constant equal to 1e3 nanoseconds.
 //
 // It is an alias of time.Microsecond.
-const Microsecond = time.Microsecond
+const Microsecond Duration = Duration(time.Microsecond)
 
 // Millisecond is a duration constant equal to 1e6 nanoseconds.
 //
 // It is an alias of time.Millisecond.
-const Millisecond = time.Millisecond
+const Millisecond Duration = Duration(time.Millisecond)
 
 // Minute is a duration constant equal to 60 seconds.
 //
 // It is an alias of time.Minute.
-const Minute = time.Minute
+const Minute Duration = Duration(time.Minute)
 
 // Nanosecond is a duration constant equal to 1.
 //
 // It is an alias of time.Nanosecond.
-const Nanosecond = time.Nanosecond
+const Nanosecond Duration = Duration(time.Nanosecond)
 
 // Second is a duration constant equal to 1e9 nanoseconds.
 //
 // It is an alias of time.Second.
-const Second = time.Second
+const Second Duration = Duration(time.Second)
 
 // RFC3339 is the RFC3339 time format layout.
 //
@@ -56,23 +57,65 @@ type Time = time.Time
 
 // Duration is the go-service duration type used across the repository.
 //
-// It is a type alias of time.Duration, meaning it has identical semantics and
-// method set to the standard library type.
-type Duration = time.Duration
+// It is a named type over the standard library time.Duration so it can expose
+// config-friendly marshaling helpers while remaining easy to convert at API
+// boundaries.
+type Duration time.Duration
+
+// Duration converts d to the standard library time.Duration type.
+func (d Duration) Duration() time.Duration {
+	return time.Duration(d)
+}
+
+// String returns the Go duration string for d.
+func (d Duration) String() string {
+	return d.Duration().String()
+}
+
+// MarshalText encodes d using the standard Go duration string format.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
+// UnmarshalText decodes a Go duration string into d.
+func (d *Duration) UnmarshalText(text []byte) error {
+	duration, err := ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+
+	*d = duration
+	return nil
+}
+
+// MarshalJSON encodes d as a quoted Go duration string.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON decodes a quoted Go duration string into d.
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+
+	return d.UnmarshalText([]byte(text))
+}
 
 // After waits for the duration to elapse and then sends the current time
 // on the returned channel.
 //
 // This is a thin wrapper around time.After and does not change semantics.
 func After(d Duration) <-chan Time {
-	return time.After(d)
+	return time.After(d.Duration())
 }
 
 // NewTicker returns a new [Ticker] containing a channel that will send the current time on the channel after each tick.
 //
 // This is a thin wrapper around time.NewTicker and does not change semantics.
 func NewTicker(d Duration) *Ticker {
-	return time.NewTicker(d)
+	return time.NewTicker(d.Duration())
 }
 
 // Now returns the current local time.
@@ -87,21 +130,22 @@ func Now() Time {
 // This is a thin wrapper around time.ParseDuration. The input uses the standard
 // Go duration format such as "250ms", "5s", or "1m".
 func ParseDuration(s string) (Duration, error) {
-	return time.ParseDuration(s)
+	d, err := time.ParseDuration(s)
+	return Duration(d), err
 }
 
 // Since returns the time elapsed since t.
 //
 // This is a thin wrapper around time.Since and does not change semantics.
 func Since(t Time) Duration {
-	return time.Since(t)
+	return Duration(time.Since(t))
 }
 
 // Sleep pauses the current goroutine for at least the duration d.
 //
 // This is a thin wrapper around time.Sleep and does not change semantics.
 func Sleep(d Duration) {
-	time.Sleep(d)
+	time.Sleep(d.Duration())
 }
 
 // MustParseDuration parses s as a duration string and panics if parsing fails.
@@ -111,7 +155,7 @@ func Sleep(d Duration) {
 // panics by calling runtime.Must on the parse error.
 //
 // If you need recoverable error handling, use ParseDuration instead.
-func MustParseDuration(s string) time.Duration {
+func MustParseDuration(s string) Duration {
 	t, err := ParseDuration(s)
 	runtime.Must(err)
 	return t

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,6 +1,7 @@
 package time_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -9,4 +10,69 @@ import (
 
 func TestMustParseDuration(t *testing.T) {
 	require.Panics(t, func() { time.MustParseDuration("test") })
+}
+
+func TestDurationTextRoundTrip(t *testing.T) {
+	duration := 5*time.Second + 250*time.Millisecond
+
+	text, err := duration.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "5.25s", string(text))
+
+	var decoded time.Duration
+	require.NoError(t, decoded.UnmarshalText(text))
+	require.Equal(t, duration, decoded)
+}
+
+func TestDurationJSONRoundTrip(t *testing.T) {
+	duration := 3*time.Minute + 15*time.Second
+
+	data, err := json.Marshal(duration)
+	require.NoError(t, err)
+	require.Equal(t, `"3m15s"`, string(data))
+
+	var decoded time.Duration
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, duration, decoded)
+}
+
+func TestDurationUnmarshalTextInvalid(t *testing.T) {
+	var duration time.Duration
+
+	err := duration.UnmarshalText([]byte("not-a-duration"))
+	require.Error(t, err)
+}
+
+func TestDurationUnmarshalJSONInvalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "null", input: "null"},
+		{name: "number", input: "5"},
+		{name: "object", input: "{}"},
+		{name: "invalid string value", input: `"bad"`},
+		{name: "malformed string", input: `"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var duration time.Duration
+
+			err := json.Unmarshal([]byte(tt.input), &duration)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDurationZeroValueEncoding(t *testing.T) {
+	var duration time.Duration
+
+	text, err := duration.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "0s", string(text))
+
+	data, err := json.Marshal(duration)
+	require.NoError(t, err)
+	require.Equal(t, `"0s"`, string(data))
 }

--- a/token/jwt/config.go
+++ b/token/jwt/config.go
@@ -1,5 +1,7 @@
 package jwt
 
+import "github.com/alexfalkowski/go-service/v2/time"
+
 // Config configures JWT issuance and verification for the go-service JWT token kind.
 //
 // This configuration is consumed by Token.Generate and Token.Verify.
@@ -9,7 +11,7 @@ package jwt
 // Issued tokens use standard registered claims and populate them from this config:
 //
 //   - Issuer is written to and verified against the `iss` claim.
-//   - Expiration is parsed as a Go duration string and is used to set/validate the `exp` claim.
+//   - Expiration is a typed duration and is used to set/validate the `exp` claim.
 //   - KeyID is written to and verified against the JWT header `kid`.
 //
 // # Key ID (kid) enforcement
@@ -24,9 +26,9 @@ package jwt
 //
 // # Expiration parsing and panics
 //
-// Issuance parses Expiration using a strict helper that panics on parse errors. This is
-// intended for fail-fast startup/configuration paths. If your deployment requires
-// non-panicking behavior, validate Expiration earlier during configuration loading.
+// Issuance uses Expiration directly. Invalid config-file values fail during decoding because
+// the field is encoded as a Go duration string. If your deployment requires additional
+// validation policy, apply it earlier during configuration loading.
 //
 // # Enablement
 //
@@ -36,18 +38,16 @@ type Config struct {
 	// Issuer is written to and verified against the `iss` claim.
 	Issuer string `yaml:"iss,omitempty" json:"iss,omitempty" toml:"iss,omitempty"`
 
-	// Expiration is a Go duration string used to set/validate the `exp` claim.
-	//
-	// Examples: "15m", "24h".
-	//
-	// Token issuance parses this value using a strict helper and will panic if it is invalid.
-	Expiration string `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
-
 	// KeyID is written to and verified against the JWT header `kid`.
 	//
-	// Note: this repository’s JWT verification expects the `kid` header to be set and
+	// Note: this repository's JWT verification expects the `kid` header to be set and
 	// to match this value exactly.
 	KeyID string `yaml:"kid,omitempty" json:"kid,omitempty" toml:"kid,omitempty"`
+
+	// Expiration is the duration used to set and validate the `exp` claim.
+	//
+	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
 }
 
 // IsEnabled reports whether JWT configuration is present.

--- a/token/jwt/doc.go
+++ b/token/jwt/doc.go
@@ -67,10 +67,9 @@
 // Config provides the issuer, expiration, and key id settings used for issuance and
 // verification. A nil *Config is treated as disabled: NewToken returns nil.
 //
-// Expiration is a Go duration string (time.ParseDuration format, such as "15m" or
-// "24h"). Issuance uses MustParseDuration and will panic if Expiration is invalid.
-// This is intended for strict startup/configuration paths; validate configuration
-// earlier if you need non-panicking behavior.
+// Expiration is a typed duration. In config files it is encoded using the standard
+// Go duration string format (such as "15m" or "24h"), so invalid values fail during
+// decoding rather than during token issuance.
 //
 // # Relationship to the top-level token facade
 //

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -52,15 +52,11 @@ type Token struct {
 // In addition, it sets the JWT header:
 //
 //   - kid: from cfg.KeyID
-//
-// Expiration parsing uses time.MustParseDuration and will panic if cfg.Expiration is invalid.
-// This is intended for fail-fast configuration behavior.
 func (t *Token) Generate(aud, sub string) (string, error) {
-	exp := time.MustParseDuration(t.cfg.Expiration)
 	key := t.signer.PrivateKey
 	now := time.Now()
 	claims := &jwt.RegisteredClaims{
-		ExpiresAt: &jwt.NumericDate{Time: now.Add(exp)},
+		ExpiresAt: &jwt.NumericDate{Time: now.Add(t.cfg.Expiration.Duration())},
 		ID:        t.generator.Generate(),
 		IssuedAt:  &jwt.NumericDate{Time: now},
 		Issuer:    t.cfg.Issuer,

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/jwt"
 	v4 "github.com/golang-jwt/jwt/v4"
@@ -56,7 +57,7 @@ func TestInvalid(t *testing.T) {
 	_, err = token.Verify(tkn, "test")
 	require.Error(t, err)
 
-	token = jwt.NewToken(&jwt.Config{Issuer: "test", Expiration: "1h", KeyID: "1234567890"}, signer, verifier, gen)
+	token = jwt.NewToken(&jwt.Config{Issuer: "test", Expiration: time.Hour, KeyID: "1234567890"}, signer, verifier, gen)
 
 	tkn, err = token.Generate("hello", test.UserID.String())
 	require.NoError(t, err)
@@ -76,7 +77,7 @@ func TestInvalidKeyID(t *testing.T) {
 	signer, _ := ed25519.NewSigner(test.PEM, ec)
 	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
 	gen := uuid.NewGenerator()
-	wrong := jwt.NewToken(&jwt.Config{Issuer: cfg.JWT.Issuer, Expiration: "1h", KeyID: "test"}, signer, verifier, gen)
+	wrong := jwt.NewToken(&jwt.Config{Issuer: cfg.JWT.Issuer, Expiration: time.Hour, KeyID: "test"}, signer, verifier, gen)
 
 	tkn, err := wrong.Generate("hello", test.UserID.String())
 	require.NoError(t, err)

--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -1,5 +1,7 @@
 package paseto
 
+import "github.com/alexfalkowski/go-service/v2/time"
+
 // Config configures PASETO issuance and verification for the go-service PASETO token kind.
 //
 // This configuration is intended to capture the common knobs for token issuance:
@@ -21,9 +23,9 @@ package paseto
 //
 // # Expiration parsing and panics
 //
-// Token issuance parses Expiration as a Go duration string (time.ParseDuration format) using
-// a strict helper that panics on parse error. This is intended for fail-fast startup/config
-// paths; validate Expiration earlier if you need non-panicking behavior.
+// Token issuance uses Expiration directly. In config files it is encoded using the standard
+// Go duration string format, so invalid values fail during decoding. Apply additional
+// validation earlier if you need stricter startup policy.
 //
 // # Enablement
 //
@@ -44,10 +46,10 @@ type Config struct {
 	// Issuer is written to and verified against the `iss` claim.
 	Issuer string `yaml:"iss,omitempty" json:"iss,omitempty" toml:"iss,omitempty"`
 
-	// Expiration is a Go duration string used to set token expiration (for example "15m", "24h").
+	// Expiration is the duration used to set token expiration.
 	//
-	// Issuance parses this value using a strict helper and will panic if it is invalid.
-	Expiration string `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
+	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
 }
 
 // IsEnabled reports whether PASETO configuration is present.

--- a/token/paseto/doc.go
+++ b/token/paseto/doc.go
@@ -60,10 +60,9 @@
 // Config provides issuer and expiration settings. A nil *Config is treated as
 // disabled: NewToken returns nil.
 //
-// Expiration is a Go duration string (time.ParseDuration format, such as "15m" or
-// "24h"). Issuance uses MustParseDuration and will panic if Expiration is invalid.
-// This is intended for strict startup/configuration paths; validate configuration
-// earlier if you need non-panicking behavior.
+// Expiration is a typed duration. In config files it is encoded using the standard
+// Go duration string format (such as "15m" or "24h"), so invalid values fail during
+// decoding rather than during token issuance.
 //
 // # Secret field note
 //

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -47,17 +47,13 @@ type Token struct {
 //   - iss: from cfg.Issuer
 //   - aud: set to the provided aud
 //   - sub: set to the provided sub
-//
-// Expiration parsing uses time.MustParseDuration and will panic if cfg.Expiration is invalid.
-// This is intended for fail-fast configuration behavior.
 func (t *Token) Generate(aud, sub string) (string, error) {
-	exp := time.MustParseDuration(t.cfg.Expiration)
 	now := time.Now()
 	token := paseto.NewToken()
 	token.SetJti(t.generator.Generate())
 	token.SetIssuedAt(now)
 	token.SetNotBefore(now)
-	token.SetExpiration(now.Add(exp))
+	token.SetExpiration(now.Add(t.cfg.Expiration.Duration()))
 	token.SetIssuer(t.cfg.Issuer)
 	token.SetAudience(aud)
 	token.SetSubject(sub)

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token/paseto"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestInvalid(t *testing.T) {
 	_, err = token.Verify(tkn, "test")
 	require.Error(t, err)
 
-	token = paseto.NewToken(&paseto.Config{Issuer: "test", Expiration: "1h"}, signer, verifier, gen)
+	token = paseto.NewToken(&paseto.Config{Issuer: "test", Expiration: time.Hour}, signer, verifier, gen)
 
 	tkn, err = token.Generate("hello", test.UserID.String())
 	require.NoError(t, err)

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -4,7 +4,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	config "github.com/alexfalkowski/go-service/v2/retry"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 )
 
@@ -12,8 +11,8 @@ import (
 //
 // It describes the retry policy for gRPC unary client calls, including:
 //   - `Attempts`: maximum number of attempts (initial call + retries).
-//   - `Timeout`: per-attempt timeout duration string.
-//   - `Backoff`: backoff duration string used by the chosen backoff strategy.
+//   - `Timeout`: per-attempt timeout duration.
+//   - `Backoff`: backoff duration used by the chosen backoff strategy.
 type Config = config.Config
 
 // UnaryClientInterceptor returns a gRPC unary client interceptor that retries failed calls.
@@ -22,7 +21,7 @@ type Config = config.Config
 // client side.
 //
 // Behavior:
-//   - It parses per-attempt timeout and backoff durations from cfg (`cfg.Timeout` and `cfg.Backoff`).
+//   - It uses the typed per-attempt timeout and backoff durations from cfg.
 //   - It retries up to `cfg.MaxAttempts()` total attempts (including the initial attempt).
 //   - It applies a per-attempt timeout (`retry.WithPerRetryTimeout`) so each attempt is bounded.
 //   - It uses a linear backoff strategy with a step duration derived from `cfg.Backoff`.
@@ -35,13 +34,10 @@ type Config = config.Config
 // This interceptor does not automatically retry on every error; application-level errors that map to other
 // status codes will not be retried by default.
 func UnaryClientInterceptor(cfg *Config) grpc.UnaryClientInterceptor {
-	timeout := time.MustParseDuration(cfg.Timeout)
-	backoff := time.MustParseDuration(cfg.Backoff)
-
 	return retry.UnaryClientInterceptor(
 		retry.WithCodes(codes.Unavailable, codes.DataLoss),
 		retry.WithMax(uint(cfg.MaxAttempts())),
-		retry.WithBackoff(retry.BackoffLinear(backoff)),
-		retry.WithPerRetryTimeout(timeout),
+		retry.WithBackoff(retry.BackoffLinear(cfg.Backoff.Duration())),
+		retry.WithPerRetryTimeout(cfg.Timeout.Duration()),
 	)
 }

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -7,15 +7,17 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	config "github.com/alexfalkowski/go-service/v2/retry"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/retry"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(&retry.Config{
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 1,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	})
 
 	calls := 0
@@ -29,10 +31,10 @@ func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 }
 
 func TestUnaryClientInterceptorRetriesWhenAttemptsIsTwo(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(&retry.Config{
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	})
 
 	calls := 0

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/server"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/telemetry"
 	"github.com/alexfalkowski/go-service/v2/os"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
@@ -101,8 +100,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, prefix(err)
 	}
 
-	timeout := time.MustParseDuration(params.Config.Timeout)
-	grpcServer := grpc.NewServer(params.Config.Options, timeout,
+	grpcServer := grpc.NewServer(params.Config.Options, params.Config.Timeout,
 		grpc.StatsHandler(telemetry.NewServerHandler()),
 		unaryServerOption(params, params.Unary...),
 		streamServerOption(params, params.Stream...),

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
@@ -37,7 +38,7 @@ func TestServer(t *testing.T) {
 func TestInvalidServer(t *testing.T) {
 	cfg := &grpc.Config{
 		Config: &server.Config{
-			Timeout: "5s",
+			Timeout: 5 * time.Second,
 			TLS:     test.NewTLSConfig("certs/client-cert.pem", "secrets/none"),
 		},
 	}

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkHTTP(b *testing.B) {
 
 		server := &http.Server{
 			Handler:           mux,
-			ReadHeaderTimeout: time.Second,
+			ReadHeaderTimeout: time.Second.Duration(),
 		}
 		defer server.Close()
 

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -14,7 +14,7 @@ import (
 //
 // It describes the retry policy used by NewRoundTripper:
 //   - `Attempts`: maximum number of attempts including the initial attempt.
-//   - `Timeout`: per-attempt timeout duration string.
+//   - `Timeout`: per-attempt timeout duration.
 //   - `Backoff`: constant delay between retries.
 type Config = config.Config
 
@@ -42,10 +42,9 @@ var ErrInvalidStatusCode = errors.New("retry: invalid status code")
 //   - If retries are exhausted after retryable HTTP responses, the first retryable response is returned.
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper) *RoundTripper {
-	timeout := time.MustParseDuration(cfg.Timeout)
-	backoff := retry.WithMaxRetries(cfg.MaxRetries(), retry.NewConstant(time.MustParseDuration(cfg.Backoff)))
+	backoff := retry.WithMaxRetries(cfg.MaxRetries(), retry.NewConstant(cfg.Backoff.Duration()))
 
-	return &RoundTripper{RoundTripper: hrt, timeout: timeout, backoff: backoff}
+	return &RoundTripper{RoundTripper: hrt, timeout: cfg.Timeout, backoff: backoff}
 }
 
 // RoundTripper wraps an underlying `http.RoundTripper` and retries requests according to its configuration.

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	"github.com/stretchr/testify/require"
@@ -30,8 +31,8 @@ func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 			rt := &roundTripper{codes: tt.codes}
 			retrying := retry.NewRoundTripper(&retry.Config{
 				Attempts: 2,
-				Timeout:  "1s",
-				Backoff:  "1ms",
+				Timeout:  time.Second,
+				Backoff:  time.Millisecond,
 			}, rt)
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -48,8 +49,8 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	rt := &roundTripper{codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -64,8 +65,8 @@ func TestRoundTripperReturnsLastRetryableResponseWhenExhausted(t *testing.T) {
 	rt := &roundTripper{codes: []int{http.StatusTooManyRequests, http.StatusTooManyRequests}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -80,8 +81,8 @@ func TestRoundTripperReturnsFirstRetryableResponseWhenExhausted(t *testing.T) {
 	rt := &bodyRoundTripper{responses: []string{"first failure", "second failure"}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -101,8 +102,8 @@ func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
 	rt := &requestRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, rt)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", strings.NewReader("hello"))
@@ -118,8 +119,8 @@ func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
 	rt := &requestRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, rt)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", &nonReplayableReader{value: "hello"})
@@ -136,8 +137,8 @@ func TestRoundTripperPreservesRetryableTransportError(t *testing.T) {
 	rt := &errorRoundTripper{err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -154,8 +155,8 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	generator := &tokenGenerator{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  "1s",
-		Backoff:  "1ms",
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
 	}, token.NewRoundTripper(env.UserID("user-id"), generator, rt))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
@@ -128,8 +127,7 @@ func NewServer(params ServerParams) (*Server, error) {
 
 	neg.UseHandler(gzhttp.GzipHandler(params.Mux))
 
-	timeout := time.MustParseDuration(params.Config.Timeout)
-	httpServer := http.NewServer(params.Config.Options, timeout, neg)
+	httpServer := http.NewServer(params.Config.Options, params.Config.Timeout, neg)
 
 	cfg, err := newConfig(fs, params.Config)
 	if err != nil {

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/mime"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func TestInvalidServer(t *testing.T) {
 
 	cfg := &http.Config{
 		Config: &server.Config{
-			Timeout: "5s",
+			Timeout: 5 * time.Second,
 			TLS:     test.NewTLSConfig("certs/client-cert.pem", "secrets/none"),
 		},
 	}


### PR DESCRIPTION
## What

Converted `go-service/time.Duration` from an alias into a real named type with text and json marshal/unmarshal support, while keeping config values encoded as Go duration strings.

Migrated typed config fields from `string` to `time.Duration` for shared client/server timeouts, retry timeout/backoff, limiter interval, SQL connection max lifetime, and JWT/PASETO expiration.

Updated runtime consumers to use typed durations directly and convert to stdlib durations only at API boundaries, plus refreshed affected docs, fixtures, helpers, benchmarks, and assertions.

## Why

Duration-backed config was forced to use raw strings because the previous alias type could not implement marshaling interfaces.

This change makes duration config first-class and type-safe, removes repeated parsing at construction sites, and keeps the external config format unchanged.

## Testing

```bash
env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./... -run '^$'
```

Focused suites were also exercised during the refactor, including `time`, `config`, `retry`, `limiter`, `token`, and the HTTP/gRPC retry packages.

Broader runtime tests that require local services like Redis/Postgres/OTLP remain environment-dependent.