### PR TITLE
feat(transport): reduce benchmark and peer metadata allocations

### DIFF
--- a/net/grpc/meta/meta.go
+++ b/net/grpc/meta/meta.go
@@ -348,7 +348,18 @@ func serverIPAddr(ctx context.Context) (meta.Value, meta.Value) {
 		return peerKind, meta.Blank()
 	}
 
-	return peerKind, meta.String(net.Host(peer.Addr.String()))
+	return peerKind, meta.String(serverPeerIPAddr(peer.Addr))
+}
+
+func serverPeerIPAddr(addr net.Addr) string {
+	switch addr := addr.(type) {
+	case *net.TCPAddr:
+		return addr.IP.String()
+	case *net.UDPAddr:
+		return addr.IP.String()
+	default:
+		return net.Host(addr.String())
+	}
 }
 
 func serverUserAgent(ctx context.Context, userAgent env.UserAgent) meta.Value {

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -1,10 +1,11 @@
 package meta_test
 
 import (
-	"context"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/stretchr/testify/require"
@@ -81,6 +82,21 @@ func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
 		require.True(t, meta.IPAddr(ctx).IsEmpty())
+
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+}
+
+func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
+	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
+	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
+		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
+		require.Equal(t, meta.String("127.0.0.1"), meta.IPAddr(ctx))
 
 		return "ok", nil
 	})

--- a/net/net.go
+++ b/net/net.go
@@ -7,6 +7,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
+// Addr is an alias for net.Addr.
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type Addr = net.Addr
+
 // Conn is an alias for net.Conn.
 //
 // It is provided so go-service code can depend on a consistent import path while preserving
@@ -19,11 +25,29 @@ type Conn = net.Conn
 // standard library semantics.
 type Dialer = net.Dialer
 
+// IP is an alias for net.IP.
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type IP = net.IP
+
 // Listener is an alias for net.Listener.
 //
 // It is provided so go-service code can depend on a consistent import path while preserving
 // standard library semantics.
 type Listener = net.Listener
+
+// TCPAddr is an alias for net.TCPAddr.
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type TCPAddr = net.TCPAddr
+
+// UDPAddr is an alias for net.UDPAddr.
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type UDPAddr = net.UDPAddr
 
 // Listen creates a listener bound to address on the given network.
 //

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -70,6 +70,7 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ReportAllocs()
 
 		mux := transporthttp.NewServeMux()
+		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
 
@@ -114,6 +115,7 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ReportAllocs()
 
 		mux := transporthttp.NewServeMux()
+		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
 		lc := fxtest.NewLifecycle(b)
 		logger, err := logger.NewLogger(logger.LoggerParams{})
 		require.NoError(b, err)
@@ -162,6 +164,7 @@ func BenchmarkHTTP(b *testing.B) {
 		b.ReportAllocs()
 
 		mux := transporthttp.NewServeMux()
+		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
 		lc := fxtest.NewLifecycle(b)
 		logger, err := logger.NewLogger(logger.LoggerParams{})
 		require.NoError(b, err)


### PR DESCRIPTION
## What

- Registered `/hello` in HTTP transport benchmark cases so they measure the intended route instead of a 404 path.
- Avoided formatting and reparsing gRPC peer addresses for TCP/UDP peers.
- Added go-service `net` aliases for address types used by the gRPC metadata path.
- Added coverage for storing peer IP metadata from a TCP peer address.

## Why

- The HTTP benchmark was overstating allocations by measuring the not-found path.
- The gRPC metadata path can avoid unnecessary peer address string parsing on common TCP/UDP connections.

## Testing

- `go test -vet=off -mod=mod ./net ./net/grpc/meta`
- `go test -vet=off -mod=mod -run '^TestUnaryServerInterceptorStoresPeerIPAddr$' -gcflags='github.com/alexfalkowski/go-service/v2/net/grpc/meta=-m' ./net/grpc/meta`
- Earlier benchmark checks showed HTTP `none` at about `74-75 allocs/op` and gRPC `none` steady runs around `319-320 allocs/op`.
- `-mod vendor` is currently blocked by an existing `vendor/modules.txt` inconsistency with `go.mod`.