### PR TITLE
docs(readme): clarify intentional config and metadata behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ Before answering any covered task, read `bin/skills/coding-standards/SKILL.md` a
 - Manual server lifecycle wiring should use `net/server.Register(...)`.
 - `telemetry.Register()` installs the global OpenTelemetry propagator.
 - `cache.Register(...)` sets the package-level cache used by generic cache helpers.
+- Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - Access policy config is passed to Casbin's file adapter, so it must be a real path.
+- IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
 - JWT verification requires both the expected algorithm and a `kid` header.
 - `telemetry/header.Map.MustSecrets` can panic if secret resolution fails during config projection.
 - Health registration helpers require `*net/http.ServeMux`.

--- a/cache/driver/doc.go
+++ b/cache/driver/doc.go
@@ -16,6 +16,9 @@
 // The built-in Redis backend resolves its URL from a go-service "source
 // string", constructs a go-redis client, and instruments that client via
 // `cache/telemetry` before exposing it through the cachego Redis adapter.
+// Redis configuration is strict by design: `Config.Options["url"]` must exist
+// and be a string. The standard config fixtures provide that shape; callers that
+// build config manually should validate it before calling `NewDriver`.
 //
 // The built-in `sync` driver comes from the upstream cachego dependency and currently has whole-second TTL
 // resolution. Callers should not rely on sub-second expiration with that backend.

--- a/limiter/doc.go
+++ b/limiter/doc.go
@@ -17,6 +17,11 @@
 // The configured kind is typically provided via `Config.Kind`. If the kind is not present in the KeyMap,
 // limiter construction fails with ErrMissingKey.
 //
+// The "ip" key uses IP metadata populated by transport metadata middleware. That
+// middleware intentionally trusts common forwarding headers such as X-Forwarded-For
+// and CF-Connecting-IP. Use this key only when requests first pass through trusted
+// proxies that strip or overwrite client-supplied forwarding headers.
+//
 // # In-memory behavior and lifecycle
 //
 // The limiter uses an in-memory store. Limits are enforced per process and are not shared across replicas.

--- a/net/grpc/meta/doc.go
+++ b/net/grpc/meta/doc.go
@@ -21,6 +21,12 @@
 // Server interceptors also emit response header metadata such as
 // "service-version" and "request-id".
 //
+// Server metadata extraction intentionally prefers common forwarding metadata such
+// as "x-forwarded-for", "x-real-ip", "cf-connecting-ip", and
+// "true-client-ip" over peer addresses. Deployments that use the extracted IP for
+// access logs, policy, or rate limiting should place the service behind trusted
+// proxies that strip or overwrite spoofed forwarding metadata.
+//
 // Start with `UnaryServerInterceptor` / `StreamServerInterceptor` for
 // server-side extraction and `UnaryClientInterceptor` /
 // `StreamClientInterceptor` for client-side injection. Use `ExtractIncoming`

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -25,5 +25,11 @@
 // `net/http/content.NewHandler` / `NewRequestHandler`), which populate the context before invoking
 // downstream logic.
 //
+// HTTP server metadata extraction intentionally prefers common forwarding headers
+// such as X-Forwarded-For, X-Real-IP, CF-Connecting-IP, and True-Client-IP over
+// RemoteAddr. Deployments that use the extracted IP for access logs, policy, or
+// rate limiting should place the service behind trusted proxies that strip or
+// overwrite spoofed forwarding headers.
+//
 // This package also provides HTTP metadata middleware via `NewHandler` and `NewRoundTripper`.
 package meta

--- a/token/access/config.go
+++ b/token/access/config.go
@@ -5,25 +5,20 @@ package access
 // The policy is consumed by NewController, which constructs a Casbin-backed
 // controller/enforcer using the embedded ModelConfig and a policy adapter.
 //
-// # Source string convention
+// # Policy path
 //
-// Policy supports the go-service “source string” pattern:
-//   - "env:NAME" to read from an environment variable
-//   - "file:/path" to read from a file
-//   - otherwise treated as the literal policy content
-//
-// Note: This package does not resolve source strings itself. If you configure Policy
-// as a source string, resolve it before calling NewController (for example by using
-// os.FS.ReadSource elsewhere in your config projection/wiring).
+// Policy is passed directly to Casbin's file adapter, so it must be a real
+// filesystem path. This package does not resolve go-service source strings such
+// as "env:" or "file:", and it does not accept literal policy payloads.
 //
 // # Enablement
 //
 // Enablement is modeled by presence: a nil *Config disables access control wiring,
 // and NewController returns (nil, nil).
 type Config struct {
-	// Policy is the access control policy document source.
+	// Policy is the access control policy file path.
 	//
-	// It may be a go-service “source string” (see Config docs) or a literal policy.
+	// The path is passed directly to Casbin's file adapter.
 	Policy string `yaml:"policy,omitempty" json:"policy,omitempty" toml:"policy,omitempty"`
 }
 

--- a/token/access/doc.go
+++ b/token/access/doc.go
@@ -25,9 +25,9 @@
 //   - The model is created from the embedded ModelConfig.
 //   - The policy is loaded using Casbin’s file adapter.
 //
-// Note: despite the adapter name, the policy string is passed directly to the adapter.
-// Ensure the configured policy value matches what the underlying adapter expects for
-// your deployment (for example a path vs. a literal policy payload).
+// Policy is passed directly to Casbin's file adapter, so it must be a real
+// filesystem path. This package does not resolve go-service source strings such
+// as "env:" or "file:", and it does not accept literal policy payloads.
 //
 // # Enablement
 //


### PR DESCRIPTION
## What

Documented intentional Redis cache and IP metadata behavior in repo guidance and package docs.

Updated access policy documentation to state that policies are passed directly to Casbin's file adapter and must be real filesystem paths.

## Why

Keeps future reviews from re-flagging intentional design choices and aligns the access docs with the current implementation.

## Testing

Passed:

```sh
go test ./token/access
make lint