### PR TITLE
feat(sql): route shared mssqlx usage through database/sql where the package graph allows it

### DIFF
--- a/database/sql/doc.go
+++ b/database/sql/doc.go
@@ -10,6 +10,22 @@
 // is treated as "disabled". Driver-specific configs typically follow the same convention, and
 // constructors that depend on config often return (nil, nil) when disabled.
 //
+// # Master/slave pool wrapper
+//
+// This package also exposes the shared master/slave pool abstraction used by
+// repository code:
+//   - `DBs`, the go-service alias for the upstream pool collection type, and
+//   - `ConnectMasterSlaves`, the go-service wrapper for opening those pools.
+//
+// This keeps internal code on a go-service import path instead of importing the
+// upstream helper package directly where the package graph allows it.
+//
+// Driver-oriented subpackages such as `database/sql/driver` and
+// `database/sql/pg` still use the upstream pool package internally because the
+// root `database/sql` package already depends on those subpackages for config
+// and module composition. Re-importing the root package from those subpackages
+// would create an import cycle.
+//
 // # Master/slave pools and telemetry
 //
 // Driver integrations typically open master/slave connection pools, configure pool limits/lifetimes,

--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -49,11 +49,14 @@ func Register(name string, driver Driver) (err error) {
 	return err
 }
 
-// Connect opens master/slave `database/sql` connection pools for a previously registered driver name.
+// Connect opens master/slave `database/sql` connection pools for a previously
+// registered driver name.
 //
-// It resolves DSNs from cfg using the provided filesystem (DSNs are configured as go-service "source strings"),
-// connects using `mssqlx.ConnectMasterSlaves`, registers OpenTelemetry DB stats metrics for each pool, and then
-// applies pool settings (connection lifetime, max idle, and max open connections).
+// It resolves DSNs from cfg using the provided filesystem (DSNs are configured
+// as go-service "source strings"), connects using
+// `mssqlx.ConnectMasterSlaves`, registers OpenTelemetry DB stats metrics for
+// each pool, and then applies pool settings (connection lifetime, max idle, and
+// max open connections).
 //
 // Preconditions:
 //   - cfg must be non-nil and already treated as enabled/validated by the caller.
@@ -61,6 +64,11 @@ func Register(name string, driver Driver) (err error) {
 // Failure behavior:
 //   - returns errors encountered while resolving DSNs or connecting, and
 //   - returns ErrNoDSNs when neither masters nor slaves are configured.
+//
+// The returned type is the upstream master/slave pool collection used
+// internally by the SQL driver layer. Higher-level repository code can usually
+// treat it interchangeably with `database/sql.DBs`, which aliases the same
+// upstream type.
 func Connect(name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 	masters := make([]string, len(cfg.Masters))
 
@@ -96,10 +104,14 @@ func Connect(name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 	return db, nil
 }
 
-// Open opens master/slave `database/sql` connection pools for a previously registered driver name.
+// Open opens master/slave `database/sql` connection pools for a previously
+// registered driver name.
 //
 // Open delegates the connection work to Connect and then appends an OnStop hook
 // to the provided lifecycle that closes all returned pools by calling Destroy.
+//
+// The returned type is the same upstream master/slave pool collection returned
+// by Connect.
 func Open(lc di.Lifecycle, name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 	db, err := Connect(name, fs, cfg)
 	if err != nil {

--- a/database/sql/pg/doc.go
+++ b/database/sql/pg/doc.go
@@ -12,9 +12,14 @@
 //
 // # Master/slave pools
 //
-// `Open` resolves master and replica DSNs from configuration (DSNs are expressed as go-service "source strings"),
-// connects using a master/slave pool abstraction, applies pool settings (max lifetime/open/idle), and registers
-// OpenTelemetry DB stats metrics.
+// `Open` resolves master and replica DSNs from configuration (DSNs are
+// expressed as go-service "source strings"), connects using the shared
+// master/slave pool abstraction used by the repository, applies pool settings
+// (max lifetime/open/idle), and registers OpenTelemetry DB stats metrics.
+//
+// Although the package-level SQL wrapper aliases this pool type as
+// `database/sql.DBs`, this package returns the underlying upstream type
+// directly to avoid an import cycle with the root `database/sql` package.
 //
 // Start with `Config`, `Register`, and `Open`.
 package pg

--- a/database/sql/pg/pg.go
+++ b/database/sql/pg/pg.go
@@ -28,6 +28,10 @@ func Register() {
 //   - connect using the previously registered driver name "pg",
 //   - register OpenTelemetry DB stats metrics, and
 //   - apply connection pool limits/lifetime.
+//
+// The returned type is the upstream master/slave pool collection used
+// throughout the SQL layer. The root `database/sql` package aliases the same
+// type as `sql.DBs` for higher-level callers.
 func Connect(fs *os.FS, cfg *Config) (*mssqlx.DBs, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
@@ -40,6 +44,9 @@ func Connect(fs *os.FS, cfg *Config) (*mssqlx.DBs, error) {
 //
 // Open preserves PostgreSQL's nil/disabled config semantics and then delegates
 // connection lifecycle ownership to the shared SQL driver helper.
+//
+// The returned type is the same upstream master/slave pool collection returned
+// by Connect.
 func Open(lc di.Lifecycle, fs *os.FS, cfg *Config) (*mssqlx.DBs, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/database/sql/config"
 	"github.com/alexfalkowski/go-service/v2/database/sql/driver"
 	"github.com/alexfalkowski/go-service/v2/database/sql/pg"
@@ -12,12 +13,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/linxGnu/mssqlx"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
 
-func up(ctx context.Context, db *mssqlx.DBs) error {
+func up(ctx context.Context, db *sql.DBs) error {
 	ctx, cancel := test.Timeout(ctx)
 	defer cancel()
 
@@ -31,7 +31,7 @@ func up(ctx context.Context, db *mssqlx.DBs) error {
 	return err
 }
 
-func down(ctx context.Context, db *mssqlx.DBs) error {
+func down(ctx context.Context, db *sql.DBs) error {
 	ctx, cancel := test.Timeout(ctx)
 	defer cancel()
 

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -1,0 +1,26 @@
+package sql
+
+import "github.com/linxGnu/mssqlx"
+
+// DBs is an alias of mssqlx.DBs.
+//
+// It represents the master/slave SQL pool collection used by go-service SQL
+// integrations and preserves the upstream behavior exactly.
+//
+// The value groups master and replica `sqlx.DB` pools behind a single type with
+// helper methods for querying masters, slaves, and running operations against
+// the configured pools.
+type DBs = mssqlx.DBs
+
+// ConnectMasterSlaves is a thin wrapper around mssqlx.ConnectMasterSlaves.
+//
+// It opens a master/slave SQL pool collection for a registered `database/sql`
+// driver name and returns any per-DSN connection errors produced by the
+// upstream helper.
+//
+// The driver name must already be registered with the global `database/sql`
+// registry. The returned `DBs` value may contain zero or more master and slave
+// pools depending on the provided DSN lists.
+func ConnectMasterSlaves(name string, masterDSNs, slaveDSNs []string) (*DBs, []error) {
+	return mssqlx.ConnectMasterSlaves(name, masterDSNs, slaveDSNs)
+}

--- a/health/checker/db.go
+++ b/health/checker/db.go
@@ -3,10 +3,10 @@ package checker
 import (
 	"github.com/alexfalkowski/go-health/v2/checker"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/jmoiron/sqlx"
-	"github.com/linxGnu/mssqlx"
 )
 
 var _ checker.Checker = (*DBChecker)(nil)
@@ -22,7 +22,7 @@ var ErrNoConnections = errors.New("db: no connections")
 //
 // Note: db is expected to be non-nil. If the database subsystem is disabled and no
 // pools are available, callers should avoid constructing/registering this checker.
-func NewDBChecker(db *mssqlx.DBs, timeout time.Duration) *DBChecker {
+func NewDBChecker(db *sql.DBs, timeout time.Duration) *DBChecker {
 	return &DBChecker{db: db, timeout: timeout}
 }
 
@@ -31,7 +31,7 @@ func NewDBChecker(db *mssqlx.DBs, timeout time.Duration) *DBChecker {
 // It pings each configured master and slave database pool using PingContext. Any
 // ping failures are aggregated and returned from Check.
 type DBChecker struct {
-	db      *mssqlx.DBs
+	db      *sql.DBs
 	timeout time.Duration
 }
 

--- a/health/checker/db_test.go
+++ b/health/checker/db_test.go
@@ -3,14 +3,14 @@ package checker_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/health/checker"
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/linxGnu/mssqlx"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDBCheckerWithoutConnections(t *testing.T) {
-	db, errs := mssqlx.ConnectMasterSlaves("pg", nil, nil)
+	db, errs := sql.ConnectMasterSlaves("pg", nil, nil)
 	require.Empty(t, errs)
 
 	check := checker.NewDBChecker(db, time.Second)

--- a/internal/test/di.go
+++ b/internal/test/di.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/hmac"
 	"github.com/alexfalkowski/go-service/v2/crypto/rsa"
 	"github.com/alexfalkowski/go-service/v2/crypto/ssh"
+	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/database/sql/pg"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
@@ -27,7 +28,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/events"
 	ht "github.com/alexfalkowski/go-service/v2/transport/http/token"
-	"github.com/linxGnu/mssqlx"
 	"github.com/open-feature/go-sdk/openfeature"
 	webhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
 )
@@ -135,7 +135,7 @@ func invokeAccessController(_ ht.AccessController, _ gt.AccessController) {}
 
 func invokeTokens(_ ht.Generator, _ ht.Verifier, _ gt.Generator, _ gt.Verifier) {}
 
-func invokeDB(_ *mssqlx.DBs) {}
+func invokeDB(_ *sql.DBs) {}
 
 func invokeCrypt(
 	signer *bcrypt.Signer,

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/cache"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/database/sql/pg"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/net"
@@ -23,7 +24,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/events"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/client"
-	"github.com/linxGnu/mssqlx"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -156,7 +156,7 @@ type World struct {
 	Sender client.Client
 	Rest   *rest.Client
 
-	DB         *mssqlx.DBs
+	DB         *sql.DBs
 	HTTPHealth *health.Server
 	GRPCHealth *health.Server
 	httpClient *http.Client


### PR DESCRIPTION
## What

Added a local `database/sql` wrapper for the shared master/slave pool abstraction used by the repo.

The root SQL package now exposes:
- `database/sql.DBs` as the local alias for the shared pool collection type
- `database/sql.ConnectMasterSlaves(...)` as the local wrapper for opening those pools

Updated the non-cyclic callers to use the local SQL package instead of importing `github.com/linxGnu/mssqlx` directly, including the health checker and shared internal test helpers.

Refreshed the SQL package docs so the new wrapper surface is documented clearly, and tightened the PostgreSQL package docs to describe the shared pool abstraction accurately.

## Why

This keeps repository code aligned with the wrapper-first pattern used elsewhere, so internal code prefers go-service import paths instead of reaching directly into third-party packages.

It also gives the repo a single local entrypoint for the shared master/slave SQL pool type in the places where the package graph allows it.

One limitation remains: `database/sql/driver` and `database/sql/pg` still import `mssqlx` directly internally, because the root `database/sql` package already depends on `database/sql/pg`, so importing the root package back from those subpackages would create an import cycle.

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./database/sql ./database/sql/driver ./database/sql/pg ./health/checker ./internal/test -run '^$' -count=1
env GOCACHE=/tmp/go-build go test ./health/checker -run 'TestDBCheckerWithoutConnections$' -count=1
```