### PR TITLE
feat(http): optimize content media api allocations

### DIFF
--- a/net/http/content/benchmark_test.go
+++ b/net/http/content/benchmark_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // benchmarkMedia prevents the compiler from eliminating media negotiation work.
-var benchmarkMedia *content.Media
+var benchmarkMedia content.Media
 
 func BenchmarkNewFromMediaJSON(b *testing.B) {
 	b.ReportAllocs()

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -3,7 +3,6 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/types/ptr"
 	"github.com/alexfalkowski/go-sync"
 	content "github.com/elnormous/contenttype"
 )
@@ -41,15 +40,15 @@ type Content struct {
 // If parsing fails, it falls back to JSON.
 //
 // Note: this parses the request Content-Type, not the Accept header.
-func (c *Content) NewFromRequest(req *http.Request) *Media {
-	return ptr.Value(c.resolveRequestMedia(req))
+func (c *Content) NewFromRequest(req *http.Request) Media {
+	return c.resolveRequestMedia(req)
 }
 
 // NewFromMedia parses mediaType and returns a matching Media.
 //
 // If parsing fails, it falls back to JSON.
-func (c *Content) NewFromMedia(mediaType string) *Media {
-	return ptr.Value(c.resolveMediaType(mediaType))
+func (c *Content) NewFromMedia(mediaType string) Media {
+	return c.resolveMediaType(mediaType)
 }
 
 func (c *Content) resolveRequestMedia(req *http.Request) Media {

--- a/net/http/content/doc.go
+++ b/net/http/content/doc.go
@@ -8,7 +8,7 @@
 // The core type is `Content`, which uses an `encoding.Map` registry to resolve an encoder by
 // media subtype (e.g. "json", "hjson", "yaml", "toml", "proto").
 //
-// `Content` can derive a `*Media` from either:
+// `Content` can derive a `Media` from either:
 //   - an incoming HTTP request's Content-Type header (`NewFromRequest`), or
 //   - a raw media type string (`NewFromMedia`).
 //

--- a/net/http/content/media.go
+++ b/net/http/content/media.go
@@ -3,7 +3,6 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/mime"
-	"github.com/alexfalkowski/go-service/v2/types/ptr"
 	content "github.com/elnormous/contenttype"
 )
 
@@ -18,8 +17,8 @@ const (
 //   - If the subtype is "error", it returns a Media without an encoder.
 //   - If no encoder is registered for the subtype, it falls back to JSON.
 //   - Otherwise it returns the encoder registered for the subtype.
-func NewMedia(media content.MediaType, enc *encoding.Map) *Media {
-	return ptr.Value(newMedia(media, enc))
+func NewMedia(media content.MediaType, enc *encoding.Map) Media {
+	return newMedia(media, enc)
 }
 
 // Media describes an HTTP media type and its associated encoder.
@@ -38,7 +37,7 @@ type Media struct {
 }
 
 // IsError reports whether the media subtype represents an error payload.
-func (t *Media) IsError() bool {
+func (t Media) IsError() bool {
 	return t.Subtype == errorSubtype
 }
 
@@ -65,8 +64,6 @@ func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {
 	}
 }
 
-// newMedia returns a value so internal hot paths can avoid the pointer allocation
-// while NewMedia keeps the public pointer-returning API unchanged.
 func newMedia(media content.MediaType, enc *encoding.Map) Media {
 	if media.Subtype == errorSubtype {
 		return Media{Type: media.String(), Subtype: media.Subtype}


### PR DESCRIPTION
## What

- Changed content media APIs to return `Media` values instead of `*Media` pointers.
- Updated `Media.IsError` to use a value receiver.
- Removed `ptr.Value` usage from content media construction.
- Updated content package docs and benchmarks for value-returning media APIs.

## Why

- Removes the allocation forced by public pointer-returning media APIs.
- Keeps the content negotiation API simpler for the internal low-level use case.
- Preserves existing media resolution behavior while improving allocation counts.

## Testing

- `go test -vet=off -mod=mod -count=1 ./net/http/content ./net/http/client`
- `go test -vet=off -mod=mod -count=1 ./net/http/... ./transport/http`
- `go test -vet=off -mod=mod -run=^$ -bench='^BenchmarkNewFrom(Media|Request)' -benchmem -count=5 ./net/http/content`
- `make http-content-benchmarks`
- `make lint`
- `git diff --check`