### PR TITLE
test(benchmarks): use shared benchmark target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,16 @@ transport-diagram:
 benchmarks: http-benchmarks grpc-benchmarks bytes-benchmarks strings-benchmarks
 
 http-benchmarks:
-	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem -benchtime=100x -memprofile test/reports/mem.prof ./transport/http
+	@make package=transport/http benchtime=100x benchmark
 
 grpc-benchmarks:
-	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem -benchtime=100x -memprofile test/reports/mem.prof ./transport/grpc
+	@make package=transport/grpc benchtime=100x benchmark
 
 bytes-benchmarks:
-	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem -benchtime=100x -memprofile test/reports/mem.prof ./bytes
+	@make package=bytes benchtime=100x benchmark
 
 strings-benchmarks:
-	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem -benchtime=100x -memprofile test/reports/mem.prof ./strings
+	@make package=strings benchtime=100x benchmark
 
 # Generate for tests.
 generate:


### PR DESCRIPTION
## What

- Update root benchmark targets to call the shared `benchmark` make target.
- Pass `package=...` and `benchtime=100x` for each benchmark package.

## Why

- Removes duplicated `go test` benchmark commands from the service Makefile.
- Uses the updated shared `bin` benchmark behavior, including package-specific memory profiles.

## Testing

- Passed: `make -n package=transport/http benchtime=100x benchmark`
- Passed: `make benchmarks`
- Passed: `make lint`
- Note: `make lint` still reports the existing `gomodguard` deprecation warning, then finishes with `0 issues`.