### PR TITLE
feat(http): max receive enforcement

### DIFF
--- a/io/io.go
+++ b/io/io.go
@@ -51,6 +51,13 @@ func NopCloser(r Reader) ReadCloser {
 	return io.NopCloser(r)
 }
 
+// LimitReader returns a Reader that reads from r but stops with EOF after n bytes.
+//
+// This is a thin wrapper around io.LimitReader.
+func LimitReader(r Reader, n int64) Reader {
+	return io.LimitReader(r, n)
+}
+
 // ReadAll reads all remaining bytes from r and returns:
 //
 //   - the captured bytes, and

--- a/net/http/config/config.go
+++ b/net/http/config/config.go
@@ -5,11 +5,11 @@ import "github.com/alexfalkowski/go-service/v2/crypto/tls"
 // Config configures the internal HTTP server wiring.
 //
 // This config is used by go-service HTTP server adapters (for example `net/http/server.NewServer`) to
-// create a listener and serve HTTP with optional TLS and inbound request-body limits.
+// create a listener and serve HTTP with optional TLS.
 //
-// It is intentionally minimal: it models the bind address, optional TLS configuration, and the inbound
-// request size cap enforced by the low-level HTTP server wrapper. Higher-level transport packages
-// typically layer additional config (timeouts, protocol settings, middleware, etc.) elsewhere.
+// It is intentionally minimal: it models the bind address and optional TLS configuration. Higher-level
+// transport packages typically layer additional config (timeouts, protocol settings, middleware, etc.)
+// elsewhere.
 type Config struct {
 	// TLS configures the TLS settings used by the HTTP server.
 	//
@@ -26,9 +26,4 @@ type Config struct {
 	// network and address can be parsed and passed to net.Listen. Some callers may also supply a raw
 	// host:port address depending on the surrounding wiring.
 	Address string
-
-	// MaxReceiveBytes limits inbound request body size in bytes.
-	//
-	// When greater than zero, server wiring wraps the root handler with MaxBytesHandler before serving.
-	MaxReceiveBytes int64
 }

--- a/net/http/server/server.go
+++ b/net/http/server/server.go
@@ -51,19 +51,10 @@ func NewService(name string, http *http.Server, cfg *config.Config, logger *logg
 // cert/key file paths (because certificate material is expected to be present in TLSConfig). If cfg.TLS is nil,
 // Serve will call Serve and serve plain HTTP.
 //
-// Inbound size limits:
-// If cfg.MaxReceiveBytes is greater than zero and the underlying server has a non-nil Handler, NewServer wraps
-// that handler with http.MaxBytesHandler before creating the listener. This caps each inbound request body at
-// the configured byte limit for all downstream handlers.
-//
 // Address formats:
 // cfg.Address may use either the go-service "<network>://<address>" convention or a raw listen address such as
 // ":8080". Raw addresses default to the "tcp" network.
 func NewServer(server *http.Server, cfg *config.Config) (*Server, error) {
-	if cfg.MaxReceiveBytes > 0 && server.Handler != nil {
-		server.Handler = http.MaxBytesHandler(server.Handler, cfg.MaxReceiveBytes)
-	}
-
 	srv := &Server{server: server, tls: cfg.TLS}
 	n, a := net.ListenNetworkAddress(cfg.Address)
 

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -8,11 +8,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/server"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
@@ -95,9 +97,8 @@ type ServerParams struct {
 //
 // Inbound size limits:
 //
-// params.Config.GetMaxReceiveSize() is projected into the low-level HTTP server config and enforced by
-// net/http/server.NewServer via http.MaxBytesHandler. The limit applies per inbound request body before
-// downstream handlers read from it.
+// params.Config.GetMaxReceiveSize() is enforced in this transport stack before downstream handlers read
+// from the request body.
 //
 // If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
 // to the actual bound listener address after construction.
@@ -112,6 +113,8 @@ func NewServer(params ServerParams) (*Server, error) {
 	if params.Logger != nil {
 		neg.Use(logger.NewHandler(params.Logger))
 	}
+
+	neg.Use(maxReceiveHandler(params.Config.GetMaxReceiveSize().Bytes()))
 
 	for _, hd := range params.Handlers {
 		neg.Use(hd)
@@ -164,8 +167,7 @@ func (s *Server) GetService() *server.Service {
 
 func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 	config := &config.Config{
-		Address:         cmp.Or(cfg.Address, net.DefaultAddress("8080")),
-		MaxReceiveBytes: cfg.GetMaxReceiveSize().Bytes(),
+		Address: cmp.Or(cfg.Address, net.DefaultAddress("8080")),
 	}
 	if !cfg.TLS.IsEnabled() {
 		return config, nil
@@ -182,4 +184,28 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 
 func prefix(err error) error {
 	return errors.Prefix("http", err)
+}
+
+func maxReceiveHandler(limit int64) negroni.Handler {
+	return negroni.HandlerFunc(func(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		if req.ContentLength > limit {
+			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
+			return
+		}
+
+		data, body, err := io.ReadAll(io.LimitReader(req.Body, limit+1))
+		if err != nil {
+			_ = status.WriteError(res, status.BadRequestError(err))
+			return
+		}
+		defer req.Body.Close()
+
+		if int64(len(data)) > limit {
+			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
+			return
+		}
+
+		req.Body = body
+		next(res, req)
+	})
 }

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -55,3 +55,31 @@ func TestServerMaxReceiveSize(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 	require.Contains(t, body, "http: request body too large")
 }
+
+func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
+	cfg := test.NewInsecureTransportConfig()
+	cfg.HTTP.MaxReceiveSize = 64
+
+	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
+	http.Handle(world.ServeMux, "POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+		return &test.Response{Greeting: "hello"}, nil
+	}))
+	world.Start()
+
+	header := http.Header{}
+	header.Set(content.TypeKey, mime.JSONMediaType)
+
+	res, body, err := world.PostBody(
+		t.Context(),
+		world.PathServerURL("http", "hello"),
+		header,
+		&unknownLengthReader{Reader: strings.NewReader(`{"name":"` + strings.Repeat("a", 256) + `"}`)},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
+	require.Contains(t, body, "http: request body too large")
+}
+
+type unknownLengthReader struct {
+	*strings.Reader
+}


### PR DESCRIPTION
## What

- Add bounded request body buffering in the `transport/http` Negroni stack using `io.LimitReader`.
- Reject known and unknown-length request bodies that exceed `MaxReceiveSize` with `413 Request Entity Too Large`.
- Add a regression test for oversized unknown-length request bodies.
- Add a go-service `io.LimitReader` wrapper.

## Why

- Oversized request bodies should be rejected before decoding so response status does not depend on JSON decoder error behavior.
- This keeps `GOEXPERIMENT=jsonv2` from turning known oversized JSON requests into `400 Bad Request`.

## Testing

- `go test -run 'TestServerMaxReceiveSize' ./transport/http`
- `GOEXPERIMENT=jsonv2 go test -run 'TestServerMaxReceiveSize' ./transport/http`
- `go test ./io ./net/http ./net/http/config ./net/http/server ./transport/http`
- `make lint`
- `git diff --check`