### PR TITLE
feat(encoding): use local encoding/json wrapper and tighten related godoc comments

### DIFF
--- a/bytes/size.go
+++ b/bytes/size.go
@@ -1,49 +1,56 @@
 package bytes
 
 import (
-	"encoding/json"
-
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	units "github.com/docker/go-units"
 )
 
-// KB is a size constant equal to 1000 bytes.
+// KB is the decimal kilobyte size constant: 1,000 bytes.
 const KB Size = Size(units.KB)
 
-// MB is a size constant equal to 1000 kilobytes.
+// MB is the decimal megabyte size constant: 1,000,000 bytes.
 const MB Size = Size(units.MB)
 
-// GB is a size constant equal to 1000 megabytes.
+// GB is the decimal gigabyte size constant: 1,000,000,000 bytes.
 const GB Size = Size(units.GB)
 
-// TB is a size constant equal to 1000 gigabytes.
+// TB is the decimal terabyte size constant: 1,000,000,000,000 bytes.
 const TB Size = Size(units.TB)
 
-// PB is a size constant equal to 1000 terabytes.
+// PB is the decimal petabyte size constant: 1,000,000,000,000,000 bytes.
 const PB Size = Size(units.PB)
 
-// Size is the go-service byte-size type used across the repository.
+// Size is the go-service decimal byte-size type used across the repository.
 //
-// It is a named type over int64 so it can expose config-friendly marshaling
-// helpers while remaining easy to convert at API boundaries.
+// It is a named type over int64 so it can expose config-friendly text and JSON
+// marshaling helpers while remaining easy to convert at API boundaries.
+//
+// Size uses the SI units understood by `github.com/docker/go-units`, such as
+// `B`, `kB`, `MB`, `GB`, and `TB`, rather than IEC binary units like `MiB`.
 type Size int64
 
-// Bytes converts s to its raw byte count.
+// Bytes returns s as a raw byte count.
 func (s Size) Bytes() int64 {
 	return int64(s)
 }
 
-// String returns the human-readable SI size string for s.
+// String returns s in the human-readable decimal size format used by this
+// package, such as `64B` or `4MB`.
 func (s Size) String() string {
 	return units.HumanSize(float64(s.Bytes()))
 }
 
-// MarshalText encodes s using the human-readable SI size format.
+// MarshalText encodes s using the same decimal size string returned by
+// [Size.String].
 func (s Size) MarshalText() ([]byte, error) {
 	return []byte(s.String()), nil
 }
 
-// UnmarshalText decodes a human-readable SI size string into s.
+// UnmarshalText parses a decimal size string into s.
+//
+// Accepted inputs use the same format as [ParseSize], such as `64B`, `2MB`, or
+// `4GB`.
 func (s *Size) UnmarshalText(text []byte) error {
 	size, err := ParseSize(string(text))
 	if err != nil {
@@ -54,12 +61,15 @@ func (s *Size) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// MarshalJSON encodes s as a quoted human-readable SI size string.
+// MarshalJSON encodes s as a quoted decimal size string, such as `"4MB"`.
 func (s Size) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
 }
 
-// UnmarshalJSON decodes a quoted human-readable SI size string into s.
+// UnmarshalJSON decodes a quoted decimal size string into s.
+//
+// Non-string JSON values are rejected by the underlying JSON decoder before the
+// size parser runs.
 func (s *Size) UnmarshalJSON(data []byte) error {
 	var text string
 	if err := json.Unmarshal(data, &text); err != nil {
@@ -71,7 +81,8 @@ func (s *Size) UnmarshalJSON(data []byte) error {
 
 // ParseSize parses a human-readable SI size string.
 //
-// The input uses SI units such as "64B", "2MB", or "4GB".
+// The input uses decimal SI units such as `64B`, `2MB`, or `4GB`. Parsing is
+// delegated to `github.com/docker/go-units`.
 func ParseSize(s string) (Size, error) {
 	size, err := units.FromHumanSize(s)
 	return Size(size), err

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -1,10 +1,10 @@
 package bytes_test
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/stretchr/testify/require"
 )
 

--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -1,6 +1,14 @@
-// Package json provides JSON encoding helpers and adapters used by go-service.
+// Package json provides the go-service JSON import path.
 //
-// This package integrates JSON encoding/decoding behind the go-service encoding abstraction.
+// The package serves two related purposes:
 //
-// Start with the package-level constructors.
+//   - it exposes [Encoder], a thin adapter that satisfies the repository's
+//     generic encoding abstraction while preserving the default behavior of the
+//     standard library encoder and decoder
+//   - it re-exports common JSON helpers and types from the standard library so
+//     packages in this repository can depend on a single go-service JSON import
+//     path instead of importing encoding/json directly
+//
+// All marshaling and unmarshaling semantics remain those of the standard
+// library's encoding/json package.
 package json

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -7,28 +7,88 @@ import (
 
 // NewEncoder constructs a JSON encoder.
 //
-// This encoder is a thin adapter around the standard library `encoding/json` package that satisfies
-// `github.com/alexfalkowski/go-service/v2/encoding.Encoder`.
+// NewEncoder returns an [Encoder] that satisfies
+// `github.com/alexfalkowski/go-service/v2/encoding.Encoder` while delegating to
+// the standard library's `encoding/json` implementation with its default
+// settings.
 func NewEncoder() *Encoder {
 	return &Encoder{}
 }
 
+// Marshaler aliases the standard library JSON marshaler interface.
+//
+// Use this alias when a package wants to refer to the marshaling contract while
+// keeping imports within the go-service JSON package.
+type Marshaler = json.Marshaler
+
+// Unmarshaler aliases the standard library JSON unmarshaler interface.
+//
+// Use this alias when a package wants to refer to the unmarshaling contract
+// while keeping imports within the go-service JSON package.
+type Unmarshaler = json.Unmarshaler
+
+// RawMessage aliases the standard library raw JSON message type.
+//
+// It is useful when callers need to defer decoding or preserve the original
+// encoded JSON payload.
+type RawMessage = json.RawMessage
+
+// Number aliases the standard library JSON number type.
+//
+// It is primarily useful with decoders configured to preserve numeric values as
+// strings until the caller decides how to interpret them.
+type Number = json.Number
+
 // Encoder implements JSON encoding and decoding.
 //
-// It uses the standard library `encoding/json` encoder/decoder with default settings.
+// It preserves the default behavior of the standard library `encoding/json`
+// encoder and decoder and does not add repository-specific options.
 type Encoder struct{}
 
 // Encode writes v to w as JSON.
 //
-// This is a thin wrapper around `json.NewEncoder(w).Encode(v)`.
+// Encode is equivalent to calling `json.NewEncoder(w).Encode(v)`. As with the
+// standard library, the encoded output is terminated with a trailing newline.
 func (e *Encoder) Encode(w io.Writer, v any) error {
 	return json.NewEncoder(w).Encode(v)
 }
 
 // Decode reads JSON from r and decodes it into v.
 //
-// In most cases v should be a pointer to the destination value (for example *MyStruct).
-// This is a thin wrapper around `json.NewDecoder(r).Decode(v)`.
+// In most cases v should be a pointer to the destination value, such as
+// `*MyStruct` or `*map[string]any`. Decode is equivalent to calling
+// `json.NewDecoder(r).Decode(v)`.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	return json.NewDecoder(r).Decode(v)
+}
+
+// Marshal encodes v as JSON using the standard library implementation.
+//
+// It exists so repository packages can use a single go-service JSON import path
+// without changing standard library marshaling behavior.
+func Marshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// MarshalIndent encodes v as indented JSON using the standard library
+// implementation.
+//
+// It behaves exactly like `encoding/json.MarshalIndent`.
+func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+	return json.MarshalIndent(v, prefix, indent)
+}
+
+// Unmarshal decodes JSON data into v using the standard library implementation.
+//
+// In most cases v should be a pointer to the destination value. The decoding
+// rules and error behavior are identical to `encoding/json.Unmarshal`.
+func Unmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}
+
+// Valid reports whether data is syntactically valid JSON.
+//
+// It behaves exactly like `encoding/json.Valid`.
+func Valid(data []byte) bool {
+	return json.Valid(data)
 }

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -27,3 +27,18 @@ func TestDecode(t *testing.T) {
 	require.NoError(t, encoder.Decode(bytes.NewBufferString("{\"test\":\"test\"}"), &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
+
+func TestMarshal(t *testing.T) {
+	msg := map[string]string{"test": "test"}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	require.JSONEq(t, "{\"test\":\"test\"}", string(data))
+}
+
+func TestUnmarshal(t *testing.T) {
+	var msg map[string]string
+
+	require.NoError(t, json.Unmarshal([]byte("{\"test\":\"test\"}"), &msg))
+	require.Equal(t, map[string]string{"test": "test"}, msg)
+}

--- a/time/duration.go
+++ b/time/duration.go
@@ -1,66 +1,80 @@
 package time
 
 import (
-	"encoding/json"
 	"time"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 )
 
-// Hour is a duration constant equal to 60 minutes.
+// Hour is the go-service representation of the standard library `time.Hour`
+// constant.
 //
-// It is an alias of time.Hour, provided so callers can depend on go-service
-// packages while using standard library time values.
+// Its value is one hour.
 const Hour Duration = Duration(time.Hour)
 
-// Microsecond is a duration constant equal to 1e3 nanoseconds.
+// Microsecond is the go-service representation of the standard library
+// `time.Microsecond` constant.
 //
-// It is an alias of time.Microsecond.
+// Its value is one microsecond.
 const Microsecond Duration = Duration(time.Microsecond)
 
-// Millisecond is a duration constant equal to 1e6 nanoseconds.
+// Millisecond is the go-service representation of the standard library
+// `time.Millisecond` constant.
 //
-// It is an alias of time.Millisecond.
+// Its value is one millisecond.
 const Millisecond Duration = Duration(time.Millisecond)
 
-// Minute is a duration constant equal to 60 seconds.
+// Minute is the go-service representation of the standard library `time.Minute`
+// constant.
 //
-// It is an alias of time.Minute.
+// Its value is one minute.
 const Minute Duration = Duration(time.Minute)
 
-// Nanosecond is a duration constant equal to 1.
+// Nanosecond is the go-service representation of the standard library
+// `time.Nanosecond` constant.
 //
-// It is an alias of time.Nanosecond.
+// Its value is one nanosecond.
 const Nanosecond Duration = Duration(time.Nanosecond)
 
-// Second is a duration constant equal to 1e9 nanoseconds.
+// Second is the go-service representation of the standard library `time.Second`
+// constant.
 //
-// It is an alias of time.Second.
+// Its value is one second.
 const Second Duration = Duration(time.Second)
 
 // Duration is the go-service duration type used across the repository.
 //
-// It is a named type over the standard library time.Duration so it can expose
-// config-friendly marshaling helpers while remaining easy to convert at API
-// boundaries.
+// It is a named type over the standard library `time.Duration` so it can expose
+// config-friendly text and JSON marshaling helpers while remaining easy to
+// convert at API boundaries.
+//
+// Duration values serialize as Go duration strings such as `250ms`, `5s`, or
+// `3m15s`.
 type Duration time.Duration
 
-// Duration converts d to the standard library time.Duration type.
+// Duration converts d to the standard library `time.Duration` type.
+//
+// Use it when calling APIs that accept the standard library duration type.
 func (d Duration) Duration() time.Duration {
 	return time.Duration(d)
 }
 
-// String returns the Go duration string for d.
+// String returns d in the standard Go duration format.
 func (d Duration) String() string {
 	return d.Duration().String()
 }
 
-// MarshalText encodes d using the standard Go duration string format.
+// MarshalText encodes d using the same duration string returned by
+// [Duration.String].
 func (d Duration) MarshalText() ([]byte, error) {
 	return []byte(d.String()), nil
 }
 
-// UnmarshalText decodes a Go duration string into d.
+// UnmarshalText parses a Go duration string into d.
+//
+// Accepted inputs use the same format as [ParseDuration], such as `250ms`,
+// `5s`, or `1m`.
 func (d *Duration) UnmarshalText(text []byte) error {
 	duration, err := ParseDuration(string(text))
 	if err != nil {
@@ -71,12 +85,15 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// MarshalJSON encodes d as a quoted Go duration string.
+// MarshalJSON encodes d as a quoted Go duration string, such as `"5s"`.
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
 
 // UnmarshalJSON decodes a quoted Go duration string into d.
+//
+// Non-string JSON values are rejected by the underlying JSON decoder before the
+// duration parser runs.
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	var text string
 	if err := json.Unmarshal(data, &text); err != nil {
@@ -88,8 +105,9 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 
 // ParseDuration parses a duration string.
 //
-// This is a thin wrapper around time.ParseDuration. The input uses the standard
-// Go duration format such as "250ms", "5s", or "1m".
+// This is a thin wrapper around `time.ParseDuration` that returns the
+// repository's [Duration] type. The input uses the standard Go duration format
+// such as `250ms`, `5s`, or `1m`.
 func ParseDuration(s string) (Duration, error) {
 	d, err := time.ParseDuration(s)
 	return Duration(d), err

--- a/time/duration_test.go
+++ b/time/duration_test.go
@@ -1,9 +1,9 @@
 package time_test
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## What

Switched repository JSON usage from the standard library import path to the local `github.com/alexfalkowski/go-service/v2/encoding/json` package.

Expanded the local JSON package so it exposes the stdlib-style helpers and types this repo needs, including `Marshal`, `MarshalIndent`, `Unmarshal`, `Valid`, and common JSON type aliases.

Updated related GoDoc comments in the JSON wrapper and the `bytes.Size` / `time.Duration` helpers so the docs more accurately describe behavior, formats, and intent.

## Why

This keeps packages inside the repo aligned on a single go-service JSON import path instead of mixing direct stdlib imports with the local wrapper.

It also makes the local wrapper practical to use across packages without losing familiar `encoding/json` functionality, while improving package documentation accuracy for consumers and maintainers.

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./encoding/json ./bytes ./time -run 'Test(Duration|MustParseDuration|Encode|Decode|Marshal|Unmarshal|Size)' -count=1
```