### PR TITLE
feat(id): enable pooled uuid generation

### DIFF
--- a/id/id_test.go
+++ b/id/id_test.go
@@ -37,3 +37,32 @@ func TestInvalidID(t *testing.T) {
 	_, err := id.NewGenerator(&id.Config{Kind: "invalid"}, test.Generators)
 	require.Error(t, err)
 }
+
+func BenchmarkGenerators(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		kind string
+	}{
+		{name: "ksuid", kind: "ksuid"},
+		{name: "nanoid", kind: "nanoid"},
+		{name: "ulid", kind: "ulid"},
+		{name: "uuid", kind: "uuid"},
+		{name: "xid", kind: "xid"},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			gen, err := id.NewGenerator(&id.Config{Kind: benchmark.kind}, test.Generators)
+			require.NoError(b, err)
+
+			b.ReportAllocs()
+
+			var value string
+			for b.Loop() {
+				value = gen.Generate()
+			}
+
+			require.NotEmpty(b, value)
+		})
+	}
+}

--- a/id/uuid/uuid.go
+++ b/id/uuid/uuid.go
@@ -5,6 +5,12 @@ import (
 	"github.com/google/uuid"
 )
 
+func init() {
+	// UUIDv7 generation is on the request metadata hot path. The google/uuid
+	// random pool cuts it from 2 allocs/op to 1 alloc/op in BenchmarkGenerators.
+	uuid.EnableRandPool()
+}
+
 // NewGenerator constructs a UUID generator.
 //
 // The returned generator produces UUIDv7 identifiers (time-ordered UUIDs) via uuid.NewV7.


### PR DESCRIPTION
## What

- Enabled the `google/uuid` random pool for UUIDv7 generation.
- Added `BenchmarkGenerators` to compare built-in ID generator allocation and timing costs.

## Why

- UUID request ID generation is on the request metadata hot path.
- Pooling reduces UUID generation from roughly `2 allocs/op` to `1 alloc/op`.

## Testing

- `go test -vet=off -mod vendor ./id ./id/uuid`
- `go test -vet=off -mod vendor -run=^$ -bench='^BenchmarkGenerators/' -benchmem -count=5 ./id`
- `make lint`
- `git diff --check`