### PR TITLE
feat(grpc): use local grpc wrappers and tighten related godoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As a rule of thumb: if you want protocol primitives or shared helpers, start in 
 
 The config decoder supports:
 
-- JSON (`encoding/json`)
+- JSON
 - HJSON (`github.com/hjson/hjson-go/v4`)
 - TOML (`github.com/BurntSushi/toml`)
 - YAML (`go.yaml.in/yaml/v3`)

--- a/internal/test/di.go
+++ b/internal/test/di.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/health"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/module"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
@@ -29,7 +30,6 @@ import (
 	"github.com/linxGnu/mssqlx"
 	"github.com/open-feature/go-sdk/openfeature"
 	webhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
-	"google.golang.org/grpc"
 )
 
 // Options returns the DI options used by tests that exercise the full server module wiring.

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -1,20 +1,18 @@
-// Package grpc provides small, stable wrappers and aliases around
-// google.golang.org/grpc for use within go-service.
+// Package grpc provides the go-service gRPC import path.
 //
-// This package deliberately exposes a narrow surface area:
+// This package deliberately exposes a small, stable surface area over
+// `google.golang.org/grpc` so repository packages can depend on a consistent
+// go-service import path instead of importing upstream gRPC packages directly.
 //
-//   - Type aliases for commonly used gRPC types (for example CallOption,
-//     DialOption, ServerOption, Server, ClientConn, interceptors, and stream
-//     types). These allow go-service code to depend on go-service packages while
-//     still using the underlying gRPC implementations.
+// It includes:
 //
-//   - Thin helper functions that forward to gRPC constructors/options (for
-//     example StatsHandler, WithStatsHandler, ChainUnaryInterceptor,
-//     ChainStreamInterceptor, Creds, NewTLS, NewInsecureCredentials, and
-//     UseCompressor).
-//
-//   - A convenience NewServer constructor that applies standard server-side
-//     keepalive configuration and registers gRPC reflection.
+//   - type aliases for commonly used gRPC types such as CallOption, DialOption,
+//     ServerOption, Server, ClientConn, interceptors, and stream interfaces
+//   - thin helper functions that forward to common constructors and options
+//     such as StatsHandler, Header, ChainUnaryInterceptor, Creds, NewTLS,
+//     NewInsecureCredentials, and UseCompressor
+//   - a convenience NewServer constructor that applies standard server-side
+//     keepalive configuration and registers gRPC reflection
 //
 // # Server construction
 //

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/net"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"google.golang.org/grpc"
@@ -13,7 +14,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	_ "google.golang.org/grpc/encoding/gzip" // Install the gzip compressor.
 	"google.golang.org/grpc/keepalive"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/stats"
 )
@@ -211,8 +211,16 @@ func NewTLS(c *tls.Config) credentials.TransportCredentials {
 //
 // This forwards to grpc.SetHeader. It is typically called by a handler to add
 // response headers.
-func SetHeader(ctx context.Context, md metadata.MD) error {
+func SetHeader(ctx context.Context, md meta.Map) error {
 	return grpc.SetHeader(ctx, md)
+}
+
+// Header returns a call option that captures response header metadata.
+//
+// This forwards to grpc.Header. The provided map is populated by the client
+// call with any header metadata returned by the server.
+func Header(md *meta.Map) CallOption {
+	return grpc.Header(md)
 }
 
 // TimeoutUnaryClientInterceptor returns a unary client interceptor that applies a per-RPC timeout.

--- a/net/grpc/health/health_test.go
+++ b/net/grpc/health/health_test.go
@@ -7,17 +7,16 @@ import (
 	"github.com/alexfalkowski/go-health/v2/server"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 	v1 "google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/metadata"
 )
 
 func TestCheck(t *testing.T) {
@@ -54,8 +53,8 @@ func TestInvalidCheck(t *testing.T) {
 	client := v1.NewHealthClient(conn)
 	req := &v1.HealthCheckRequest{Service: test.Name.String()}
 
-	md := metadata.New(map[string]string{"request-id": "test-id", "user-agent": "test-user-agent"})
-	ctx := metadata.NewOutgoingContext(t.Context(), md)
+	md := meta.New(map[string]string{"request-id": "test-id", "user-agent": "test-user-agent"})
+	ctx := meta.NewOutgoingContext(t.Context(), md)
 
 	resp, err := client.Check(ctx, req)
 	require.NoError(t, err)
@@ -73,8 +72,8 @@ func TestNotFoundCheck(t *testing.T) {
 	client := v1.NewHealthClient(conn)
 	req := &v1.HealthCheckRequest{Service: "bob"}
 
-	md := metadata.New(map[string]string{"request-id": "test-id", "user-agent": "test-user-agent"})
-	ctx := metadata.NewOutgoingContext(t.Context(), md)
+	md := meta.New(map[string]string{"request-id": "test-id", "user-agent": "test-user-agent"})
+	ctx := meta.NewOutgoingContext(t.Context(), md)
 
 	_, err := client.Check(ctx, req)
 	require.Error(t, err)
@@ -374,15 +373,15 @@ func (w *watchStream) Send(resp *v1.HealthCheckResponse) error {
 	}
 }
 
-func (*watchStream) SetHeader(metadata.MD) error {
+func (*watchStream) SetHeader(meta.Map) error {
 	return nil
 }
 
-func (*watchStream) SendHeader(metadata.MD) error {
+func (*watchStream) SendHeader(meta.Map) error {
 	return nil
 }
 
-func (*watchStream) SetTrailer(metadata.MD) {}
+func (*watchStream) SetTrailer(meta.Map) {}
 
 func (*watchStream) SendMsg(any) error {
 	return nil

--- a/net/grpc/meta/doc.go
+++ b/net/grpc/meta/doc.go
@@ -1,13 +1,28 @@
-// Package meta provides gRPC metadata interceptors and helpers for go-service.
+// Package meta provides the go-service gRPC metadata import path.
 //
-// This package extracts incoming request metadata into the context on the server side and injects
-// outgoing metadata on the client side. It also provides small helpers around gRPC metadata maps so
-// higher-level transport code can build on consistent metadata behavior.
+// The package serves two related purposes:
 //
-// Metadata keys used by this package include: "user-agent", "request-id", "authorization", and "geolocation".
-// Server interceptors also set response header metadata such as "service-version" and "request-id".
+//   - it wraps common `google.golang.org/grpc/metadata` context helpers and map
+//     constructors so repository code can depend on a single go-service import
+//     path for gRPC metadata operations
+//   - it re-exports the small subset of the root `meta` package that gRPC
+//     transport code commonly needs, so callers can work with metadata maps and
+//     request-scoped attributes through one package
 //
-// Start with `UnaryServerInterceptor` / `StreamServerInterceptor` for server-side extraction and
-// `UnaryClientInterceptor` / `StreamClientInterceptor` for client-side injection. Use
-// `ExtractIncoming` and `ExtractOutgoing` when you need mutable copies of metadata maps.
+// In addition, the package provides client and server interceptors that keep a
+// consistent metadata contract across gRPC transports. The main keys used by
+// those interceptors are:
+//
+//   - "user-agent"
+//   - "request-id"
+//   - "authorization"
+//   - "geolocation"
+//
+// Server interceptors also emit response header metadata such as
+// "service-version" and "request-id".
+//
+// Start with `UnaryServerInterceptor` / `StreamServerInterceptor` for
+// server-side extraction and `UnaryClientInterceptor` /
+// `StreamClientInterceptor` for client-side injection. Use `ExtractIncoming`
+// and `ExtractOutgoing` when you need mutable copies of metadata maps.
 package meta

--- a/net/grpc/meta/extract.go
+++ b/net/grpc/meta/extract.go
@@ -1,29 +1,26 @@
 package meta
 
-import (
-	"github.com/alexfalkowski/go-service/v2/context"
-	"google.golang.org/grpc/metadata"
-)
+import "github.com/alexfalkowski/go-service/v2/context"
 
 // ExtractIncoming extracts incoming gRPC metadata from ctx.
 //
 // If no incoming metadata is present, it returns an empty metadata map.
 // The returned metadata is a copy and is safe to mutate by the caller.
-func ExtractIncoming(ctx context.Context) metadata.MD {
-	return extract(metadata.FromIncomingContext(ctx))
+func ExtractIncoming(ctx context.Context) Map {
+	return extract(FromIncomingContext(ctx))
 }
 
 // ExtractOutgoing extracts outgoing gRPC metadata from ctx.
 //
 // If no outgoing metadata is present, it returns an empty metadata map.
 // The returned metadata is a copy and is safe to mutate by the caller.
-func ExtractOutgoing(ctx context.Context) metadata.MD {
-	return extract(metadata.FromOutgoingContext(ctx))
+func ExtractOutgoing(ctx context.Context) Map {
+	return extract(FromOutgoingContext(ctx))
 }
 
-func extract(md metadata.MD, ok bool) metadata.MD {
+func extract(md Map, ok bool) Map {
 	if !ok {
-		return metadata.MD{}
+		return Map{}
 	}
 
 	return md.Copy()

--- a/net/grpc/meta/meta.go
+++ b/net/grpc/meta/meta.go
@@ -1,6 +1,8 @@
 package meta
 
 import (
+	"fmt"
+
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
@@ -16,35 +18,183 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-// Map is an alias for metadata.MD.
+// Map aliases gRPC metadata.MD.
+//
+// It represents the incoming or outgoing metadata map attached to a gRPC
+// context. The alias exists so callers can work with gRPC metadata through the
+// go-service import path rather than importing `google.golang.org/grpc/metadata`
+// directly.
 type Map = metadata.MD
 
-// Authorization is an alias for meta.Authorization.
+// Value aliases the root go-service metadata value type.
+//
+// Use it when working with request-scoped attributes such as user agents,
+// request IDs, authorization tokens, and IP-derived metadata through this
+// package's helper functions.
+type Value = meta.Value
+
+// IPAddrKindKey is the attribute key that describes how an IP address was derived.
+//
+// The value typically distinguishes between peer-derived addresses and trusted
+// forwarding headers.
+const IPAddrKindKey = meta.IPAddrKindKey
+
+// Authorization returns the authorization attribute stored on ctx.
+//
+// It forwards to the root `meta.Authorization` helper so callers can keep gRPC
+// metadata and request attribute access under one import path.
 func Authorization(ctx context.Context) meta.Value {
 	return meta.Authorization(ctx)
 }
 
-// Ignored is an alias for meta.Ignored.
+// Attribute returns the stored request attribute for key.
+//
+// If no attribute is present, it returns the zero-value [Value]. It forwards to
+// the root `meta.Attribute` helper.
+func Attribute(ctx context.Context, key string) meta.Value {
+	return meta.Attribute(ctx, key)
+}
+
+// AppendToOutgoingContext adds kv to the outgoing metadata in ctx.
+//
+// It is an alias for metadata.AppendToOutgoingContext. The kv slice must
+// contain an even number of elements arranged as alternating key/value pairs.
+func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, kv...)
+}
+
+// Ignored constructs a [Value] that is retained in-context but omitted when
+// rendered/exported.
+//
+// It forwards to the root `meta.Ignored` helper and is useful for sensitive
+// metadata such as authorization-derived values.
 func Ignored(value string) meta.Value {
 	return meta.Ignored(value)
 }
 
-// NewOutgoingContext is an alias for metadata.NewOutgoingContext.
+// IPAddr returns the stored IP address attribute from ctx.
+//
+// It forwards to the root `meta.IPAddr` helper.
+func IPAddr(ctx context.Context) meta.Value {
+	return meta.IPAddr(ctx)
+}
+
+// FromOutgoingContext returns the outgoing metadata in ctx, if any.
+//
+// It is an alias for metadata.FromOutgoingContext.
+func FromOutgoingContext(ctx context.Context) (Map, bool) {
+	return metadata.FromOutgoingContext(ctx)
+}
+
+// FromIncomingContext returns the incoming metadata in ctx, if any.
+//
+// It is an alias for metadata.FromIncomingContext.
+func FromIncomingContext(ctx context.Context) (Map, bool) {
+	return metadata.FromIncomingContext(ctx)
+}
+
+// New constructs metadata from a string map.
+//
+// It forwards to `metadata.New`. Keys are normalized using the same rules as
+// upstream gRPC metadata handling.
+func New(md map[string]string) Map {
+	return metadata.New(md)
+}
+
+// NewIncomingContext attaches md as incoming metadata to ctx.
+//
+// It is an alias for metadata.NewIncomingContext.
+func NewIncomingContext(ctx context.Context, md Map) context.Context {
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+// NewOutgoingContext attaches md as outgoing metadata to ctx.
+//
+// It forwards to `metadata.NewOutgoingContext`.
 func NewOutgoingContext(ctx context.Context, md Map) context.Context {
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
-// Pairs is an alias for metadata.Pairs.
+// Pairs constructs metadata from alternating key/value arguments.
+//
+// It forwards to `metadata.Pairs`. The kv slice must contain an even number of
+// elements.
 func Pairs(kv ...string) Map {
 	return metadata.Pairs(kv...)
 }
 
-// WithUserID is an alias for meta.WithUserID.
+// Redacted constructs a [Value] that renders as a mask while preserving the
+// underlying value in-context.
+//
+// It forwards to the root `meta.Redacted` helper.
+func Redacted(value string) meta.Value {
+	return meta.Redacted(value)
+}
+
+// String constructs a normal [Value] that renders as-is.
+//
+// It forwards to the root `meta.String` helper.
+func String(value string) meta.Value {
+	return meta.String(value)
+}
+
+// ToIgnored converts st to an ignored [Value] using st.String().
+//
+// If st is nil, it returns a blank value. It forwards to the root
+// `meta.ToIgnored` helper.
+func ToIgnored(st fmt.Stringer) meta.Value {
+	return meta.ToIgnored(st)
+}
+
+// ToRedacted converts st to a redacted [Value] using st.String().
+//
+// If st is nil, it returns a blank value. It forwards to the root
+// `meta.ToRedacted` helper.
+func ToRedacted(st fmt.Stringer) meta.Value {
+	return meta.ToRedacted(st)
+}
+
+// ToString converts st to a normal [Value] using st.String().
+//
+// If st is nil, it returns a blank value. It forwards to the root
+// `meta.ToString` helper.
+func ToString(st fmt.Stringer) meta.Value {
+	return meta.ToString(st)
+}
+
+// WithAttribute stores key/value on ctx as a request-scoped attribute.
+//
+// It forwards to the root `meta.WithAttribute` helper and is primarily useful
+// when tests or interceptors need to seed context values before gRPC transport
+// processing begins.
+func WithAttribute(ctx context.Context, key string, value meta.Value) context.Context {
+	return meta.WithAttribute(ctx, key, value)
+}
+
+// WithRequestID stores a request ID attribute on ctx.
+//
+// It forwards to the root `meta.WithRequestID` helper.
+func WithRequestID(ctx context.Context, id meta.Value) context.Context {
+	return meta.WithRequestID(ctx, id)
+}
+
+// WithUserID stores a user ID attribute on ctx.
+//
+// It forwards to the root `meta.WithUserID` helper.
 func WithUserID(ctx context.Context, id meta.Value) context.Context {
 	return meta.WithUserID(ctx, id)
 }
 
-// WithAuthorization is an alias for meta.WithAuthorization.
+// WithUserAgent stores a user-agent attribute on ctx.
+//
+// It forwards to the root `meta.WithUserAgent` helper.
+func WithUserAgent(ctx context.Context, userAgent meta.Value) context.Context {
+	return meta.WithUserAgent(ctx, userAgent)
+}
+
+// WithAuthorization stores an authorization attribute on ctx.
+//
+// It forwards to the root `meta.WithAuthorization` helper.
 func WithAuthorization(ctx context.Context, auth meta.Value) context.Context {
 	return meta.WithAuthorization(ctx, auth)
 }
@@ -52,11 +202,21 @@ func WithAuthorization(ctx context.Context, auth meta.Value) context.Context {
 // UnaryServerInterceptor returns a gRPC unary server interceptor that extracts metadata into the context.
 //
 // Requests with ignorable methods bypass extraction.
-// It extracts metadata from incoming headers (when present) and stores it into the context, including:
-// "user-agent", "request-id", "authorization", and "geolocation", along with IP address and its source kind.
-// If the Authorization header is present but invalid, it returns InvalidArgument.
 //
-// It also sets response header metadata including "service-version" and "request-id".
+// For non-ignored methods, the interceptor:
+//
+//   - copies incoming metadata from the request context
+//   - resolves "user-agent" and "request-id", preferring existing context
+//     attributes and then incoming metadata values
+//   - derives IP address information from trusted forwarding headers or, if
+//     absent, from the gRPC peer address
+//   - parses the "authorization" header into the request attribute model
+//   - stores "geolocation" when present
+//   - sets response header metadata including "service-version" and
+//     "request-id"
+//
+// If the Authorization header is present but invalid, the interceptor returns a
+// `codes.InvalidArgument` gRPC status error.
 func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, generator id.Generator) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if strings.IsIgnorable(info.FullMethod) {
@@ -82,7 +242,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 		}
 		ctx = meta.WithAuthorization(ctx, auth)
 
-		_ = grpc.SetHeader(ctx, metadata.Pairs("service-version", version.String(), "request-id", id.Value()))
+		_ = grpc.SetHeader(ctx, Pairs("service-version", version.String(), "request-id", id.Value()))
 
 		return handler(ctx, req)
 	}
@@ -91,24 +251,24 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 // StreamServerInterceptor returns a gRPC stream server interceptor that extracts metadata into the stream context.
 //
 // Requests with ignorable methods bypass extraction.
-// It extracts metadata from incoming headers (when present) and stores it into the stream context, including:
-// "user-agent", "request-id", "authorization", and "geolocation", along with IP address and its source kind.
 //
-// It sets response header metadata including "service-version" and "request-id".
+// For non-ignored methods, the interceptor performs the same metadata-to-context
+// projection as [UnaryServerInterceptor], but applies it to the wrapped stream
+// context and emits response headers through the stream API.
 func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, generator id.Generator) grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if strings.IsIgnorable(info.FullMethod) {
 			return handler(srv, stream)
 		}
 
-		_ = stream.SetHeader(metadata.Pairs("service-version", version.String()))
+		_ = stream.SetHeader(Pairs("service-version", version.String()))
 
 		ctx := stream.Context()
 		md := ExtractIncoming(ctx)
 		ctx = meta.WithUserAgent(ctx, extractUserAgent(ctx, md, userAgent))
 
 		id := extractRequestID(ctx, generator, md)
-		_ = stream.SetHeader(metadata.Pairs("request-id", id.Value()))
+		_ = stream.SetHeader(Pairs("request-id", id.Value()))
 
 		ctx = meta.WithRequestID(ctx, id)
 
@@ -133,11 +293,13 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 
 // UnaryClientInterceptor returns a gRPC unary client interceptor that injects metadata into outgoing requests.
 //
-// It ensures "user-agent" and "request-id" are present in outgoing metadata, preferring values already
-// present in the context or outgoing metadata, and stores the chosen values back into the context.
+// It ensures "user-agent" and "request-id" are present in outgoing metadata,
+// preferring values already present in the context or outgoing metadata, and
+// stores the chosen values back into the context.
 //
-// Existing outgoing metadata values for these keys are replaced so repeated interceptor invocation does not
-// accumulate duplicates or preserve stale values ahead of the resolved value.
+// Existing outgoing metadata values for these keys are replaced so repeated
+// interceptor invocation does not accumulate duplicates or preserve stale
+// values ahead of the resolved value.
 func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		md := ExtractOutgoing(ctx)
@@ -150,18 +312,20 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 		ctx = meta.WithRequestID(ctx, id)
 		md.Set("request-id", id.Value())
 
-		ctx = metadata.NewOutgoingContext(ctx, md)
+		ctx = NewOutgoingContext(ctx, md)
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
 	}
 }
 
 // StreamClientInterceptor returns a gRPC stream client interceptor that injects metadata into outgoing requests.
 //
-// It ensures "user-agent" and "request-id" are present in outgoing metadata, preferring values already
-// present in the context or outgoing metadata, and stores the chosen values back into the context.
+// It ensures "user-agent" and "request-id" are present in outgoing metadata,
+// preferring values already present in the context or outgoing metadata, and
+// stores the chosen values back into the context.
 //
-// Existing outgoing metadata values for these keys are replaced so repeated interceptor invocation does not
-// accumulate duplicates or preserve stale values ahead of the resolved value.
+// Existing outgoing metadata values for these keys are replaced so repeated
+// interceptor invocation does not accumulate duplicates or preserve stale
+// values ahead of the resolved value.
 func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		md := ExtractOutgoing(ctx)
@@ -174,7 +338,7 @@ func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) gr
 		ctx = meta.WithRequestID(ctx, id)
 		md.Set("request-id", id.Value())
 
-		ctx = metadata.NewOutgoingContext(ctx, md)
+		ctx = NewOutgoingContext(ctx, md)
 		return streamer(ctx, desc, conn, fullMethod, opts...)
 	}
 }

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/env"
-	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
-	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 )
 
@@ -17,14 +15,14 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 	ctx := context.Background()
 	ctx = meta.WithUserAgent(ctx, meta.String("current-agent"))
 	ctx = meta.WithRequestID(ctx, meta.String("current-id"))
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+	ctx = meta.NewOutgoingContext(ctx, meta.Pairs(
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), staticGenerator("generated-id"))
+	interceptor := meta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), staticGenerator("generated-id"))
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		md, ok := metadata.FromOutgoingContext(ctx)
+		md, ok := meta.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
@@ -38,13 +36,13 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 	ctx := context.Background()
 	ctx = meta.WithUserAgent(ctx, meta.String("current-agent"))
 	ctx = meta.WithRequestID(ctx, meta.String("current-id"))
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+	ctx = meta.NewOutgoingContext(ctx, meta.Pairs(
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), staticGenerator("generated-id"))
+	interceptor := meta.StreamClientInterceptor(env.UserAgent("fallback-agent"), staticGenerator("generated-id"))
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
-		md, ok := metadata.FromOutgoingContext(ctx)
+		md, ok := meta.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
@@ -60,8 +58,8 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
@@ -74,8 +72,8 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {

--- a/net/grpc/server/doc.go
+++ b/net/grpc/server/doc.go
@@ -1,14 +1,13 @@
 // Package server provides helpers for running a gRPC server as a managed go-service server.
 //
 // This package is intentionally small: it adapts a configured
-// google.golang.org/grpc.Server to the go-service `server.Service` lifecycle,
+// `net/grpc.Server` to the go-service `server.Service` lifecycle,
 // and it provides a lightweight wrapper that binds a listener and exposes a
 // `Serve`/`Shutdown` API compatible with the generic server runner.
 //
 // In most cases you will:
 //
-//  1. Construct a *grpc.Server (for example via net/grpc.NewServer, or by calling
-//     google.golang.org/grpc.NewServer directly with your chosen options).
+//  1. Construct a *grpc.Server (typically via net/grpc.NewServer).
 //  2. Provide a bind address via net/grpc/config.Config.
 //  3. Call NewService to get a `server.Service` that starts and stops the gRPC
 //     server and wires shutdown and logging.

--- a/net/grpc/server/server.go
+++ b/net/grpc/server/server.go
@@ -4,10 +4,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
-	"google.golang.org/grpc"
 )
 
 // Service is an alias for server.Service.

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -61,7 +61,9 @@
 //
 // # Non-goals
 //
-// This package intentionally does not expose the full status API surface (for
-// example status.FromError, status.New, or Status.Details). Higher-level code
-// that needs structured details should use the upstream status package directly.
+// This package intentionally exposes only the small subset of the upstream
+// status API that go-service uses broadly: Code, FromError, Error, Errorf, and
+// the Status type alias. Higher-level code that needs additional constructors or
+// richer structured-detail helpers should use the upstream status package
+// directly.
 package status

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -5,6 +5,13 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Status aliases the upstream gRPC status type.
+//
+// It is re-exported so callers can inspect gRPC errors through the go-service
+// import path while preserving upstream behavior and methods such as Code,
+// Message, Details, Err, and Proto.
+type Status = status.Status
+
 // Code returns the gRPC status code for err as a go-service codes.Code.
 //
 // This is a thin wrapper around google.golang.org/grpc/status.Code, returning
@@ -22,6 +29,22 @@ import (
 // response strategy (retry, map to HTTP status codes, etc.).
 func Code(err error) codes.Code {
 	return status.Code(err)
+}
+
+// FromError returns a status representation for err, if err is or wraps a gRPC
+// status error.
+//
+// This is a thin wrapper around google.golang.org/grpc/status.FromError.
+// Behavior is identical to the upstream implementation:
+//
+//   - If err was produced from a gRPC status, the returned Status reflects the
+//     embedded code and message and ok is true.
+//   - If err wraps a gRPC status error, the returned Status preserves the
+//     underlying status while the message may incorporate wrapping context,
+//     matching upstream behavior.
+//   - Otherwise, ok is false and the returned Status represents codes.Unknown.
+func FromError(err error) (*Status, bool) {
+	return status.FromError(err)
 }
 
 // Error constructs a gRPC status error with code c and message msg.

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -1,0 +1,35 @@
+package status_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromError(t *testing.T) {
+	err := status.Error(codes.NotFound, "missing")
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, s.Code())
+	require.Equal(t, "missing", s.Message())
+}
+
+func TestFromErrorWrapped(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", status.Error(codes.InvalidArgument, "invalid"))
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, s.Code())
+	require.Contains(t, s.Message(), "wrapped:")
+}
+
+func TestFromErrorUnknown(t *testing.T) {
+	s, ok := status.FromError(errors.New("plain error"))
+	require.False(t, ok)
+	require.Equal(t, codes.Unknown, s.Code())
+}

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"google.golang.org/grpc/status"
 )
 
 // Error constructs an error that carries an HTTP status code and a message.

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 func TestTokenErrorAuthUnary(t *testing.T) {
@@ -72,8 +72,8 @@ func TestInvalidAuthUnary(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	ctx = metadata.AppendToOutgoingContext(ctx, "x-forwarded-for", "127.0.0.1")
-	ctx = metadata.AppendToOutgoingContext(ctx, "geolocation", "geo:47,11")
+	ctx = meta.AppendToOutgoingContext(ctx, "x-forwarded-for", "127.0.0.1")
+	ctx = meta.AppendToOutgoingContext(ctx, "geolocation", "geo:47,11")
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -89,7 +89,7 @@ func TestAuthUnaryWithAppend(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC())
 
 	ctx := t.Context()
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "What Invalid")
+	ctx = meta.AppendToOutgoingContext(ctx, "authorization", "What Invalid")
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -105,7 +105,7 @@ func TestAuthStreamWithAppend(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC())
 
 	ctx := t.Context()
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "What Invalid")
+	ctx = meta.AppendToOutgoingContext(ctx, "authorization", "What Invalid")
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -126,7 +126,7 @@ func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldGRPC())
 
 	ctx := t.Context()
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "bearer test")
+	ctx = meta.AppendToOutgoingContext(ctx, "authorization", "bearer test")
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
-	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 func TestInsecureUnary(t *testing.T) {
@@ -28,7 +27,7 @@ func TestInsecureUnary(t *testing.T) {
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
-	var header metadata.MD
+	var header meta.Map
 
 	resp, err := client.SayHello(ctx, req, grpc.Header(&header))
 	require.NoError(t, err)

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestServerLimiterUnary(t *testing.T) {

--- a/transport/grpc/telemetry/logger/logger_test.go
+++ b/transport/grpc/telemetry/logger/logger_test.go
@@ -3,9 +3,9 @@ package logger_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
 )
 
 func TestLogger(t *testing.T) {

--- a/transport/grpc/token/token_test.go
+++ b/transport/grpc/token/token_test.go
@@ -6,17 +6,17 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 )
 
 func TestUnaryClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", "Bearer stale-token"))
+	ctx := meta.NewOutgoingContext(context.Background(), meta.Pairs("authorization", "Bearer stale-token"))
 	interceptor := token.UnaryClientInterceptor(env.UserID("service-user"), staticTokenGenerator("fresh-token"))
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		md, ok := metadata.FromOutgoingContext(ctx)
+		md, ok := meta.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{"Bearer fresh-token"}, md.Get("authorization"))
 
@@ -26,10 +26,10 @@ func TestUnaryClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 }
 
 func TestStreamClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", "Bearer stale-token"))
+	ctx := meta.NewOutgoingContext(context.Background(), meta.Pairs("authorization", "Bearer stale-token"))
 	interceptor := token.StreamClientInterceptor(env.UserID("service-user"), staticTokenGenerator("fresh-token"))
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
-		md, ok := metadata.FromOutgoingContext(ctx)
+		md, ok := meta.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{"Bearer fresh-token"}, md.Get("authorization"))
 


### PR DESCRIPTION
## What

Standardized internal package usage so repo code prefers the local wrapper packages instead of direct upstream imports for JSON and gRPC helpers.

Expanded the local wrapper packages where needed:
- `encoding/json` now exposes common marshal/unmarshal helpers and type aliases used in the repo
- `net/grpc/status` now exposes `FromError` and the `Status` alias
- `net/grpc/meta` now exposes the metadata/context helpers and root metadata aliases needed by gRPC code
- `net/grpc` now exposes `Header`

Updated non-generated callers and tests to use the local wrapper packages, and removed unnecessary import aliases like `stdjson`, `encodingjson`, `grpcstatus`, `grpcmeta`, and `basemeta`.

Tightened related Godoc comments across the touched wrapper packages and helper types, and made the README wording around JSON a little more implementation-neutral.

## Why

This keeps the codebase aligned on the repo’s own import paths instead of mixing local wrappers with direct upstream imports.

It also makes the wrapper packages complete enough for normal internal use, reduces import churn in callers, and improves API clarity for maintainers by making the Godoc reflect the actual intended usage.

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./encoding/json ./bytes ./time -run 'Test(Duration|MustParseDuration|Encode|Decode|Marshal|Unmarshal|Size)' -count=1
env GOCACHE=/tmp/go-build go test ./net/grpc/status ./net/http/status -count=1
env GOCACHE=/tmp/go-build go test ./net/grpc/meta -run 'Test(UnaryClientInterceptorReplacesOutgoingMetadata|StreamClientInterceptorReplacesOutgoingMetadata|UnaryServerInterceptorHandlesMissingPeer|UnaryServerInterceptorHandlesPeerWithoutAddr)$' -count=1
env GOCACHE=/tmp/go-build go test ./transport/grpc/token -run 'Test(UnaryClientInterceptorReplacesOutgoingAuthorization|StreamClientInterceptorReplacesOutgoingAuthorization)$' -count=1
env GOCACHE=/tmp/go-build go test ./net/grpc/meta ./net/grpc ./net/grpc/server -run '^$' -count=1
env GOCACHE=/tmp/go-build go test ./transport/grpc ./net/grpc/health -run '^$' -count=1
```

Notes:
- Full `./time` testing is blocked in this environment by existing network-dependent NTP/NTS tests.
- Broader `transport/grpc` runtime tests depend on external services like Valkey, so compile-only checks were used where appropriate.