### PR TITLE
test(strings): use local strings helpers in tests instead of direct stdlib strings imports

### DIFF
--- a/encoding/bytes/bytes_test.go
+++ b/encoding/bytes/bytes_test.go
@@ -1,12 +1,12 @@
 package bytes_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	eb "github.com/alexfalkowski/go-service/v2/encoding/bytes"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -1,12 +1,12 @@
 package toml_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/toml"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -1,12 +1,12 @@
 package yaml_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -3,7 +3,6 @@ package content_test
 import (
 	"io"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -12,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/mime"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -2,7 +2,6 @@ package http_test
 
 import (
 	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -12,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/html"
 )

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"


### PR DESCRIPTION
## What

Replaced the remaining direct `strings` standard library imports in non-wrapper code with the local `github.com/alexfalkowski/go-service/v2/strings` package.

Updated the affected test packages to use the local wrapper for the stdlib helpers they already relied on, including `NewReader` and `TrimSpace`.

No new wrapper functions were needed because the existing `strings` package already exposed the required helpers.

## Why

This keeps the codebase consistent with the wrapper-first import pattern used elsewhere in the repo, so internal code prefers go-service package paths instead of mixing local wrappers with direct standard library imports.

It also keeps the `strings` package as the single internal entrypoint for common string helpers without changing behavior in the touched tests.

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./net/http/content ./encoding/yaml ./encoding/bytes ./encoding/toml ./transport/http ./transport/http/retry -run 'Test(NewRequestHandlerRejectsErrorContentType|NewHandlerRejectsErrorContentType|NewHandlerDoesNotLeakPartialBodyWhenEncodeFails|Encode|Decode|Encoder|DecodeResetsDestination|RouteSuccess|RoutePartialViewSuccess|RouteError|StaticFileSuccess|StaticFileError|StaticPathValueSuccess|StaticPathValueError|MissingViews|RoundTripperRetriesRetryableResponses|RoundTripperDoesNotRetryWhenAttemptsIsOne|RoundTripperReturnsLastRetryableResponseWhenExhausted|RoundTripperReturnsFirstRetryableResponseWhenExhausted|RoundTripperReplaysRequestBodyAcrossRetries|RoundTripperDoesNotRetryNonReplayableRequestBody|RoundTripperPreservesRetryableTransportError|RoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries)$' -count=1
```

Notes:
- `./net/http/content`, `./encoding/yaml`, `./encoding/bytes`, `./encoding/toml`, and `./transport/http/retry` passed.
- The `./transport/http` MVC-style tests still fail in this environment because they depend on Valkey at `127.0.0.1:6379`, which is not available in the sandbox.