### PR TITLE
feat(tls): add explicit mtls ca configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ feature:
   tls:
     cert: file:test/certs/client-cert.pem
     key: file:test/certs/client-key.pem
+    ca: file:test/certs/rootCA.pem
+    server_name: localhost
 ```
 
 Notes:
@@ -789,11 +791,17 @@ transport:
     tls:
       cert: file:test/certs/cert.pem
       key: file:test/certs/key.pem
+      ca: file:test/certs/rootCA.pem
   grpc:
     tls:
       cert: file:test/certs/cert.pem
       key: file:test/certs/key.pem
+      ca: file:test/certs/rootCA.pem
 ```
+
+Set `ca` on server TLS config to require and verify client certificates for mTLS. Set `ca` on client TLS
+config to verify server certificates issued by the same local or private CA. `server_name` is only needed
+on clients when the dial address differs from the certificate DNS name.
 
 Important note:
 
@@ -874,6 +882,7 @@ debug:
   tls:
     cert: file:test/certs/cert.pem
     key: file:test/certs/key.pem
+    ca: file:test/certs/rootCA.pem
 ```
 
 All debug endpoints are namespaced by service name: `/<name>/debug/...`.

--- a/config/client/config.go
+++ b/config/client/config.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"github.com/alexfalkowski/go-service/v2/config/options"
-	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls"
+	tlsconfig "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/limiter"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/retry"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
@@ -15,7 +17,7 @@ type Config struct {
 	Limiter *limiter.Config `yaml:"limiter,omitempty" json:"limiter,omitempty" toml:"limiter,omitempty"`
 
 	// TLS configures client-side TLS settings (for example trusted roots, certs, and keys where applicable).
-	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
+	TLS *tlsconfig.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Token configures client-side token handling (for example minting/attaching auth tokens).
 	Token *token.Config `yaml:"token,omitempty" json:"token,omitempty" toml:"token,omitempty"`
@@ -38,4 +40,42 @@ type Config struct {
 // IsEnabled reports whether client configuration is present.
 func (c *Config) IsEnabled() bool {
 	return c != nil
+}
+
+// NewConfig constructs a client-side runtime TLS config from cfg.
+//
+// It uses CA as RootCAs and uses any configured certificate/key pair as the
+// client certificate presented to servers that request one. If ServerName is
+// configured, it is copied into the runtime TLS config for server certificate
+// hostname verification.
+func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if !cfg.IsEnabled() {
+		return config, nil
+	}
+
+	if cfg.HasKeyPair() {
+		pair, err := tlsconfig.NewKeyPair(fs, cfg)
+		if err != nil {
+			return config, err
+		}
+
+		config.Certificates = []tls.Certificate{pair}
+	}
+
+	if cfg.HasCA() {
+		pool, err := tlsconfig.NewCertPool(fs, cfg)
+		if err != nil {
+			return config, err
+		}
+
+		config.RootCAs = pool
+	}
+
+	config.ServerName = cfg.ServerName
+
+	return config, nil
 }

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -1,0 +1,94 @@
+package client_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/config/client"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	require.False(t, (*client.Config)(nil).IsEnabled())
+	require.True(t, (&client.Config{}).IsEnabled())
+}
+
+func TestNewConfig(t *testing.T) {
+	tlsConfig, err := client.NewConfig(test.FS, test.NewTLSClientConfig())
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	require.Len(t, tlsConfig.Certificates, 1)
+	require.NotNil(t, tlsConfig.RootCAs)
+	require.Equal(t, "localhost", tlsConfig.ServerName)
+
+	data, err := test.FS.ReadSource(test.FilePath("certs/cert.pem"))
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	_, err = cert.Verify(x509.VerifyOptions{DNSName: tlsConfig.ServerName, Roots: tlsConfig.RootCAs})
+	require.NoError(t, err)
+}
+
+func TestNewConfigDefaults(t *testing.T) {
+	tests := []struct {
+		config *config.Config
+		name   string
+	}{
+		{name: "nil"},
+		{name: "empty", config: &config.Config{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tlsConfig, err := client.NewConfig(test.FS, tt.config)
+			require.NoError(t, err)
+			require.NotNil(t, tlsConfig)
+			require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+			require.Empty(t, tlsConfig.Certificates)
+			require.Nil(t, tlsConfig.RootCAs)
+			require.Empty(t, tlsConfig.ServerName)
+		})
+	}
+}
+
+func TestNewConfigWithKeyPairOnly(t *testing.T) {
+	tlsConfig, err := client.NewConfig(test.FS, &config.Config{
+		Cert: test.FilePath("certs/client-cert.pem"),
+		Key:  test.FilePath("certs/client-key.pem"),
+	})
+	require.NoError(t, err)
+	require.Len(t, tlsConfig.Certificates, 1)
+	require.Nil(t, tlsConfig.RootCAs)
+}
+
+func TestNewConfigWithCAOnly(t *testing.T) {
+	tlsConfig, err := client.NewConfig(test.FS, &config.Config{CA: test.FilePath("certs/rootCA.pem")})
+	require.NoError(t, err)
+	require.Empty(t, tlsConfig.Certificates)
+	require.NotNil(t, tlsConfig.RootCAs)
+}
+
+func TestNewConfigInvalidKeyPair(t *testing.T) {
+	_, err := client.NewConfig(test.FS, &config.Config{
+		Cert: test.FilePath("certs/client-cert.pem"),
+		Key:  test.FilePath("secrets/none"),
+	})
+	require.Error(t, err)
+}
+
+func TestNewConfigInvalidCA(t *testing.T) {
+	_, err := client.NewConfig(test.FS, &config.Config{CA: "invalid ca"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, config.ErrInvalidCA))
+}

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -3,8 +3,10 @@ package server
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
-	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls"
+	tlsconfig "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/limiter"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/retry"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
@@ -22,7 +24,7 @@ type Config struct {
 	Retry *retry.Config `yaml:"retry,omitempty" json:"retry,omitempty" toml:"retry,omitempty"`
 
 	// TLS configures server-side TLS (certificate and key material).
-	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
+	TLS *tlsconfig.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Token configures server-side token validation/handling.
 	Token *token.Config `yaml:"token,omitempty" json:"token,omitempty" toml:"token,omitempty"`
@@ -60,4 +62,40 @@ func (c *Config) GetMaxReceiveSize() bytes.Size {
 	}
 
 	return c.MaxReceiveSize
+}
+
+// NewConfig constructs a server-side runtime TLS config from cfg.
+//
+// If cfg has a CA configured, NewConfig uses it as ClientCAs and sets
+// ClientAuth to tls.RequireAndVerifyClientCert. Without CA, the server config
+// does not request client certificates.
+func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if !cfg.IsEnabled() {
+		return config, nil
+	}
+
+	if cfg.HasKeyPair() {
+		pair, err := tlsconfig.NewKeyPair(fs, cfg)
+		if err != nil {
+			return config, err
+		}
+
+		config.Certificates = []tls.Certificate{pair}
+	}
+
+	if cfg.HasCA() {
+		pool, err := tlsconfig.NewCertPool(fs, cfg)
+		if err != nil {
+			return config, err
+		}
+
+		config.ClientCAs = pool
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return config, nil
 }

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -1,10 +1,15 @@
 package server_test
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/server"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -30,4 +35,86 @@ func TestGetMaxReceiveSize(t *testing.T) {
 func TestConfigRejectsNegativeMaxReceiveSize(t *testing.T) {
 	cfg := &server.Config{MaxReceiveSize: -1}
 	require.Error(t, test.Validator.Struct(cfg))
+}
+
+func TestConfig(t *testing.T) {
+	require.False(t, (*server.Config)(nil).IsEnabled())
+	require.True(t, (&server.Config{}).IsEnabled())
+}
+
+func TestNewConfig(t *testing.T) {
+	tlsConfig, err := server.NewConfig(test.FS, test.NewTLSServerConfig())
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	require.Len(t, tlsConfig.Certificates, 1)
+	require.NotNil(t, tlsConfig.ClientCAs)
+	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+
+	data, err := test.FS.ReadSource(test.FilePath("certs/client-cert.pem"))
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	_, err = cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
+	require.NoError(t, err)
+}
+
+func TestNewConfigDefaults(t *testing.T) {
+	tests := []struct {
+		config *config.Config
+		name   string
+	}{
+		{name: "nil"},
+		{name: "empty", config: &config.Config{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tlsConfig, err := server.NewConfig(test.FS, tt.config)
+			require.NoError(t, err)
+			require.NotNil(t, tlsConfig)
+			require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+			require.Empty(t, tlsConfig.Certificates)
+			require.Nil(t, tlsConfig.ClientCAs)
+			require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+		})
+	}
+}
+
+func TestNewConfigWithKeyPairOnly(t *testing.T) {
+	tlsConfig, err := server.NewConfig(test.FS, &config.Config{
+		Cert: test.FilePath("certs/cert.pem"),
+		Key:  test.FilePath("certs/key.pem"),
+	})
+	require.NoError(t, err)
+	require.Len(t, tlsConfig.Certificates, 1)
+	require.Nil(t, tlsConfig.ClientCAs)
+	require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+}
+
+func TestNewConfigWithCAOnly(t *testing.T) {
+	tlsConfig, err := server.NewConfig(test.FS, &config.Config{CA: test.FilePath("certs/rootCA.pem")})
+	require.NoError(t, err)
+	require.Empty(t, tlsConfig.Certificates)
+	require.NotNil(t, tlsConfig.ClientCAs)
+	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+}
+
+func TestNewConfigInvalidKeyPair(t *testing.T) {
+	_, err := server.NewConfig(test.FS, &config.Config{
+		Cert: test.FilePath("certs/cert.pem"),
+		Key:  test.FilePath("secrets/none"),
+	})
+	require.Error(t, err)
+}
+
+func TestNewConfigInvalidCA(t *testing.T) {
+	_, err := server.NewConfig(test.FS, &config.Config{CA: "invalid ca"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, config.ErrInvalidCA))
 }

--- a/crypto/tls/config/config.go
+++ b/crypto/tls/config/config.go
@@ -1,37 +1,56 @@
 package config
 
 import (
+	"crypto/x509"
+
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
+// ErrInvalidCA is returned when configured CA PEM does not contain any certificates.
+var ErrInvalidCA = errors.New("tls: invalid ca")
+
 // Config configures TLS key material loading from go-service source strings.
 //
-// Cert and Key are "source strings" resolved by `os.FS.ReadSource`.
+// Cert, Key, and CA are "source strings" resolved by `os.FS.ReadSource`.
 // They may be:
 //   - "env:NAME" to read PEM bytes from environment variable NAME,
 //   - "file:/path/to/pem" to read PEM bytes from a file, or
 //   - any other value treated as the literal PEM content.
 //
-// This config is intentionally minimal: it only models the leaf
-// certificate/private-key pair that `NewConfig` loads into a runtime TLS
-// config. It does not model trust roots, client CA pools, cipher suites,
-// ALPN, session tickets, or the many other knobs on `crypto/tls.Config`.
+// This config is intentionally minimal: it models leaf certificate/private-key
+// material, an optional peer CA bundle, and an optional client-side server name.
+// It does not model cipher suites, ALPN, session tickets, or the many other
+// knobs on `crypto/tls.Config`.
 type Config struct {
 	// Cert is a "source string" for the TLS certificate (PEM-encoded).
 	//
 	// The resolved value must contain a PEM-encoded certificate suitable for
 	// tls.X509KeyPair. Its contents are not parsed or validated until
-	// `NewConfig` is called.
+	// a runtime TLS config is constructed.
 	Cert string `yaml:"cert,omitempty" json:"cert,omitempty" toml:"cert,omitempty"`
 
 	// Key is a "source string" for the TLS private key (PEM-encoded).
 	//
 	// The resolved value must contain a PEM-encoded private key suitable for
 	// tls.X509KeyPair. Its contents are not parsed or validated until
-	// `NewConfig` is called.
+	// a runtime TLS config is constructed.
 	Key string `yaml:"key,omitempty" json:"key,omitempty" toml:"key,omitempty"`
+
+	// CA is a "source string" for the peer CA bundle (PEM-encoded).
+	//
+	// Server TLS config uses CA as the client CA pool. Client TLS config uses CA
+	// as the root CA pool for verifying the server certificate.
+	CA string `yaml:"ca,omitempty" json:"ca,omitempty" toml:"ca,omitempty"`
+
+	// ServerName is the optional server name clients use for certificate verification.
+	//
+	// Leave this empty when the transport can infer the server name from the
+	// dial target or request URL. Set it when the dial address differs from the
+	// certificate's DNS name, such as dialing 127.0.0.1 with a localhost cert.
+	ServerName string `yaml:"server_name,omitempty" json:"server_name,omitempty" toml:"server_name,omitempty"`
 }
 
 // IsEnabled reports whether TLS configuration is present.
@@ -49,7 +68,15 @@ func (c *Config) IsEnabled() bool {
 // that the resolved contents are readable, well-formed PEM, or that they form a
 // valid X.509 key pair.
 func (c *Config) HasKeyPair() bool {
-	return !strings.IsEmpty(c.Cert) && !strings.IsEmpty(c.Key)
+	return c != nil && !strings.IsEmpty(c.Cert) && !strings.IsEmpty(c.Key)
+}
+
+// HasCA reports whether a peer CA source is configured.
+//
+// This only checks that the source string is non-empty. It does not validate
+// that the resolved contents are readable or contain PEM-encoded certificates.
+func (c *Config) HasCA() bool {
+	return c != nil && !strings.IsEmpty(c.CA)
 }
 
 // GetCert resolves and returns the certificate bytes from the configured source
@@ -70,59 +97,46 @@ func (c *Config) GetKey(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.Key)
 }
 
-// NewConfig constructs a runtime `*crypto/tls.Config` from cfg.
+// GetCA resolves and returns the peer CA bytes from the configured source
+// string.
 //
-// # Defaults
-//
-// NewConfig always applies the following defaults:
-//   - MinVersion: TLS 1.2 (tls.VersionTLS12)
-//   - ClientAuth: require and verify client certificates (mTLS) via tls.RequireAndVerifyClientCert
-//
-// These defaults are conservative service-to-service defaults. Callers that
-// need to adjust additional runtime TLS settings can modify the returned config
-// after construction.
-//
-// # Key material loading
-//
-// If cfg is nil (disabled) or cfg does not have both a certificate and key configured (see cfg.HasKeyPair),
-// NewConfig returns a config with the defaults above and does not attempt to load any key material.
-//
-// When cfg is enabled and has a key pair, certificate and key bytes are resolved via the provided filesystem
-// using go-service "source strings" (literal value, `file:` path, or `env:` reference). The resolved PEM
-// is then parsed using tls.X509KeyPair and attached to the returned config.
-//
-// # Errors
-//
-// NewConfig returns the partially constructed config along with any error encountered while resolving the
-// certificate/key sources or parsing them as an X.509 key pair.
-//
-// The returned config contains no leaf certificates when TLS is disabled or no
-// key pair is configured.
-func NewConfig(fs *os.FS, cfg *Config) (*tls.Config, error) {
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		ClientAuth: tls.RequireAndVerifyClientCert,
-	}
+// It delegates to `fs.ReadSource(c.CA)` and returns any read/resolve error
+// from that operation.
+func (c *Config) GetCA(fs *os.FS) ([]byte, error) {
+	return fs.ReadSource(c.CA)
+}
 
-	if !cfg.IsEnabled() || !cfg.HasKeyPair() {
-		return tlsConfig, nil
-	}
-
+// NewKeyPair resolves and parses cfg's configured leaf certificate/private-key pair.
+func NewKeyPair(fs *os.FS, cfg *Config) (tls.Certificate, error) {
 	cert, err := cfg.GetCert(fs)
 	if err != nil {
-		return tlsConfig, err
+		return tls.Certificate{}, err
 	}
 
 	key, err := cfg.GetKey(fs)
 	if err != nil {
-		return tlsConfig, err
+		return tls.Certificate{}, err
 	}
 
 	pair, err := tls.X509KeyPair(cert, key)
 	if err != nil {
-		return tlsConfig, err
+		return tls.Certificate{}, err
 	}
 
-	tlsConfig.Certificates = []tls.Certificate{pair}
-	return tlsConfig, nil
+	return pair, nil
+}
+
+// NewCertPool resolves and parses cfg's configured CA bundle.
+func NewCertPool(fs *os.FS, cfg *Config) (*x509.CertPool, error) {
+	ca, err := cfg.GetCA(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca) {
+		return nil, ErrInvalidCA
+	}
+
+	return pool, nil
 }

--- a/crypto/tls/config/config_test.go
+++ b/crypto/tls/config/config_test.go
@@ -1,9 +1,12 @@
 package config_test
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -15,13 +18,15 @@ func TestConfig(t *testing.T) {
 	}{
 		{name: "nil config", config: nil},
 		{name: "empty config", config: &tls.Config{}},
+		{name: "valid config", config: test.NewTLSConfig("certs/cert.pem", "certs/key.pem")},
 	}
 
 	for _, tt := range validTests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := tls.NewConfig(test.FS, tt.config)
-			require.NoError(t, err)
-			require.NotNil(t, config)
+			if tt.config.HasKeyPair() {
+				_, err := tls.NewKeyPair(test.FS, tt.config)
+				require.NoError(t, err)
+			}
 		})
 	}
 
@@ -36,8 +41,38 @@ func TestConfig(t *testing.T) {
 
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tls.NewConfig(test.FS, tt.config)
+			_, err := tls.NewKeyPair(test.FS, tt.config)
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestNewCertPool(t *testing.T) {
+	pool, err := tls.NewCertPool(test.FS, test.NewTLSServerConfig())
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+
+	data, err := test.FS.ReadSource(test.FilePath("certs/client-cert.pem"))
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	_, err = cert.Verify(x509.VerifyOptions{Roots: pool})
+	require.NoError(t, err)
+}
+
+func TestNewCertPoolInvalid(t *testing.T) {
+	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: "invalid ca"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, tls.ErrInvalidCA))
+}
+
+func TestNewCertPoolSourceError(t *testing.T) {
+	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: test.FilePath("certs/missing.pem")})
+	require.Error(t, err)
+	require.False(t, errors.Is(err, tls.ErrInvalidCA))
 }

--- a/crypto/tls/config/doc.go
+++ b/crypto/tls/config/doc.go
@@ -3,12 +3,13 @@
 //
 // This package is the configuration-facing counterpart to `crypto/tls`.
 // It contains:
-//   - the lightweight `Config` struct used to describe certificate and key
-//     source strings in decoded application config, and
-//   - `NewConfig`, which resolves those source strings and materializes a
-//     runtime `*crypto/tls.Config`.
+//   - the lightweight `Config` struct used to describe certificate, key, CA,
+//     and server-name settings in decoded application config, and
+//   - helper functions that resolve those source strings into runtime TLS key
+//     material.
 //
-// Use this package in higher-level config and transport code. Use `crypto/tls`
+// Use `config/server.NewConfig` and `config/client.NewConfig` when code needs a
+// runtime `*crypto/tls.Config` for a specific TLS role. Use `crypto/tls`
 // directly when code already has a runtime TLS config and only needs low-level
 // TLS types or helpers.
 package config

--- a/debug/doc.go
+++ b/debug/doc.go
@@ -22,7 +22,7 @@
 // # TLS
 //
 // When TLS is enabled for the debug server, the package uses
-// `crypto/tls/config.NewConfig` to resolve `crypto/tls/config.Config` source
+// `config/server.NewConfig` to resolve `crypto/tls/config.Config` source
 // strings and build the runtime `*crypto/tls.Config` assigned to the underlying
 // HTTP server.
 //

--- a/debug/server.go
+++ b/debug/server.go
@@ -3,14 +3,14 @@ package debug
 import (
 	"cmp"
 
-	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/config/server"
 	debug "github.com/alexfalkowski/go-service/v2/debug/http"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
-	"github.com/alexfalkowski/go-service/v2/net/http/server"
+	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 )
@@ -25,7 +25,7 @@ import (
 //   - Mux: the debug HTTP mux where debug endpoints (pprof/fgprof/statsviz/psutil/etc.) are registered.
 //   - Config: enables and configures the debug server (address/timeout/TLS/options).
 //   - Logger: used by the underlying HTTP service wrapper.
-//   - FS: filesystem used to resolve TLS certificate/key source strings when TLS is enabled.
+//   - FS: filesystem used to resolve TLS source strings when TLS is enabled.
 type ServerParams struct {
 	di.In
 	Shutdowner di.Shutdowner
@@ -63,7 +63,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, prefix(err)
 	}
 
-	service, err := server.NewService("debug", httpServer, cfg, params.Logger, params.Shutdowner)
+	service, err := httpserver.NewService("debug", httpServer, cfg, params.Logger, params.Shutdowner)
 	if err != nil {
 		return nil, prefix(err)
 	}
@@ -73,17 +73,17 @@ func NewServer(params ServerParams) (*Server, error) {
 
 // Server wraps the managed debug HTTP service.
 //
-// The embedded *server.Service provides lifecycle integration and start/stop behavior.
+// The embedded *httpserver.Service provides lifecycle integration and start/stop behavior.
 // This wrapper adds a nil-safe accessor via GetService.
 type Server struct {
-	*server.Service
+	*httpserver.Service
 }
 
 // GetService returns the underlying service.
 //
 // It is nil-safe: if the receiver is nil (e.g. debug server disabled and not constructed), GetService
 // returns nil.
-func (s *Server) GetService() *server.Service {
+func (s *Server) GetService() *httpserver.Service {
 	if s == nil {
 		return nil
 	}
@@ -98,7 +98,7 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 		return config, nil
 	}
 
-	tlsConfig, err := tls.NewConfig(fs, cfg.TLS)
+	tlsConfig, err := server.NewConfig(fs, cfg.TLS)
 	if err != nil {
 		return nil, prefix(err)
 	}

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -155,11 +155,13 @@ func NewTLSServerConfig() *tls.Config {
 	return NewTLSConfig("certs/cert.pem", "certs/key.pem")
 }
 
-// NewTLSConfig returns a TLS config that resolves the given certificate and key relative to `test/`.
+// NewTLSConfig returns a TLS config that resolves test TLS fixtures relative to `test/`.
 func NewTLSConfig(c, k string) *tls.Config {
 	tc := &tls.Config{
-		Cert: FilePath(c),
-		Key:  FilePath(k),
+		Cert:       FilePath(c),
+		Key:        FilePath(k),
+		CA:         FilePath("certs/rootCA.pem"),
+		ServerName: "localhost",
 	}
 
 	return tc

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"github.com/alexfalkowski/go-service/v2/config/client"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
@@ -127,8 +128,8 @@ func WithClientBreaker(opts ...breaker.Option) ClientOption {
 
 // WithClientTLS enables TLS for the client connection using sec.
 //
-// TLS configuration is materialized when building dial options. If TLS is enabled, certificate/key
-// sources may be resolved via the package-registered filesystem (see the package `Register` function).
+// TLS configuration is materialized when building dial options. If TLS is enabled, source strings may be
+// resolved via the package-registered filesystem (see the package `Register` function).
 func WithClientTLS(sec *tls.Config) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.security = sec
@@ -216,7 +217,7 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //
 // Transport security:
 //   - if TLS is enabled, TLS config is constructed using the package-registered filesystem (see `Register`)
-//     to resolve certificate and key sources.
+//     to resolve TLS source strings.
 //   - otherwise, insecure transport credentials are used.
 func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
 	os := options(opts...)
@@ -231,7 +232,7 @@ func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
 
 	var security grpc.DialOption
 	if os.security.IsEnabled() {
-		conf, err := tls.NewConfig(fs, os.security)
+		conf, err := client.NewConfig(fs, os.security)
 		if err != nil {
 			return nil, err
 		}

--- a/transport/grpc/doc.go
+++ b/transport/grpc/doc.go
@@ -29,8 +29,8 @@
 // # Manual composition note (TLS filesystem)
 //
 // This package uses package-level registration to inject filesystem access used when constructing TLS configuration.
-// The registered filesystem is used by `crypto/tls/config.NewConfig` to
-// resolve certificate/key "source strings" (for example `file:/path/to/cert`
+// The registered filesystem is used by `config/server.NewConfig` and `config/client.NewConfig`
+// to resolve TLS "source strings" (for example `file:/path/to/cert`
 // or `env:VAR`) during TLS configuration.
 //
 // When you use `Module` (directly or through higher-level bundles such as `module.Server`), DI performs

--- a/transport/grpc/module.go
+++ b/transport/grpc/module.go
@@ -19,7 +19,7 @@ import (
 //   - health service wiring (`net/grpc/health.Module`)
 //
 // This module also registers `Register`, which injects the filesystem dependency used by this package
-// (required when constructing TLS configuration from certificate/key source strings).
+// (required when constructing TLS configuration from source strings).
 var Module = di.Module(
 	di.Register(Register),
 	di.Constructor(NewServerLimiter),

--- a/transport/grpc/register.go
+++ b/transport/grpc/register.go
@@ -9,7 +9,7 @@ var fs *os.FS
 // Register injects the filesystem dependency used by this package.
 //
 // The registered filesystem is consulted when constructing TLS configuration for both clients and servers.
-// It is used by `crypto/tls/config.NewConfig` to resolve certificate/key
+// It is used by `config/server.NewConfig` and `config/client.NewConfig` to resolve TLS
 // "source strings" (for example `file:/path/to/cert` or `env:VAR`) via the
 // `os.FS.ReadSource` helper when materializing a runtime `*crypto/tls.Config`.
 //

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -4,7 +4,7 @@ import (
 	"cmp"
 	"math"
 
-	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -13,7 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/server"
+	grpcserver "github.com/alexfalkowski/go-service/v2/net/grpc/server"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/telemetry"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
@@ -115,7 +115,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	grpcServer := grpc.NewServer(params.Config.Options, params.Config.Timeout, options...)
 	cfg := &config.Config{Address: cmp.Or(params.Config.Address, net.DefaultAddress("9090"))}
 
-	service, err := server.NewService("grpc", grpcServer, cfg, params.Logger, params.Shutdowner)
+	service, err := grpcserver.NewService("grpc", grpcServer, cfg, params.Logger, params.Shutdowner)
 	if err != nil {
 		return nil, prefix(err)
 	}
@@ -125,12 +125,12 @@ func NewServer(params ServerParams) (*Server, error) {
 
 // Server wraps a configured gRPC server and its runnable service wrapper.
 //
-// The embedded `*server.Service` provides start/stop orchestration and integrates with the application's
+// The embedded `*grpcserver.Service` provides start/stop orchestration and integrates with the application's
 // lifecycle, while the underlying `*grpc.Server` is used as the `grpc.ServiceRegistrar` for registering
 // service implementations.
 type Server struct {
 	server *grpc.Server
-	*server.Service
+	*grpcserver.Service
 }
 
 // ServiceRegistrar returns the underlying gRPC service registrar.
@@ -149,7 +149,7 @@ func (s *Server) ServiceRegistrar() grpc.ServiceRegistrar {
 // It returns nil if s is nil (for example, when the transport is disabled).
 // This method is commonly used by higher-level wiring to collect enabled server services for lifecycle
 // registration (see `transport.NewServers` and `net/server.Register`).
-func (s *Server) GetService() *server.Service {
+func (s *Server) GetService() *grpcserver.Service {
 	if s == nil {
 		return nil
 	}
@@ -203,7 +203,7 @@ func credsServerOption(fs *os.FS, cfg *Config) (grpc.ServerOption, error) {
 		return grpc.EmptyServerOption{}, nil
 	}
 
-	conf, err := tls.NewConfig(fs, cfg.TLS)
+	conf, err := server.NewConfig(fs, cfg.TLS)
 	if err != nil {
 		return grpc.EmptyServerOption{}, prefix(err)
 	}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/alexfalkowski/go-service/v2/config/client"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
@@ -147,7 +148,7 @@ func WithClientUserAgent(userAgent env.UserAgent) ClientOption {
 // round tripper is provided explicitly, it is used as-is.
 //
 // If TLS is enabled and no base round tripper is provided, TLS config is constructed using the package-
-// registered filesystem dependency (see `Register` in this package) to resolve certificate/key sources.
+// registered filesystem dependency (see `Register` in this package) to resolve TLS source strings.
 func WithClientTLS(sec *tls.Config) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.tls = sec
@@ -268,7 +269,7 @@ func roundTripper(os *clientOpts) (http.RoundTripper, error) {
 		return http.Transport(nil), nil
 	}
 
-	conf, err := tls.NewConfig(fs, os.tls)
+	conf, err := client.NewConfig(fs, os.tls)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/http/doc.go
+++ b/transport/http/doc.go
@@ -44,7 +44,7 @@
 //
 // This package uses package-level registration to inject filesystem access used when constructing TLS
 // configuration. The registered filesystem is used by
-// `crypto/tls/config.NewConfig` to resolve certificate/key "source strings"
+// `config/server.NewConfig` and `config/client.NewConfig` to resolve TLS "source strings"
 // (for example `file:/path/to/cert` or `env:VAR`) when materializing the
 // runtime `*crypto/tls.Config`.
 //

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSecure(t *testing.T) {
-	world := test.NewStartedWorld(t, test.WithWorldSecure(), test.WithWorldTelemetry("prometheus"), test.WithWorldHTTP())
+	world := test.NewStartedWorld(t, test.WithWorldSecure(), test.WithWorldTelemetry("prometheus"), test.WithWorldHTTP(), test.WithWorldHello())
 
 	client, err := world.NewHTTP(
 		breaker.WithSettings(breaker.Settings{}),
@@ -18,7 +18,7 @@ func TestSecure(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://github.com/alexfalkowski", http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, world.PathServerURL("https", "hello"), http.NoBody)
 	require.NoError(t, err)
 
 	resp, err := client.Do(req)

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -25,7 +25,7 @@ import (
 //   - operational endpoints (Prometheus metrics and health)
 //
 // This module also registers `Register`, which injects the filesystem dependency used by this package
-// (required when constructing TLS configuration from certificate/key source strings).
+// (required when constructing TLS configuration from source strings).
 var Module = di.Module(
 	di.Register(Register),
 	di.Constructor(http.NewServeMux),

--- a/transport/http/register.go
+++ b/transport/http/register.go
@@ -9,7 +9,7 @@ var fs *os.FS
 // Register injects the filesystem dependency used by this package.
 //
 // The registered filesystem is consulted when constructing TLS configuration for both clients and servers.
-// It is used by `crypto/tls/config.NewConfig` to resolve certificate/key
+// It is used by `config/server.NewConfig` and `config/client.NewConfig` to resolve TLS
 // "source strings" (for example `file:/path/to/cert` or `env:VAR`) via the
 // `os.FS.ReadSource` helper when materializing a runtime `*crypto/tls.Config`.
 //

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -3,7 +3,7 @@ package http
 import (
 	"cmp"
 
-	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -12,7 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
-	"github.com/alexfalkowski/go-service/v2/net/http/server"
+	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/transport/http/body"
 	"github.com/alexfalkowski/go-service/v2/transport/http/limiter"
@@ -92,7 +92,7 @@ type ServerParams struct {
 // TLS:
 //
 // If TLS is enabled, TLS configuration is constructed using the package-registered filesystem dependency
-// (see `Register` in this package) to resolve certificate/key "source strings" (for example `file:` or `env:`).
+// (see `Register` in this package) to resolve TLS "source strings" (for example `file:` or `env:`).
 //
 // Inbound size limits:
 //
@@ -136,7 +136,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, prefix(err)
 	}
 
-	service, err := server.NewService("http", httpServer, cfg, params.Logger, params.Shutdowner)
+	service, err := httpserver.NewService("http", httpServer, cfg, params.Logger, params.Shutdowner)
 	if err != nil {
 		return nil, prefix(err)
 	}
@@ -146,10 +146,10 @@ func NewServer(params ServerParams) (*Server, error) {
 
 // Server wraps an HTTP server service wrapper.
 //
-// The embedded `*server.Service` provides start/stop orchestration and integrates with the application's
+// The embedded `*httpserver.Service` provides start/stop orchestration and integrates with the application's
 // lifecycle.
 type Server struct {
-	*server.Service
+	*httpserver.Service
 }
 
 // GetService returns the runnable service wrapper.
@@ -157,7 +157,7 @@ type Server struct {
 // It returns nil if s is nil (for example, when the transport is disabled).
 // This method is commonly used by higher-level wiring to collect enabled server services for lifecycle
 // registration (see `transport.NewServers` and `net/server.Register`).
-func (s *Server) GetService() *server.Service {
+func (s *Server) GetService() *httpserver.Service {
 	if s == nil {
 		return nil
 	}
@@ -172,7 +172,7 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 		return config, nil
 	}
 
-	tlsConfig, err := tls.NewConfig(fs, cfg.TLS)
+	tlsConfig, err := server.NewConfig(fs, cfg.TLS)
 	if err != nil {
 		return nil, prefix(err)
 	}


### PR DESCRIPTION
## What

- Added `ca` and `server_name` support to TLS config.
- Moved runtime TLS construction into `config/client.NewConfig` and `config/server.NewConfig`.
- Server TLS now uses `ca` as `ClientCAs` and enables `RequireAndVerifyClientCert`.
- Client TLS now uses `ca` as `RootCAs` and supports optional `server_name`.
- Added exported `tls/config.ErrInvalidCA` for `errors.Is` checks.
- Updated docs, test fixtures, and HTTP/gRPC/debug wiring.

## Why

This makes mTLS explicit and role-aware: servers verify client certificates with configured client CAs, and clients verify server certificates with configured root CAs.

## Testing

- `go test ./crypto/tls/config ./config/client ./config/server`
- `go test ./transport/http ./transport/grpc ./debug`
- `go test ./...`
- `make lint`
- `git diff --check`