### PR TITLE
feat(docs): clarify that standard template and module wiring handle framework registration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 This repo is primarily a **library of packages** (no top-level `cmd/` binary). Services built on top typically define their own `main` package elsewhere and import this module.
 
+Most services are expected to be bootstrapped from [`go-service-template`](https://github.com/alexfalkowski/go-service-template) and to compose the high-level module bundles from this repository. That is the primary supported path. Lower-level package-by-package composition is still available, but it is an advanced mode and may require extra manual registration.
+
 ---
 
 ## Dependency Injection (Fx)
@@ -26,6 +28,8 @@ The module package exposes three top-level bundles:
 - `module.Library` for shared foundations (env, compress, encoding, crypto, time, sync buffer-pool wiring, id)
 - `module.Server` for server processes (Library + config, transports, telemetry, debug, health, etc.)
 - `module.Client` for short-lived/batch/client processes (Library + config, telemetry, sql, hooks, etc.)
+
+These bundles are the intended default for services generated from `go-service-template`. They handle the internal registration expected by the framework so most services do not need to wire lower-level transport or lifecycle helpers manually.
 
 ### Minimal CLI bootstrap example
 
@@ -62,7 +66,7 @@ Services commonly expose two command shapes:
 
 The framework uses [acmd](https://github.com/cristalhq/acmd). Your service’s `main` typically wires Fx modules + commands.
 
-> This repo intentionally does not ship a ready-to-run `main` — it provides the building blocks.
+> This repo intentionally does not ship a ready-to-run `main` — it provides the building blocks. In normal usage those building blocks are consumed through `go-service-template` plus `module.Server` / `module.Client`, not by wiring every subsystem manually.
 
 ---
 
@@ -78,6 +82,8 @@ The repo is intentionally split between high-level service composition and lower
 - `internal/test/` contains the shared test world and fixtures used across packages
 
 As a rule of thumb: if you want protocol primitives or shared helpers, start in `net/...`; if you want service wiring and middleware policy, start in `transport/...`.
+
+For most service authors, the right starting point is still the high-level module bundles rather than these lower-level packages directly.
 
 ---
 
@@ -784,9 +790,10 @@ transport:
       key: file:test/certs/key.pem
 ```
 
-Important gotcha:
+Important note:
 
-- Some transport packages require that you call a package `Register(...)` function to provide an `os.FS` used to read key material. If you enable TLS and have not registered the FS, TLS construction may not have access to the filesystem.
+- If you are using `go-service-template` or composing the standard bundles such as `module.Server`, `module.Client`, or `transport.Module`, the required transport registration is handled for you by DI.
+- You only need to call transport-level `Register(...)` functions yourself when you intentionally wire transports manually or compose lower-level packages outside the standard module graph.
 - If you are wiring server lifecycle manually, use `net/server.Register(...)`.
 
 ### Transport Dependencies
@@ -1034,9 +1041,10 @@ All exported identifiers should have GoDoc comments, and each comment should sta
 ### Additional gotchas
 
 - `make kind=status encode-config` uses `base64 -w 0` (GNU style). On macOS/BSD use `base64 | tr -d '\n'`.
-- If you enable transport TLS and wire transports manually (without transport modules), call:
+- If you enable transport TLS and wire transports manually (without `transport.Module` or the higher-level `module.Server` bundle), call:
   - `transport/http.Register(fs)`
   - `transport/grpc.Register(fs)`
+- Services built from `go-service-template` normally do not need to call those registration helpers directly.
 - Shared metadata and header helpers live under `net/...`, for example:
   - `net/http/meta`
   - `net/grpc/meta`

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -10,7 +10,8 @@
 //
 // In addition to the instance API on `*Cache`, this package exposes package-level generic helpers
 // (`Get` and `Persist`). Those helpers are nil-safe after `Register` has been called (via DI wiring in
-// `Module`), and they become no-ops / return zero values when caching is disabled.
+// `Module`), and they become no-ops / return zero values when caching is disabled. In the standard
+// service composition this registration is performed for you by the module graph.
 //
 // # Value encoding
 //

--- a/config/default.go
+++ b/config/default.go
@@ -43,8 +43,11 @@ type Default struct {
 // The first match is opened and decoded using the encoder keyed by the discovered kind/extension.
 // If no configuration file is found, Decode returns ErrLocationMissing.
 //
-// Note: this decoder assumes the encoding.Map contains decoders for the supported kinds. If a kind is
-// missing, Decode may panic due to a nil encoder; ensure your wiring registers the standard encoders.
+// Note: this decoder assumes the encoding.Map contains decoders for the supported kinds. In the standard
+// go-service module graph, those encoders are registered for you (for example via `encoding.Module` in
+// higher-level bundles such as `module.Server` and `module.Client`). The nil-encoder panic risk therefore
+// only applies when you intentionally construct custom or partial wiring without the standard encoder
+// registrations.
 func (c *Default) Decode(v any) error {
 	kind, file, err := c.find()
 	if err != nil {

--- a/config/doc.go
+++ b/config/doc.go
@@ -26,4 +26,9 @@
 //
 // `Module` wires the decoder, validator, and a standard top-level `Config` into Fx/Dig, and also
 // provides constructors for commonly-used sub-config projections.
+//
+// In normal service applications, this package is consumed through higher-level bundles such as
+// `module.Server` or `module.Client`, which also include the standard encoder registrations needed by
+// the config decoders. Custom or partial wiring is still supported, but advanced compositions are
+// responsible for registering any required encoders themselves.
 package config

--- a/module/doc.go
+++ b/module/doc.go
@@ -2,6 +2,8 @@
 //
 // This package defines opinionated, high-level module bundles that compose multiple lower-level
 // feature modules into a single `di.Option` suitable for inclusion in an Fx/Dig application graph.
+// These bundles are the primary supported entrypoints for service applications and are the defaults
+// used by `go-service-template`.
 //
 // # Bundles
 //
@@ -21,5 +23,6 @@
 // pointer sub-configs (nil meaning "disabled"). These bundles wire constructors and registrations;
 // whether a subsystem is active depends on the configuration supplied to the graph.
 //
-// Start with `Library`, `Server`, and `Client`.
+// Start with `Library`, `Server`, and `Client`. Drop down to lower-level package composition only when
+// you intentionally need custom wiring beyond what the standard bundles provide.
 package module

--- a/module/module.go
+++ b/module/module.go
@@ -61,6 +61,8 @@ var (
 	// Many of these subsystems are optional and are enabled/disabled by configuration (often via nil pointer
 	// sub-configs). This bundle wires constructors/registrations; runtime behavior depends on the config
 	// supplied to the graph.
+	//
+	// This is the primary entrypoint for server applications built from `go-service-template`.
 	Server = di.Module(
 		Library,
 		debug.Module,
@@ -88,6 +90,8 @@ var (
 	//
 	// Unlike Server, Client does not wire debug endpoints, transports, or a health server by default.
 	// Those can be added explicitly by composing additional modules on top of Client if needed.
+	//
+	// This is the primary entrypoint for client-style applications built from `go-service-template`.
 	Client = di.Module(
 		Library,
 		cache.Module,

--- a/transport/doc.go
+++ b/transport/doc.go
@@ -7,20 +7,21 @@
 // (for example `net/http/meta`, `net/grpc/meta`, `net/header`, and `net/server`).
 //
 // Typical usage is to include `transport.Module` in your application module graph and let DI construct the
-// underlying transports:
+// underlying transports. Services created from `go-service-template` usually reach this package indirectly
+// via `module.Server`, so transport registration and lifecycle wiring are handled by the standard module
+// graph.
 //
 // - `transport/http` for HTTP servers and clients.
 // - `transport/grpc` for gRPC servers and clients.
 // - `debug` (wired via `transport.NewServers`) for the optional debug server.
 //
-// # Registration gotchas
+// # Manual composition notes
 //
 // Some transport subpackages require package-level registration to inject dependencies that cannot be
 // automatically provided via constructors. In particular, the HTTP and gRPC transport packages use a
 // registered filesystem when building TLS configuration (to read certificates/keys via source strings such
-// as `file:` and `env:`). If you enable TLS and do not call the relevant transport registration prior to
-// constructing clients/servers, TLS configuration may fail to load key material.
+// as `file:` and `env:`). The standard module graph performs this registration for you.
 //
-// When in doubt, call the transport-specific registration during application initialization (for example in
-// your application's composition root) before constructing any transport servers or clients.
+// Call the transport-specific registration yourself only when you intentionally bypass `transport.Module`
+// (or higher-level bundles such as `module.Server`) and construct transport clients/servers manually.
 package transport

--- a/transport/grpc/doc.go
+++ b/transport/grpc/doc.go
@@ -6,7 +6,8 @@
 //
 // The primary entrypoint for DI wiring is `Module`, which composes this package with supporting subpackages:
 // breaker, retry, limiter, metadata extraction/injection, token auth, and the gRPC health wiring in
-// `net/grpc/health`.
+// `net/grpc/health`. In typical service applications this happens through `module.Server` and
+// `go-service-template`, so most consumers do not need to wire this package manually.
 //
 // Lower-level gRPC primitives and shared helpers live under sibling `net/grpc/...` packages. This package
 // focuses on higher-level server/client composition, middleware policy, and Fx wiring.
@@ -25,13 +26,14 @@
 // Client-side concerns are expressed via options such as `WithClientTimeout`, `WithClientRetry`, `WithClientBreaker`,
 // `WithClientLimiter`, and token-generator options. These options configure which interceptors are installed.
 //
-// # Registration gotcha (TLS filesystem)
+// # Manual composition note (TLS filesystem)
 //
 // This package uses package-level registration to inject filesystem access used when constructing TLS configuration.
 // The registered filesystem is used by `crypto/tls/config.NewConfig` to
 // resolve certificate/key "source strings" (for example `file:/path/to/cert`
 // or `env:VAR`) during TLS configuration.
 //
-// If you enable TLS and do not call `Register` before constructing clients/servers, TLS configuration may fail to
-// load key material.
+// When you use `Module` (directly or through higher-level bundles such as `module.Server`), DI performs
+// this registration for you. Call `Register` yourself only when you intentionally compose the gRPC transport
+// package manually outside the standard module graph.
 package grpc

--- a/transport/grpc/register.go
+++ b/transport/grpc/register.go
@@ -13,9 +13,12 @@ var fs *os.FS
 // "source strings" (for example `file:/path/to/cert` or `env:VAR`) via the
 // `os.FS.ReadSource` helper when materializing a runtime `*crypto/tls.Config`.
 //
-// Registration is required because the filesystem is stored in a package-level variable. If TLS is enabled,
-// call Register during application startup (composition root) before constructing any gRPC clients or servers;
-// otherwise TLS config construction may fail to load key material.
+// In the standard go-service module graph, this registration is performed automatically by `Module`
+// (and therefore by higher-level bundles such as `module.Server`). Call Register directly only when you
+// intentionally compose gRPC transport pieces manually outside that graph.
+//
+// If TLS is enabled and registration has not happened before constructing gRPC clients or servers, TLS
+// config construction may fail to load key material.
 func Register(f *os.FS) {
 	fs = f
 }

--- a/transport/http/doc.go
+++ b/transport/http/doc.go
@@ -18,7 +18,9 @@
 // middleware policy, and Fx wiring.
 //
 // The primary entrypoint for DI consumers is `Module`, which composes the HTTP transport stack and
-// registers handlers/constructors needed to run an HTTP server.
+// registers handlers/constructors needed to run an HTTP server. In typical service applications this
+// happens through `module.Server` and `go-service-template`, so most consumers never call lower-level
+// registration helpers directly.
 //
 // # Server wiring
 //
@@ -38,7 +40,7 @@
 // retries, optional circuit breaking, and optional client-side rate limiting, depending on the provided
 // client options.
 //
-// # Registration gotcha (TLS filesystem)
+// # Manual composition note (TLS filesystem)
 //
 // This package uses package-level registration to inject filesystem access used when constructing TLS
 // configuration. The registered filesystem is used by
@@ -46,6 +48,7 @@
 // (for example `file:/path/to/cert` or `env:VAR`) when materializing the
 // runtime `*crypto/tls.Config`.
 //
-// If you enable TLS and do not call `Register` before constructing HTTP servers or clients, TLS configuration
-// may fail to load key material.
+// When you use `Module` (directly or through higher-level bundles such as `module.Server`), DI performs
+// this registration for you. Call `Register` yourself only when you intentionally compose the HTTP transport
+// package manually outside the standard module graph.
 package http

--- a/transport/http/register.go
+++ b/transport/http/register.go
@@ -13,9 +13,12 @@ var fs *os.FS
 // "source strings" (for example `file:/path/to/cert` or `env:VAR`) via the
 // `os.FS.ReadSource` helper when materializing a runtime `*crypto/tls.Config`.
 //
-// Registration is required because the filesystem is stored in a package-level variable. If TLS is enabled,
-// call Register during application startup (composition root) before constructing any HTTP clients or servers;
-// otherwise TLS config construction may fail to load key material.
+// In the standard go-service module graph, this registration is performed automatically by `Module`
+// (and therefore by higher-level bundles such as `module.Server`). Call Register directly only when you
+// intentionally compose HTTP transport pieces manually outside that graph.
+//
+// If TLS is enabled and registration has not happened before constructing HTTP clients or servers, TLS
+// config construction may fail to load key material.
 func Register(f *os.FS) {
 	fs = f
 }

--- a/transport/module.go
+++ b/transport/module.go
@@ -21,6 +21,9 @@ import (
 // Server lifecycle wiring:
 // This module also provides `NewServers` (to collect enabled `*server.Service` instances) and registers
 // `net/server.Register`, which attaches lifecycle hooks to start and stop those services.
+//
+// In typical service applications this module is consumed through `module.Server`, so callers normally do
+// not need to invoke lower-level transport registration or lifecycle helpers themselves.
 var Module = di.Module(
 	grpc.Module,
 	http.Module,


### PR DESCRIPTION
## What

Clarifies the documentation around the intended `go-service` integration path and when manual wiring guidance actually applies.

This updates the README and package docs to make it explicit that:

- the normal path is `go-service-template` plus the high-level module bundles
- the standard DI/module graph performs the expected internal framework registration
- manual transport and config registration guidance is primarily for intentional custom or partial wiring

## Why

Some existing docs described advanced wiring details as general gotchas, which could make framework internals look like requirements for every consumer.

In practice, services built through the standard template and bundles like `module.Server`, `module.Client`, and `transport.Module` already get the required setup through DI. This PR makes that expectation clear while still preserving the lower-level guidance for advanced use cases.

## Testing

Documentation-only change.

No runtime behavior was changed.