### PR TITLE
feat(telemetry): gate instrumentation when providers are disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,19 @@ transport-diagram:
 	@make package=transport create-diagram
 
 # Run all the benchmarks.
-benchmarks: http-benchmarks grpc-benchmarks bytes-benchmarks strings-benchmarks id-benchmarks http-content-benchmarks
+benchmarks: http-benchmarks grpc-benchmarks sql-benchmarks cache-benchmarks bytes-benchmarks strings-benchmarks id-benchmarks http-content-benchmarks
 
 http-benchmarks:
 	@make package=transport/http benchtime=100x benchmark
 
 grpc-benchmarks:
 	@make package=transport/grpc benchtime=100x benchmark
+
+sql-benchmarks:
+	@make package=database/sql/driver benchtime=100x benchmark
+
+cache-benchmarks:
+	@make package=cache/driver benchtime=100x benchmark
 
 bytes-benchmarks:
 	@make package=bytes benchtime=100x benchmark

--- a/cache/driver/benchmark_test.go
+++ b/cache/driver/benchmark_test.go
@@ -1,0 +1,87 @@
+package driver_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/cache/config"
+	"github.com/alexfalkowski/go-service/v2/cache/driver"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+var driverSink driver.Driver
+
+func BenchmarkRedisTelemetry(b *testing.B) {
+	bench := func(name string, setup func(testing.TB)) {
+		b.Run(name, func(b *testing.B) {
+			resetTelemetry(b)
+			setup(b)
+			defer resetTelemetry(b)
+
+			cfg := &config.Config{
+				Kind: "redis",
+				Options: map[string]any{
+					"url": "redis://localhost:6379",
+				},
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				cache, err := driver.NewDriver(test.FS, cfg)
+				require.NoError(b, err)
+				driverSink = cache
+			}
+		})
+	}
+
+	bench("disabled", func(testing.TB) {})
+	bench("metrics", enableMetrics)
+	bench("tracer", enableTracer)
+	bench("enabled", enableTelemetry)
+}
+
+func resetTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
+}
+
+func enableMetrics(tb testing.TB) {
+	tb.Helper()
+
+	metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+}
+
+func enableTracer(tb testing.TB) {
+	tb.Helper()
+
+	tracer.Register(tracer.TracerParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &tracer.Config{},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+}
+
+func enableTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	enableMetrics(tb)
+	enableTracer(tb)
+}

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -7,6 +7,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/faabiosr/cachego"
 	"github.com/faabiosr/cachego/redis"
 	"github.com/faabiosr/cachego/sync"
@@ -40,8 +42,8 @@ var ErrNotFound = errors.New("cache: driver not found")
 //   - options["url"] to be a string "source string" (e.g. "env:REDIS_URL" or "file:/path/to/url" or a literal URL)
 //
 // The URL is read via fs.ReadSource, parsed using redis/go-redis ParseURL, and
-// then the client is instrumented for tracing and metrics via
-// `cache/telemetry`.
+// then the client is instrumented for tracing and metrics via `cache/telemetry`
+// when those telemetry providers are enabled.
 //
 // Instrumentation errors are treated as fatal configuration/runtime errors and
 // are converted into panics via runtime.Must, matching the existing repository
@@ -79,8 +81,12 @@ func NewDriver(fs *os.FS, cfg *cache.Config) (Driver, error) {
 		}
 
 		client := client.NewClient(opts)
-		runtime.Must(telemetry.InstrumentTracing(client))
-		runtime.Must(telemetry.InstrumentMetrics(client))
+		if tracer.IsEnabled() {
+			runtime.Must(telemetry.InstrumentTracing(client))
+		}
+		if metrics.IsEnabled() {
+			runtime.Must(telemetry.InstrumentMetrics(client))
+		}
 
 		return redis.New(client), nil
 	case "sync":

--- a/database/sql/driver/benchmark_test.go
+++ b/database/sql/driver/benchmark_test.go
@@ -1,0 +1,130 @@
+package driver_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/database/sql"
+	"github.com/alexfalkowski/go-service/v2/database/sql/driver"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/alexfalkowski/go-sync"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+var driverID sync.Uint64
+
+func BenchmarkSQLTelemetry(b *testing.B) {
+	bench := func(name string, setup func(testing.TB)) {
+		b.Run(name, func(b *testing.B) {
+			resetTelemetry(b)
+			setup(b)
+			defer resetTelemetry(b)
+
+			driverName := "benchmark-sql-" + name + "-" + strconv.FormatUint(driverID.Add(1), 10)
+			require.NoError(b, driver.Register(driverName, benchmarkDriver{}))
+
+			db, err := sql.Open(driverName, "benchmark")
+			require.NoError(b, err)
+			defer db.Close()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				rows, err := db.QueryContext(b.Context(), "SELECT 1")
+				require.NoError(b, err)
+				require.NoError(b, rows.Err())
+				require.NoError(b, rows.Close())
+			}
+		})
+	}
+
+	bench("disabled", func(testing.TB) {})
+	bench("metrics", enableMetrics)
+	bench("tracer", enableTracer)
+	bench("enabled", enableTelemetry)
+}
+
+type benchmarkDriver struct{}
+
+func (benchmarkDriver) Open(string) (driver.Conn, error) {
+	return benchmarkConn{}, nil
+}
+
+type benchmarkConn struct{}
+
+func (benchmarkConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (benchmarkConn) Close() error {
+	return nil
+}
+
+func (benchmarkConn) Begin() (driver.Tx, error) {
+	return nil, driver.ErrSkip
+}
+
+func (benchmarkConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return benchmarkRows{}, nil
+}
+
+type benchmarkRows struct{}
+
+func (benchmarkRows) Columns() []string {
+	return []string{"value"}
+}
+
+func (benchmarkRows) Close() error {
+	return nil
+}
+
+func (benchmarkRows) Next([]driver.Value) error {
+	return io.EOF
+}
+
+func resetTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
+}
+
+func enableMetrics(tb testing.TB) {
+	tb.Helper()
+
+	metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+}
+
+func enableTracer(tb testing.TB) {
+	tb.Helper()
+
+	tracer.Register(tracer.TracerParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &tracer.Config{},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+}
+
+func enableTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	enableMetrics(tb)
+	enableTracer(tb)
+}

--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -13,6 +13,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/jmoiron/sqlx"
 	"github.com/linxGnu/mssqlx"
 )
@@ -22,16 +24,37 @@ import (
 // It is the concrete driver type expected by Register.
 type Driver = driver.Driver
 
+// Conn aliases `database/sql/driver`.Conn.
+type Conn = driver.Conn
+
+// NamedValue aliases `database/sql/driver`.NamedValue.
+type NamedValue = driver.NamedValue
+
+// Rows aliases `database/sql/driver`.Rows.
+type Rows = driver.Rows
+
+// Stmt aliases `database/sql/driver`.Stmt.
+type Stmt = driver.Stmt
+
+// Tx aliases `database/sql/driver`.Tx.
+type Tx = driver.Tx
+
+// Value aliases `database/sql/driver`.Value.
+type Value = driver.Value
+
+// ErrSkip aliases `database/sql/driver`.ErrSkip.
+var ErrSkip = driver.ErrSkip
+
 // ErrNoDSNs is returned when SQL configuration enables a driver without any master or slave DSNs.
 var ErrNoDSNs = errors.New("driver: no database DSNs configured")
 
-// Register registers a `database/sql` driver under name and wraps it with OpenTelemetry instrumentation.
+// Register registers a `database/sql` driver under name.
 //
-// This function registers the wrapped driver with the global `database/sql` driver registry. It is therefore
-// intended to be called during process initialization (for example from an init hook or DI registration).
+// This function registers the driver with the global `database/sql` driver registry. It is therefore intended
+// to be called during process initialization (for example from an init hook or DI registration).
 //
 // Telemetry:
-//   - The driver is wrapped using database/sql/telemetry.WrapDriver.
+//   - The driver is wrapped using database/sql/telemetry.WrapDriver when tracing or metrics are enabled.
 //   - The DB system name attribute is set to the provided name (attributes.DBSystemNameKey).
 //
 // Errors:
@@ -44,7 +67,11 @@ func Register(name string, driver Driver) (err error) {
 		}
 	}()
 
-	sql.Register(name, telemetry.WrapDriver(driver, telemetry.WithAttributes(attributes.DBSystemNameKey.String(name))))
+	if metrics.IsEnabled() || tracer.IsEnabled() {
+		driver = telemetry.WrapDriver(driver, telemetry.WithAttributes(attributes.DBSystemNameKey.String(name)))
+	}
+
+	sql.Register(name, driver)
 
 	return err
 }
@@ -55,8 +82,8 @@ func Register(name string, driver Driver) (err error) {
 // It resolves DSNs from cfg using the provided filesystem (DSNs are configured
 // as go-service "source strings"), connects using
 // `mssqlx.ConnectMasterSlaves`, registers OpenTelemetry DB stats metrics for
-// each pool, and then applies pool settings (connection lifetime, max idle, and
-// max open connections).
+// each pool when metrics are enabled, and then applies pool settings
+// (connection lifetime, max idle, and max open connections).
 //
 // Preconditions:
 //   - cfg must be non-nil and already treated as enabled/validated by the caller.
@@ -137,13 +164,15 @@ func connectDBs(name string, masterDSNs, slaveDSNs []string) (*mssqlx.DBs, error
 		return nil, err
 	}
 
-	attrs := telemetry.WithAttributes(attributes.DBSystemNameKey.String(name))
+	if metrics.IsEnabled() {
+		attrs := telemetry.WithAttributes(attributes.DBSystemNameKey.String(name))
 
-	masters, _ := db.GetAllMasters()
-	register(masters, attrs)
+		masters, _ := db.GetAllMasters()
+		register(masters, attrs)
 
-	slaves, _ := db.GetAllSlaves()
-	register(slaves, attrs)
+		slaves, _ := db.GetAllSlaves()
+		register(slaves, attrs)
+	}
 
 	return db, nil
 }

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -1,6 +1,16 @@
 package sql
 
-import "github.com/linxGnu/mssqlx"
+import (
+	"database/sql"
+
+	"github.com/linxGnu/mssqlx"
+)
+
+// DB aliases `database/sql`.DB.
+//
+// It is exposed so go-service SQL packages can use the local package namespace
+// while preserving standard-library behavior.
+type DB = sql.DB
 
 // DBs is an alias of mssqlx.DBs.
 //
@@ -11,6 +21,20 @@ import "github.com/linxGnu/mssqlx"
 // helper methods for querying masters, slaves, and running operations against
 // the configured pools.
 type DBs = mssqlx.DBs
+
+// Rows aliases `database/sql`.Rows.
+//
+// It is exposed so go-service SQL packages can use the local package namespace
+// while preserving standard-library behavior.
+type Rows = sql.Rows
+
+// Open aliases `database/sql`.Open.
+//
+// The driver name must already be registered with the global `database/sql`
+// registry. The returned DB uses standard-library database/sql behavior.
+func Open(driverName, dataSourceName string) (*DB, error) {
+	return sql.Open(driverName, dataSourceName)
+}
 
 // ConnectMasterSlaves is a thin wrapper around mssqlx.ConnectMasterSlaves.
 //

--- a/database/sql/sql_test.go
+++ b/database/sql/sql_test.go
@@ -1,0 +1,15 @@
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/database/sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenUnknownDriver(t *testing.T) {
+	db, err := sql.Open("go-service-missing-driver", "benchmark")
+
+	require.Error(t, err)
+	require.Nil(t, db)
+}

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect

--- a/io/io.go
+++ b/io/io.go
@@ -6,6 +6,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 )
 
+// EOF aliases io.EOF.
+var EOF = io.EOF
+
 // WriterTo is an alias for io.WriterTo.
 //
 // It is provided so go-service code can depend on a consistent import path while

--- a/module/module.go
+++ b/module/module.go
@@ -49,11 +49,11 @@ var (
 	//
 	// It builds on Library and adds server-oriented wiring commonly needed by services:
 	//   - debug.Module (debug server + diagnostic endpoints)
-	//   - cache.Module (cache drivers, cache facade, and package-level cache registration)
 	//   - config.Module (config decoding + validation + common sub-config projections)
+	//   - telemetry.Module (logging/tracing/metrics wiring)
+	//   - cache.Module (cache drivers, cache facade, and package-level cache registration)
 	//   - feature.Module (OpenFeature client + optional provider registration)
 	//   - sql.Module (SQL database wiring; currently PostgreSQL)
-	//   - telemetry.Module (logging/tracing/metrics wiring)
 	//   - limiter.Module (rate limiter key map wiring; transport modules typically construct limiters)
 	//   - transport.Module (HTTP/gRPC transports and related client/server integrations)
 	//   - health.Module (health server wiring)
@@ -66,11 +66,11 @@ var (
 	Server = di.Module(
 		Library,
 		debug.Module,
-		cache.Module,
 		config.Module,
+		telemetry.Module,
+		cache.Module,
 		feature.Module,
 		sql.Module,
-		telemetry.Module,
 		limiter.Module,
 		transport.Module,
 		health.Module,
@@ -80,12 +80,12 @@ var (
 	//
 	// It builds on Library and adds client-oriented wiring commonly needed by client processes
 	// and batch jobs:
-	//   - cache.Module (cache drivers/facade; optional by config)
 	//   - config.Module (config decoding + validation + common sub-config projections)
+	//   - telemetry.Module (logging/tracing/metrics wiring)
+	//   - cache.Module (cache drivers/facade; optional by config)
 	//   - feature.Module (OpenFeature client + optional provider registration)
 	//   - hooks.Module (Standard Webhooks helpers; used by HTTP hook integrations)
 	//   - sql.Module (SQL database wiring; currently PostgreSQL)
-	//   - telemetry.Module (logging/tracing/metrics wiring)
 	//   - limiter.Module (rate limiter key map wiring)
 	//
 	// Unlike Server, Client does not wire debug endpoints, transports, or a health server by default.
@@ -94,12 +94,12 @@ var (
 	// This is the primary entrypoint for client-style applications built from `go-service-template`.
 	Client = di.Module(
 		Library,
-		cache.Module,
 		config.Module,
+		telemetry.Module,
+		cache.Module,
 		feature.Module,
 		hooks.Module,
 		sql.Module,
-		telemetry.Module,
 		limiter.Module,
 	)
 )

--- a/net/http/benchmark_test.go
+++ b/net/http/benchmark_test.go
@@ -1,0 +1,82 @@
+package http_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func BenchmarkClientTelemetry(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer server.Close()
+
+	bench := func(name string, setup func(testing.TB)) {
+		b.Run(name, func(b *testing.B) {
+			resetTelemetry(b)
+			setup(b)
+			defer resetTelemetry(b)
+
+			b.ReportAllocs()
+
+			client := http.NewClient(http.DefaultTransport, time.Second)
+			req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, server.URL, http.NoBody)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+
+			for b.Loop() {
+				resp, err := client.Do(req)
+				require.NoError(b, err)
+				resp.Body.Close()
+			}
+
+			b.StopTimer()
+			client.CloseIdleConnections()
+		})
+	}
+
+	bench("disabled", func(testing.TB) {})
+	bench("metrics", enableMetrics)
+	bench("tracer", enableTracer)
+}
+
+func resetTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
+}
+
+func enableMetrics(tb testing.TB) {
+	tb.Helper()
+
+	metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+}
+
+func enableTracer(tb testing.TB) {
+	tb.Helper()
+
+	tracer.Register(tracer.TracerParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &tracer.Config{},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+}

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -73,8 +73,8 @@ func WithIgnoreRedirect() ClientOption {
 //
 // It reuses buffers from pool and applies the configured transport, timeout, and redirect policy.
 //
-// The underlying *http.Client is constructed via http.NewClient, which instruments requests with
-// OpenTelemetry and sets http.Client.Timeout.
+// The underlying *http.Client is constructed via http.NewClient, which sets http.Client.Timeout and
+// instruments requests with OpenTelemetry when tracing or metrics are enabled.
 //
 // Callers should treat the returned Client as safe for concurrent use.
 func NewClient(content *content.Content, pool *sync.BufferPool, opts ...ClientOption) *Client {

--- a/net/http/doc.go
+++ b/net/http/doc.go
@@ -3,9 +3,10 @@
 // This package primarily re-exports common net/http types and constants behind go-service aliases and
 // provides a few convenience helpers used by transport wiring, such as:
 //
-//   - NewClient, which wraps a RoundTripper with OpenTelemetry instrumentation and applies a client timeout,
+//   - NewClient, which applies a client timeout and wraps a RoundTripper with OpenTelemetry instrumentation
+//     when tracing or metrics are enabled,
 //   - NewServer, which builds an http.Server using configured timeouts and protocol settings,
-//   - Handle/HandleFunc, which register handlers wrapped with OpenTelemetry instrumentation,
+//   - Handle/HandleFunc, which register handlers with OpenTelemetry instrumentation when tracing or metrics are enabled,
 //   - Pattern and ParseServiceMethod, which help standardize route naming for telemetry.
 //
 // Server construction reads timeout keys from options.Map (`read_timeout`, `write_timeout`,

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -14,6 +14,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/alexfalkowski/go-service/v2/net/http/telemetry"
 	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
@@ -152,23 +154,33 @@ var (
 	NoBody = http.NoBody
 )
 
-// NewClient constructs an HTTP client with OpenTelemetry instrumentation and a request timeout.
+// NewClient constructs an HTTP client with a request timeout.
 //
-// The returned client wraps the provided RoundTripper with a telemetry transport and installs an
-// httptrace-based client trace derived from the request context. This enables client-side spans and
-// timing events to be captured by the configured OpenTelemetry instrumentation.
+// When tracing or metrics are enabled, the returned client wraps the provided RoundTripper with a telemetry
+// transport. When tracing is enabled, it also installs an httptrace-based client trace derived from the
+// request context.
 //
 // The provided timeout is assigned to http.Client.Timeout (total time limit for requests, including
 // connection time, redirects, and reading the response body).
 func NewClient(rt http.RoundTripper, timeout time.Duration) *http.Client {
-	return &http.Client{
-		Transport: telemetry.NewTransport(
-			rt,
-			telemetry.WithClientTrace(func(ctx context.Context) *httptrace.ClientTrace {
+	var transport http.RoundTripper
+
+	if metrics.IsEnabled() || tracer.IsEnabled() {
+		options := []telemetry.Option{}
+		if tracer.IsEnabled() {
+			options = append(options, telemetry.WithClientTrace(func(ctx context.Context) *httptrace.ClientTrace {
 				return telemetry.NewClientTrace(ctx)
-			}),
-		),
-		Timeout: timeout.Duration(),
+			}))
+		}
+
+		transport = telemetry.NewTransport(rt, options...)
+	} else {
+		transport = rt
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   timeout.Duration(),
 	}
 }
 
@@ -194,19 +206,24 @@ func MaxBytesHandler(h Handler, n int64) Handler {
 	return http.MaxBytesHandler(h, n)
 }
 
-// HandleFunc registers handler for pattern on mux and wraps it with OpenTelemetry instrumentation.
+// HandleFunc registers handler for pattern on mux.
 //
-// This helper ensures that handlers registered via this package are consistently instrumented by
-// wrapping them with telemetry.NewHandler before registration.
+// When tracing or metrics are enabled, handler is wrapped with OpenTelemetry instrumentation before
+// registration.
 func HandleFunc(mux *ServeMux, pattern string, handler http.HandlerFunc) {
 	Handle(mux, pattern, handler)
 }
 
-// Handle registers handler for pattern on mux and wraps it with OpenTelemetry instrumentation.
+// Handle registers handler for pattern on mux.
 //
-// The handler is wrapped with telemetry.NewHandler using the provided pattern as the handler name.
-// This is useful for consistent HTTP server span naming and handler metrics attribution.
+// When tracing or metrics are enabled, handler is wrapped with telemetry.NewHandler using the provided
+// pattern as the handler name.
 func Handle(mux *ServeMux, pattern string, handler http.Handler) {
+	if !metrics.IsEnabled() && !tracer.IsEnabled() {
+		mux.Handle(pattern, handler)
+		return
+	}
+
 	mux.Handle(pattern, telemetry.NewHandler(handler, pattern))
 }
 

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -1,23 +1,81 @@
 package http_test
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	"github.com/alexfalkowski/go-service/v2/config/options"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
 )
 
-func TestNewServerWithMaxHeaderBytes(t *testing.T) {
-	server := http.NewServer(options.Map{"max_header_bytes": "16KB"}, time.Second, http.NewServeMux())
+func TestMaxBytesHandler(t *testing.T) {
+	handler := http.MaxBytesHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		_, _, err := io.ReadAll(req.Body)
+		var maxBytesError *http.MaxBytesError
+		require.ErrorAs(t, err, &maxBytesError)
 
-	require.Equal(t, int(16*bytes.KB), server.MaxHeaderBytes)
+		_, _ = res.Write([]byte("ok"))
+	}), 1)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", bytes.NewBufferString("too large"))
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
 }
 
-func TestNewServerWithDefaultMaxHeaderBytes(t *testing.T) {
-	server := http.NewServer(options.Map{}, time.Second, http.NewServeMux())
+func TestHandleWhenTelemetryDisabled(t *testing.T) {
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 
-	require.Equal(t, http.DefaultMaxHeaderBytes, server.MaxHeaderBytes)
+	mux := http.NewServeMux()
+	called := false
+
+	http.Handle(mux, "/hello", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		called = true
+		_, _ = res.Write([]byte("hello"))
+	}))
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+
+	mux.ServeHTTP(res, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "hello", res.Body.String())
+}
+
+func TestHandleWhenMetricsEnabled(t *testing.T) {
+	t.Cleanup(func() {
+		tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config:    &metrics.Config{},
+		Reader:    metrics.NewManualReader(),
+	})
+
+	mux := http.NewServeMux()
+
+	http.Handle(mux, "/hello", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		_, _ = res.Write([]byte("hello"))
+	}))
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "hello", res.Body.String())
 }

--- a/net/http/telemetry/telemetry.go
+++ b/net/http/telemetry/telemetry.go
@@ -9,6 +9,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+// Option configures OpenTelemetry HTTP instrumentation.
+type Option = otelhttp.Option
+
 // NewClientTrace returns a net/http/httptrace.ClientTrace that is integrated with
 // OpenTelemetry.
 //
@@ -53,7 +56,7 @@ func WithClientTrace(f func(context.Context) *httptrace.ClientTrace) otelhttp.Op
 // This function delegates to otelhttp.NewTransport. For exact semantics and
 // supported otelhttp.Option values, consult the upstream otelhttp documentation
 // for the version you vend.
-func NewTransport(base http.RoundTripper, opts ...otelhttp.Option) *otelhttp.Transport {
+func NewTransport(base http.RoundTripper, opts ...Option) *otelhttp.Transport {
 	return otelhttp.NewTransport(base, opts...)
 }
 

--- a/telemetry/metrics/doc.go
+++ b/telemetry/metrics/doc.go
@@ -23,7 +23,9 @@
 //     Config is non-nil (this allows DI to short-circuit metrics when reader
 //     construction fails or is intentionally omitted).
 //
-// When disabled, NewReader returns (nil, nil) and NewMeterProvider returns nil.
+// When disabled, NewReader returns (nil, nil) and NewMeterProvider installs and
+// returns this package's noop provider. IsEnabled reports whether the current global
+// provider is not that noop provider.
 //
 // # Exporters / readers
 //

--- a/telemetry/metrics/module.go
+++ b/telemetry/metrics/module.go
@@ -11,9 +11,12 @@ import "github.com/alexfalkowski/go-service/v2/di"
 //   - `NewMeter`, which returns a Meter scoped to the service name and instrumentation version.
 //
 // When metrics are disabled (`*Config` is nil), `NewReader` returns a nil reader and
-// `NewMeterProvider` returns a nil provider.
+// `NewMeterProvider` installs and returns the package noop provider.
 var Module = di.Module(
 	di.Constructor(NewReader),
 	di.Constructor(NewMeterProvider),
 	di.Constructor(NewMeter),
+	di.Register(registerMeterProvider),
 )
+
+func registerMeterProvider(_ MeterProvider) {}

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -9,9 +9,13 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/host"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
+
+var noopProvider metric.MeterProvider = noop.NewMeterProvider()
 
 // MeterProviderParams declares the dependencies required by NewMeterProvider.
 //
@@ -59,10 +63,11 @@ type MeterProviderParams struct {
 //
 // Provider shutdown errors are intentionally ignored to avoid blocking other stop hooks.
 //
-// If metrics are disabled or Reader is nil, it returns nil.
+// If metrics are disabled or Reader is nil, it installs and returns the package noop provider.
 func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	if !params.Config.IsEnabled() || params.Reader == nil {
-		return nil
+		otel.SetMeterProvider(noopProvider)
+		return noopProvider
 	}
 
 	reader := params.Reader
@@ -85,10 +90,21 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		OnStop: func(ctx context.Context) error {
 			// Do not return error as this will stop all others.
 			_ = provider.Shutdown(ctx)
+			otel.SetMeterProvider(noopProvider)
 
 			return nil
 		},
 	})
 
 	return provider
+}
+
+// IsEnabled reports whether metrics are backed by a non-noop provider installed by this package.
+func IsEnabled() bool {
+	return otel.GetMeterProvider() != noopProvider
+}
+
+// NewManualReader constructs an OpenTelemetry SDK manual metric reader.
+func NewManualReader() sdk.Reader {
+	return sdk.NewManualReader()
 }

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -1,0 +1,31 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestIsEnabled(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	require.False(t, metrics.IsEnabled())
+
+	provider := metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(t),
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+	require.NotNil(t, provider)
+	require.True(t, metrics.IsEnabled())
+}

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -12,7 +12,8 @@
 // # Enablement model
 //
 // Tracing is enabled by presence: a nil *Config indicates tracing is disabled.
-// When disabled, Register is a no-op.
+// When disabled, Register installs this package's noop provider. IsEnabled reports
+// whether the current global provider is not that noop provider.
 //
 // # Global provider installation
 //

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -10,7 +10,11 @@ import (
 	otlp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
+
+var noopProvider trace.TracerProvider = noop.NewTracerProvider()
 
 // TracerParams declares the dependencies required by Register.
 //
@@ -52,6 +56,7 @@ type TracerParams struct {
 // Shutdown errors are intentionally ignored to avoid blocking other stop hooks.
 func Register(params TracerParams) {
 	if !params.Config.IsEnabled() {
+		otel.SetTracerProvider(noopProvider)
 		return
 	}
 
@@ -76,8 +81,14 @@ func Register(params TracerParams) {
 			// Do not return error as this will stop all others.
 			_ = provider.Shutdown(ctx)
 			_ = exporter.Shutdown(ctx)
+			otel.SetTracerProvider(noopProvider)
 
 			return nil
 		},
 	})
+}
+
+// IsEnabled reports whether tracing is backed by a non-noop provider installed by this package.
+func IsEnabled() bool {
+	return otel.GetTracerProvider() != noopProvider
 }

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -1,0 +1,29 @@
+package tracer_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestIsEnabled(t *testing.T) {
+	t.Cleanup(func() {
+		tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	require.False(t, tracer.IsEnabled())
+
+	tracer.Register(tracer.TracerParams{
+		Lifecycle:   fxtest.NewLifecycle(t),
+		Config:      &tracer.Config{},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+	require.True(t, tracer.IsEnabled())
+}

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
@@ -57,6 +59,8 @@ func BenchmarkGRPC(b *testing.B) {
 
 	b.Run("none", func(b *testing.B) {
 		b.ReportAllocs()
+		disableTelemetry(b)
+		defer disableTelemetry(b)
 
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
@@ -188,4 +192,11 @@ func BenchmarkGRPC(b *testing.B) {
 		require.NoError(b, conn.Close())
 		lc.RequireStop()
 	})
+}
+
+func disableTelemetry(b *testing.B) {
+	b.Helper()
+
+	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(b)})
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(b)})
 }

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -8,6 +8,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/telemetry"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
@@ -264,8 +266,8 @@ type ClientConn = grpc.ClientConn
 
 // NewClient constructs and dials a gRPC client connection to target.
 //
-// It uses dial options derived from opts (see `NewDialOptions`) and always adds OpenTelemetry stats handling
-// via `grpc.WithStatsHandler(telemetry.NewClientHandler())` so that client RPCs are instrumented.
+// It uses dial options derived from opts (see `NewDialOptions`) and adds OpenTelemetry stats handling
+// when tracing or metrics are enabled.
 //
 // The returned connection should be closed by the caller when no longer needed.
 func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
@@ -274,7 +276,9 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 		return nil, err
 	}
 
-	os = append(os, grpc.WithStatsHandler(telemetry.NewClientHandler()))
+	if metrics.IsEnabled() || tracer.IsEnabled() {
+		os = append(os, grpc.WithStatsHandler(telemetry.NewClientHandler()))
+	}
 
 	return grpc.NewClient(target, os...)
 }

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -16,6 +16,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/server"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/telemetry"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
@@ -74,7 +76,7 @@ type ServerParams struct {
 // as not configured.
 //
 // The constructed server includes:
-//   - OpenTelemetry stats handling (server-side RPC instrumentation).
+//   - OpenTelemetry stats handling when tracing or metrics are enabled.
 //   - A unary interceptor chain that performs metadata extraction/injection, and optionally logging,
 //     token verification, and rate limiting, followed by any user-provided interceptors.
 //   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging
@@ -100,13 +102,17 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, prefix(err)
 	}
 
-	grpcServer := grpc.NewServer(params.Config.Options, params.Config.Timeout,
-		grpc.StatsHandler(telemetry.NewServerHandler()),
+	options := []grpc.ServerOption{
 		unaryServerOption(params, params.Unary...),
 		streamServerOption(params, params.Stream...),
 		maxReceiveSizeOption(params.Config),
 		opt,
-	)
+	}
+	if metrics.IsEnabled() || tracer.IsEnabled() {
+		options = append(options, grpc.StatsHandler(telemetry.NewServerHandler()))
+	}
+
+	grpcServer := grpc.NewServer(params.Config.Options, params.Config.Timeout, options...)
 	cfg := &config.Config{Address: cmp.Or(params.Config.Address, net.DefaultAddress("9090"))}
 
 	service, err := server.NewService("grpc", grpcServer, cfg, params.Logger, params.Shutdowner)

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -239,14 +239,14 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 	return hrt, nil
 }
 
-// NewClient constructs a new instrumented `http.Client`.
+// NewClient constructs a new `http.Client`.
 //
 // The returned client:
 //   - uses the RoundTripper stack built by `NewRoundTripper`, and
 //   - applies the configured client timeout (see `WithClientTimeout`).
 //
-// Note: `http.NewClient` wraps the provided transport with OpenTelemetry instrumentation, so requests
-// made with the returned client are traced/observed by default.
+// Note: `http.NewClient` wraps the provided transport with OpenTelemetry instrumentation when tracing
+// or metrics are enabled.
 func NewClient(opts ...ClientOption) (*http.Client, error) {
 	os := options(opts...)
 

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -115,12 +115,12 @@ func MaxBytesHandler(h Handler, n int64) Handler {
 	return http.MaxBytesHandler(h, n)
 }
 
-// HandleFunc registers handler for pattern on mux and wraps it with OpenTelemetry instrumentation.
+// HandleFunc registers handler for pattern on mux.
 func HandleFunc(mux *ServeMux, pattern string, handler HandlerFunc) {
 	http.HandleFunc(mux, pattern, handler)
 }
 
-// Handle registers handler for pattern on mux and wraps it with OpenTelemetry instrumentation.
+// Handle registers handler for pattern on mux.
 func Handle(mux *ServeMux, pattern string, handler Handler) {
 	http.Handle(mux, pattern, handler)
 }


### PR DESCRIPTION
## What

- Adds project-owned noop tracer and meter provider detection.
- Skips HTTP, gRPC, SQL, and Redis telemetry instrumentation when tracing/metrics are disabled.
- Adds disabled/enabled benchmarks for HTTP, gRPC, SQL, and Redis cache telemetry paths.
- Wires SQL and cache benchmarks into `make benchmarks`.
- Adds focused coverage for HTTP telemetry-disabled handling, max body wrapper behavior, SQL wrapper access, and telemetry provider enabled detection.

## Why

Disabled telemetry should avoid paying OpenTelemetry wrapper and hook allocation costs on hot paths. This keeps constructors free from extra telemetry config plumbing while allowing instrumentation code to cheaply detect whether tracing or metrics are active.

## Testing

Passed:

- `go test ./...`
- `make lint`
- `git diff --check`
- `make sql-benchmarks`
- `make cache-benchmarks`
- `go test -coverprofile=/private/tmp/net-http.cover ./net/http`
- focused benchmark runs for HTTP, gRPC, SQL, and cache telemetry paths.