### PR TITLE
feat(cli): add cli run code exit mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ This repository is a library, so your binary is usually in another module. A typ
 package main
 
 import (
-    "context"
-
     "github.com/alexfalkowski/go-service/v2/cli"
+    "github.com/alexfalkowski/go-service/v2/context"
     "github.com/alexfalkowski/go-service/v2/module"
+    "github.com/alexfalkowski/go-service/v2/os"
 )
 
 func main() {
@@ -51,9 +51,13 @@ func main() {
        server.AddInput("file:./config.yml") // enables the `-i` flag used by config.NewDecoder
     })
 
-    app.ExitOnError(context.Background())
+    os.Exit(app.RunCode(context.Background()))
 }
 ```
+
+Use `app.Run(context.Background())` when the caller should receive the execution error directly, or
+`app.RunCode(context.Background())` when the caller wants a process exit code. Applications can pass
+`cli.WithExitCodeFunc` to `cli.NewApplication` to map specific errors to specific exit codes.
 
 ---
 

--- a/cli/application.go
+++ b/cli/application.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
@@ -16,11 +17,6 @@ import (
 
 // ErrCommandRegistered indicates a subcommand name has already been registered on an Application.
 var ErrCommandRegistered = errors.New("command already registered")
-
-// Exit is invoked by (*Application).ExitOnError after logging a startup failure.
-//
-// Tests may replace this variable to avoid terminating the test process.
-var Exit = os.Exit
 
 // RegisterFunc registers subcommands on a Commander.
 //
@@ -32,8 +28,9 @@ type RegisterFunc = func(commander Commander)
 //
 // The returned Application is pre-populated with module-level Name and Version derived from the environment
 // (see cli.Name and cli.Version).
-func NewApplication(register RegisterFunc) *Application {
-	app := &Application{name: Name, version: Version}
+func NewApplication(register RegisterFunc, opts ...ApplicationOption) *Application {
+	options := newApplicationOpts(opts...)
+	app := &Application{name: Name, version: Version, exitCode: options.exitCode}
 	register(app)
 
 	return app
@@ -44,9 +41,10 @@ func NewApplication(register RegisterFunc) *Application {
 // An Application maintains a set of commands and delegates parsing/execution to the underlying command
 // framework (github.com/cristalhq/acmd).
 type Application struct {
-	cmds    map[string]cmd.Command
-	name    env.Name
-	version env.Version
+	cmds     map[string]cmd.Command
+	exitCode ExitCodeFunc
+	name     env.Name
+	version  env.Version
 }
 
 // AddServer adds a long-running server subcommand with DI lifecycle wiring.
@@ -156,14 +154,19 @@ func (a *Application) Run(ctx context.Context) error {
 	return runner.Run()
 }
 
-// ExitOnError runs the application and terminates the process with exit status 1 if Run returns an error.
+// RunCode executes the application and returns the process exit code that represents the result.
 //
-// The error is logged using the telemetry logger before Exit is invoked.
-func (a *Application) ExitOnError(ctx context.Context) {
+// RunCode returns 0 when Run succeeds. When Run returns an error, RunCode logs the error using the
+// telemetry logger and returns the configured exit code for that error.
+func (a *Application) RunCode(ctx context.Context) int {
 	if err := a.Run(ctx); err != nil {
-		logger.LogError(ctx, "could not start", logger.Error(err))
-		Exit(1)
+		code := a.code(err)
+		logger.LogError(ctx, "could not start", logger.Error(err), logger.Int(meta.CodeKey, code))
+
+		return code
 	}
+
+	return 0
 }
 
 func (a *Application) register(command cmd.Command) error {
@@ -182,6 +185,20 @@ func (a *Application) register(command cmd.Command) error {
 
 func (a *Application) prefix(prefix string, err error) error {
 	return errors.Prefix(prefix+": failed to run", di.RootCause(err))
+}
+
+func (a *Application) code(err error) int {
+	exitCode := a.exitCode
+	if exitCode == nil {
+		exitCode = defaultExitCode
+	}
+
+	code := exitCode(err)
+	if code <= 0 {
+		return defaultExitCode(err)
+	}
+
+	return code
 }
 
 func (a *Application) stopContext(ctx context.Context) context.Context {

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -31,19 +31,28 @@ func TestApplicationRun(t *testing.T) {
 	require.NoError(t, app.Run(t.Context()))
 }
 
-func TestApplicationExitOnRun(t *testing.T) {
+func TestApplicationRunCode(t *testing.T) {
 	config := test.FilePath("configs/invalid_http.config.yml")
 
 	os.Args = []string{test.Name.String(), "server", "-i", config}
 
-	var exitCode int
-	previous := cli.Exit
-	cli.Exit = func(code int) {
-		exitCode = code
-	}
-	t.Cleanup(func() {
-		cli.Exit = previous
-	})
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			cmd := c.AddServer("server", "Start the server.", test.Options()...)
+			cmd.AddInput(strings.Empty)
+		},
+		cli.WithExitCodeFunc(func(error) int {
+			return 4
+		}),
+	)
+
+	require.Equal(t, 4, app.RunCode(t.Context()))
+}
+
+func TestApplicationRunCodeWithDefaultExitCode(t *testing.T) {
+	config := test.FilePath("configs/invalid_http.config.yml")
+
+	os.Args = []string{test.Name.String(), "server", "-i", config}
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -52,8 +61,39 @@ func TestApplicationExitOnRun(t *testing.T) {
 		},
 	)
 
-	app.ExitOnError(t.Context())
-	require.Equal(t, 1, exitCode)
+	require.Equal(t, 1, app.RunCode(t.Context()))
+}
+
+func TestApplicationRunCodeWithInvalidExitCode(t *testing.T) {
+	config := test.FilePath("configs/invalid_http.config.yml")
+
+	os.Args = []string{test.Name.String(), "server", "-i", config}
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			cmd := c.AddServer("server", "Start the server.", test.Options()...)
+			cmd.AddInput(strings.Empty)
+		},
+		cli.WithExitCodeFunc(func(error) int {
+			return 0
+		}),
+	)
+
+	require.Equal(t, 1, app.RunCode(t.Context()))
+}
+
+func TestApplicationRunCodeOnSuccess(t *testing.T) {
+	os.Args = []string{test.Name.String(), "client"}
+	cli.Name = test.Name
+	cli.Version = test.Version
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddClient("client", "Start the client.", di.NoLogger)
+		},
+	)
+
+	require.Equal(t, 0, app.RunCode(t.Context()))
 }
 
 func TestApplicationRunWithInvalidFlag(t *testing.T) {

--- a/cli/doc.go
+++ b/cli/doc.go
@@ -12,7 +12,9 @@
 // Most applications then call either:
 //
 //   - `(*Application).Run` to execute the CLI and return any error, or
-//   - `(*Application).ExitOnError` to log failures and invoke `cli.Exit` with a non-zero status code.
+//   - `(*Application).RunCode` to execute the CLI and return a process exit code.
+//
+// Use `WithExitCodeFunc` when an application needs to map specific errors to specific process exit codes.
 //
 // # Subcommands and DI wiring
 //

--- a/cli/options.go
+++ b/cli/options.go
@@ -1,0 +1,46 @@
+package cli
+
+// ExitCodeFunc maps an application execution error to a process exit code.
+type ExitCodeFunc func(error) int
+
+// ApplicationOption configures an Application constructed by NewApplication.
+//
+// Options are applied in the order provided to NewApplication. If multiple options configure
+// the same field, the last one wins.
+type ApplicationOption interface {
+	apply(opts *applicationOpts)
+}
+
+type applicationOpts struct {
+	exitCode ExitCodeFunc
+}
+
+type applicationOptionFunc func(*applicationOpts)
+
+func (f applicationOptionFunc) apply(o *applicationOpts) {
+	f(o)
+}
+
+// WithExitCodeFunc configures how RunCode chooses a process exit code for an error.
+//
+// If f returns zero or a negative value for a non-nil error, the application falls back to exit code 1.
+func WithExitCodeFunc(f ExitCodeFunc) ApplicationOption {
+	return applicationOptionFunc(func(o *applicationOpts) {
+		if f != nil {
+			o.exitCode = f
+		}
+	})
+}
+
+func newApplicationOpts(opts ...ApplicationOption) *applicationOpts {
+	options := &applicationOpts{exitCode: defaultExitCode}
+	for _, opt := range opts {
+		opt.apply(options)
+	}
+
+	return options
+}
+
+func defaultExitCode(error) int {
+	return 1
+}


### PR DESCRIPTION
## What

- Replaced `Application.ExitOnError` and the test-only `cli.Exit` hook with `Application.RunCode`.
- Added configurable CLI exit-code mapping via `WithExitCodeFunc`.
- Moved application option types and helpers into `cli/options.go`.
- Updated CLI docs, README bootstrap example, and application tests.

## Why

- Keeps `os.Exit` ownership in the consuming `main` package instead of the library.
- Removes the package-level exit hook that only existed to make tests possible.
- Lets callers map specific run errors to specific process exit codes while preserving `Run(ctx) error`.

## Testing

- Passed: `go test ./cli`
- Passed: `go vet ./cli`
- Passed: `git diff --check`