### PR TITLE
feat(http): reduce request allocations

### DIFF
--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -67,8 +67,6 @@ func NewHandler[Res any](cont *Content, handler Handler[Res]) http.HandlerFunc {
 func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res, error)) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		ctx = meta.WithRequest(ctx, req)
-		ctx = meta.WithResponse(ctx, res)
 
 		media := cont.NewFromRequest(req)
 		if media.Encoder == nil {
@@ -77,7 +75,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 			return
 		}
 
-		ctx = meta.WithEncoder(ctx, media.Encoder)
+		ctx = meta.WithContent(ctx, req, res, media.Encoder)
 		res.Header().Add(TypeKey, media.Type)
 
 		data, err := handler(ctx)

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -18,8 +18,8 @@
 // # Safety and expectations
 //
 // Request, Response, and Encoder are intentionally strict helpers: they expect the corresponding values
-// to have been stored in the context via WithRequest, WithResponse, and WithEncoder. Calling them without
-// those values present will panic due to type assertions.
+// to have been stored in the context via WithContent. Calling them without content metadata present will
+// panic due to type assertions.
 //
 // These helpers are typically used in tightly controlled handler pipelines (for example those created by
 // `net/http/content.NewHandler` / `NewRequestHandler`), which populate the context before invoking

--- a/net/http/meta/meta.go
+++ b/net/http/meta/meta.go
@@ -13,11 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/strings"
 )
 
-const (
-	requestKey  = context.Key("request")
-	responseKey = context.Key("response")
-	encoderKey  = context.Key("encoder")
-)
+const contentKey = context.Key("content")
 
 // NoPrefix is an alias for meta.NoPrefix.
 const NoPrefix = meta.NoPrefix
@@ -27,6 +23,12 @@ type Map = meta.Map
 
 // Pair is an alias for meta.Pair.
 type Pair = meta.Pair
+
+type content struct {
+	request  *http.Request
+	response http.ResponseWriter
+	encoder  encoding.Encoder
+}
 
 // CamelStrings exports all stored meta attributes as a string map with lowerCamelCased keys.
 //
@@ -51,52 +53,35 @@ func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
 	return meta.WithAttributes(ctx, pairs...)
 }
 
-// WithRequest stores req in ctx and returns the derived context.
-//
-// This is commonly used by go-service HTTP content handlers/middleware to make the request available to
-// downstream handlers via Request(ctx).
-func WithRequest(ctx context.Context, req *http.Request) context.Context {
-	return context.WithValue(ctx, requestKey, req)
-}
-
 // Request returns the stored *http.Request from ctx.
 //
-// Panics: Request expects WithRequest to have been called. It will panic if no request is stored in ctx
-// or if the stored value is not a *http.Request.
+// Panics: Request expects WithContent to have been called. It will panic if no content metadata is stored
+// in ctx or if the stored value is invalid.
 func Request(ctx context.Context) *http.Request {
-	return ctx.Value(requestKey).(*http.Request)
-}
-
-// WithResponse stores res in ctx and returns the derived context.
-//
-// This is commonly used by go-service HTTP content handlers/middleware to make the response writer available
-// to downstream handlers via Response(ctx).
-func WithResponse(ctx context.Context, res http.ResponseWriter) context.Context {
-	return context.WithValue(ctx, responseKey, res)
+	return ctx.Value(contentKey).(content).request
 }
 
 // Response returns the stored http.ResponseWriter from ctx.
 //
-// Panics: Response expects WithResponse to have been called. It will panic if no response writer is stored
-// in ctx or if the stored value is not an http.ResponseWriter.
+// Panics: Response expects WithContent to have been called. It will panic if no content metadata is stored
+// in ctx or if the stored value is invalid.
 func Response(ctx context.Context) http.ResponseWriter {
-	return ctx.Value(responseKey).(http.ResponseWriter)
-}
-
-// WithEncoder stores enc in ctx and returns the derived context.
-//
-// This is commonly used by go-service HTTP content handlers/middleware to make the negotiated encoder
-// (selected from Content-Type) available to downstream handlers via Encoder(ctx).
-func WithEncoder(ctx context.Context, enc encoding.Encoder) context.Context {
-	return context.WithValue(ctx, encoderKey, enc)
+	return ctx.Value(contentKey).(content).response
 }
 
 // Encoder returns the stored encoding.Encoder from ctx.
 //
-// Panics: Encoder expects WithEncoder to have been called. It will panic if no encoder is stored in ctx
-// or if the stored value is not an encoding.Encoder.
+// Panics: Encoder expects WithContent to have been called. It will panic if no content metadata is stored
+// in ctx or if the stored value is invalid.
 func Encoder(ctx context.Context) encoding.Encoder {
-	return ctx.Value(encoderKey).(encoding.Encoder)
+	return ctx.Value(contentKey).(content).encoder
+}
+
+// WithContent stores HTTP content metadata in ctx and returns the derived context.
+//
+// The encoder may be nil when a handler only needs request and response access.
+func WithContent(ctx context.Context, req *http.Request, res http.ResponseWriter, enc encoding.Encoder) context.Context {
+	return context.WithValue(ctx, contentKey, content{request: req, response: res, encoder: enc})
 }
 
 // NewHandler constructs server-side metadata middleware for HTTP requests.

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -1,0 +1,42 @@
+package meta_test
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithContent(t *testing.T) {
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	enc := &encoder{}
+
+	ctx := meta.WithContent(t.Context(), req, res, enc)
+
+	require.Same(t, req, meta.Request(ctx))
+	require.Same(t, res, meta.Response(ctx))
+	require.Same(t, enc, meta.Encoder(ctx))
+}
+
+func TestWithContentAllowsPartialContent(t *testing.T) {
+	res := httptest.NewRecorder()
+
+	ctx := meta.WithContent(t.Context(), nil, res, nil)
+
+	require.Same(t, res, meta.Response(ctx))
+}
+
+type encoder struct{}
+
+func (e *encoder) Decode(_ io.Reader, _ any) error {
+	return nil
+}
+
+func (e *encoder) Encode(_ io.Writer, _ any) error {
+	return nil
+}

--- a/net/http/mvc/controller.go
+++ b/net/http/mvc/controller.go
@@ -5,8 +5,7 @@ import "github.com/alexfalkowski/go-service/v2/context"
 // Controller executes an MVC action and returns a View, a model, and an error.
 //
 // Controllers are invoked by the routing helpers in this package (see Route/Get/Post/etc.). Those helpers
-// populate the request context with HTTP request/response values using `net/http/meta.WithRequest` and
-// `net/http/meta.WithResponse` before calling the Controller.
+// populate the request context with HTTP content metadata before calling the Controller.
 //
 // Return values:
 //   - view: the view that should be rendered. It is typically created via NewFullView/NewPartialView or NewViewPair.

--- a/net/http/mvc/doc.go
+++ b/net/http/mvc/doc.go
@@ -12,5 +12,5 @@
 // Context requirements:
 //
 // Controllers and views use net/http/meta to retrieve the request and response writer from context.
-// The routing helpers set these values via meta.WithRequest and meta.WithResponse before invoking the controller.
+// The routing helpers set these values before invoking the controller.
 package mvc

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -60,8 +60,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 		res.Header().Set(content.TypeKey, mime.HTMLMediaType)
 
 		ctx := req.Context()
-		ctx = meta.WithRequest(ctx, req)
-		ctx = meta.WithResponse(ctx, res)
+		ctx = meta.WithContent(ctx, req, res, nil)
 
 		view, model, err := controller(ctx)
 		if err != nil {

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -70,7 +70,7 @@ func TestViewRenderReturnsWriteError(t *testing.T) {
 	})
 
 	view := mvc.NewFullView("views/hello.tmpl")
-	ctx := hm.WithResponse(t.Context(), &test.ErrResponseWriter{})
+	ctx := hm.WithContent(t.Context(), nil, &test.ErrResponseWriter{}, nil)
 
 	err := view.Render(ctx, &test.Model)
 

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -101,7 +101,7 @@ type View struct {
 // Render executes the view template against a Template model and writes it to the HTTP response writer.
 //
 // Context requirements:
-// Render expects the HTTP response writer to be present in ctx via net/http/meta.WithResponse.
+// Render expects the HTTP response writer to be present in ctx via net/http/meta.
 // (Handlers created by this package's routing helpers populate that value before invoking controllers/views.)
 //
 // Render model:

--- a/transport/http/body/body.go
+++ b/transport/http/body/body.go
@@ -23,6 +23,11 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		return
 	}
 
+	if req.Body == nil || req.Body == http.NoBody {
+		next(res, req)
+		return
+	}
+
 	data, body, err := io.ReadAll(io.LimitReader(req.Body, h.limit+1))
 	if err != nil {
 		_ = status.WriteError(res, status.BadRequestError(err))

--- a/transport/http/body/body_test.go
+++ b/transport/http/body/body_test.go
@@ -1,0 +1,39 @@
+package body_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/transport/http/body"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerSkipsEmptyBodyBuffering(t *testing.T) {
+	handler := body.NewHandler(1024)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, http.NoBody, req.Body)
+		res.WriteHeader(http.StatusOK)
+	})
+
+	require.Equal(t, http.StatusOK, res.Code)
+}
+
+func TestHandlerWritesBadRequestWhenBodyReadFails(t *testing.T) {
+	handler := body.NewHandler(1024)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", &test.ErrReaderCloser{})
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {
+		require.Fail(t, "next handler should not be called")
+	})
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, test.ErrFailed.Error()+"\n", res.Body.String())
+}


### PR DESCRIPTION
## What

- Skip request body buffering in HTTP body middleware when the request has no body.
- Replace separate HTTP content context writes with `meta.WithContent(ctx, req, res, enc)`.
- Remove unused individual HTTP meta context helpers/keys for request, response, and encoder.
- Update MVC/content docs and tests for the consolidated content metadata path.

## Why

- Reduces allocations on the HTTP benchmark path by avoiding unnecessary empty-body buffering.
- Keeps HTTP content metadata storage as one context value instead of multiple context wrappers.
- Simplifies the HTTP meta API now that callers use the batched content path.

## Testing

- `go test -vet=off -mod vendor ./net/http/meta ./net/http/content ./net/http/mvc ./transport/http`
- `go test -vet=off -mod vendor -run=^$ -bench='^BenchmarkHTTP/none$' -benchmem -benchtime=100x -count=5 ./transport/http`
- `make lint`
- `git diff --check`

`make lint` passed with the existing `gomodguard` deprecation warning.