### PR TITLE
feat(telemetry): wrap otelsql under database/sql/telemetry and add focused wrapper coverage

### DIFF
--- a/database/sql/telemetry/doc.go
+++ b/database/sql/telemetry/doc.go
@@ -2,6 +2,6 @@
 // SQL import tree.
 //
 // This package keeps repository SQL instrumentation on a go-service import path
-// while preserving otelsql behavior for driver wrapping and DB stats metrics
-// registration.
+// while preserving otelsql behavior for opening instrumented connections,
+// wrapping drivers, and registering DB stats metrics.
 package telemetry

--- a/database/sql/telemetry/telemetry.go
+++ b/database/sql/telemetry/telemetry.go
@@ -15,6 +15,13 @@ import (
 // attributes and metric/tracing options.
 type Option = otelsql.Option
 
+// Open opens a `database/sql` DB handle with OpenTelemetry instrumentation.
+//
+// This is a thin wrapper around otelsql.Open.
+func Open(driverName, dataSourceName string, options ...Option) (*sql.DB, error) {
+	return otelsql.Open(driverName, dataSourceName, options...)
+}
+
 // WrapDriver wraps a `database/sql/driver.Driver` with OpenTelemetry
 // instrumentation.
 //

--- a/database/sql/telemetry/telemetry_test.go
+++ b/database/sql/telemetry/telemetry_test.go
@@ -1,0 +1,15 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/database/sql/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen(t *testing.T) {
+	db, err := telemetry.Open("missing", "dsn")
+	require.Nil(t, db)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `sql: unknown driver "missing"`)
+}


### PR DESCRIPTION
## What

Added a local `database/sql/telemetry` wrapper package for the SQL OpenTelemetry helpers currently used by the repo.

The new wrapper now exposes:
- `Open`
- `WrapDriver`
- `WithAttributes`
- `RegisterDBStatsMetrics`

Updated the SQL driver layer to use the local wrapper instead of importing `github.com/XSAM/otelsql` directly, and refreshed the related GoDocs so the wrapper boundary and SQL instrumentation behavior are clearly documented.

Added a small focused test for the new `Open` wrapper.

## Why

This keeps the SQL subsystem aligned with the wrapper-first import pattern used across the repo, so internal code prefers go-service package paths instead of importing third-party instrumentation helpers directly.

It also isolates the `otelsql` dependency behind a local package boundary, which makes the instrumentation surface easier to evolve and document without leaking the third-party import path through the rest of the codebase.

## Testing

```bash
env GOCACHE=/tmp/go-build go test ./database/sql/telemetry ./database/sql/driver ./database/sql/pg -run '^$' -count=1
env GOCACHE=/tmp/go-build go test ./database/sql/telemetry -run 'TestOpen$' -count=1
```