### PR TITLE
test(token): add access controller edge case tests

### DIFF
--- a/token/access/access_test.go
+++ b/token/access/access_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +32,56 @@ func TestHasAccess(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestNewControllerErrors(t *testing.T) {
+	tests := []struct {
+		err    error
+		config *access.Config
+		name   string
+	}{
+		{
+			name: "missing model env source",
+			config: &access.Config{
+				Model:  "env:ACCESS_MODEL",
+				Policy: test.FilePath("configs/rbac.csv"),
+			},
+			err: os.ErrEnvSourceMissing,
+		},
+		{
+			name: "missing policy env source",
+			config: &access.Config{
+				Model:  test.FilePath("configs/rbac.conf"),
+				Policy: "env:ACCESS_POLICY",
+			},
+			err: os.ErrEnvSourceMissing,
+		},
+		{
+			name: "invalid model content",
+			config: &access.Config{
+				Model:  "not a casbin model",
+				Policy: test.FilePath("configs/rbac.csv"),
+			},
+		},
+		{
+			name: "empty policy content",
+			config: &access.Config{
+				Model: test.FilePath("configs/rbac.conf"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, err := access.NewController(tt.config, test.FS)
+			require.Error(t, err)
+			require.Nil(t, controller)
+
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+			}
+		})
+	}
+}
+
 func TestHasAccessWithEnvSources(t *testing.T) {
 	model, err := test.FS.ReadFile(test.Path("configs/rbac.conf"))
 	require.NoError(t, err)
@@ -44,6 +95,24 @@ func TestHasAccessWithEnvSources(t *testing.T) {
 	controller, err := access.NewController(&access.Config{
 		Model:  "env:ACCESS_MODEL",
 		Policy: "env:ACCESS_POLICY",
+	}, test.FS)
+	require.NoError(t, err)
+
+	ok, err := controller.HasAccess("alice", "service:read")
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestHasAccessWithLiteralSources(t *testing.T) {
+	model, err := test.FS.ReadFile(test.Path("configs/rbac.conf"))
+	require.NoError(t, err)
+
+	policy, err := test.FS.ReadFile(test.Path("configs/rbac.csv"))
+	require.NoError(t, err)
+
+	controller, err := access.NewController(&access.Config{
+		Model:  string(model),
+		Policy: string(policy),
 	}, test.FS)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What

- Added `NewController` error coverage for missing model and policy `env:` sources.
- Added coverage for invalid model content and empty policy content.
- Added a successful literal model and policy source test.

## Why

These tests lock in the new source-string behavior for access controller construction and cover failure paths around config resolution and Casbin model/policy loading.

## Testing

- `go test ./token/access ./config`
- `make lint`