### PR TITLE
feat(http): add http max_header_bytes option

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,6 +300,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 			"write_timeout":       "10s",
 			"idle_timeout":        "10s",
 			"read_header_timeout": "10s",
+			"max_header_bytes":    "32KB",
 		},
 		config.Transport.HTTP.Options,
 	)

--- a/net/http/doc.go
+++ b/net/http/doc.go
@@ -8,5 +8,8 @@
 //   - Handle/HandleFunc, which register handlers wrapped with OpenTelemetry instrumentation,
 //   - Pattern and ParseServiceMethod, which help standardize route naming for telemetry.
 //
+// Server construction reads timeout keys from options.Map (`read_timeout`, `write_timeout`,
+// `idle_timeout`, `read_header_timeout`) and also supports `max_header_bytes` as an SI size string.
+//
 // Start with `NewClient` and `NewServer`.
 package http

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -1,15 +1,19 @@
 package http
 
 import (
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptrace"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/alexfalkowski/go-service/v2/net/http/telemetry"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
@@ -63,6 +67,9 @@ const StatusTooManyRequests = http.StatusTooManyRequests
 
 // StatusUnauthorized is an alias of http.StatusUnauthorized.
 const StatusUnauthorized = http.StatusUnauthorized
+
+// DefaultMaxHeaderBytes is an alias of http.DefaultMaxHeaderBytes.
+const DefaultMaxHeaderBytes = http.DefaultMaxHeaderBytes
 
 type (
 	// Client is an alias for net/http.Client.
@@ -218,6 +225,9 @@ func StatusText(code int) string {
 //   - idle_timeout
 //   - read_header_timeout
 //
+// Additional low-level server tuning may be provided through options using:
+//   - max_header_bytes
+//
 // Protocols are configured via Protocols().
 //
 // Note: options.Duration uses MustParseDuration under the hood; invalid option values will panic at
@@ -229,8 +239,18 @@ func NewServer(options options.Map, timeout time.Duration, handler Handler) *Ser
 		WriteTimeout:      options.Duration("write_timeout", timeout).Duration(),
 		IdleTimeout:       options.Duration("idle_timeout", timeout).Duration(),
 		ReadHeaderTimeout: options.Duration("read_header_timeout", timeout).Duration(),
+		MaxHeaderBytes:    mustIntSize(options, "max_header_bytes", bytes.Size(DefaultMaxHeaderBytes)),
 		Protocols:         Protocols(),
 	}
+}
+
+func mustIntSize(options options.Map, key string, fallback bytes.Size) int {
+	size := options.Size(key, fallback)
+	if size.Bytes() > math.MaxInt {
+		runtime.Must(fmt.Errorf("http: %s exceeds max int: %s", key, size))
+	}
+
+	return int(size.Bytes())
 }
 
 // ParseServiceMethod derives a logical "service" and "method" name from an HTTP request.

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -1,0 +1,23 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/config/options"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServerWithMaxHeaderBytes(t *testing.T) {
+	server := http.NewServer(options.Map{"max_header_bytes": "16KB"}, time.Second, http.NewServeMux())
+
+	require.Equal(t, int(16*bytes.KB), server.MaxHeaderBytes)
+}
+
+func TestNewServerWithDefaultMaxHeaderBytes(t *testing.T) {
+	server := http.NewServer(options.Map{}, time.Second, http.NewServeMux())
+
+	require.Equal(t, http.DefaultMaxHeaderBytes, server.MaxHeaderBytes)
+}

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -99,6 +99,7 @@
         write_timeout: "10s"
         idle_timeout: "10s"
         read_header_timeout: "10s"
+        max_header_bytes: "32KB"
       }
       retry: {
         backoff: "100ms"

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -92,6 +92,7 @@ read_timeout = "10s"
 write_timeout = "10s"
 idle_timeout = "10s"
 read_header_timeout = "10s"
+max_header_bytes = "32KB"
 
 [transport.http.retry]
 backoff = "100ms"

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -69,6 +69,7 @@ transport:
       write_timeout: 10s
       idle_timeout: 10s
       read_header_timeout: 10s
+      max_header_bytes: 32KB
     retry:
       backoff: 100ms
       timeout: 1s


### PR DESCRIPTION
## What

Added support for `max_header_bytes` in the existing `transport.http.options` / `server.Config.Options` path.

This change:
- extends `net/http.NewServer(...)` to read `max_header_bytes` from `options.Map`
- updates HTTP package docs to describe the new option
- adds a focused constructor test for the HTTP server
- updates YAML, TOML, and HJSON config fixtures plus config assertions to cover the new key

## Why

The HTTP transport already supported timeout tuning through `options.Map`, but it was missing a simple low-level guardrail for request header size.

This keeps the current config shape unchanged while exposing a useful server hardening knob through the same existing options path.

## Testing

Ran:
- `go test ./config ./net/http`
- `make lint`

Notes:
- validation was intentionally scoped to the affected config and HTTP packages