### PR TITLE
feat(telemetry): centralize semconv aliases in telemetry attributes and improve godocs

### DIFF
--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -12,9 +12,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/jmoiron/sqlx"
 	"github.com/linxGnu/mssqlx"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // Driver aliases `database/sql/driver`.Driver.
@@ -32,7 +32,7 @@ var ErrNoDSNs = errors.New("driver: no database DSNs configured")
 //
 // Telemetry:
 //   - The driver is wrapped using database/sql/telemetry.WrapDriver.
-//   - The DB system name attribute is set to the provided name (semconv.DBSystemNameKey).
+//   - The DB system name attribute is set to the provided name (attributes.DBSystemNameKey).
 //
 // Errors:
 //   - If the underlying `sql.Register` panics (for example, due to registering the same name more than once),
@@ -44,7 +44,7 @@ func Register(name string, driver Driver) (err error) {
 		}
 	}()
 
-	sql.Register(name, telemetry.WrapDriver(driver, telemetry.WithAttributes(semconv.DBSystemNameKey.String(name))))
+	sql.Register(name, telemetry.WrapDriver(driver, telemetry.WithAttributes(attributes.DBSystemNameKey.String(name))))
 
 	return err
 }
@@ -137,7 +137,7 @@ func connectDBs(name string, masterDSNs, slaveDSNs []string) (*mssqlx.DBs, error
 		return nil, err
 	}
 
-	attrs := telemetry.WithAttributes(semconv.DBSystemNameKey.String(name))
+	attrs := telemetry.WithAttributes(attributes.DBSystemNameKey.String(name))
 
 	masters, _ := db.GetAllMasters()
 	register(masters, attrs)

--- a/telemetry/attributes/attributes.go
+++ b/telemetry/attributes/attributes.go
@@ -8,26 +8,55 @@ import (
 // SchemaURL is the OpenTelemetry semantic conventions schema URL used by this package.
 //
 // It is an alias of semconv.SchemaURL and is typically passed to
-// resource.NewWithAttributes to indicate which schema version the provided
-// attributes follow.
+// resource.NewWithAttributes to declare which semantic-convention schema version
+// the provided attributes follow.
 const SchemaURL = semconv.SchemaURL
 
-// Key is an alias of attribute.Key.
+// Key aliases attribute.Key for callers that want to work with OpenTelemetry
+// attribute keys through this package without importing attribute directly.
+//
+// It is primarily useful when building additional semantic-convention helpers in
+// packages that already depend on telemetry/attributes.
 type Key = attribute.Key
 
-// KeyValue is an alias of attribute.KeyValue.
+// KeyValue aliases attribute.KeyValue for callers that want to exchange
+// OpenTelemetry attributes through this package without importing attribute
+// directly.
+//
+// Functions in this package return KeyValue-compatible values.
 type KeyValue = attribute.KeyValue
+
+// DBSystemNamePostgreSQL identifies PostgreSQL as the value of the
+// db.system.name semantic-convention attribute.
+//
+// It is an alias of semconv.DBSystemNamePostgreSQL and is a fully-formed
+// attribute.KeyValue that can be attached directly to spans, metrics, logs, or
+// resources.
+var DBSystemNamePostgreSQL = semconv.DBSystemNamePostgreSQL
 
 // RPCSystemNameGRPC identifies gRPC as the RPC system for semantic conventions.
 //
 // It is an alias of semconv.RPCSystemNameGRPC and is commonly used by
-// instrumentation to label RPC-related telemetry consistently.
+// instrumentation to label RPC-related telemetry consistently. The exported
+// value is already an attribute.KeyValue and can be attached directly.
 var RPCSystemNameGRPC = semconv.RPCSystemNameGRPC
+
+// DBSystemNameKey identifies the semantic convention key for a database system.
+//
+// It is an alias of semconv.DBSystemNameKey and is commonly used by SQL
+// instrumentation to attach the database system name consistently.
+//
+// Callers typically use DBSystemNameKey.String("postgresql") or reuse one of the
+// predeclared attribute values such as DBSystemNamePostgreSQL.
+var DBSystemNameKey = semconv.DBSystemNameKey
 
 // HostID returns a host.id attribute with value val.
 //
 // This is a thin wrapper around semconv.HostID and is typically used when
 // constructing a Resource to describe the running service instance.
+//
+// Parameters:
+//   - val: the host identifier reported for the current process or machine
 func HostID(val string) attribute.KeyValue {
 	return semconv.HostID(val)
 }
@@ -36,6 +65,9 @@ func HostID(val string) attribute.KeyValue {
 //
 // This is a thin wrapper around semconv.ServiceName and is typically used when
 // constructing a Resource to describe the running service.
+//
+// Parameters:
+//   - val: the logical service name to report in telemetry
 func ServiceName(val string) attribute.KeyValue {
 	return semconv.ServiceName(val)
 }
@@ -44,6 +76,9 @@ func ServiceName(val string) attribute.KeyValue {
 //
 // This is a thin wrapper around semconv.ServiceVersion and is typically used when
 // constructing a Resource to describe the running service.
+//
+// Parameters:
+//   - val: the version string to report for the running service build
 func ServiceVersion(val string) attribute.KeyValue {
 	return semconv.ServiceVersion(val)
 }
@@ -53,6 +88,9 @@ func ServiceVersion(val string) attribute.KeyValue {
 // This is a thin wrapper around semconv.DeploymentEnvironmentName and is typically
 // used when constructing a Resource to describe the deployment environment (for
 // example "prod", "staging").
+//
+// Parameters:
+//   - val: the deployment environment name, such as "prod" or "staging"
 func DeploymentEnvironmentName(val string) attribute.KeyValue {
 	return semconv.DeploymentEnvironmentName(val)
 }

--- a/telemetry/attributes/doc.go
+++ b/telemetry/attributes/doc.go
@@ -2,11 +2,8 @@
 // semantic convention attributes used by go-service.
 //
 // This package is intentionally thin. It primarily re-exports selected identifiers
-// from the OpenTelemetry semantic conventions package:
-//
-//	go.opentelemetry.io/otel/semconv/v1.40.0
-//
-// The goal is to centralize common resource/telemetry attributes that are used
+// from the vendored OpenTelemetry semantic conventions package. The goal is to
+// centralize common resource/telemetry attributes that are used
 // across go-service telemetry wiring (logging, metrics, tracing) without requiring
 // every package to import semconv directly.
 //
@@ -33,7 +30,11 @@
 //
 // Some instrumentation requires standard system identifiers (for example RPC system
 // names). This package re-exports the gRPC RPC system name constant
-// (RPCSystemNameGRPC) from semconv.
+// (RPCSystemNameGRPC) and selected attribute keys from semconv.
+//
+// Database instrumentation can also reuse database-system helpers such as
+// DBSystemNameKey and DBSystemNamePostgreSQL instead of importing semconv
+// directly.
 //
 // # Notes
 //


### PR DESCRIPTION
## What

- Centralized the OpenTelemetry `semconv` dependency in `telemetry/attributes` so downstream packages no longer import `go.opentelemetry.io/otel/semconv/v1.40.0` directly.
- Added `DBSystemNameKey` and documented `DBSystemNamePostgreSQL` in [attributes.go](/Users/alejandro/code/go-service/telemetry/attributes/attributes.go).
- Updated [driver.go](/Users/alejandro/code/go-service/database/sql/driver/driver.go) to use `telemetry/attributes` aliases instead of importing `semconv` directly.
- Improved package and symbol GoDocs in [doc.go](/Users/alejandro/code/go-service/telemetry/attributes/doc.go) and [attributes.go](/Users/alejandro/code/go-service/telemetry/attributes/attributes.go) to clearly describe aliases, wrappers, and intended usage.

## Why

- Keeps semantic-convention ownership in one place, which makes future OpenTelemetry upgrades and refactors safer.
- Reduces direct coupling to the versioned `semconv` import path across the codebase.
- Makes the `telemetry/attributes` package a clearer public surface for shared telemetry attributes.
- Improves pkg.go.dev readability and accuracy for contributors using these helpers.

## Testing

- Ran `go test ./telemetry/attributes`
- Ran `go test ./telemetry/attributes ./database/sql/driver ./database/sql/telemetry`
- Verified with `rg` that the only remaining `go.opentelemetry.io/otel/semconv/v1.40.0` import is in [attributes.go](/Users/alejandro/code/go-service/telemetry/attributes/attributes.go)