### PR TITLE
feat(bytes): add bytes size config type and rename max receive limit to max_receive_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,17 +724,17 @@ Notes:
 
 - Address format should be `<network>://<address>` (for example `tcp://:8000`).
 - If address is omitted, defaults are `tcp://:8080` (HTTP) and `tcp://:9090` (gRPC).
-- `max_receive_bytes` limits inbound payload size. A zero value uses the default `4194304` bytes (`4 MiB`).
-- For HTTP, `max_receive_bytes` applies per request body. For gRPC, it applies per inbound unary request and per inbound stream message.
+- `max_receive_size` limits inbound payload size. A zero value uses the default `4MB`.
+- For HTTP, `max_receive_size` applies per request body. For gRPC, it applies per inbound unary request and per inbound stream message.
 
 Receive-limit example:
 
 ```yaml
 transport:
   http:
-    max_receive_bytes: 2097152
+    max_receive_size: 2MB
   grpc:
-    max_receive_bytes: 3145728
+    max_receive_size: 3MB
 ```
 
 With retry + low-level options map:

--- a/bytes/doc.go
+++ b/bytes/doc.go
@@ -15,4 +15,10 @@
 // This package also exposes `String`, which converts a `[]byte` to a `string` without allocating.
 // This is an advanced, performance-oriented helper with important safety constraints; see `String`
 // for details.
+//
+// # Human-readable sizes
+//
+// `Size` is a named byte-count type that marshals to and from human-readable SI strings such as
+// `64B`, `2MB`, and `4GB`. It is intended for typed configuration surfaces that need text/JSON
+// encoding while still being easy to convert back to raw bytes.
 package bytes

--- a/bytes/size.go
+++ b/bytes/size.go
@@ -1,0 +1,91 @@
+package bytes
+
+import (
+	"encoding/json"
+
+	"github.com/alexfalkowski/go-service/v2/runtime"
+	units "github.com/docker/go-units"
+)
+
+// KB is a size constant equal to 1000 bytes.
+const KB Size = Size(units.KB)
+
+// MB is a size constant equal to 1000 kilobytes.
+const MB Size = Size(units.MB)
+
+// GB is a size constant equal to 1000 megabytes.
+const GB Size = Size(units.GB)
+
+// TB is a size constant equal to 1000 gigabytes.
+const TB Size = Size(units.TB)
+
+// PB is a size constant equal to 1000 terabytes.
+const PB Size = Size(units.PB)
+
+// Size is the go-service byte-size type used across the repository.
+//
+// It is a named type over int64 so it can expose config-friendly marshaling
+// helpers while remaining easy to convert at API boundaries.
+type Size int64
+
+// Bytes converts s to its raw byte count.
+func (s Size) Bytes() int64 {
+	return int64(s)
+}
+
+// String returns the human-readable SI size string for s.
+func (s Size) String() string {
+	return units.HumanSize(float64(s.Bytes()))
+}
+
+// MarshalText encodes s using the human-readable SI size format.
+func (s Size) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText decodes a human-readable SI size string into s.
+func (s *Size) UnmarshalText(text []byte) error {
+	size, err := ParseSize(string(text))
+	if err != nil {
+		return err
+	}
+
+	*s = size
+	return nil
+}
+
+// MarshalJSON encodes s as a quoted human-readable SI size string.
+func (s Size) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON decodes a quoted human-readable SI size string into s.
+func (s *Size) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+
+	return s.UnmarshalText([]byte(text))
+}
+
+// ParseSize parses a human-readable SI size string.
+//
+// The input uses SI units such as "64B", "2MB", or "4GB".
+func ParseSize(s string) (Size, error) {
+	size, err := units.FromHumanSize(s)
+	return Size(size), err
+}
+
+// MustParseSize parses s as a human-readable SI size string and panics if parsing fails.
+//
+// This helper is intended for strict startup/configuration paths where an invalid
+// size is considered a fatal configuration/programming error. It panics by
+// calling runtime.Must on the parse error.
+//
+// If you need recoverable error handling, use ParseSize instead.
+func MustParseSize(s string) Size {
+	size, err := ParseSize(s)
+	runtime.Must(err)
+	return size
+}

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -1,0 +1,78 @@
+package bytes_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustParseSize(t *testing.T) {
+	require.Panics(t, func() { bytes.MustParseSize("test") })
+}
+
+func TestSizeTextRoundTrip(t *testing.T) {
+	size := bytes.MustParseSize("4MB")
+
+	text, err := size.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "4MB", string(text))
+
+	var decoded bytes.Size
+	require.NoError(t, decoded.UnmarshalText(text))
+	require.Equal(t, size, decoded)
+}
+
+func TestSizeJSONRoundTrip(t *testing.T) {
+	size := bytes.MustParseSize("64B")
+
+	data, err := json.Marshal(size)
+	require.NoError(t, err)
+	require.Equal(t, `"64B"`, string(data))
+
+	var decoded bytes.Size
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, size, decoded)
+}
+
+func TestSizeUnmarshalTextInvalid(t *testing.T) {
+	var size bytes.Size
+
+	err := size.UnmarshalText([]byte("not-a-size"))
+	require.Error(t, err)
+}
+
+func TestSizeUnmarshalJSONInvalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "null", input: "null"},
+		{name: "number", input: "5"},
+		{name: "object", input: "{}"},
+		{name: "invalid string value", input: `"bad"`},
+		{name: "malformed string", input: `"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var size bytes.Size
+
+			err := json.Unmarshal([]byte(tt.input), &size)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSizeZeroValueEncoding(t *testing.T) {
+	var size bytes.Size
+
+	text, err := size.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "0B", string(text))
+
+	data, err := json.Marshal(size)
+	require.NoError(t, err)
+	require.Equal(t, `"0B"`, string(data))
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config"
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
@@ -258,7 +259,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "1234567890", config.Transport.GRPC.Token.JWT.KeyID)
 	require.True(t, config.Transport.GRPC.Config.IsEnabled())
 	require.Equal(t, "tcp://localhost:12000", config.Transport.GRPC.Address)
-	require.Equal(t, int64(3145728), config.Transport.GRPC.MaxReceiveBytes)
+	require.Equal(t, 3*bytes.MB, config.Transport.GRPC.MaxReceiveSize)
 	require.Equal(t, "user-agent", config.Transport.GRPC.Limiter.Kind)
 	require.Equal(t, 10, int(config.Transport.GRPC.Limiter.Tokens))
 	require.Equal(t, time.Second, config.Transport.GRPC.Limiter.Interval)
@@ -283,7 +284,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "1234567890", config.Transport.HTTP.Token.JWT.KeyID)
 	require.True(t, config.Transport.HTTP.Config.IsEnabled())
 	require.Equal(t, "tcp://localhost:11000", config.Transport.HTTP.Address)
-	require.Equal(t, int64(2097152), config.Transport.HTTP.MaxReceiveBytes)
+	require.Equal(t, 2*bytes.MB, config.Transport.HTTP.MaxReceiveSize)
 	require.Equal(t, "user-agent", config.Transport.HTTP.Limiter.Kind)
 	require.Equal(t, 10, int(config.Transport.HTTP.Limiter.Tokens))
 	require.Equal(t, time.Second, config.Transport.HTTP.Limiter.Interval)

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/limiter"
@@ -9,8 +10,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/token"
 )
 
-// DefaultMaxReceiveBytes is the default inbound payload limit applied when MaxReceiveBytes is omitted or zero.
-const DefaultMaxReceiveBytes int64 = 4 * 1024 * 1024
+// DefaultMaxReceiveSize is the default inbound payload limit applied when MaxReceiveSize is omitted or zero.
+const DefaultMaxReceiveSize bytes.Size = 4 * bytes.MB
 
 // Config configures server-side behavior shared across transports.
 type Config struct {
@@ -37,10 +38,12 @@ type Config struct {
 	// In config files it is encoded as a Go duration string (for example "30s", "5m").
 	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
 
-	// MaxReceiveBytes limits inbound request payload size in bytes.
+	// MaxReceiveSize limits inbound request payload size.
 	//
-	// A zero value applies DefaultMaxReceiveBytes. Negative values are invalid.
-	MaxReceiveBytes int64 `yaml:"max_receive_bytes,omitempty" json:"max_receive_bytes,omitempty" toml:"max_receive_bytes,omitempty" validate:"gte=0"`
+	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
+	//
+	// A zero value applies DefaultMaxReceiveSize. Negative values are invalid.
+	MaxReceiveSize bytes.Size `yaml:"max_receive_size,omitempty" json:"max_receive_size,omitempty" toml:"max_receive_size,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether server configuration is present.
@@ -48,13 +51,13 @@ func (c *Config) IsEnabled() bool {
 	return c != nil
 }
 
-// GetMaxReceiveBytes returns the configured inbound payload limit in bytes.
+// GetMaxReceiveSize returns the configured inbound payload limit.
 //
-// A nil receiver or a zero value falls back to DefaultMaxReceiveBytes.
-func (c *Config) GetMaxReceiveBytes() int64 {
-	if c == nil || c.MaxReceiveBytes == 0 {
-		return DefaultMaxReceiveBytes
+// A nil receiver or a zero value falls back to DefaultMaxReceiveSize.
+func (c *Config) GetMaxReceiveSize() bytes.Size {
+	if c == nil || c.MaxReceiveSize == 0 {
+		return DefaultMaxReceiveSize
 	}
 
-	return c.MaxReceiveBytes
+	return c.MaxReceiveSize
 }

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -3,30 +3,31 @@ package server_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMaxReceiveBytes(t *testing.T) {
+func TestGetMaxReceiveSize(t *testing.T) {
 	tests := []struct {
 		cfg  *server.Config
 		name string
-		want int64
+		want bytes.Size
 	}{
-		{name: "nil", want: server.DefaultMaxReceiveBytes},
-		{name: "zero", cfg: &server.Config{}, want: server.DefaultMaxReceiveBytes},
-		{name: "explicit", cfg: &server.Config{MaxReceiveBytes: 64}, want: 64},
+		{name: "nil", want: server.DefaultMaxReceiveSize},
+		{name: "zero", cfg: &server.Config{}, want: server.DefaultMaxReceiveSize},
+		{name: "explicit", cfg: &server.Config{MaxReceiveSize: 64}, want: 64},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.cfg.GetMaxReceiveBytes())
+			require.Equal(t, tt.want, tt.cfg.GetMaxReceiveSize())
 		})
 	}
 }
 
-func TestConfigRejectsNegativeMaxReceiveBytes(t *testing.T) {
-	cfg := &server.Config{MaxReceiveBytes: -1}
+func TestConfigRejectsNegativeMaxReceiveSize(t *testing.T) {
+	cfg := &server.Config{MaxReceiveSize: -1}
 	require.Error(t, test.Validator.Struct(cfg))
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/cristalhq/acmd v0.12.0
+	github.com/docker/go-units v0.5.0
 	github.com/elnormous/contenttype v1.0.4
 	github.com/faabiosr/cachego v0.26.0
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
+github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elnormous/contenttype v1.0.4 h1:FjmVNkvQOGqSX70yvocph7keC8DtmJaLzTTq6ZOQCI8=

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -88,7 +88,7 @@
   transport: {
     http: {
       address: "tcp://localhost:11000"
-      max_receive_bytes: 2097152
+      max_receive_size: 2MB
       limiter: {
         kind: "user-agent"
         tokens: 10
@@ -120,7 +120,7 @@
     }
     grpc: {
       address: "tcp://localhost:12000"
-      max_receive_bytes: 3145728
+      max_receive_size: 3MB
       limiter: {
         kind: "user-agent"
         tokens: 10

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -78,7 +78,7 @@ address = "time.cloudflare.com"
 
 [transport.http]
 address = "tcp://localhost:11000"
-max_receive_bytes = 2097152
+max_receive_size = "2MB"
 user_agent = "Service http/1.0"
 timeout = "10s"
 
@@ -111,7 +111,7 @@ kid = "1234567890"
 
 [transport.grpc]
 address = "tcp://localhost:12000"
-max_receive_bytes = 3145728
+max_receive_size = "3MB"
 user_agent = "Service grpc/1.0"
 timeout = "10s"
 

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -59,7 +59,7 @@ time:
 transport:
   http:
     address: tcp://localhost:11000
-    max_receive_bytes: 2097152
+    max_receive_size: 2MB
     limiter:
       kind: user-agent
       tokens: 10
@@ -84,7 +84,7 @@ transport:
         kid: "1234567890"
   grpc:
     address: tcp://localhost:12000
-    max_receive_bytes: 3145728
+    max_receive_size: 3MB
     limiter:
       kind: user-agent
       tokens: 10

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/meta"
@@ -77,7 +78,7 @@ func TestStream(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestUnaryMaxReceiveBytes(t *testing.T) {
+func TestUnaryMaxReceiveSize(t *testing.T) {
 	world := newStartedGRPCWorld(t, 64)
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -89,7 +90,7 @@ func TestUnaryMaxReceiveBytes(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
-func TestStreamMaxReceiveBytes(t *testing.T) {
+func TestStreamMaxReceiveSize(t *testing.T) {
 	world := newStartedGRPCWorld(t, 64)
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -107,11 +108,11 @@ func TestStreamMaxReceiveBytes(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
-func newStartedGRPCWorld(t *testing.T, maxReceiveBytes int64) *test.World {
+func newStartedGRPCWorld(t *testing.T, maxReceiveSize bytes.Size) *test.World {
 	t.Helper()
 
 	cfg := test.NewInsecureTransportConfig()
-	cfg.GRPC.MaxReceiveBytes = maxReceiveBytes
+	cfg.GRPC.MaxReceiveSize = maxReceiveSize
 
 	return test.NewStartedWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldGRPC())
 }

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -85,7 +85,7 @@ type ServerParams struct {
 // sources may be resolved via the package-registered filesystem (see `Register` in this package).
 //
 // Inbound size limits:
-// params.Config.GetMaxReceiveBytes() is applied via grpc.MaxRecvMsgSize, which caps each inbound unary
+// params.Config.GetMaxReceiveSize() is applied via grpc.MaxRecvMsgSize, which caps each inbound unary
 // request and each inbound stream message independently.
 //
 // If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
@@ -187,7 +187,7 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 }
 
 func maxReceiveSizeOption(cfg *Config) grpc.ServerOption {
-	limit := min(cfg.GetMaxReceiveBytes(), int64(math.MaxInt))
+	limit := min(cfg.GetMaxReceiveSize().Bytes(), int64(math.MaxInt))
 
 	return grpc.MaxRecvMsgSize(int(limit))
 }

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -95,7 +95,7 @@ type ServerParams struct {
 //
 // Inbound size limits:
 //
-// params.Config.GetMaxReceiveBytes() is projected into the low-level HTTP server config and enforced by
+// params.Config.GetMaxReceiveSize() is projected into the low-level HTTP server config and enforced by
 // net/http/server.NewServer via http.MaxBytesHandler. The limit applies per inbound request body before
 // downstream handlers read from it.
 //
@@ -165,7 +165,7 @@ func (s *Server) GetService() *server.Service {
 func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 	config := &config.Config{
 		Address:         cmp.Or(cfg.Address, net.DefaultAddress("8080")),
-		MaxReceiveBytes: cfg.GetMaxReceiveBytes(),
+		MaxReceiveBytes: cfg.GetMaxReceiveSize().Bytes(),
 	}
 	if !cfg.TLS.IsEnabled() {
 		return config, nil

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -32,9 +32,9 @@ func TestInvalidServer(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestServerMaxReceiveBytes(t *testing.T) {
+func TestServerMaxReceiveSize(t *testing.T) {
 	cfg := test.NewInsecureTransportConfig()
-	cfg.HTTP.MaxReceiveBytes = 64
+	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
 	http.Handle(world.ServeMux, "POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {


### PR DESCRIPTION
## What

Added a new typed `bytes.Size` wrapper backed by `github.com/docker/go-units` with text and JSON marshal/unmarshal support using human-readable size strings.

Renamed shared server config from `MaxReceiveBytes` to `MaxReceiveSize` and updated the HTTP/gRPC transport wiring to convert the typed size back to raw bytes only at the low-level server boundaries.

Updated config fixtures, README examples, and tests to use `max_receive_size` values like `2MB` and `3MB`.

## Why

The old field was a raw integer byte count, which made config less expressive and inconsistent with the recent move toward typed marshalable config values.

This change makes the receive limit easier to read in config files, keeps the shared server config strongly typed, and removes the need to treat this setting as a plain numeric byte literal at the config layer.

## Testing

```bash
env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./... -run '^$'
make lint
```

Focused package tests for `./bytes`, `./config/server`, and `./config` also passed.

The targeted runtime transport tests remain environment-dependent because teardown expects local Redis on `127.0.0.1:6379`.