### PR TITLE
feat(context): add cause-aware context wrappers and timeout causes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,66 +24,47 @@ git submodule update --init
 ## Common commands
 
 - `make help`: list targets.
-- `make dep`: runs `go mod download`, `go mod tidy`, and `go mod vendor`.
-  Tests use `-mod vendor`, so run this after dependency changes.
-- `make specs`: race + coverage via `gotestsum`.
-  Outputs `test/reports/specs.xml` and `test/reports/profile.cov`.
-- `make lint`, `make fix-lint`, `make format`
-- `make sec`
-- `make benchmarks`, `make http-benchmarks`, `make grpc-benchmarks`, `make bytes-benchmarks`, `make strings-benchmarks`
+- `make dep`: runs `go mod download`, `go mod tidy`, and `go mod vendor`. Tests use `-mod vendor`, so run this after dependency changes.
+- `make specs`, `make lint`, `make fix-lint`, `make format`, `make sec`
+- `make benchmarks` and focused variants such as `make http-benchmarks`, `make grpc-benchmarks`, `make bytes-benchmarks`, `make strings-benchmarks`
 - `make coverage`, `make html-coverage`, `make func-coverage`
-- `make generate`
-- `make diagrams`, `make crypto-diagram`, `make database-diagram`, `make telemetry-diagram`, `make transport-diagram`
-- `make start`, `make stop`
+- `make generate`, `make diagrams`, `make start`, `make stop`
 - `mkcert -install && make create-certs`
 - `make kind=status encode-config`
   `encode-config` uses GNU `base64 -w 0`; on macOS/BSD use `base64 | tr -d '\n'`.
 
-## Repo layout
+## Layout and wiring
 
 - Feature packages usually follow `config.go`, `module.go`, and implementation files.
 - `module/` exports the top-level Fx bundles: `module.Library`, `module.Server`, `module.Client`.
-- `config/` defines the standard top-level config plus projections into nested transport/SQL/telemetry config.
-- `net/` contains lower-level protocol helpers: `net/http`, `net/grpc`, metadata helpers, `net/header`, `net/server`, and gRPC health.
-- `transport/` contains the higher-level service transport layer: composed HTTP/gRPC stacks, middleware policy, operational endpoints, and transport modules.
+- `config/` defines the top-level config and projections into nested transport, SQL, and telemetry config.
+- `net/` contains lower-level HTTP/gRPC, metadata, header, and server helpers.
+- `transport/` contains the higher-level transport layer: composed HTTP/gRPC stacks, middleware, and operational endpoints.
 - `internal/test/` provides shared test helpers, especially `internal/test/world.go`.
-- `test/` stores fixtures (configs, certs, secrets, reports).
-
-## Wiring patterns
-
-- Modules are composed with `di.Module(...)`.
-- Many constructors consume `di.In` parameter structs.
-- `module.Server` already includes config, telemetry, transports, health, debug, cache, feature, limiter, and SQL.
-- `module.Client` includes config, telemetry, feature, hooks, cache, limiter, and SQL, but not debug/transport/health by default.
+- `test/` stores fixtures such as configs, certs, secrets, and reports.
+- Modules are composed with `di.Module(...)`; many constructors consume `di.In` parameter structs.
+- `module.Server` includes debug, cache, config, feature, SQL, telemetry, limiter, transport, and health wiring.
+- `module.Client` includes cache, config, feature, hooks, SQL, telemetry, and limiter wiring, but not debug, transport, or health by default.
 
 ## Configuration rules
 
-- `config.NewDecoder` dispatches `-i` values as:
-  - `file:<path>`
-  - `env:<ENV_VAR>`
-  - otherwise default lookup for `<serviceName>.{yaml,yml,hjson,toml,json}`
-- Default lookup checks:
-  - executable directory
-  - `$XDG_CONFIG_HOME/<serviceName>/`
-  - `/etc/<serviceName>/`
-- Many fields use go-service “source strings” resolved by `os.FS.ReadSource`:
-  - `env:NAME`
-  - `file:/path`
-  - otherwise literal value
-- Nil pointer sub-configs usually mean “disabled”.
+- `config.NewDecoder` dispatches `-i` values as `file:<path>`, `env:<ENV_VAR>`, or default lookup for `<serviceName>.{yaml,yml,hjson,toml,json}`.
+- Default lookup checks the executable directory, `$XDG_CONFIG_HOME/<serviceName>/`, and `/etc/<serviceName>/`.
+- Many fields use go-service source strings resolved by `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
+- Nil pointer sub-configs usually mean "disabled".
 
 ## Gotchas
 
-- Transport TLS requires `transport/http.Register(fs)` and `transport/grpc.Register(fs)` if you wire transports manually; `transport.Module` handles normal Fx wiring.
+- Manual transport TLS wiring needs `transport/http.Register(fs)` and `transport/grpc.Register(fs)`; `transport.Module` handles this in the normal path.
 - Manual server lifecycle wiring should use `net/server.Register(...)`.
 - `telemetry.Register()` installs the global OpenTelemetry propagator.
-- `cache.Register(...)` sets the package-level cache used by generic helpers in `cache/generic.go`.
-- `token/access` passes `access.policy` directly to Casbin’s file adapter; it needs a real path.
+- `cache.Register(...)` sets the package-level cache used by helpers in `cache/generic.go`.
+- `token/access` passes `access.policy` directly to Casbin's file adapter; it needs a real path.
 - JWT verification requires both the expected algorithm and a `kid` header.
-- `telemetry/header` uses `header.Map.MustSecrets`; secret-resolution failures can panic during config projection.
-- `transport/http/health.RegisterParams` requires an `*net/http.ServeMux`; `internal/test.RegisterHealth` does too.
-- Shared metadata/header/string helpers live under `net/...`, not `transport/...`.
-- `vendor/` is ignored by git and regenerated via `make dep`.
+- `telemetry/header.Map.MustSecrets` can panic during config projection if secret resolution fails.
+- `transport/http/health.RegisterParams` and `internal/test.RegisterHealth` both require an `*net/http.ServeMux`.
+- Shared metadata, header, and string helpers live under `net/...`, not `transport/...`.
+- `vendor/` is gitignored and regenerated via `make dep`.
 
 ## Testing, style, and docs
 
@@ -95,7 +76,7 @@ git submodule update --init
 
 ## CI
 
-- CircleCI runs: submodule init, `make source-key`, `mkcert -install`, `make create-certs`, waits for services, then `make clean`, `make dep`, `make lint`, `make sec`, `make specs`, `make benchmarks`, `make coverage`.
+- CircleCI runs submodule init, `make source-key`, `mkcert -install`, `make create-certs`, waits for services, then runs `make clean`, `make dep`, `make lint`, `make sec`, `make specs`, `make benchmarks`, and `make coverage`.
 - CI services:
   - Postgres: `localhost:5432`
   - Valkey: `localhost:6379`

--- a/context/context.go
+++ b/context/context.go
@@ -6,6 +6,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
+// CancelCauseFunc is an alias for context.CancelCauseFunc.
+//
+// It cancels a Context created by WithCancelCause and records the provided cause. Context.Err still
+// reports context.Canceled, while Cause exposes the richer diagnostic error.
+type CancelCauseFunc = context.CancelCauseFunc
+
 // CancelFunc is an alias for context.CancelFunc.
 //
 // It cancels a Context created by WithCancel, WithDeadline, or WithTimeout, releasing resources
@@ -36,12 +42,29 @@ type Key string
 //nolint:errname
 var Canceled = context.Canceled
 
+// DeadlineExceeded is an alias for context.DeadlineExceeded.
+//
+// It is returned by Context.Err when the context deadline passes. When a cause-aware deadline or timeout
+// API is used, Cause can expose a richer diagnostic error while Err still reports DeadlineExceeded.
+//
+//nolint:errname
+var DeadlineExceeded = context.DeadlineExceeded
+
 // Background returns an empty, non-cancelable context.
 //
 // This is a thin wrapper around context.Background. Use it as the top-level parent for main,
 // initialization, and tests. Request handlers should typically use the request-provided context instead.
 func Background() Context {
 	return context.Background()
+}
+
+// Cause returns the reason a context was canceled.
+//
+// This is a thin wrapper around context.Cause. Cause returns nil until the context is canceled. When a
+// cause-aware API is used, Cause can expose a more specific diagnostic error while Err still reports the
+// standard cancellation sentinel.
+func Cause(ctx Context) error {
+	return context.Cause(ctx)
 }
 
 // WithCancel returns a derived context that points to the parent context but has a new Done channel.
@@ -52,6 +75,14 @@ func WithCancel(parent Context) (Context, CancelFunc) {
 	return context.WithCancel(parent)
 }
 
+// WithCancelCause returns a derived context that points to the parent context and records an optional cause.
+//
+// This is a thin wrapper around context.WithCancelCause. Context.Err still reports Canceled, while Cause
+// returns the provided diagnostic error (or Canceled when cancel is called with nil).
+func WithCancelCause(parent Context) (Context, CancelCauseFunc) {
+	return context.WithCancelCause(parent)
+}
+
 // WithDeadline returns a copy of parent with the deadline adjusted to be no later than d.
 //
 // This is a thin wrapper around context.WithDeadline. The returned CancelFunc should be called to release
@@ -60,12 +91,30 @@ func WithDeadline(parent Context, d time.Time) (Context, CancelFunc) {
 	return context.WithDeadline(parent, d)
 }
 
+// WithDeadlineCause returns a copy of parent with the deadline adjusted to be no later than d.
+//
+// This is a thin wrapper around context.WithDeadlineCause. If the deadline expires, Err reports
+// DeadlineExceeded while Cause returns the configured diagnostic error. Calling the returned CancelFunc
+// directly cancels the context without setting the configured cause.
+func WithDeadlineCause(parent Context, d time.Time, cause error) (Context, CancelFunc) {
+	return context.WithDeadlineCause(parent, d, cause)
+}
+
 // WithTimeout returns a copy of parent with a timeout applied.
 //
 // This is a thin wrapper around context.WithTimeout. The returned CancelFunc should be called to release
 // resources associated with the derived context.
 func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
 	return context.WithTimeout(parent, timeout.Duration())
+}
+
+// WithTimeoutCause returns a copy of parent with a timeout applied.
+//
+// This is a thin wrapper around context.WithTimeoutCause. If the timeout expires, Err reports
+// DeadlineExceeded while Cause returns the configured diagnostic error. Calling the returned CancelFunc
+// directly cancels the context without setting the configured cause.
+func WithTimeoutCause(parent Context, timeout time.Duration, cause error) (Context, CancelFunc) {
+	return context.WithTimeoutCause(parent, timeout.Duration(), cause)
 }
 
 // WithoutCancel returns a copy of parent that is not canceled when parent is canceled.

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,0 +1,210 @@
+package context_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackground(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	deadline, ok := ctx.Deadline()
+	require.False(t, ok)
+	require.True(t, deadline.IsZero())
+	require.Nil(t, ctx.Done())
+	require.NoError(t, ctx.Err())
+	require.NoError(t, context.Cause(ctx))
+}
+
+func TestCauseBeforeCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, context.Cause(ctx))
+}
+
+func TestWithCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cancel()
+
+	<-ctx.Done()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, context.Cause(ctx), context.Canceled)
+}
+
+func TestWithCancelCause(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records provided cause", func(t *testing.T) {
+		t.Parallel()
+
+		cause := errors.New("cancel cause")
+		ctx, cancel := context.WithCancelCause(context.Background())
+
+		cancel(cause)
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.ErrorIs(t, context.Cause(ctx), cause)
+	})
+
+	t.Run("falls back to canceled when nil cause", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+
+		cancel(nil)
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.ErrorIs(t, context.Cause(ctx), context.Canceled)
+	})
+}
+
+func TestWithTimeoutCause(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns configured cause when timeout expires", func(t *testing.T) {
+		t.Parallel()
+
+		cause := errors.New("timeout cause")
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 0, cause)
+		defer cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+		require.ErrorIs(t, context.Cause(ctx), cause)
+	})
+
+	t.Run("manual cancel keeps canceled as cause", func(t *testing.T) {
+		t.Parallel()
+
+		cause := errors.New("timeout cause")
+		ctx, cancel := context.WithTimeoutCause(context.Background(), time.Minute, cause)
+
+		cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.ErrorIs(t, context.Cause(ctx), context.Canceled)
+	})
+}
+
+func TestWithDeadline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns deadline exceeded when deadline passes", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Millisecond.Duration()))
+		defer cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+	})
+
+	t.Run("manual cancel keeps canceled as cause", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute.Duration()))
+
+		cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.ErrorIs(t, context.Cause(ctx), context.Canceled)
+	})
+}
+
+func TestWithDeadlineCause(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("deadline cause")
+	ctx, cancel := context.WithDeadlineCause(context.Background(), time.Now().Add(-time.Millisecond.Duration()), cause)
+	defer cancel()
+
+	<-ctx.Done()
+	require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	require.ErrorIs(t, context.Cause(ctx), cause)
+}
+
+func TestWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns deadline exceeded when timeout expires", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+	})
+
+	t.Run("manual cancel keeps canceled as cause", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+
+		cancel()
+
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.ErrorIs(t, context.Cause(ctx), context.Canceled)
+	})
+}
+
+func TestCausePropagatesFromParent(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("parent cause")
+	parent, cancel := context.WithCancelCause(context.Background())
+	child, childCancel := context.WithTimeout(parent, time.Minute)
+	defer childCancel()
+
+	cancel(cause)
+
+	<-child.Done()
+	require.ErrorIs(t, parent.Err(), context.Canceled)
+	require.ErrorIs(t, context.Cause(parent), cause)
+	require.ErrorIs(t, context.Cause(child), cause)
+}
+
+func TestWithoutCancel(t *testing.T) {
+	t.Parallel()
+
+	parent, cancel := context.WithCancelCause(context.WithValue(context.Background(), context.Key("key"), "value"))
+	child := context.WithoutCancel(parent)
+
+	cancel(errors.New("parent cause"))
+
+	deadline, ok := child.Deadline()
+	require.False(t, ok)
+	require.True(t, deadline.IsZero())
+	require.Nil(t, child.Done())
+	require.NoError(t, child.Err())
+	require.NoError(t, context.Cause(child))
+	require.Equal(t, "value", child.Value(context.Key("key")))
+}
+
+func TestWithValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), context.Key("key"), "value")
+
+	require.Equal(t, "value", ctx.Value(context.Key("key")))
+	require.Nil(t, ctx.Value(context.Key("missing")))
+}

--- a/context/doc.go
+++ b/context/doc.go
@@ -4,9 +4,13 @@
 // context primitives while preserving the exact semantics of the standard library `context` package.
 //
 // Most identifiers are thin aliases/wrappers around `context` (for example `Context`, `CancelFunc`,
-// `Background`, `WithDeadline`, `WithTimeout`, and `WithValue`). They exist so packages within go-service
-// and downstream services can consistently import `github.com/alexfalkowski/go-service/v2/context`
-// without mixing direct stdlib imports across the codebase.
+// `CancelCauseFunc`, `Background`, `WithDeadline`, `WithTimeout`, `Cause`, and `WithValue`). They exist so
+// packages within go-service and downstream services can consistently import
+// `github.com/alexfalkowski/go-service/v2/context` without mixing direct stdlib imports across the codebase.
+//
+// Cause-aware APIs mirror the standard library behavior: `Context.Err()` continues to report the standard
+// sentinels (`Canceled` or `DeadlineExceeded`), while `Cause(ctx)` can expose a richer diagnostic error when
+// a cause-aware constructor was used.
 //
 // This package also defines `Key`, a typed helper for context value keys to reduce accidental collisions
 // when multiple packages store values in the same context.

--- a/health/checker/db.go
+++ b/health/checker/db.go
@@ -14,6 +14,9 @@ var _ checker.Checker = (*DBChecker)(nil)
 // ErrNoConnections is returned when a DBChecker has no master or slave pools to verify.
 var ErrNoConnections = errors.New("db: no connections")
 
+// ErrPingTimeout is the cause recorded when a DB health-check ping times out.
+var ErrPingTimeout = errors.New("db: ping timeout")
+
 // NewDBChecker constructs a DBChecker that verifies database connectivity by pinging
 // all configured master and slave pools in db.
 //
@@ -64,7 +67,7 @@ func (c *DBChecker) dbs() []*sqlx.DB {
 }
 
 func (o *DBChecker) ping(ctx context.Context, db *sqlx.DB) error {
-	ctx, cancel := context.WithTimeout(ctx, o.timeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, o.timeout, ErrPingTimeout)
 	defer cancel()
 
 	return db.PingContext(ctx)

--- a/internal/test/context.go
+++ b/internal/test/context.go
@@ -2,13 +2,17 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
 // DefaultTimeout is the standard timeout used by test contexts in this package.
 const DefaultTimeout = 10 * time.Minute
 
+// ErrTimeout is the cause recorded when a test helper context times out.
+var ErrTimeout = errors.New("test: timeout")
+
 // Timeout returns a child context with DefaultTimeout applied.
 func Timeout(parent context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(parent, DefaultTimeout)
+	return context.WithTimeoutCause(parent, DefaultTimeout, ErrTimeout)
 }

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -26,6 +26,9 @@ type Config = config.Config
 // `429 Too Many Requests` or retryable `5xx` responses.
 var ErrInvalidStatusCode = errors.New("retry: invalid status code")
 
+// ErrAttemptTimeout is the cause recorded when a retry attempt times out.
+var ErrAttemptTimeout = errors.New("retry: attempt timeout")
+
 // NewRoundTripper constructs a RoundTripper that applies per-attempt timeouts and retries.
 //
 // The constructed RoundTripper wraps hrt and, for each request:
@@ -93,7 +96,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (r *RoundTripper) attempt(req *http.Request, ctx context.Context, attempt *roundTripAttempt) (*http.Response, error) {
-	ctx, cancel := context.WithTimeout(ctx, r.timeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, r.timeout, ErrAttemptTimeout)
 	defer cancel()
 
 	attemptReq, err := attempt.request(req, ctx)

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -168,6 +169,23 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	require.Equal(t, []int{1, 1}, rt.authCounts)
 }
 
+func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {
+	transport := &causeRoundTripper{}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 1,
+		Timeout:  0,
+		Backoff:  time.Millisecond,
+	}, transport)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.ErrorIs(t, transport.err, context.DeadlineExceeded)
+	require.ErrorIs(t, transport.cause, retry.ErrAttemptTimeout)
+}
+
 type roundTripper struct {
 	codes []int
 	calls int
@@ -248,6 +266,23 @@ func (r *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return &http.Response{
 		StatusCode: code,
 		Status:     fmt.Sprintf("%d %s", code, http.StatusText(code)),
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}, nil
+}
+
+type causeRoundTripper struct {
+	cause error
+	err   error
+}
+
+func (r *causeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.cause = context.Cause(req.Context())
+	r.err = req.Context().Err()
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
 		Body:       http.NoBody,
 		Header:     make(http.Header),
 	}, nil


### PR DESCRIPTION
## What

Add cause-aware wrappers to the `context` package by exposing `Cause`, `CancelCauseFunc`, `WithCancelCause`, `WithDeadlineCause`, `WithTimeoutCause`, and `DeadlineExceeded`.

Adopt cause-aware timeout creation in current internal call sites so timeout-derived contexts now record exported causes:
- `checker.ErrPingTimeout`
- `retry.ErrAttemptTimeout`
- `test.ErrTimeout`

Add focused tests for the `context` package and merge retry timeout-cause coverage into the main retry test suite.

## Why

This keeps existing `ctx.Err()` behavior unchanged while making timeout and cancellation diagnostics available through `context.Cause(ctx)`.

Exporting the timeout cause errors also lets downstream code use `errors.Is` against stable sentinels instead of relying on string matching or private implementation details.

## Testing

```sh
env GOCACHE=/tmp/go-build go test ./context ./health/checker ./transport/http/retry ./internal/test
```