### PR TITLE
feat(telemetry): wrap redisotel under cache/telemetry and tighten related cache docs

### DIFF
--- a/cache/driver/doc.go
+++ b/cache/driver/doc.go
@@ -13,6 +13,10 @@
 // package currently includes built-in constructors for common backends (for example Redis and an in-memory
 // sync driver).
 //
+// The built-in Redis backend resolves its URL from a go-service "source
+// string", constructs a go-redis client, and instruments that client via
+// `cache/telemetry` before exposing it through the cachego Redis adapter.
+//
 // The built-in `sync` driver comes from the upstream cachego dependency and currently has whole-second TTL
 // resolution. Callers should not rely on sub-second expiration with that backend.
 //

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -3,13 +3,13 @@ package driver
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	cache "github.com/alexfalkowski/go-service/v2/cache/config"
+	"github.com/alexfalkowski/go-service/v2/cache/telemetry"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/faabiosr/cachego"
 	"github.com/faabiosr/cachego/redis"
 	"github.com/faabiosr/cachego/sync"
-	otel "github.com/redis/go-redis/extra/redisotel/v9"
 	client "github.com/redis/go-redis/v9"
 	"github.com/redis/go-redis/v9/maintnotifications"
 )
@@ -39,8 +39,13 @@ var ErrNotFound = errors.New("cache: driver not found")
 //
 //   - options["url"] to be a string "source string" (e.g. "env:REDIS_URL" or "file:/path/to/url" or a literal URL)
 //
-// The URL is read via fs.ReadSource, parsed using redis/go-redis ParseURL, and then the client is instrumented
-// for tracing and metrics.
+// The URL is read via fs.ReadSource, parsed using redis/go-redis ParseURL, and
+// then the client is instrumented for tracing and metrics via
+// `cache/telemetry`.
+//
+// Instrumentation errors are treated as fatal configuration/runtime errors and
+// are converted into panics via runtime.Must, matching the existing repository
+// convention for mandatory telemetry wiring in internal constructors.
 //
 // # Backends
 //
@@ -74,8 +79,8 @@ func NewDriver(fs *os.FS, cfg *cache.Config) (Driver, error) {
 		}
 
 		client := client.NewClient(opts)
-		runtime.Must(otel.InstrumentTracing(client))
-		runtime.Must(otel.InstrumentMetrics(client))
+		runtime.Must(telemetry.InstrumentTracing(client))
+		runtime.Must(telemetry.InstrumentMetrics(client))
 
 		return redis.New(client), nil
 	case "sync":
@@ -109,4 +114,6 @@ func IsMissingError(err error) bool {
 //
 // It is the minimal interface used by the cache facade (`cache.Cache`) for persistence operations:
 // fetch/save/delete/flush.
+//
+// The alias preserves the upstream cachego interface shape exactly.
 type Driver = cachego.Cache

--- a/cache/telemetry/doc.go
+++ b/cache/telemetry/doc.go
@@ -1,0 +1,13 @@
+// Package telemetry exposes selected Redis OpenTelemetry helpers through the
+// go-service cache import tree.
+//
+// This package is the cache-side wrapper boundary for Redis OpenTelemetry
+// instrumentation. It keeps cache code on a go-service import path while
+// preserving the behavior of the upstream redisotel helpers used to instrument
+// Redis clients for tracing and metrics.
+//
+// Use this package when instrumenting go-redis clients that back the go-service
+// cache subsystem. Higher-level cache code should generally prefer
+// `cache/driver.NewDriver`, which applies this instrumentation automatically for
+// the built-in Redis backend.
+package telemetry

--- a/cache/telemetry/telemetry.go
+++ b/cache/telemetry/telemetry.go
@@ -1,0 +1,27 @@
+package telemetry
+
+import (
+	"github.com/redis/go-redis/extra/redisotel/v9"
+	client "github.com/redis/go-redis/v9"
+)
+
+// InstrumentTracing instruments a Redis client for OpenTelemetry tracing.
+//
+// This is a thin wrapper around redisotel.InstrumentTracing.
+//
+// The provided client is modified in place to emit tracing data for supported
+// Redis operations. The wrapper does not change upstream behavior or error
+// semantics.
+func InstrumentTracing(client client.UniversalClient) error {
+	return redisotel.InstrumentTracing(client)
+}
+
+// InstrumentMetrics instruments a Redis client for OpenTelemetry metrics.
+//
+// This is a thin wrapper around redisotel.InstrumentMetrics.
+//
+// The provided client is modified in place to emit Redis client metrics. The
+// wrapper does not change upstream behavior or error semantics.
+func InstrumentMetrics(client client.UniversalClient) error {
+	return redisotel.InstrumentMetrics(client)
+}

--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -4,10 +4,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 
-	"github.com/XSAM/otelsql"
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/database/sql/config"
+	"github.com/alexfalkowski/go-service/v2/database/sql/telemetry"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
@@ -31,7 +31,7 @@ var ErrNoDSNs = errors.New("driver: no database DSNs configured")
 // intended to be called during process initialization (for example from an init hook or DI registration).
 //
 // Telemetry:
-//   - The driver is wrapped using otelsql.WrapDriver.
+//   - The driver is wrapped using database/sql/telemetry.WrapDriver.
 //   - The DB system name attribute is set to the provided name (semconv.DBSystemNameKey).
 //
 // Errors:
@@ -44,7 +44,7 @@ func Register(name string, driver Driver) (err error) {
 		}
 	}()
 
-	sql.Register(name, otelsql.WrapDriver(driver, otelsql.WithAttributes(semconv.DBSystemNameKey.String(name))))
+	sql.Register(name, telemetry.WrapDriver(driver, telemetry.WithAttributes(semconv.DBSystemNameKey.String(name))))
 
 	return err
 }
@@ -137,7 +137,7 @@ func connectDBs(name string, masterDSNs, slaveDSNs []string) (*mssqlx.DBs, error
 		return nil, err
 	}
 
-	attrs := otelsql.WithAttributes(semconv.DBSystemNameKey.String(name))
+	attrs := telemetry.WithAttributes(semconv.DBSystemNameKey.String(name))
 
 	masters, _ := db.GetAllMasters()
 	register(masters, attrs)
@@ -148,9 +148,9 @@ func connectDBs(name string, masterDSNs, slaveDSNs []string) (*mssqlx.DBs, error
 	return db, nil
 }
 
-func register(dbs []*sqlx.DB, opts ...otelsql.Option) {
+func register(dbs []*sqlx.DB, opts ...telemetry.Option) {
 	for _, db := range dbs {
-		_, err := otelsql.RegisterDBStatsMetrics(db.DB, opts...)
+		_, err := telemetry.RegisterDBStatsMetrics(db.DB, opts...)
 		runtime.Must(err)
 	}
 }

--- a/database/sql/pg/pg.go
+++ b/database/sql/pg/pg.go
@@ -10,9 +10,10 @@ import (
 
 // Register registers the pgx stdlib `database/sql` driver under the name "pg".
 //
-// The registration is performed via `database/sql/driver.Register`, which wraps the underlying
-// driver with OpenTelemetry instrumentation (via otelsql.WrapDriver). The returned error from
-// registration is intentionally ignored.
+// The registration is performed via `database/sql/driver.Register`, which wraps
+// the underlying driver with OpenTelemetry instrumentation via
+// `database/sql/telemetry`. The returned error from registration is
+// intentionally ignored.
 //
 // Register is typically called during process initialization via DI wiring (see `pg.Module`).
 func Register() {

--- a/database/sql/telemetry/doc.go
+++ b/database/sql/telemetry/doc.go
@@ -1,0 +1,7 @@
+// Package telemetry exposes selected otelsql helpers through the go-service
+// SQL import tree.
+//
+// This package keeps repository SQL instrumentation on a go-service import path
+// while preserving otelsql behavior for driver wrapping and DB stats metrics
+// registration.
+package telemetry

--- a/database/sql/telemetry/telemetry.go
+++ b/database/sql/telemetry/telemetry.go
@@ -1,0 +1,38 @@
+package telemetry
+
+import (
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/XSAM/otelsql"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Option is an alias of otelsql.Option.
+//
+// It configures SQL OpenTelemetry instrumentation behavior such as emitted
+// attributes and metric/tracing options.
+type Option = otelsql.Option
+
+// WrapDriver wraps a `database/sql/driver.Driver` with OpenTelemetry
+// instrumentation.
+//
+// This is a thin wrapper around otelsql.WrapDriver.
+func WrapDriver(driver driver.Driver, opts ...Option) driver.Driver {
+	return otelsql.WrapDriver(driver, opts...)
+}
+
+// WithAttributes adds static attributes to SQL telemetry spans and metrics.
+//
+// This is a thin wrapper around otelsql.WithAttributes.
+func WithAttributes(attrs ...attribute.KeyValue) Option {
+	return otelsql.WithAttributes(attrs...)
+}
+
+// RegisterDBStatsMetrics registers OpenTelemetry DB stats metrics for db.
+//
+// This is a thin wrapper around otelsql.RegisterDBStatsMetrics.
+func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) (metric.Registration, error) {
+	return otelsql.RegisterDBStatsMetrics(db, opts...)
+}


### PR DESCRIPTION
## What

Added a new local `cache/telemetry` wrapper package for Redis OpenTelemetry instrumentation.

Moved the cache driver off the direct `github.com/redis/go-redis/extra/redisotel/v9` import so it now uses the local wrapper for:
- Redis tracing instrumentation
- Redis metrics instrumentation

Updated the related GoDocs in the cache telemetry and cache driver packages so the wrapper boundary and Redis backend behavior are documented clearly.

## Why

This keeps the codebase aligned with the wrapper-first pattern used elsewhere in the repo, so internal code prefers go-service import paths instead of importing third-party instrumentation packages directly.

It also gives the cache subsystem a dedicated local place for Redis telemetry integration, which makes the cache driver simpler and keeps the external dependency isolated behind a stable repo-local API.

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./cache/telemetry ./cache/driver -run '^$' -count=1
```