### PR TITLE
feat(http): optimize content media negotiation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ transport-diagram:
 	@make package=transport create-diagram
 
 # Run all the benchmarks.
-benchmarks: http-benchmarks grpc-benchmarks bytes-benchmarks strings-benchmarks
+benchmarks: http-benchmarks grpc-benchmarks bytes-benchmarks strings-benchmarks id-benchmarks http-content-benchmarks
 
 http-benchmarks:
 	@make package=transport/http benchtime=100x benchmark
@@ -31,6 +31,12 @@ bytes-benchmarks:
 
 strings-benchmarks:
 	@make package=strings benchtime=100x benchmark
+
+id-benchmarks:
+	@make package=id benchtime=100x benchmark
+
+http-content-benchmarks:
+	@make package=net/http/content benchtime=100x benchmark
 
 # Generate for tests.
 generate:

--- a/id/benchmark_test.go
+++ b/id/benchmark_test.go
@@ -1,0 +1,38 @@
+package id_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/id"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkGenerators(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		kind string
+	}{
+		{name: "ksuid", kind: "ksuid"},
+		{name: "nanoid", kind: "nanoid"},
+		{name: "ulid", kind: "ulid"},
+		{name: "uuid", kind: "uuid"},
+		{name: "xid", kind: "xid"},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			gen, err := id.NewGenerator(&id.Config{Kind: benchmark.kind}, test.Generators)
+			require.NoError(b, err)
+
+			b.ReportAllocs()
+
+			var value string
+			for b.Loop() {
+				value = gen.Generate()
+			}
+
+			require.NotEmpty(b, value)
+		})
+	}
+}

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -37,32 +37,3 @@ func TestInvalidID(t *testing.T) {
 	_, err := id.NewGenerator(&id.Config{Kind: "invalid"}, test.Generators)
 	require.Error(t, err)
 }
-
-func BenchmarkGenerators(b *testing.B) {
-	benchmarks := []struct {
-		name string
-		kind string
-	}{
-		{name: "ksuid", kind: "ksuid"},
-		{name: "nanoid", kind: "nanoid"},
-		{name: "ulid", kind: "ulid"},
-		{name: "uuid", kind: "uuid"},
-		{name: "xid", kind: "xid"},
-	}
-
-	for _, benchmark := range benchmarks {
-		b.Run(benchmark.name, func(b *testing.B) {
-			gen, err := id.NewGenerator(&id.Config{Kind: benchmark.kind}, test.Generators)
-			require.NoError(b, err)
-
-			b.ReportAllocs()
-
-			var value string
-			for b.Loop() {
-				value = gen.Generate()
-			}
-
-			require.NotEmpty(b, value)
-		})
-	}
-}

--- a/net/http/content/benchmark_test.go
+++ b/net/http/content/benchmark_test.go
@@ -1,0 +1,37 @@
+package content_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/mime"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+)
+
+// benchmarkMedia prevents the compiler from eliminating media negotiation work.
+var benchmarkMedia *content.Media
+
+func BenchmarkNewFromMediaJSON(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia = test.Content.NewFromMedia(mime.JSONMediaType)
+	}
+}
+
+func BenchmarkNewFromRequestJSON(b *testing.B) {
+	req := httptest.NewRequestWithContext(b.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.TypeKey, mime.JSONMediaType)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia = test.Content.NewFromRequest(req)
+	}
+}
+
+func BenchmarkNewFromMediaWithCharset(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia = test.Content.NewFromMedia("application/json; charset=utf-8")
+	}
+}

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -2,19 +2,14 @@ package content
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
-	"github.com/alexfalkowski/go-service/v2/mime"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/types/ptr"
 	"github.com/alexfalkowski/go-sync"
 	content "github.com/elnormous/contenttype"
 )
 
-const (
-	jsonKind     = "json"
-	errorSubtype = "error"
-
-	// TypeKey is the HTTP header key used for Content-Type.
-	TypeKey = "Content-Type"
-)
+// TypeKey is the HTTP header key used for Content-Type.
+const TypeKey = "Content-Type"
 
 // NewContent constructs a Content that resolves encoders from enc and buffers responses using pool.
 func NewContent(enc *encoding.Map, pool *sync.BufferPool) *Content {
@@ -47,61 +42,38 @@ type Content struct {
 //
 // Note: this parses the request Content-Type, not the Accept header.
 func (c *Content) NewFromRequest(req *http.Request) *Media {
-	t, err := content.GetMediaType(req)
-	if err != nil {
-		return &Media{Type: mime.JSONMediaType, Subtype: jsonKind, Encoder: c.enc.Get(jsonKind)}
-	}
-
-	return NewMedia(t, c.enc)
+	return ptr.Value(c.resolveRequestMedia(req))
 }
 
 // NewFromMedia parses mediaType and returns a matching Media.
 //
 // If parsing fails, it falls back to JSON.
 func (c *Content) NewFromMedia(mediaType string) *Media {
+	return ptr.Value(c.resolveMediaType(mediaType))
+}
+
+func (c *Content) resolveRequestMedia(req *http.Request) Media {
+	if media, ok := knownMedia(req.Header.Get(TypeKey), c.enc); ok {
+		return media
+	}
+
+	t, err := content.GetMediaType(req)
+	if err != nil {
+		return jsonMedia(c.enc)
+	}
+
+	return newMedia(t, c.enc)
+}
+
+func (c *Content) resolveMediaType(mediaType string) Media {
+	if media, ok := knownMedia(mediaType, c.enc); ok {
+		return media
+	}
+
 	t, err := content.ParseMediaType(mediaType)
 	if err != nil {
-		return &Media{Type: mime.JSONMediaType, Subtype: jsonKind, Encoder: c.enc.Get(jsonKind)}
+		return jsonMedia(c.enc)
 	}
 
-	return NewMedia(t, c.enc)
-}
-
-// NewMedia builds a Media from a parsed media type and encoder map.
-//
-// Encoder selection:
-//   - If the subtype is "error", it returns a Media without an encoder.
-//   - If no encoder is registered for the subtype, it falls back to JSON.
-//   - Otherwise it returns the encoder registered for the subtype.
-func NewMedia(media content.MediaType, enc *encoding.Map) *Media {
-	if media.Subtype == errorSubtype {
-		return &Media{Type: media.String(), Subtype: media.Subtype}
-	}
-
-	e := enc.Get(media.Subtype)
-	if e == nil {
-		return &Media{Type: mime.JSONMediaType, Subtype: jsonKind, Encoder: enc.Get(jsonKind)}
-	}
-
-	return &Media{Type: media.String(), Subtype: media.Subtype, Encoder: e}
-}
-
-// Media describes an HTTP media type and its associated encoder.
-//
-// Type is the full media type string (including parameters if present). Subtype is the parsed media subtype used
-// for encoder lookup. Encoder may be nil when Subtype is "error".
-type Media struct {
-	// Encoder is the encoder/decoder associated with the media subtype.
-	Encoder encoding.Encoder
-
-	// Type is the full media type string (for example "application/json", "application/hjson", or "text/plain; charset=utf-8").
-	Type string
-
-	// Subtype is the parsed subtype (for example "json", "hjson", or "plain").
-	Subtype string
-}
-
-// IsError reports whether the media subtype represents an error payload.
-func (t *Media) IsError() bool {
-	return t.Subtype == errorSubtype
+	return newMedia(t, c.enc)
 }

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -68,7 +68,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		media := cont.NewFromRequest(req)
+		media := cont.resolveRequestMedia(req)
 		if media.Encoder == nil {
 			_ = status.WriteError(res, status.Errorf(http.StatusBadRequest, "content: invalid request media type %q", media.Type))
 

--- a/net/http/content/media.go
+++ b/net/http/content/media.go
@@ -1,0 +1,85 @@
+package content
+
+import (
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/mime"
+	"github.com/alexfalkowski/go-service/v2/types/ptr"
+	content "github.com/elnormous/contenttype"
+)
+
+const (
+	jsonKind     = "json"
+	errorSubtype = "error"
+)
+
+// NewMedia builds a Media from a parsed media type and encoder map.
+//
+// Encoder selection:
+//   - If the subtype is "error", it returns a Media without an encoder.
+//   - If no encoder is registered for the subtype, it falls back to JSON.
+//   - Otherwise it returns the encoder registered for the subtype.
+func NewMedia(media content.MediaType, enc *encoding.Map) *Media {
+	return ptr.Value(newMedia(media, enc))
+}
+
+// Media describes an HTTP media type and its associated encoder.
+//
+// Type is the full media type string (including parameters if present). Subtype is the parsed media subtype used
+// for encoder lookup. Encoder may be nil when Subtype is "error".
+type Media struct {
+	// Encoder is the encoder/decoder associated with the media subtype.
+	Encoder encoding.Encoder
+
+	// Type is the full media type string (for example "application/json", "application/hjson", or "text/plain; charset=utf-8").
+	Type string
+
+	// Subtype is the parsed subtype (for example "json", "hjson", or "plain").
+	Subtype string
+}
+
+// IsError reports whether the media subtype represents an error payload.
+func (t *Media) IsError() bool {
+	return t.Subtype == errorSubtype
+}
+
+func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {
+	// Exact built-in media types avoid the general parser on hot request paths.
+	// Parameterized values still use the parser so their normalized Type string stays unchanged.
+	switch mediaType {
+	case mime.JSONMediaType:
+		return jsonMedia(enc), true
+	case mime.HJSONMediaType:
+		return Media{Type: mime.HJSONMediaType, Subtype: "hjson", Encoder: enc.Get("hjson")}, true
+	case mime.YAMLMediaType:
+		return Media{Type: mime.YAMLMediaType, Subtype: "yaml", Encoder: enc.Get("yaml")}, true
+	case mime.TOMLMediaType:
+		return Media{Type: mime.TOMLMediaType, Subtype: "toml", Encoder: enc.Get("toml")}, true
+	case mime.ProtobufMediaType:
+		return Media{Type: mime.ProtobufMediaType, Subtype: "protobuf", Encoder: enc.Get("protobuf")}, true
+	case mime.ProtobufJSONMediaType:
+		return Media{Type: mime.ProtobufJSONMediaType, Subtype: "pbjson", Encoder: enc.Get("pbjson")}, true
+	case mime.ProtobufTextMediaType:
+		return Media{Type: mime.ProtobufTextMediaType, Subtype: "pbtxt", Encoder: enc.Get("pbtxt")}, true
+	default:
+		return Media{}, false
+	}
+}
+
+// newMedia returns a value so internal hot paths can avoid the pointer allocation
+// while NewMedia keeps the public pointer-returning API unchanged.
+func newMedia(media content.MediaType, enc *encoding.Map) Media {
+	if media.Subtype == errorSubtype {
+		return Media{Type: media.String(), Subtype: media.Subtype}
+	}
+
+	e := enc.Get(media.Subtype)
+	if e == nil {
+		return jsonMedia(enc)
+	}
+
+	return Media{Type: media.String(), Subtype: media.Subtype, Encoder: e}
+}
+
+func jsonMedia(enc *encoding.Map) Media {
+	return Media{Type: mime.JSONMediaType, Subtype: jsonKind, Encoder: enc.Get(jsonKind)}
+}


### PR DESCRIPTION
## What

- Optimized HTTP content media negotiation with fast paths for known exact media types.
- Kept parameterized media types on the parser path to preserve normalized output.
- Moved media-specific logic into `net/http/content/media.go`.
- Updated internal handler paths to use value-returning media helpers while preserving public pointer-returning APIs.
- Added HTTP content benchmarks.
- Moved ID generator benchmarks into `id/benchmark_test.go`.
- Added `id` and `net/http/content` benchmark targets to `make benchmarks`.

## Why

- Reduces allocations on common content negotiation paths without changing public APIs.
- Keeps benchmark tests consistently organized in `benchmark_test.go`.
- Ensures CI runs the newly added benchmark coverage through the existing `make benchmarks` step.

## Testing

- `go test -vet=off -mod=mod -count=1 ./net/http/content`
- `go test -vet=off -mod=mod -count=1 ./id`
- `go test -vet=off -mod=mod -run=^$ -bench='^BenchmarkGenerators' -benchmem -count=1 ./id`
- `go test -vet=off -mod=mod -run=^$ -bench='^BenchmarkNewFrom(Media|Request)' -benchmem -count=3 ./net/http/content`
- `make id-benchmarks http-content-benchmarks`
- `make benchmarks`
- `make lint`
- `git diff --check`