### PR TITLE
feat(cli): recover cli dependency injection panics by default

### DIFF
--- a/cli/application.go
+++ b/cli/application.go
@@ -57,7 +57,8 @@ type Application struct {
 //
 // Execution semantics:
 //   - parse the command args into the command's FlagSet
-//   - build a DI application with a fresh copy of the provided options, plus the command's module and runtime.Module
+//   - build a DI application with panic recovery, a fresh copy of the provided options, plus the
+//     command's module and runtime.Module
 //   - start the DI application
 //   - block until the DI application's Done channel is closed or ctx is canceled
 //   - stop the DI application
@@ -102,7 +103,8 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 //
 // Execution semantics:
 //   - parse the command args into the command's FlagSet
-//   - build a DI application with a fresh copy of the provided options, plus the command's module
+//   - build a DI application with panic recovery, a fresh copy of the provided options, plus the
+//     command's module
 //   - start the DI application
 //   - stop the DI application immediately after startup completes
 //

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -189,6 +189,29 @@ func TestApplicationClientCanRunTwice(t *testing.T) {
 	require.NoError(t, app.Run(t.Context()))
 }
 
+func TestApplicationClientRecoversFromPanic(t *testing.T) {
+	os.Args = []string{test.Name.String(), "client"}
+	cli.Name = test.Name
+	cli.Version = test.Version
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddClient(
+				"client",
+				"Start the client.",
+				di.Constructor(func() string {
+					panic("bad client")
+				}),
+				di.Register(func(string) {}),
+			)
+		},
+	)
+
+	err := app.Run(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `panic: "bad client"`)
+}
+
 func TestApplicationServerHonorsContextCancellation(t *testing.T) {
 	os.Args = []string{test.Name.String(), "server"}
 	cli.Name = test.Name

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -5,25 +5,23 @@ import (
 	"github.com/alexfalkowski/go-service/v2/os"
 )
 
-var (
-	// FS is the filesystem used by CLI helpers for configuration lookup and reading sources.
-	//
-	// It defaults to an `*os.FS` rooted in the host filesystem (see `os.NewFS`). Tests may override
-	// this variable to control filesystem reads performed during CLI setup.
-	FS = os.NewFS()
+// FS is the filesystem used by CLI helpers for configuration lookup and reading sources.
+//
+// It defaults to an `*os.FS` rooted in the host filesystem (see `os.NewFS`). Tests may override
+// this variable to control filesystem reads performed during CLI setup.
+var FS = os.NewFS()
 
-	// Name is the CLI application name derived from the environment.
-	//
-	// The name is resolved via `env.NewName(FS)` and is used by `Application.Run` to populate the
-	// command runner's app metadata (for example help text and descriptions).
-	Name = env.NewName(FS)
+// Name is the CLI application name derived from the environment.
+//
+// The name is resolved via `env.NewName(FS)` and is used by `Application.Run` to populate the
+// command runner's app metadata (for example help text and descriptions).
+var Name = env.NewName(FS)
 
-	// Version is the CLI application version derived from the environment.
-	//
-	// The version is resolved via `env.NewVersion()` and is used by `Application.Run` to populate the
-	// command runner's version information.
-	Version = env.NewVersion()
-)
+// Version is the CLI application version derived from the environment.
+//
+// The version is resolved via `env.NewVersion()` and is used by `Application.Run` to populate the
+// command runner's version information.
+var Version = env.NewVersion()
 
 func provide() (*os.FS, env.Name, env.Version) {
 	return FS, Name, Version

--- a/cli/command.go
+++ b/cli/command.go
@@ -19,7 +19,7 @@ func NewCommand(name string) *Command {
 //
 // The embedded FlagSet is intended to be configured with flags by the caller, then parsed by the
 // subcommand execution path. The `module` method exposes providers for the filesystem/name/version
-// metadata and the command's FlagSet.
+// metadata and the command's FlagSet, and enables DI panic recovery.
 type Command struct {
 	*flag.FlagSet
 }
@@ -32,6 +32,7 @@ func (c *Command) module() di.Option {
 	return di.Module(
 		di.Constructor(provide),
 		di.Constructor(c.provide),
+		di.Recover(),
 		di.NoLogger,
 	)
 }

--- a/cli/commander.go
+++ b/cli/commander.go
@@ -2,35 +2,33 @@ package cli
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-type (
-	// Option is an alias for di.Option.
-	Option = di.Option
+// Option is an alias for di.Option.
+type Option = di.Option
 
-	// Commander registers CLI subcommands on an application.
+// Commander registers CLI subcommands on an application.
+//
+// Implementations typically add subcommands that build and run a DI application using go-service's
+// `di` package. The returned `*Command` embeds a `*flag.FlagSet` so you can define command-specific
+// flags before execution.
+type Commander interface {
+	// AddServer registers a long-running server-style subcommand.
 	//
-	// Implementations typically add subcommands that build and run a DI application using go-service's
-	// `di` package. The returned `*Command` embeds a `*flag.FlagSet` so you can define command-specific
-	// flags before execution.
-	Commander interface {
-		// AddServer registers a long-running server-style subcommand.
-		//
-		// Command names must be unique across the entire application.
-		//
-		// The subcommand:
-		//   - parses command args into the returned `*Command`'s FlagSet,
-		//   - starts a DI application built from opts plus server-specific wiring,
-		//   - blocks until the DI application signals completion,
-		//   - then stops the DI application.
-		AddServer(name, description string, opts ...Option) *Command
+	// Command names must be unique across the entire application.
+	//
+	// The subcommand:
+	//   - parses command args into the returned `*Command`'s FlagSet,
+	//   - starts a DI application built from opts plus server-specific wiring,
+	//   - blocks until the DI application signals completion,
+	//   - then stops the DI application.
+	AddServer(name, description string, opts ...Option) *Command
 
-		// AddClient registers a short-lived client-style subcommand.
-		//
-		// Command names must be unique across the entire application.
-		//
-		// The subcommand:
-		//   - parses command args into the returned `*Command`'s FlagSet,
-		//   - starts a DI application built from opts plus client-specific wiring,
-		//   - then stops the DI application immediately after startup completes.
-		AddClient(name, description string, opts ...Option) *Command
-	}
-)
+	// AddClient registers a short-lived client-style subcommand.
+	//
+	// Command names must be unique across the entire application.
+	//
+	// The subcommand:
+	//   - parses command args into the returned `*Command`'s FlagSet,
+	//   - starts a DI application built from opts plus client-specific wiring,
+	//   - then stops the DI application immediately after startup completes.
+	AddClient(name, description string, opts ...Option) *Command
+}

--- a/di/di.go
+++ b/di/di.go
@@ -81,6 +81,13 @@ func Register(funcs ...any) Option {
 	return fx.Invoke(funcs...)
 }
 
+// Recover recovers panics from constructors, decorators, and invocations.
+//
+// This is a thin wrapper around fx.RecoverFromPanics and should be included as a top-level app option.
+func Recover() Option {
+	return fx.RecoverFromPanics()
+}
+
 // RootCause returns the underlying root cause of an error returned by Fx/Dig.
 //
 // This is a thin wrapper around dig.RootCause and is useful for formatting/attributing startup failures.

--- a/di/doc.go
+++ b/di/doc.go
@@ -15,7 +15,8 @@
 //   - Use `di.Constructor` to provide constructors (Fx Provide).
 //   - Use `di.Decorate` to wrap/modify provided values (Fx Decorate).
 //   - Use `di.Register` to run registration/invocation hooks at startup (Fx Invoke).
+//   - Use `di.Recover` to recover constructor, decorator, and invocation panics.
 //   - Use `di.RootCause` to unwrap Fx/Dig errors to the underlying cause for reporting.
 //
-// Start with `Module`, `Constructor`, `Register`, `Decorate`, and `RootCause`.
+// Start with `Module`, `Constructor`, `Register`, `Decorate`, `Recover`, and `RootCause`.
 package di


### PR DESCRIPTION
## What

- Added `di.Recover()` as a wrapper around Fx panic recovery.
- Enabled DI panic recovery through the shared CLI command module.
- Updated CLI application docs to describe panic recovery during DI app construction.
- Added test coverage for recovering client command DI startup panics.
- Simplified `cli.Commander` type declarations and documentation formatting.

## Why

CLI commands should consistently convert DI constructor, decorator, and invocation panics into startup errors instead of requiring each command path or caller to wire recovery manually.

## Testing

- `go test ./cli`
- `go test ./di`
- `make lint`