### PR TITLE
feat(http): move body limit middleware

### DIFF
--- a/transport/http/body/body.go
+++ b/transport/http/body/body.go
@@ -1,0 +1,40 @@
+package body
+
+import (
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+)
+
+// NewHandler constructs request body size limiting middleware.
+func NewHandler(limit int64) *Handler {
+	return &Handler{limit: limit}
+}
+
+// Handler limits request bodies before downstream handlers decode them.
+type Handler struct {
+	limit int64
+}
+
+// ServeHTTP enforces the configured request body limit.
+func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	if req.ContentLength > h.limit {
+		_ = status.WriteError(res, &http.MaxBytesError{Limit: h.limit})
+		return
+	}
+
+	data, body, err := io.ReadAll(io.LimitReader(req.Body, h.limit+1))
+	if err != nil {
+		_ = status.WriteError(res, status.BadRequestError(err))
+		return
+	}
+	defer req.Body.Close()
+
+	if int64(len(data)) > h.limit {
+		_ = status.WriteError(res, &http.MaxBytesError{Limit: h.limit})
+		return
+	}
+
+	req.Body = body
+	next(res, req)
+}

--- a/transport/http/body/doc.go
+++ b/transport/http/body/doc.go
@@ -1,0 +1,2 @@
+// Package body provides HTTP request body middleware.
+package body

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -8,14 +8,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/server"
-	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/transport/http/body"
 	"github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
@@ -114,7 +113,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(logger.NewHandler(params.Logger))
 	}
 
-	neg.Use(maxReceiveHandler(params.Config.GetMaxReceiveSize().Bytes()))
+	neg.Use(body.NewHandler(params.Config.GetMaxReceiveSize().Bytes()))
 
 	for _, hd := range params.Handlers {
 		neg.Use(hd)
@@ -184,28 +183,4 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 
 func prefix(err error) error {
 	return errors.Prefix("http", err)
-}
-
-func maxReceiveHandler(limit int64) negroni.Handler {
-	return negroni.HandlerFunc(func(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-		if req.ContentLength > limit {
-			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
-			return
-		}
-
-		data, body, err := io.ReadAll(io.LimitReader(req.Body, limit+1))
-		if err != nil {
-			_ = status.WriteError(res, status.BadRequestError(err))
-			return
-		}
-		defer req.Body.Close()
-
-		if int64(len(data)) > limit {
-			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
-			return
-		}
-
-		req.Body = body
-		next(res, req)
-	})
 }


### PR DESCRIPTION
## What

- Move HTTP request body size limiting into `transport/http/body`.
- Install the new body middleware from `transport/http/server.go`.
- Keep the handler Negroni-compatible without importing Negroni in the body package.

## Why

- Keeps request body enforcement separate from server wiring.
- Gives the body limit behavior a focused package while it remains transport-specific.

## Testing

- `go test ./io ./transport/http/body ./transport/http`
- `GOEXPERIMENT=jsonv2 go test -run 'TestServerMaxReceiveSize' ./transport/http`
- `make lint`
- `git diff --check`