### PR TITLE
feat(meta): reduce metadata context allocations with pairs

### DIFF
--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -118,7 +118,7 @@ func TestDBQuery(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 	rows, err := world.DB.QueryContext(ctx, "SELECT table_name FROM information_schema.tables WHERE table_schema='public'")
 	require.NoError(t, err)
 
@@ -141,7 +141,7 @@ func TestDBExec(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	result, err := world.DB.ExecContext(ctx, "INSERT INTO accounts(created_at) VALUES($1)", time.Now())
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestDBCommitTransExec(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	tx, err := world.DB.BeginTx(ctx, nil)
 	require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestDBRollbackTransExec(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	tx, err := world.DB.BeginTx(ctx, nil)
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestStatementQuery(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	_, stmt, err := world.DB.PrepareContext(ctx, "SELECT table_name FROM information_schema.tables WHERE table_schema = $1")
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestStatementExec(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	_, stmt, err := world.DB.PrepareContext(ctx, "INSERT INTO accounts(created_at) VALUES($1)")
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestTransStatementExec(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	tx, err := world.DB.Begin()
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestInvalidStatementQuery(t *testing.T) {
 	ctx, cancel := test.Timeout(t.Context())
 	defer cancel()
 
-	ctx = meta.WithAttribute(ctx, "test", meta.String("test"))
+	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 
 	_, stmt, err := world.DB.PrepareContext(ctx, "SELECT table_name FROM information_schema.tables WHERE table_schema = $1")
 	require.NoError(t, err)

--- a/internal/test/meta.go
+++ b/internal/test/meta.go
@@ -5,12 +5,16 @@ import (
 	"github.com/alexfalkowski/go-service/v2/meta"
 )
 
-// WithTest stores a metadata attribute named `test` on the context.
-func WithTest(ctx context.Context, value meta.Value) context.Context {
-	return meta.WithAttribute(ctx, "test", value)
+// WithTest creates a test metadata pair for meta.WithAttributes.
+//
+// The pair stores value under the `test` key used by shared test helpers.
+func WithTest(value meta.Value) meta.Pair {
+	return meta.NewPair("test", value)
 }
 
 // Test retrieves the metadata attribute stored under the `test` key.
+//
+// If no value is present, this returns the zero-value meta.Value.
 func Test(ctx context.Context) meta.Value {
 	return meta.Attribute(ctx, "test")
 }

--- a/meta/attrs.go
+++ b/meta/attrs.go
@@ -63,11 +63,60 @@ const (
 	GeolocationKey = "geoLocation"
 )
 
-// WithUserAgent stores a user agent attribute on ctx under UserAgentKey.
+// WithRequestID creates a request ID pair for WithAttributes.
 //
-// This is a convenience wrapper over WithAttribute.
-func WithUserAgent(ctx context.Context, userAgent Value) context.Context {
-	return WithAttribute(ctx, UserAgentKey, userAgent)
+// The pair stores value under RequestIDKey.
+func WithRequestID(value Value) Pair {
+	return NewPair(RequestIDKey, value)
+}
+
+// RequestID returns the stored request ID attribute from ctx.
+//
+// If no value is present, this returns the zero-value Value.
+func RequestID(ctx context.Context) Value {
+	return Attribute(ctx, RequestIDKey)
+}
+
+// WithSystem creates a system pair for WithAttributes.
+//
+// The pair stores value under SystemKey.
+func WithSystem(value Value) Pair {
+	return NewPair(SystemKey, value)
+}
+
+// WithService creates a service pair for WithAttributes.
+//
+// The pair stores value under ServiceKey.
+func WithService(value Value) Pair {
+	return NewPair(ServiceKey, value)
+}
+
+// WithMethod creates a method pair for WithAttributes.
+//
+// The pair stores value under MethodKey.
+func WithMethod(value Value) Pair {
+	return NewPair(MethodKey, value)
+}
+
+// WithCode creates a status code pair for WithAttributes.
+//
+// The pair stores value under CodeKey.
+func WithCode(value Value) Pair {
+	return NewPair(CodeKey, value)
+}
+
+// WithDuration creates a duration pair for WithAttributes.
+//
+// The pair stores value under DurationKey.
+func WithDuration(value Value) Pair {
+	return NewPair(DurationKey, value)
+}
+
+// WithUserAgent creates a user agent pair for WithAttributes.
+//
+// The pair stores value under UserAgentKey.
+func WithUserAgent(value Value) Pair {
+	return NewPair(UserAgentKey, value)
 }
 
 // UserAgent returns the stored user agent attribute from ctx.
@@ -77,11 +126,11 @@ func UserAgent(ctx context.Context) Value {
 	return Attribute(ctx, UserAgentKey)
 }
 
-// WithUserID stores a user ID attribute on ctx under UserIDKey.
+// WithUserID creates a user ID pair for WithAttributes.
 //
-// This is a convenience wrapper over WithAttribute.
-func WithUserID(ctx context.Context, id Value) context.Context {
-	return WithAttribute(ctx, UserIDKey, id)
+// The pair stores value under UserIDKey.
+func WithUserID(value Value) Pair {
+	return NewPair(UserIDKey, value)
 }
 
 // UserID returns the stored user ID attribute from ctx.
@@ -91,11 +140,11 @@ func UserID(ctx context.Context) Value {
 	return Attribute(ctx, UserIDKey)
 }
 
-// WithIPAddr stores an IP address attribute on ctx under IPAddrKey.
+// WithIPAddr creates an IP address pair for WithAttributes.
 //
-// This is a convenience wrapper over WithAttribute.
-func WithIPAddr(ctx context.Context, addr Value) context.Context {
-	return WithAttribute(ctx, IPAddrKey, addr)
+// The pair stores value under IPAddrKey.
+func WithIPAddr(value Value) Pair {
+	return NewPair(IPAddrKey, value)
 }
 
 // IPAddr returns the stored IP address attribute from ctx.
@@ -105,34 +154,19 @@ func IPAddr(ctx context.Context) Value {
 	return Attribute(ctx, IPAddrKey)
 }
 
-// WithGeolocation stores a geolocation attribute on ctx under GeolocationKey.
+// WithIPAddrKind creates an IP address kind pair for WithAttributes.
 //
-// This is a convenience wrapper over WithAttribute.
-func WithGeolocation(ctx context.Context, location Value) context.Context {
-	return WithAttribute(ctx, GeolocationKey, location)
+// The pair stores value under IPAddrKindKey.
+func WithIPAddrKind(value Value) Pair {
+	return NewPair(IPAddrKindKey, value)
 }
 
-// Geolocation returns the stored geolocation attribute from ctx.
+// WithAuthorization creates an authorization pair for WithAttributes.
 //
-// If no value is present, this returns the zero-value Value.
-func Geolocation(ctx context.Context) Value {
-	return Attribute(ctx, GeolocationKey)
-}
-
-// WithIPAddrKind stores the IP address kind attribute on ctx under IPAddrKindKey.
-//
-// This is a convenience wrapper over WithAttribute. It is useful for tracking whether an IP address was
-// derived directly (e.g. peer IP) or indirectly (e.g. from trusted proxy headers).
-func WithIPAddrKind(ctx context.Context, kind Value) context.Context {
-	return WithAttribute(ctx, IPAddrKindKey, kind)
-}
-
-// WithAuthorization stores an authorization attribute on ctx under AuthorizationKey.
-//
-// This is a convenience wrapper over WithAttribute. Because authorization values often contain secrets,
-// callers should prefer using Redacted or Ignored values unless the raw value is strictly required in-process.
-func WithAuthorization(ctx context.Context, auth Value) context.Context {
-	return WithAttribute(ctx, AuthorizationKey, auth)
+// The pair stores value under AuthorizationKey. Authorization values often
+// contain secrets; prefer Ignored or Redacted values if they might be exported.
+func WithAuthorization(value Value) Pair {
+	return NewPair(AuthorizationKey, value)
 }
 
 // Authorization returns the stored authorization attribute from ctx.
@@ -142,16 +176,16 @@ func Authorization(ctx context.Context) Value {
 	return Attribute(ctx, AuthorizationKey)
 }
 
-// WithRequestID stores a request ID attribute on ctx under RequestIDKey.
+// WithGeolocation creates a geolocation pair for WithAttributes.
 //
-// This is a convenience wrapper over WithAttribute.
-func WithRequestID(ctx context.Context, id Value) context.Context {
-	return WithAttribute(ctx, RequestIDKey, id)
+// The pair stores value under GeolocationKey.
+func WithGeolocation(value Value) Pair {
+	return NewPair(GeolocationKey, value)
 }
 
-// RequestID returns the stored request ID attribute from ctx.
+// Geolocation returns the stored geolocation attribute from ctx.
 //
 // If no value is present, this returns the zero-value Value.
-func RequestID(ctx context.Context) Value {
-	return Attribute(ctx, RequestIDKey)
+func Geolocation(ctx context.Context) Value {
+	return Attribute(ctx, GeolocationKey)
 }

--- a/meta/doc.go
+++ b/meta/doc.go
@@ -5,9 +5,11 @@
 //
 // # Storage model
 //
-// Attributes are stored on the context under a single internal key as a map-like Storage. Helpers such as
-// WithAttribute update that storage using copy-on-write semantics so derived contexts do not mutate parent
-// or sibling context metadata.
+// Attributes are stored on the context under a single internal key as a map-like Storage. WithAttributes
+// updates that storage using copy-on-write semantics so derived contexts do not mutate parent or sibling
+// context metadata. Callers provide updates as Pair values so multiple attributes can be stored with one
+// storage clone. Use NewPair for arbitrary keys, or the typed With* helpers such as WithRequestID and
+// WithUserID for standard metadata keys.
 //
 // # Value rendering semantics
 //
@@ -27,6 +29,7 @@
 //
 // Export helpers skip attributes whose rendered string is empty. A prefix may be prepended to each exported key.
 //
-// Start with `WithAttribute` / `Attribute` for arbitrary attributes, `Value` constructors (String/Blank/Ignored/Redacted)
-// for controlling rendering, and `Strings` / `SnakeStrings` / `CamelStrings` for exporting attributes.
+// Start with `WithAttributes`, `NewPair`, the typed With* pair helpers, and `Attribute` for arbitrary
+// attributes. Use `Value` constructors (String/Blank/Ignored/Redacted) for controlling rendering, and
+// `Strings` / `SnakeStrings` / `CamelStrings` for exporting attributes.
 package meta

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -13,17 +13,17 @@ const (
 	meta = context.Key("meta")
 )
 
-// WithAttribute returns a copy of ctx with the given attribute stored under key.
+// WithAttributes returns a copy of ctx with all provided attributes stored.
 //
-// Attributes are stored on the context under a single internal key as a Storage map. Each call to
-// WithAttribute returns a derived context containing an updated Storage. The storage update is
-// copy-on-write so parent and sibling contexts remain isolated.
-//
-// Rendering and export behavior is controlled by the provided Value. For example:
-//   - Blank and Ignored values render as empty strings and are skipped by export helpers.
-//   - Redacted values render as asterisks while preserving the underlying value in-context.
-func WithAttribute(ctx context.Context, key string, value Value) context.Context {
-	return context.WithValue(ctx, meta, attributes(ctx).Add(key, value))
+// The storage update is copy-on-write and clones existing attributes only once before applying the
+// full batch. Metadata writes use pairs so hot paths can set several attributes without repeated
+// map copies and context wrappers.
+func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
+	if len(pairs) == 0 {
+		return ctx
+	}
+
+	return context.WithValue(ctx, meta, attributes(ctx).AddPairs(pairs...))
 }
 
 // Attribute returns the stored attribute value for key.

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -9,43 +9,86 @@ import (
 
 func TestSnakeCase(t *testing.T) {
 	ctx := t.Context()
-	ctx = meta.WithAttribute(ctx, "testId", meta.String("1"))
-	ctx = meta.WithAttribute(ctx, "see", meta.Ignored("secret"))
-	ctx = meta.WithAttribute(ctx, "redacted", meta.Redacted("2"))
+	ctx = meta.WithAttributes(ctx,
+		meta.NewPair("testId", meta.String("1")),
+		meta.NewPair("see", meta.Ignored("secret")),
+		meta.NewPair("redacted", meta.Redacted("2")),
+	)
 
 	require.Equal(t, meta.Map{"test_id": "1", "redacted": "*"}, meta.SnakeStrings(ctx, meta.NoPrefix))
 }
 
 func TestCamelCase(t *testing.T) {
 	ctx := t.Context()
-	ctx = meta.WithAttribute(ctx, "testId", meta.String("1"))
-	ctx = meta.WithAttribute(ctx, "see", meta.Ignored("secret"))
-	ctx = meta.WithAttribute(ctx, "redacted", meta.Redacted("2"))
+	ctx = meta.WithAttributes(ctx,
+		meta.NewPair("testId", meta.String("1")),
+		meta.NewPair("see", meta.Ignored("secret")),
+		meta.NewPair("redacted", meta.Redacted("2")),
+	)
 
 	require.Equal(t, meta.Map{"testId": "1", "redacted": "*"}, meta.CamelStrings(ctx, meta.NoPrefix))
 }
 
 func TestNoneCase(t *testing.T) {
 	ctx := t.Context()
-	ctx = meta.WithAttribute(ctx, "testId", meta.String("1"))
-	ctx = meta.WithAttribute(ctx, "see", meta.Ignored("secret"))
-	ctx = meta.WithAttribute(ctx, "redacted", meta.Redacted("2"))
+	ctx = meta.WithAttributes(ctx,
+		meta.NewPair("testId", meta.String("1")),
+		meta.NewPair("see", meta.Ignored("secret")),
+		meta.NewPair("redacted", meta.Redacted("2")),
+	)
 
 	require.Equal(t, meta.Map{"testId": "1", "redacted": "*"}, meta.Strings(ctx, meta.NoPrefix))
 }
 
 func TestPrefix(t *testing.T) {
 	ctx := t.Context()
-	ctx = meta.WithAttribute(ctx, "testId", meta.String("1"))
-	ctx = meta.WithAttribute(ctx, "see", meta.Ignored("secret"))
-	ctx = meta.WithAttribute(ctx, "redacted", meta.Redacted("2"))
+	ctx = meta.WithAttributes(ctx,
+		meta.NewPair("testId", meta.String("1")),
+		meta.NewPair("see", meta.Ignored("secret")),
+		meta.NewPair("redacted", meta.Redacted("2")),
+	)
 
 	require.Equal(t, meta.Map{"test.testId": "1", "test.redacted": "*"}, meta.Strings(ctx, "test."))
 }
 
-func TestWithAttributeKeepsParentContextIsolated(t *testing.T) {
-	parent := meta.WithAttribute(t.Context(), "requestId", meta.String("parent"))
-	child := meta.WithAttribute(parent, "userId", meta.String("child"))
+func TestWithAttributesReturnsSameContextWithoutPairs(t *testing.T) {
+	ctx := t.Context()
+
+	require.Same(t, ctx, meta.WithAttributes(ctx))
+}
+
+func TestPairHelpers(t *testing.T) {
+	for _, test := range []struct {
+		pair  func(meta.Value) meta.Pair
+		name  string
+		key   string
+		value string
+	}{
+		{name: "request id", key: meta.RequestIDKey, value: "request-id", pair: meta.WithRequestID},
+		{name: "system", key: meta.SystemKey, value: "system", pair: meta.WithSystem},
+		{name: "service", key: meta.ServiceKey, value: "service", pair: meta.WithService},
+		{name: "method", key: meta.MethodKey, value: "method", pair: meta.WithMethod},
+		{name: "code", key: meta.CodeKey, value: "code", pair: meta.WithCode},
+		{name: "duration", key: meta.DurationKey, value: "duration", pair: meta.WithDuration},
+		{name: "user agent", key: meta.UserAgentKey, value: "user-agent", pair: meta.WithUserAgent},
+		{name: "user id", key: meta.UserIDKey, value: "user-id", pair: meta.WithUserID},
+		{name: "ip addr", key: meta.IPAddrKey, value: "ip-addr", pair: meta.WithIPAddr},
+		{name: "ip addr kind", key: meta.IPAddrKindKey, value: "ip-addr-kind", pair: meta.WithIPAddrKind},
+		{name: "authorization", key: meta.AuthorizationKey, value: "authorization", pair: meta.WithAuthorization},
+		{name: "geolocation", key: meta.GeolocationKey, value: "geolocation", pair: meta.WithGeolocation},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pair := test.pair(meta.String(test.value))
+
+			require.Equal(t, test.key, pair.Key)
+			require.Equal(t, meta.String(test.value), pair.Value)
+		})
+	}
+}
+
+func TestWithAttributesKeepsParentContextIsolatedWithSinglePairs(t *testing.T) {
+	parent := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("parent")))
+	child := meta.WithAttributes(parent, meta.WithUserID(meta.String("child")))
 
 	require.Equal(t, meta.String("parent"), meta.Attribute(parent, "requestId"))
 	require.True(t, meta.Attribute(parent, "userId").IsEmpty())
@@ -53,12 +96,30 @@ func TestWithAttributeKeepsParentContextIsolated(t *testing.T) {
 	require.Equal(t, meta.String("child"), meta.Attribute(child, "userId"))
 }
 
+func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
+	parent := meta.WithAttributes(t.Context(),
+		meta.WithRequestID(meta.String("parent")),
+		meta.WithUserAgent(meta.String("test-agent")),
+	)
+	child := meta.WithAttributes(parent,
+		meta.WithRequestID(meta.String("child")),
+		meta.WithUserID(meta.String("user")),
+	)
+
+	require.Equal(t, meta.String("parent"), meta.Attribute(parent, "requestId"))
+	require.Equal(t, meta.String("test-agent"), meta.Attribute(parent, "userAgent"))
+	require.True(t, meta.Attribute(parent, "userId").IsEmpty())
+	require.Equal(t, meta.String("child"), meta.Attribute(child, "requestId"))
+	require.Equal(t, meta.String("test-agent"), meta.Attribute(child, "userAgent"))
+	require.Equal(t, meta.String("user"), meta.Attribute(child, "userId"))
+}
+
 func TestUserID(t *testing.T) {
-	ctx := meta.WithUserID(t.Context(), meta.String("user-id"))
+	ctx := meta.WithAttributes(t.Context(), meta.WithUserID(meta.String("user-id")))
 	require.Equal(t, meta.String("user-id"), meta.UserID(ctx))
 }
 
 func TestGeolocation(t *testing.T) {
-	ctx := meta.WithGeolocation(t.Context(), meta.String("geo:47,11"))
+	ctx := meta.WithAttributes(t.Context(), meta.WithGeolocation(meta.String("geo:47,11")))
 	require.Equal(t, meta.String("geo:47,11"), meta.Geolocation(ctx))
 }

--- a/meta/pair.go
+++ b/meta/pair.go
@@ -1,0 +1,18 @@
+package meta
+
+// NewPair creates one metadata key/value pair for batched storage updates.
+//
+// Use NewPair for custom metadata keys. Prefer the typed With* helpers in
+// attrs.go for standard metadata keys so call sites stay consistent.
+func NewPair(key string, value Value) Pair {
+	return Pair{Key: key, Value: value}
+}
+
+// Pair stores one metadata key/value pair for batched storage updates.
+//
+// Pairs are passed to WithAttributes so multiple metadata attributes can be
+// applied with one copy-on-write storage update.
+type Pair struct {
+	Key   string
+	Value Value
+}

--- a/meta/storage.go
+++ b/meta/storage.go
@@ -15,17 +15,22 @@ type Converter func(string) string
 // Storage stores meta values keyed by attribute name.
 //
 // Storage is the internal backing map used by this package to hold context-scoped attributes.
-// It is typically treated as immutable by callers. Helpers such as WithAttribute use copy-on-write
-// updates so derived contexts do not mutate parent storage.
+// It is typically treated as immutable by callers. WithAttributes uses copy-on-write updates so
+// derived contexts do not mutate parent storage.
 type Storage map[string]Value
 
-// Add stores value under key in a copied Storage and returns the updated copy.
+// AddPairs stores pairs in a copied Storage and returns the updated copy.
 //
-// The receiver is not mutated. This preserves context isolation when a derived context adds or
-// overrides attributes.
-func (s Storage) Add(key string, value Value) Storage {
-	cloned := s.Clone()
-	cloned[key] = value
+// The receiver is cloned once before all pairs are applied. This preserves context isolation while
+// avoiding repeated map copies when several attributes are added together.
+func (s Storage) AddPairs(pairs ...Pair) Storage {
+	cloned := make(Storage, len(s)+len(pairs))
+	maps.Copy(cloned, s)
+
+	for _, pair := range pairs {
+		cloned[pair.Key] = pair.Value
+	}
+
 	return cloned
 }
 
@@ -76,7 +81,8 @@ func (s Storage) key(prefix, key string) string {
 func attributes(ctx context.Context) Storage {
 	m := ctx.Value(meta)
 	if m == nil {
-		return make(Storage)
+		// Nil Storage avoids allocating on read-only paths; map reads, ranges, and the first AddPairs call are nil-safe.
+		return nil
 	}
 
 	return m.(Storage)

--- a/net/grpc/health/health_test.go
+++ b/net/grpc/health/health_test.go
@@ -26,9 +26,10 @@ func TestCheck(t *testing.T) {
 	)
 	requireGRPCReady(t, world)
 
-	ctx := t.Context()
-	ctx = meta.WithRequestID(ctx, meta.String("test-id"))
-	ctx = meta.WithUserAgent(ctx, meta.String("test-user-agent"))
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithRequestID(meta.String("test-id")),
+		meta.WithUserAgent(meta.String("test-user-agent")),
+	)
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -106,9 +107,10 @@ func TestList(t *testing.T) {
 	)
 	requireGRPCReady(t, world)
 
-	ctx := t.Context()
-	ctx = meta.WithRequestID(ctx, meta.String("test-id"))
-	ctx = meta.WithUserAgent(ctx, meta.String("test-user-agent"))
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithRequestID(meta.String("test-id")),
+		meta.WithUserAgent(meta.String("test-user-agent")),
+	)
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()

--- a/net/grpc/meta/meta.go
+++ b/net/grpc/meta/meta.go
@@ -33,26 +33,66 @@ type Map = metadata.MD
 // package's helper functions.
 type Value = meta.Value
 
+// Pair aliases the root go-service metadata pair type.
+type Pair = meta.Pair
+
 // IPAddrKindKey is the attribute key that describes how an IP address was derived.
 //
 // The value typically distinguishes between peer-derived addresses and trusted
 // forwarding headers.
 const IPAddrKindKey = meta.IPAddrKindKey
 
-// Authorization returns the authorization attribute stored on ctx.
-//
-// It forwards to the root `meta.Authorization` helper so callers can keep gRPC
-// metadata and request attribute access under one import path.
-func Authorization(ctx context.Context) meta.Value {
-	return meta.Authorization(ctx)
-}
-
 // Attribute returns the stored request attribute for key.
 //
-// If no attribute is present, it returns the zero-value [Value]. It forwards to
-// the root `meta.Attribute` helper.
+// If no attribute is present, it returns the zero-value [Value].
 func Attribute(ctx context.Context, key string) meta.Value {
 	return meta.Attribute(ctx, key)
+}
+
+// NewPair creates one metadata key/value pair for batched storage updates.
+func NewPair(key string, value meta.Value) Pair {
+	return meta.NewPair(key, value)
+}
+
+// WithAttributes stores all provided metadata pairs on ctx.
+func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
+	return meta.WithAttributes(ctx, pairs...)
+}
+
+// WithRequestID creates a request ID pair for WithAttributes.
+func WithRequestID(value meta.Value) Pair {
+	return meta.WithRequestID(value)
+}
+
+// WithUserAgent creates a user agent pair for WithAttributes.
+func WithUserAgent(value meta.Value) Pair {
+	return meta.WithUserAgent(value)
+}
+
+// WithUserID creates a user ID pair for WithAttributes.
+func WithUserID(value meta.Value) Pair {
+	return meta.WithUserID(value)
+}
+
+// IPAddr returns the stored IP address attribute from ctx.
+//
+// If no value is present, it returns the zero-value meta.Value.
+func IPAddr(ctx context.Context) meta.Value {
+	return meta.IPAddr(ctx)
+}
+
+// WithAuthorization creates an authorization pair for WithAttributes.
+//
+// Authorization values often contain secrets; prefer Ignored or Redacted values if they might be exported.
+func WithAuthorization(value meta.Value) Pair {
+	return meta.WithAuthorization(value)
+}
+
+// Authorization returns the authorization attribute stored on ctx.
+//
+// If no value is present, it returns the zero-value meta.Value.
+func Authorization(ctx context.Context) meta.Value {
+	return meta.Authorization(ctx)
 }
 
 // AppendToOutgoingContext adds kv to the outgoing metadata in ctx.
@@ -66,17 +106,9 @@ func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context 
 // Ignored constructs a [Value] that is retained in-context but omitted when
 // rendered/exported.
 //
-// It forwards to the root `meta.Ignored` helper and is useful for sensitive
-// metadata such as authorization-derived values.
+// It is useful for sensitive metadata such as authorization-derived values.
 func Ignored(value string) meta.Value {
 	return meta.Ignored(value)
-}
-
-// IPAddr returns the stored IP address attribute from ctx.
-//
-// It forwards to the root `meta.IPAddr` helper.
-func IPAddr(ctx context.Context) meta.Value {
-	return meta.IPAddr(ctx)
 }
 
 // FromOutgoingContext returns the outgoing metadata in ctx, if any.
@@ -95,8 +127,7 @@ func FromIncomingContext(ctx context.Context) (Map, bool) {
 
 // New constructs metadata from a string map.
 //
-// It forwards to `metadata.New`. Keys are normalized using the same rules as
-// upstream gRPC metadata handling.
+// Keys are normalized using the same rules as upstream gRPC metadata handling.
 func New(md map[string]string) Map {
 	return metadata.New(md)
 }
@@ -109,94 +140,47 @@ func NewIncomingContext(ctx context.Context, md Map) context.Context {
 }
 
 // NewOutgoingContext attaches md as outgoing metadata to ctx.
-//
-// It forwards to `metadata.NewOutgoingContext`.
 func NewOutgoingContext(ctx context.Context, md Map) context.Context {
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
 // Pairs constructs metadata from alternating key/value arguments.
 //
-// It forwards to `metadata.Pairs`. The kv slice must contain an even number of
-// elements.
+// The kv slice must contain an even number of elements.
 func Pairs(kv ...string) Map {
 	return metadata.Pairs(kv...)
 }
 
 // Redacted constructs a [Value] that renders as a mask while preserving the
 // underlying value in-context.
-//
-// It forwards to the root `meta.Redacted` helper.
 func Redacted(value string) meta.Value {
 	return meta.Redacted(value)
 }
 
 // String constructs a normal [Value] that renders as-is.
-//
-// It forwards to the root `meta.String` helper.
 func String(value string) meta.Value {
 	return meta.String(value)
 }
 
 // ToIgnored converts st to an ignored [Value] using st.String().
 //
-// If st is nil, it returns a blank value. It forwards to the root
-// `meta.ToIgnored` helper.
+// If st is nil, it returns a blank value.
 func ToIgnored(st fmt.Stringer) meta.Value {
 	return meta.ToIgnored(st)
 }
 
 // ToRedacted converts st to a redacted [Value] using st.String().
 //
-// If st is nil, it returns a blank value. It forwards to the root
-// `meta.ToRedacted` helper.
+// If st is nil, it returns a blank value.
 func ToRedacted(st fmt.Stringer) meta.Value {
 	return meta.ToRedacted(st)
 }
 
 // ToString converts st to a normal [Value] using st.String().
 //
-// If st is nil, it returns a blank value. It forwards to the root
-// `meta.ToString` helper.
+// If st is nil, it returns a blank value.
 func ToString(st fmt.Stringer) meta.Value {
 	return meta.ToString(st)
-}
-
-// WithAttribute stores key/value on ctx as a request-scoped attribute.
-//
-// It forwards to the root `meta.WithAttribute` helper and is primarily useful
-// when tests or interceptors need to seed context values before gRPC transport
-// processing begins.
-func WithAttribute(ctx context.Context, key string, value meta.Value) context.Context {
-	return meta.WithAttribute(ctx, key, value)
-}
-
-// WithRequestID stores a request ID attribute on ctx.
-//
-// It forwards to the root `meta.WithRequestID` helper.
-func WithRequestID(ctx context.Context, id meta.Value) context.Context {
-	return meta.WithRequestID(ctx, id)
-}
-
-// WithUserID stores a user ID attribute on ctx.
-//
-// It forwards to the root `meta.WithUserID` helper.
-func WithUserID(ctx context.Context, id meta.Value) context.Context {
-	return meta.WithUserID(ctx, id)
-}
-
-// WithUserAgent stores a user-agent attribute on ctx.
-//
-// It forwards to the root `meta.WithUserAgent` helper.
-func WithUserAgent(ctx context.Context, userAgent meta.Value) context.Context {
-	return meta.WithUserAgent(ctx, userAgent)
-}
-
-// WithAuthorization stores an authorization attribute on ctx.
-//
-// It forwards to the root `meta.WithAuthorization` helper.
-func WithAuthorization(ctx context.Context, auth meta.Value) context.Context {
-	return meta.WithAuthorization(ctx, auth)
 }
 
 // UnaryServerInterceptor returns a gRPC unary server interceptor that extracts metadata into the context.
@@ -225,22 +209,25 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 
 		md := ExtractIncoming(ctx)
 
-		ctx = meta.WithUserAgent(ctx, extractUserAgent(ctx, md, userAgent))
+		ua := extractUserAgent(ctx, md, userAgent)
 
 		id := extractRequestID(ctx, generator, md)
-		ctx = meta.WithRequestID(ctx, id)
 
 		kind, ip := extractIPAddr(ctx, md)
-		ctx = meta.WithIPAddr(ctx, ip)
-		ctx = meta.WithIPAddrKind(ctx, kind)
-
-		ctx = meta.WithGeolocation(ctx, extractGeolocation(md))
+		geolocation := extractGeolocation(md)
 
 		auth, err := extractAuthorization(md)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		ctx = meta.WithAuthorization(ctx, auth)
+		ctx = meta.WithAttributes(ctx,
+			meta.WithUserAgent(ua),
+			meta.WithRequestID(id),
+			meta.WithIPAddr(ip),
+			meta.WithIPAddrKind(kind),
+			meta.WithGeolocation(geolocation),
+			meta.WithAuthorization(auth),
+		)
 
 		_ = grpc.SetHeader(ctx, Pairs("service-version", version.String(), "request-id", id.Value()))
 
@@ -265,24 +252,26 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 
 		ctx := stream.Context()
 		md := ExtractIncoming(ctx)
-		ctx = meta.WithUserAgent(ctx, extractUserAgent(ctx, md, userAgent))
+		ua := extractUserAgent(ctx, md, userAgent)
 
 		id := extractRequestID(ctx, generator, md)
 		_ = stream.SetHeader(Pairs("request-id", id.Value()))
 
-		ctx = meta.WithRequestID(ctx, id)
-
 		kind, ip := extractIPAddr(ctx, md)
-		ctx = meta.WithIPAddr(ctx, ip)
-		ctx = meta.WithIPAddrKind(ctx, kind)
-
-		ctx = meta.WithGeolocation(ctx, extractGeolocation(md))
+		geolocation := extractGeolocation(md)
 
 		auth, err := extractAuthorization(md)
 		if err != nil {
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
-		ctx = meta.WithAuthorization(ctx, auth)
+		ctx = meta.WithAttributes(ctx,
+			meta.WithUserAgent(ua),
+			meta.WithRequestID(id),
+			meta.WithIPAddr(ip),
+			meta.WithIPAddrKind(kind),
+			meta.WithGeolocation(geolocation),
+			meta.WithAuthorization(auth),
+		)
 
 		wrappedStream := middleware.WrapServerStream(stream)
 		wrappedStream.WrappedContext = ctx
@@ -305,13 +294,15 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 		md := ExtractOutgoing(ctx)
 
 		ua := extractUserAgent(ctx, md, userAgent)
-		ctx = meta.WithUserAgent(ctx, ua)
-		md.Set("user-agent", ua.Value())
-
 		id := extractRequestID(ctx, generator, md)
-		ctx = meta.WithRequestID(ctx, id)
+
+		md.Set("user-agent", ua.Value())
 		md.Set("request-id", id.Value())
 
+		ctx = meta.WithAttributes(ctx,
+			meta.WithUserAgent(ua),
+			meta.WithRequestID(id),
+		)
 		ctx = NewOutgoingContext(ctx, md)
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
 	}
@@ -331,13 +322,15 @@ func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) gr
 		md := ExtractOutgoing(ctx)
 
 		ua := extractUserAgent(ctx, md, userAgent)
-		ctx = meta.WithUserAgent(ctx, ua)
-		md.Set("user-agent", ua.Value())
-
 		id := extractRequestID(ctx, generator, md)
-		ctx = meta.WithRequestID(ctx, id)
+
+		md.Set("user-agent", ua.Value())
 		md.Set("request-id", id.Value())
 
+		ctx = meta.WithAttributes(ctx,
+			meta.WithUserAgent(ua),
+			meta.WithRequestID(id),
+		)
 		ctx = NewOutgoingContext(ctx, md)
 		return streamer(ctx, desc, conn, fullMethod, opts...)
 	}

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
-	ctx := context.Background()
-	ctx = meta.WithUserAgent(ctx, meta.String("current-agent"))
-	ctx = meta.WithRequestID(ctx, meta.String("current-id"))
+	ctx := meta.WithAttributes(context.Background(),
+		meta.WithUserAgent(meta.String("current-agent")),
+		meta.WithRequestID(meta.String("current-id")),
+	)
 	ctx = meta.NewOutgoingContext(ctx, meta.Pairs(
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
@@ -33,9 +34,10 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 }
 
 func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
-	ctx := context.Background()
-	ctx = meta.WithUserAgent(ctx, meta.String("current-agent"))
-	ctx = meta.WithRequestID(ctx, meta.String("current-id"))
+	ctx := meta.WithAttributes(context.Background(),
+		meta.WithUserAgent(meta.String("current-agent")),
+		meta.WithRequestID(meta.String("current-id")),
+	)
 	ctx = meta.NewOutgoingContext(ctx, meta.Pairs(
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",

--- a/net/http/meta/meta.go
+++ b/net/http/meta/meta.go
@@ -25,26 +25,30 @@ const NoPrefix = meta.NoPrefix
 // Map is an alias for meta.Map.
 type Map = meta.Map
 
+// Pair is an alias for meta.Pair.
+type Pair = meta.Pair
+
 // CamelStrings exports all stored meta attributes as a string map with lowerCamelCased keys.
 //
-// This is a thin wrapper around meta.CamelStrings. The prefix parameter is prepended to each exported key
-// (if non-empty). Attributes whose rendered value is empty are skipped.
+// The prefix parameter is prepended to each exported key (if non-empty). Attributes whose rendered value is
+// empty are skipped.
 func CamelStrings(ctx context.Context, prefix string) Map {
 	return meta.CamelStrings(ctx, prefix)
 }
 
 // Error converts err to a meta.Value using err.Error().
-//
-// This is a thin wrapper around meta.Error.
 func Error(err error) meta.Value {
 	return meta.Error(err)
 }
 
-// WithAttribute stores an arbitrary meta attribute on ctx.
-//
-// This is a thin wrapper around meta.WithAttribute.
-func WithAttribute(ctx context.Context, key string, value meta.Value) context.Context {
-	return meta.WithAttribute(ctx, key, value)
+// NewPair creates one metadata key/value pair for batched storage updates.
+func NewPair(key string, value meta.Value) Pair {
+	return meta.NewPair(key, value)
+}
+
+// WithAttributes stores all provided metadata pairs on ctx.
+func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
+	return meta.WithAttributes(ctx, pairs...)
 }
 
 // WithRequest stores req in ctx and returns the derived context.
@@ -145,24 +149,27 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	header.Add("Service-Version", h.version.String())
 
 	ctx := req.Context()
-	ctx = meta.WithUserAgent(ctx, extractUserAgent(ctx, req, h.userAgent))
+	userAgent := extractUserAgent(ctx, req, h.userAgent)
 
 	requestID := extractRequestID(ctx, h.generator, req)
 	header.Set("Request-Id", requestID.Value())
-	ctx = meta.WithRequestID(ctx, requestID)
 
 	kind, ip := extractIP(req)
-	ctx = meta.WithIPAddr(ctx, ip)
-	ctx = meta.WithIPAddrKind(ctx, kind)
-
-	ctx = meta.WithGeolocation(ctx, extractGeolocation(req))
+	geolocation := extractGeolocation(req)
 
 	auth, err := extractAuthorization(req)
 	if err != nil {
 		_ = status.WriteError(res, status.BadRequestError(err))
 		return
 	}
-	ctx = meta.WithAuthorization(ctx, auth)
+	ctx = meta.WithAttributes(ctx,
+		meta.WithUserAgent(userAgent),
+		meta.WithRequestID(requestID),
+		meta.WithIPAddr(ip),
+		meta.WithIPAddrKind(kind),
+		meta.WithGeolocation(geolocation),
+		meta.WithAuthorization(auth),
+	)
 
 	next(res, req.WithContext(ctx))
 }
@@ -198,14 +205,14 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
 	userAgent := extractUserAgent(ctx, req, r.userAgent)
-
-	req.Header.Set("User-Agent", userAgent.Value())
-	ctx = meta.WithUserAgent(ctx, userAgent)
-
 	requestID := extractRequestID(ctx, r.generator, req)
 
+	req.Header.Set("User-Agent", userAgent.Value())
 	req.Header.Set("Request-Id", requestID.Value())
-	ctx = meta.WithRequestID(ctx, requestID)
+	ctx = meta.WithAttributes(ctx,
+		meta.WithUserAgent(userAgent),
+		meta.WithRequestID(requestID),
+	)
 
 	return r.RoundTripper.RoundTrip(req.WithContext(ctx))
 }

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -65,7 +65,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 
 		view, model, err := controller(ctx)
 		if err != nil {
-			ctx = meta.WithAttribute(ctx, "mvcModelError", meta.Error(err))
+			ctx = meta.WithAttributes(ctx, meta.NewPair("mvcModelError", meta.Error(err)))
 			writeView(ctx, res, view, err, status.Code(err))
 			return
 		}

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -19,9 +19,11 @@ import (
 func TestInsecureUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC())
 
-	ctx := meta.WithAttribute(t.Context(), "test", meta.Ignored("test"))
-	ctx = meta.WithAttribute(ctx, "real-ip", meta.ToString(net.ParseIP("192.168.8.0")))
-	ctx = meta.WithAttribute(ctx, "redacted-ip", meta.ToRedacted(net.ParseIP("192.168.8.0")))
+	ctx := meta.WithAttributes(t.Context(),
+		test.WithTest(meta.Ignored("test")),
+		meta.NewPair("real-ip", meta.ToString(net.ParseIP("192.168.8.0"))),
+		meta.NewPair("redacted-ip", meta.ToRedacted(net.ParseIP("192.168.8.0"))),
+	)
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -42,7 +44,7 @@ func TestInsecureUnary(t *testing.T) {
 func TestSecureUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC(), test.WithWorldSecure())
 
-	ctx := meta.WithAttribute(t.Context(), "ip", meta.ToIgnored(net.ParseIP("192.168.8.0")))
+	ctx := meta.WithAttributes(t.Context(), meta.NewPair("ip", meta.ToIgnored(net.ParseIP("192.168.8.0"))))
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -58,7 +60,7 @@ func TestSecureUnary(t *testing.T) {
 func TestStream(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC())
 
-	ctx := meta.WithAttribute(t.Context(), "test", meta.Redacted("test"))
+	ctx := meta.WithAttributes(t.Context(), test.WithTest(meta.Redacted("test")))
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -100,7 +100,7 @@ func UnaryServerInterceptor(id env.UserID, verifier Verifier) grpc.UnaryServerIn
 			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 
-		ctx = meta.WithUserID(ctx, meta.Ignored(sub))
+		ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
 		return handler(ctx, req)
 	}
 }
@@ -133,7 +133,7 @@ func StreamServerInterceptor(id env.UserID, verifier Verifier) grpc.StreamServer
 			return status.Error(codes.Unauthenticated, err.Error())
 		}
 
-		ctx = meta.WithUserID(ctx, meta.Ignored(sub))
+		ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
 		wrapped := middleware.WrapServerStream(stream)
 		wrapped.WrappedContext = ctx
 
@@ -163,7 +163,7 @@ type Generator token.Generator
 // For each outbound unary RPC, it generates a token scoped to `fullMethod` and the provided user id and
 // stores it in outgoing metadata under the "authorization" key using the `Bearer` scheme.
 //
-// The interceptor also stores the Authorization value in the context via `meta.WithAuthorization`, which can
+// The interceptor also stores the Authorization value in the context via `meta.WithAttributes`, which can
 // be useful for downstream instrumentation. Any existing outgoing "authorization" metadata is replaced so
 // stale values do not take precedence over the newly generated token.
 //
@@ -189,7 +189,7 @@ func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClient
 		md := meta.ExtractOutgoing(ctx)
 		md.Set("authorization", auth.Value())
 
-		ctx = meta.WithAuthorization(ctx, auth)
+		ctx = meta.WithAttributes(ctx, meta.WithAuthorization(auth))
 		ctx = meta.NewOutgoingContext(ctx, md)
 
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
@@ -201,7 +201,7 @@ func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClient
 // For each outbound streaming RPC, it generates a token scoped to `fullMethod` and the provided user id and
 // stores it in outgoing metadata under the "authorization" key using the `Bearer` scheme.
 //
-// The interceptor also stores the Authorization value in the context via `meta.WithAuthorization`. Any
+// The interceptor also stores the Authorization value in the context via `meta.WithAttributes`. Any
 // existing outgoing "authorization" metadata is replaced so stale values do not take precedence over the
 // newly generated token.
 //
@@ -227,7 +227,7 @@ func StreamClientInterceptor(id env.UserID, generator Generator) grpc.StreamClie
 		md := meta.ExtractOutgoing(ctx)
 		md.Set("authorization", auth.Value())
 
-		ctx = meta.WithAuthorization(ctx, auth)
+		ctx = meta.WithAttributes(ctx, meta.WithAuthorization(auth))
 		ctx = meta.NewOutgoingContext(ctx, md)
 
 		return streamer(ctx, desc, conn, fullMethod, opts...)

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -21,9 +21,10 @@ func TestHealth(t *testing.T) {
 				test.WithWorldHTTPHealth(test.Name.String(), test.StatusURL("200"), test.HealthObserve(check, "http")),
 			)
 
-			ctx := t.Context()
-			ctx = meta.WithRequestID(ctx, meta.String("test-id"))
-			ctx = meta.WithUserAgent(ctx, meta.String("test-user-agent"))
+			ctx := meta.WithAttributes(t.Context(),
+				meta.WithRequestID(meta.String("test-id")),
+				meta.WithUserAgent(meta.String("test-user-agent")),
+			)
 
 			header := http.Header{}
 			url := world.NamedServerURL("http", check)
@@ -84,9 +85,10 @@ func TestMissingHealth(t *testing.T) {
 				test.WithWorldHTTPHealth(test.Name.String(), test.StatusURL("200")),
 			)
 
-			ctx := t.Context()
-			ctx = meta.WithRequestID(ctx, meta.String("test-id"))
-			ctx = meta.WithUserAgent(ctx, meta.String("test-user-agent"))
+			ctx := meta.WithAttributes(t.Context(),
+				meta.WithRequestID(meta.String("test-id")),
+				meta.WithUserAgent(meta.String("test-user-agent")),
+			)
 
 			header := http.Header{}
 			header.Set(content.TypeKey, mime.JSONMediaType)

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -111,7 +111,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		return
 	}
 
-	ctx = meta.WithUserID(ctx, meta.Ignored(sub))
+	ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
 	next(res, req.WithContext(ctx))
 }
 


### PR DESCRIPTION
## What

- Add `meta.Pair`, `meta.NewPair`, and batched `meta.WithAttributes(ctx, pairs...)`.
- Add typed pair helpers for standard metadata keys, such as `WithRequestID`, `WithUserID`, `WithUserAgent`, and `WithAuthorization`.
- Update HTTP/gRPC metadata extraction and token paths to batch metadata writes instead of repeatedly wrapping context.
- Keep custom metadata writes readable through `NewPair`.
- Remove unused transport metadata aliases that were only added for symmetry.
- Update tests and GoDocs for the new pair-based metadata API.
- Add coverage for the empty `WithAttributes(ctx)` path.

## Why

- Reduces allocations from repeated metadata storage cloning on HTTP/gRPC request paths.
- Keeps standard metadata writes readable while preserving a generic escape hatch for custom keys.
- Shrinks unnecessary public wrapper surface in transport metadata packages.
- Makes the metadata API clearer: pairs describe updates, `WithAttributes` applies them.

## Testing

- `go test -vet=off -mod vendor ./meta ./internal/test ./net/http/meta ./net/grpc/meta ./net/grpc/health ./net/http/mvc ./transport/http ./transport/grpc ./database/sql/pg`
- `go test -vet=off -mod vendor ./net/http/meta ./net/http/mvc ./transport/http`
- `go test -vet=off -mod vendor -coverprofile=/tmp/meta.cover ./meta`
- `go test -vet=off -mod vendor -coverpkg=./net/http/meta -coverprofile=/tmp/http-meta.cover ./net/http/meta ./net/http/content ./net/http/mvc ./transport/http`
- `go test -vet=off -mod vendor -coverpkg=./net/grpc/meta -coverprofile=/tmp/grpc-meta.cover ./net/grpc/meta ./net/grpc/health ./transport/grpc`
- `git diff --check`
- `make lint`
- Focused HTTP/gRPC `none` benchmarks with `-benchmem`; allocation counts stayed in the reduced range.