### PR TITLE
docs(agents): clarify agent skill reference workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,76 +1,68 @@
 # AGENTS.md
 
-## Shared skill
+## Shared Skill
 
 Use the shared `coding-standards` skill from `bin/skills/coding-standards` for code changes, bug fixes, refactors, reviews, tests, linting, documentation, PR summaries, commits, Makefile changes, CI validation, and verification.
 
-## Repo snapshot
+Before answering any covered task, read `bin/skills/coding-standards/SKILL.md` and the relevant reference file under `bin/skills/coding-standards/references/`.
 
-- Module: `github.com/alexfalkowski/go-service/v2`
-- Library repo; no top-level `cmd/`
-- Go: `1.26.0`
-- DI: Uber Fx/Dig via `di/`
-- CLI helpers: `github.com/cristalhq/acmd` via `cli/`
-- Many `make` targets come from the `bin/` submodule
+- Commit messages and PR summaries: read `references/pr.md` and follow its required format exactly.
+- Reviews: read `references/review.md`.
+- Verification: read `references/verification.md`.
+- Go changes: read `references/go.md`, plus workflow or change-safety references when relevant.
+
+## Repo Snapshot
+
+- Library repo; check `go.mod` for module and Go version details.
+- DI is under `di/`; CLI helpers are under `cli/`.
+- Many `make` targets come from the `bin/` submodule.
 
 ## Setup
 
-- Initialize the submodule before using `make`:
+- Initialize the submodule before using `make`: `git submodule sync` then `git submodule update --init`.
+- Equivalent: `make submodule`.
+- Submodule fetches use SSH.
 
-```sh
-git submodule sync
-git submodule update --init
-```
+## Common Commands
 
-- Equivalent: `make submodule`
-- Submodule fetches use SSH via `git@github.com:alexfalkowski/bin.git`
+- Discover targets: `make help`.
+- Dependencies: `make dep` after dependency changes.
+- Quality: `make specs`, `make lint`, `make fix-lint`, `make format`, `make sec`.
+- Coverage and benchmarks: use the repo `make` targets shown by `make help`.
+- TLS fixtures: `mkcert -install` then `make create-certs`.
+- `encode-config` expects GNU `base64 -w 0`; on macOS/BSD use `base64 | tr -d '\n'`.
 
-## Common commands
-
-- `make help`
-- `make dep`: run after dependency changes; it does `go mod download`, `go mod tidy`, and `go mod vendor`. Tests use `-mod vendor`.
-- Quality: `make specs`, `make lint`, `make fix-lint`, `make format`, `make sec`
-- Coverage: `make coverage`, `make html-coverage`, `make func-coverage`
-- Benchmarks: `make benchmarks`, `make http-benchmarks`, `make grpc-benchmarks`, `make bytes-benchmarks`, `make strings-benchmarks`
-- Other: `make generate`, `make diagrams`, `make start`, `make stop`
-- TLS setup: `mkcert -install && make create-certs`
-- `make kind=status encode-config`
-- `encode-config` expects GNU `base64 -w 0`; on macOS/BSD use `base64 | tr -d '\n'`
-
-## Layout and wiring
+## Layout And Wiring
 
 - Feature packages usually use `config.go`, `module.go`, plus implementation files.
-- `module/` exports the main Fx bundles: `module.Library`, `module.Server`, `module.Client`.
+- `module/` exports the main Fx bundles.
 - `config/` owns top-level config plus projections into transport, SQL, and telemetry config.
 - `net/` holds lower-level HTTP/gRPC, metadata, header, and server helpers.
 - `transport/` holds the higher-level HTTP/gRPC stacks, middleware, and ops endpoints.
-- `internal/test/` contains shared test helpers, especially `internal/test/world.go`.
-- `test/` stores fixtures such as configs, certs, secrets, and reports.
+- `internal/test/` contains shared test helpers; `test/` stores fixtures and reports.
 - Modules are composed with `di.Module(...)`; many constructors use `di.In`.
-- `module.Server` wires debug, cache, config, feature, SQL, telemetry, limiter, transport, and health.
-- `module.Client` wires cache, config, feature, hooks, SQL, telemetry, and limiter, but not debug, transport, or health by default.
 
 ## Configuration
 
-- `config.NewDecoder` resolves `-i` as `file:<path>`, `env:<ENV_VAR>`, or `<serviceName>.{yaml,yml,hjson,toml,json}`.
+- `config.NewDecoder` resolves `-i` as `file:<path>`, `env:<ENV_VAR>`, or a default config file named for the service.
 - Default file lookup checks the executable directory, `$XDG_CONFIG_HOME/<serviceName>/`, and `/etc/<serviceName>/`.
-- Many config fields use go-service source strings through `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
+- Many config fields use source strings through `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
 - Nil pointer sub-configs usually mean "disabled".
 
 ## Gotchas
 
-- Manual transport TLS setup must call `transport/http.Register(fs)` and `transport/grpc.Register(fs)`; `transport.Module` does this on the normal path.
+- Manual transport TLS setup must call the HTTP and gRPC transport register functions; `transport.Module` does this on the normal path.
 - Manual server lifecycle wiring should use `net/server.Register(...)`.
 - `telemetry.Register()` installs the global OpenTelemetry propagator.
-- `cache.Register(...)` sets the package-level cache used by `cache/generic.go`.
-- `token/access` passes `access.policy` directly to Casbin's file adapter, so it must be a real path.
+- `cache.Register(...)` sets the package-level cache used by generic cache helpers.
+- Access policy config is passed to Casbin's file adapter, so it must be a real path.
 - JWT verification requires both the expected algorithm and a `kid` header.
 - `telemetry/header.Map.MustSecrets` can panic if secret resolution fails during config projection.
-- `transport/http/health.RegisterParams` and `internal/test.RegisterHealth` both require `*net/http.ServeMux`.
+- Health registration helpers require `*net/http.ServeMux`.
 - Shared metadata, header, and string helpers live under `net/...`, not `transport/...`.
 - `vendor/` is gitignored and regenerated via `make dep`.
 
-## Testing, style, and docs
+## Testing, Style, And Docs
 
 - Tests commonly use `stretchr/testify/require`.
 - Go files use tabs; YAML uses 2 spaces per `.editorconfig`.
@@ -79,5 +71,5 @@ git submodule update --init
 
 ## CI
 
-- CircleCI runs submodule init, `make source-key`, `mkcert -install`, `make create-certs`, waits for services, then runs `make clean`, `make dep`, `make lint`, `make sec`, `make specs`, `make benchmarks`, and `make coverage`.
-- Services: Postgres `localhost:5432`, Valkey `localhost:6379`, `alexfalkowski/status` `localhost:6000`, Grafana Mimir `localhost:9009`
+- CI initializes submodules, prepares certs/services, then runs dependency, lint, security, spec, benchmark, and coverage targets.
+- Check CI config for exact service images, ports, and command order.


### PR DESCRIPTION
## What

Compressed `AGENTS.md` to keep repo guidance shorter and less version-prone.

Added explicit instructions to read `bin/skills/coding-standards/SKILL.md` and the relevant reference file before covered tasks, including `references/pr.md` for commit messages and PR summaries.

## Why

Keeps changing facts in their source-of-truth files while making the shared skill workflow harder to miss in new chats.

## Testing

Not run; docs-only change.