### PR TITLE
feat(grpc): make connection timeout follow repo timeout defaults

### DIFF
--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -18,26 +18,25 @@
 //
 // NewServer builds a *grpc.Server with keepalive enforcement and server
 // parameters. Configuration values are sourced from an options.Map using the
-// following keys:
+// following duration keys. When a duration key is absent, NewServer falls back
+// to the timeout argument:
 //
 //   - keepalive_enforcement_policy_ping_min_time
 //   - keepalive_max_connection_idle
 //   - keepalive_max_connection_age
 //   - keepalive_max_connection_age_grace
 //   - keepalive_ping_time
+//   - connection_timeout
 //
-// The keepalive values use Go duration strings. NewServer also supports the
-// following low-level server tuning keys:
+// NewServer also supports the following low-level server tuning keys:
 //
 //   - max_concurrent_streams: base-10 unsigned integer string
-//   - connection_timeout: Go duration string
 //   - max_header_list_size: SI size string such as 16MB
 //   - initial_window_size: SI size string such as 1MB
 //   - initial_conn_window_size: SI size string such as 4MB
 //   - max_send_msg_size: SI size string such as 16MB
 //
-// The timeout argument is used as the default value for each key when it is not
-// present in the options map, and is also used as the keepalive ping Timeout.
+// The timeout argument is also used as the keepalive ping Timeout.
 //
 // NewServer always enables server reflection via reflection.Register.
 //

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -306,21 +306,22 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 
 // NewServer constructs a *grpc.Server with standard keepalive configuration and reflection enabled.
 //
-// Keepalive enforcement and server parameters are populated from options using the
-// following duration keys (falling back to timeout when a key is not present):
+// Keepalive enforcement, connection establishment timeout, and server parameters are
+// populated from options using the following duration keys (falling back to timeout
+// when a key is not present):
 //
 //   - keepalive_enforcement_policy_ping_min_time
 //   - keepalive_max_connection_idle
 //   - keepalive_max_connection_age
 //   - keepalive_max_connection_age_grace
 //   - keepalive_ping_time
+//   - connection_timeout
 //
 // In addition, the provided timeout is used as the keepalive ping Timeout.
 //
 // Additional low-level server tuning may be provided through options using:
 //
 //   - max_concurrent_streams
-//   - connection_timeout
 //   - max_header_list_size
 //   - initial_window_size
 //   - initial_conn_window_size
@@ -344,12 +345,9 @@ func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption)
 		Time:                  options.Duration("keepalive_ping_time", timeout).Duration(),
 		Timeout:               timeout.Duration(),
 	}))
+	os = append(os, grpc.ConnectionTimeout(options.Duration("connection_timeout", timeout).Duration()))
 	if _, ok := options["max_concurrent_streams"]; ok {
 		os = append(os, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 0)))
-	}
-
-	if _, ok := options["connection_timeout"]; ok {
-		os = append(os, grpc.ConnectionTimeout(options.Duration("connection_timeout", 0).Duration()))
 	}
 
 	if _, ok := options["max_header_list_size"]; ok {


### PR DESCRIPTION
## What

Update `net/grpc.NewServer` so `connection_timeout` now falls back to the repo `timeout` argument when it is not explicitly set, matching the timeout-handling pattern already used for the other duration-based server options.

Refresh the gRPC package docs to describe the duration keys accurately and clarify that `connection_timeout` is part of the timeout-fallback behavior.

## Why

The previous implementation mixed timeout default ownership across transports and fields: HTTP timeout-style fields used repo defaults, while gRPC `connection_timeout` silently relied on grpc-go's internal default. This change makes timeout policy more consistent and predictable across the fields we expose.

It also brings the package documentation back in line with the actual constructor behavior.

## Testing

Ran `go test ./net/grpc ./net/http`.

Validation was intentionally scoped to the affected packages. No additional integration or end-to-end checks were run.