### PR TITLE
feat(docs): add godoc examples for the default module and config entrypoints

### DIFF
--- a/cli/doc.go
+++ b/cli/doc.go
@@ -3,6 +3,9 @@
 // This package wraps the command framework used by this module (github.com/cristalhq/acmd) and provides
 // a small layer of conveniences for wiring subcommands using go-service DI (Fx/Dig via the `di` package).
 //
+// In typical service applications, this package is used together with `go-service-template` and the
+// high-level module bundles from the `module` package.
+//
 // # Entry points
 //
 // Start with `NewApplication` to construct an `Application` and register subcommands via a `RegisterFunc`.

--- a/config/doc.go
+++ b/config/doc.go
@@ -28,7 +28,7 @@
 // provides constructors for commonly-used sub-config projections.
 //
 // In normal service applications, this package is consumed through higher-level bundles such as
-// `module.Server` or `module.Client`, which also include the standard encoder registrations needed by
-// the config decoders. Custom or partial wiring is still supported, but advanced compositions are
-// responsible for registering any required encoders themselves.
+// `module.Server` or `module.Client` from `go-service-template`, which also include the standard
+// encoder registrations needed by the config decoders. Custom or partial wiring is still supported,
+// but advanced compositions are responsible for registering any required encoders themselves.
 package config

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -1,0 +1,59 @@
+package config_test
+
+import (
+	"fmt"
+
+	"github.com/alexfalkowski/go-service/v2/config"
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
+	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/flag"
+	"github.com/alexfalkowski/go-service/v2/os"
+)
+
+type exampleConfig struct {
+	Name string `yaml:"name" validate:"required"`
+}
+
+func ExampleNewConfig() {
+	fs := os.NewFS()
+
+	dir, err := fs.MkdirTemp("", "go-service-config-example")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := fs.RemoveAll(dir); err != nil {
+			panic(err)
+		}
+	}()
+
+	path := fs.Join(dir, "config.yml")
+	if err := fs.WriteFile(path, []byte("name: payments"), 0o600); err != nil {
+		panic(err)
+	}
+
+	flags := flag.NewFlagSet("serve")
+	flags.AddInput("file:" + path)
+
+	decoder := config.NewDecoder(config.DecoderParams{
+		Flags:   flags,
+		Encoder: exampleEncodingMap(),
+		FS:      fs,
+		Name:    env.Name("payments"),
+	})
+
+	cfg, err := config.NewConfig[exampleConfig](decoder, config.NewValidator())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(cfg.Name)
+	// Output: payments
+}
+
+func exampleEncodingMap() *encoding.Map {
+	return encoding.NewMap(encoding.MapParams{
+		YAML: yaml.NewEncoder(),
+	})
+}

--- a/module/example_test.go
+++ b/module/example_test.go
@@ -1,0 +1,26 @@
+package module_test
+
+import (
+	"github.com/alexfalkowski/go-service/v2/cli"
+	"github.com/alexfalkowski/go-service/v2/module"
+)
+
+func ExampleServer() {
+	app := cli.NewApplication(func(commander cli.Commander) {
+		server := commander.AddServer("serve", "Run the service", module.Server)
+		server.AddInput("file:./config.yml")
+	})
+
+	_ = app
+	// Output:
+}
+
+func ExampleClient() {
+	app := cli.NewApplication(func(commander cli.Commander) {
+		client := commander.AddClient("migrate", "Run client tasks", module.Client)
+		client.AddInput("file:./config.yml")
+	})
+
+	_ = app
+	// Output:
+}


### PR DESCRIPTION
## What

Clarifies the intended `go-service` integration path and improves engineer-facing documentation for the default entrypoints.

This PR:

- updates the README and package docs to make it explicit that the normal path is `go-service-template` plus the high-level module bundles
- clarifies that standard DI/module wiring performs the expected internal framework registration
- keeps manual transport and config registration guidance scoped to intentional custom or partial wiring
- adds executable GoDoc examples for the main module and config entrypoints

## Why

Some existing docs described advanced wiring details as if they were general gotchas for every consumer.

In practice, services built through the standard template and bundles such as `module.Server`, `module.Client`, and `transport.Module` already get the required setup through DI. This PR makes that expectation clearer and adds pkg.go.dev-friendly examples so engineers can discover the intended path more easily.

## Testing

```bash
make lint
env GOCACHE=/tmp/go-build go test ./module ./config
```

Both passed.