### PR TITLE
feat(grpc): add grpc server tuning options

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -270,6 +270,12 @@ func verifyConfig(t *testing.T, config *config.Config) {
 			"keepalive_max_connection_age":               "10s",
 			"keepalive_max_connection_age_grace":         "10s",
 			"keepalive_ping_time":                        "10s",
+			"max_concurrent_streams":                     "64",
+			"connection_timeout":                         "3s",
+			"max_header_list_size":                       "16MB",
+			"initial_window_size":                        "1MB",
+			"initial_conn_window_size":                   "2MB",
+			"max_send_msg_size":                          "8MB",
 		},
 		config.Transport.GRPC.Options,
 	)

--- a/config/options/options.go
+++ b/config/options/options.go
@@ -1,6 +1,12 @@
 package options
 
-import "github.com/alexfalkowski/go-service/v2/time"
+import (
+	"strconv"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
 
 // Map contains string key-value pairs used to represent transport- or feature-specific options.
 //
@@ -20,5 +26,38 @@ func (m Map) Duration(key string, fallback time.Duration) time.Duration {
 	if val, ok := m[key]; ok {
 		return time.MustParseDuration(val)
 	}
+	return fallback
+}
+
+// Uint32 returns an unsigned integer option for key if present; otherwise it returns fallback.
+//
+// The stored value must be a base-10 unsigned integer accepted by strconv.ParseUint for a 32-bit size.
+//
+// Failure mode: if key is present but the value cannot be parsed as a uint32, Uint32 will panic because
+// it treats invalid startup/configuration values as fatal.
+func (m Map) Uint32(key string, fallback uint32) uint32 {
+	if val, ok := m[key]; ok {
+		num, err := strconv.ParseUint(val, 10, 32)
+		runtime.Must(err)
+
+		return uint32(num)
+	}
+
+	return fallback
+}
+
+// Size returns a byte-size option for key if present; otherwise it returns fallback.
+//
+// The stored value must be a human-readable SI size string accepted by bytes.ParseSize, such as "64B",
+// "2MB", or "4GB".
+//
+// Failure mode: if key is present but the value cannot be parsed as a size, Size will panic because
+// it uses bytes.MustParseSize. Use this helper only when the option values are validated or come from
+// trusted configuration.
+func (m Map) Size(key string, fallback bytes.Size) bytes.Size {
+	if val, ok := m[key]; ok {
+		return bytes.MustParseSize(val)
+	}
+
 	return fallback
 }

--- a/config/options/options_test.go
+++ b/config/options/options_test.go
@@ -3,6 +3,8 @@ package options_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -12,4 +14,22 @@ func TestDuration(t *testing.T) {
 	require.Equal(t, 10*time.Minute, test.ConfigOptions.Duration("read_timeout", 5*time.Second))
 	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("timeout", 5*time.Second))
 	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("bob", 5*time.Second))
+}
+
+func TestUint32(t *testing.T) {
+	opts := options.Map{"count": "12"}
+
+	require.EqualValues(t, 12, opts.Uint32("count", 5))
+	require.EqualValues(t, 5, opts.Uint32("missing", 5))
+	require.Panics(t, func() { options.Map{"negative": "-1"}.Uint32("negative", 5) })
+	require.Panics(t, func() { options.Map{"invalid": "abc"}.Uint32("invalid", 5) })
+	require.Panics(t, func() { options.Map{"overflow": "4294967296"}.Uint32("overflow", 5) })
+}
+
+func TestSize(t *testing.T) {
+	opts := options.Map{"limit": "16MB"}
+
+	require.Equal(t, 16*bytes.MB, opts.Size("limit", bytes.MB))
+	require.Equal(t, bytes.MB, opts.Size("missing", bytes.MB))
+	require.Panics(t, func() { options.Map{"invalid": "abc"}.Size("invalid", bytes.MB) })
 }

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -18,13 +18,23 @@
 //
 // NewServer builds a *grpc.Server with keepalive enforcement and server
 // parameters. Configuration values are sourced from an options.Map using the
-// following keys (each value is a duration):
+// following keys:
 //
 //   - keepalive_enforcement_policy_ping_min_time
 //   - keepalive_max_connection_idle
 //   - keepalive_max_connection_age
 //   - keepalive_max_connection_age_grace
 //   - keepalive_ping_time
+//
+// The keepalive values use Go duration strings. NewServer also supports the
+// following low-level server tuning keys:
+//
+//   - max_concurrent_streams: base-10 unsigned integer string
+//   - connection_timeout: Go duration string
+//   - max_header_list_size: SI size string such as 16MB
+//   - initial_window_size: SI size string such as 1MB
+//   - initial_conn_window_size: SI size string such as 4MB
+//   - max_send_msg_size: SI size string such as 16MB
 //
 // The timeout argument is used as the default value for each key when it is not
 // present in the options map, and is also used as the keepalive ping Timeout.

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -1,11 +1,15 @@
 package grpc
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"google.golang.org/grpc"
@@ -313,13 +317,22 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 //
 // In addition, the provided timeout is used as the keepalive ping Timeout.
 //
+// Additional low-level server tuning may be provided through options using:
+//
+//   - max_concurrent_streams
+//   - connection_timeout
+//   - max_header_list_size
+//   - initial_window_size
+//   - initial_conn_window_size
+//   - max_send_msg_size
+//
 // This function always registers server reflection via reflection.Register so
 // tools such as grpcurl can discover services when reflection is permitted.
 //
 // Any additional opts are appended after the keepalive options and may further
 // customize server behavior (for example interceptors, credentials, or stats handlers).
 func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption) *Server {
-	os := make([]ServerOption, 0, 2+len(opts))
+	os := make([]ServerOption, 0, 8+len(opts))
 	os = append(os, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 		MinTime:             options.Duration("keepalive_enforcement_policy_ping_min_time", timeout).Duration(),
 		PermitWithoutStream: true,
@@ -331,10 +344,62 @@ func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption)
 		Time:                  options.Duration("keepalive_ping_time", timeout).Duration(),
 		Timeout:               timeout.Duration(),
 	}))
+	if _, ok := options["max_concurrent_streams"]; ok {
+		os = append(os, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 0)))
+	}
+
+	if _, ok := options["connection_timeout"]; ok {
+		os = append(os, grpc.ConnectionTimeout(options.Duration("connection_timeout", 0).Duration()))
+	}
+
+	if _, ok := options["max_header_list_size"]; ok {
+		os = append(os, grpc.MaxHeaderListSize(mustUint32Size(options, "max_header_list_size")))
+	}
+
+	if _, ok := options["initial_window_size"]; ok {
+		os = append(os, grpc.InitialWindowSize(mustInt32Size(options, "initial_window_size")))
+	}
+
+	if _, ok := options["initial_conn_window_size"]; ok {
+		os = append(os, grpc.InitialConnWindowSize(mustInt32Size(options, "initial_conn_window_size")))
+	}
+
+	if _, ok := options["max_send_msg_size"]; ok {
+		os = append(os, grpc.MaxSendMsgSize(mustIntSize(options, "max_send_msg_size")))
+	}
 	os = append(os, opts...)
 
 	server := grpc.NewServer(os...)
 	reflection.Register(server)
 
 	return server
+}
+
+func mustInt32Size(options options.Map, key string) int32 {
+	size := options.Size(key, 0)
+	if size.Bytes() > math.MaxInt32 {
+		runtime.Must(fmt.Errorf("grpc: %s exceeds max int32: %s", key, size))
+	}
+
+	//nolint:gosec // Size is range-checked against MaxInt32 above.
+	return int32(size.Bytes())
+}
+
+func mustIntSize(options options.Map, key string) int {
+	size := options.Size(key, 0)
+	if size.Bytes() > math.MaxInt {
+		runtime.Must(fmt.Errorf("grpc: %s exceeds max int: %s", key, size))
+	}
+
+	return int(size.Bytes())
+}
+
+func mustUint32Size(options options.Map, key string) uint32 {
+	size := options.Size(key, 0)
+	if size.Bytes() > math.MaxUint32 {
+		runtime.Must(fmt.Errorf("grpc: %s exceeds max uint32: %s", key, size))
+	}
+
+	//nolint:gosec // Size is range-checked against MaxUint32 above.
+	return uint32(size.Bytes())
 }

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -1,0 +1,36 @@
+package grpc_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/config/options"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServerWithAdvancedOptions(t *testing.T) {
+	opts := options.Map{
+		"max_concurrent_streams":   "7",
+		"connection_timeout":       "250ms",
+		"max_header_list_size":     "9MB",
+		"initial_window_size":      "3MB",
+		"initial_conn_window_size": "4MB",
+		"max_send_msg_size":        "5MB",
+	}
+
+	require.NotPanics(t, func() {
+		server := grpc.NewServer(opts, time.Second)
+		require.NotNil(t, server)
+	})
+}
+
+func TestNewServerWithOverflowingAdvancedOptions(t *testing.T) {
+	require.Panics(t, func() {
+		grpc.NewServer(options.Map{"initial_window_size": "3GB"}, time.Second)
+	})
+
+	require.Panics(t, func() {
+		grpc.NewServer(options.Map{"max_header_list_size": "5GB"}, time.Second)
+	})
+}

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -132,6 +132,12 @@
         keepalive_max_connection_age: "10s"
         keepalive_max_connection_age_grace: "10s"
         keepalive_ping_time: "10s"
+        max_concurrent_streams: "64"
+        connection_timeout: "3s"
+        max_header_list_size: "16MB"
+        initial_window_size: "1MB"
+        initial_conn_window_size: "2MB"
+        max_send_msg_size: "8MB"
       }
       retry: {
         backoff: "100ms"

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -126,6 +126,12 @@ keepalive_max_connection_idle = "10s"
 keepalive_max_connection_age = "10s"
 keepalive_max_connection_age_grace = "10s"
 keepalive_ping_time = "10s"
+max_concurrent_streams = "64"
+connection_timeout = "3s"
+max_header_list_size = "16MB"
+initial_window_size = "1MB"
+initial_conn_window_size = "2MB"
+max_send_msg_size = "8MB"
 
 [transport.grpc.retry]
 backoff = "100ms"

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -95,6 +95,12 @@ transport:
       keepalive_max_connection_age: 10s
       keepalive_max_connection_age_grace: 10s
       keepalive_ping_time: 10s
+      max_concurrent_streams: "64"
+      connection_timeout: 3s
+      max_header_list_size: 16MB
+      initial_window_size: 1MB
+      initial_conn_window_size: 2MB
+      max_send_msg_size: 8MB
     retry:
       backoff: 100ms
       timeout: 1s

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -1,6 +1,7 @@
 package grpc_test
 
 import (
+	"maps"
 	"net"
 	"testing"
 
@@ -107,11 +108,53 @@ func TestStreamMaxReceiveSize(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
+func TestUnaryMaxSendSize(t *testing.T) {
+	world := newStartedGRPCWorldWithOptions(t, 0, map[string]string{"max_send_msg_size": "64B"})
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	_, err := client.SayHello(t.Context(), &v1.SayHelloRequest{Name: strings.Repeat("a", 256)})
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestStreamMaxSendSize(t *testing.T) {
+	world := newStartedGRPCWorldWithOptions(t, 0, map[string]string{"max_send_msg_size": "64B"})
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&v1.SayStreamHelloRequest{Name: strings.Repeat("a", 256)}))
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
 func newStartedGRPCWorld(t *testing.T, maxReceiveSize bytes.Size) *test.World {
 	t.Helper()
 
+	return newStartedGRPCWorldWithOptions(t, maxReceiveSize, nil)
+}
+
+func newStartedGRPCWorldWithOptions(t *testing.T, maxReceiveSize bytes.Size, opts map[string]string) *test.World {
+	t.Helper()
+
 	cfg := test.NewInsecureTransportConfig()
-	cfg.GRPC.MaxReceiveSize = maxReceiveSize
+	if maxReceiveSize > 0 {
+		cfg.GRPC.MaxReceiveSize = maxReceiveSize
+	}
+	if len(opts) > 0 {
+		if cfg.GRPC.Options == nil {
+			cfg.GRPC.Options = map[string]string{}
+		}
+		maps.Copy(cfg.GRPC.Options, opts)
+	}
 
 	return test.NewStartedWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldGRPC())
 }


### PR DESCRIPTION
## What

Added config-driven gRPC server tuning through `transport.grpc.options` / `server.Config.Options`.

This change:
- adds `options.Map.Uint32(...)` and `options.Map.Size(...)`
- extends `net/grpc.NewServer(...)` to support:
  - `max_concurrent_streams`
  - `connection_timeout`
  - `max_header_list_size`
  - `initial_window_size`
  - `initial_conn_window_size`
  - `max_send_msg_size`
- keeps existing keepalive behavior unchanged when the new keys are absent
- fails fast on invalid or overflowing size-based values
- updates `net/grpc` docs to describe the new option keys and value formats
- adds focused tests for the new option helpers and gRPC server option wiring
- updates YAML, TOML, and HJSON config fixtures plus config assertions to cover the new keys through the decoder path

## Why

The server already supported config-driven keepalive tuning via `options.Map`, but broader public or high-scale deployments needed a few more low-level grpc-go server knobs without expanding the top-level config schema.

This keeps the existing design intact while making advanced server tuning available through the same config path.

## Testing

Ran:
- `make dep`
- `go test ./config/options`
- `go test ./net/grpc`
- `go test ./config`
- `go test ./net/grpc/server`

Notes:
- `go test ./net/grpc/server` needed to be rerun outside the sandbox because the existing test binds a local port and the sandbox blocked `listen tcp :0`
- validation was intentionally scoped to the affected packages and config decoder coverage