### PR TITLE
feat(content): media parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/cristalhq/acmd v0.12.0
 	github.com/docker/go-units v0.5.0
-	github.com/elnormous/contenttype v1.0.4
 	github.com/faabiosr/cachego v0.26.0
 	github.com/felixge/fgprof v0.9.5
 	github.com/felixge/httpsnoop v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/elnormous/contenttype v1.0.4 h1:FjmVNkvQOGqSX70yvocph7keC8DtmJaLzTTq6ZOQCI8=
-github.com/elnormous/contenttype v1.0.4/go.mod h1:5KTOW8m1kdX1dLMiUJeN9szzR2xkngiv2K+RVZwWBbI=
 github.com/faabiosr/cachego v0.26.0 h1:EDDv2y9T0XJ4Cx3tUhbKSUayGWxCGkkZUivNLceHRWY=
 github.com/faabiosr/cachego v0.26.0/go.mod h1:p54WXVzeB1CctH1ix/rjqv1EotNzD0Xoxk2IsR1PQX8=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -4,7 +4,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-sync"
-	content "github.com/elnormous/contenttype"
 )
 
 // TypeKey is the HTTP header key used for Content-Type.
@@ -41,38 +40,12 @@ type Content struct {
 //
 // Note: this parses the request Content-Type, not the Accept header.
 func (c *Content) NewFromRequest(req *http.Request) Media {
-	return c.resolveRequestMedia(req)
+	return NewMedia(req.Header.Get(TypeKey), c.enc)
 }
 
 // NewFromMedia parses mediaType and returns a matching Media.
 //
 // If parsing fails, it falls back to JSON.
 func (c *Content) NewFromMedia(mediaType string) Media {
-	return c.resolveMediaType(mediaType)
-}
-
-func (c *Content) resolveRequestMedia(req *http.Request) Media {
-	if media, ok := knownMedia(req.Header.Get(TypeKey), c.enc); ok {
-		return media
-	}
-
-	t, err := content.GetMediaType(req)
-	if err != nil {
-		return jsonMedia(c.enc)
-	}
-
-	return newMedia(t, c.enc)
-}
-
-func (c *Content) resolveMediaType(mediaType string) Media {
-	if media, ok := knownMedia(mediaType, c.enc); ok {
-		return media
-	}
-
-	t, err := content.ParseMediaType(mediaType)
-	if err != nil {
-		return jsonMedia(c.enc)
-	}
-
-	return newMedia(t, c.enc)
+	return NewMedia(mediaType, c.enc)
 }

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -35,6 +35,14 @@ func TestNewFromRequest(t *testing.T) {
 	}
 }
 
+func TestNewFromMediaWithParameters(t *testing.T) {
+	media := test.Content.NewFromMedia("application/json; charset=utf-8")
+
+	require.Equal(t, "application/json", media.Type)
+	require.Equal(t, "json", media.Subtype)
+	require.Same(t, test.Encoder.Get("json"), media.Encoder)
+}
+
 type mediaTest struct {
 	name      string
 	mediaType string

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -68,7 +68,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		media := cont.resolveRequestMedia(req)
+		media := cont.NewFromRequest(req)
 		if media.Encoder == nil {
 			_ = status.WriteError(res, status.Errorf(http.StatusBadRequest, "content: invalid request media type %q", media.Type))
 

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -35,7 +35,7 @@ func TestNewRequestHandlerRejectsErrorContentType(t *testing.T) {
 	require.False(t, called)
 	require.Equal(t, http.StatusBadRequest, res.Code)
 	require.Equal(t, media.Error, res.Header().Get(content.TypeKey))
-	require.Contains(t, res.Body.String(), `content: invalid request media type "text/error;charset=utf-8"`)
+	require.Contains(t, res.Body.String(), `content: invalid request media type "text/error"`)
 }
 
 func TestNewHandlerRejectsErrorContentType(t *testing.T) {
@@ -57,7 +57,7 @@ func TestNewHandlerRejectsErrorContentType(t *testing.T) {
 	require.False(t, called)
 	require.Equal(t, http.StatusBadRequest, res.Code)
 	require.Equal(t, media.Error, res.Header().Get(content.TypeKey))
-	require.Contains(t, res.Body.String(), `content: invalid request media type "text/error;charset=utf-8"`)
+	require.Contains(t, res.Body.String(), `content: invalid request media type "text/error"`)
 }
 
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {

--- a/net/http/content/media.go
+++ b/net/http/content/media.go
@@ -3,32 +3,40 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
-	content "github.com/elnormous/contenttype"
 )
 
 const jsonKind = "json"
 
 const errorSubtype = "error"
 
-// NewMedia builds a Media from a parsed media type and encoder map.
+// NewMedia builds a Media from a media type string and encoder map.
 //
 // Encoder selection:
 //   - If the subtype is "error", it returns a Media without an encoder.
 //   - If no encoder is registered for the subtype, it falls back to JSON.
 //   - Otherwise it returns the encoder registered for the subtype.
-func NewMedia(mediaType content.MediaType, enc *encoding.Map) Media {
-	return newMedia(mediaType, enc)
+func NewMedia(mediaType string, enc *encoding.Map) Media {
+	if media, ok := knownMedia(mediaType, enc); ok {
+		return media
+	}
+
+	value, subtype, err := media.Parse(mediaType)
+	if err != nil {
+		return jsonMedia(enc)
+	}
+
+	return newMedia(value, subtype, enc)
 }
 
 // Media describes an HTTP media type and its associated encoder.
 //
-// Type is the full media type string (including parameters if present). Subtype is the parsed media subtype used
-// for encoder lookup. Encoder may be nil when Subtype is "error".
+// Type is the base media type string. Subtype is the parsed media subtype used for encoder lookup.
+// Encoder may be nil when Subtype is "error".
 type Media struct {
 	// Encoder is the encoder/decoder associated with the media subtype.
 	Encoder encoding.Encoder
 
-	// Type is the full media type string (for example "application/json", "application/hjson", or "text/plain; charset=utf-8").
+	// Type is the base media type string (for example "application/json", "application/hjson", or "text/plain").
 	Type string
 
 	// Subtype is the parsed subtype (for example "json", "hjson", or "plain").
@@ -63,17 +71,17 @@ func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {
 	}
 }
 
-func newMedia(mediaType content.MediaType, enc *encoding.Map) Media {
-	if mediaType.Subtype == errorSubtype {
-		return Media{Type: mediaType.String(), Subtype: mediaType.Subtype}
+func newMedia(value, subtype string, enc *encoding.Map) Media {
+	if subtype == errorSubtype {
+		return Media{Type: value, Subtype: subtype}
 	}
 
-	e := enc.Get(mediaType.Subtype)
+	e := enc.Get(subtype)
 	if e == nil {
 		return jsonMedia(enc)
 	}
 
-	return Media{Type: mediaType.String(), Subtype: mediaType.Subtype, Encoder: e}
+	return Media{Type: value, Subtype: subtype, Encoder: e}
 }
 
 func jsonMedia(enc *encoding.Map) Media {

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -1,5 +1,28 @@
 package media
 
+import (
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+// ErrInvalidType is returned when a media type cannot be parsed.
+var ErrInvalidType = errors.New("media: invalid type")
+
+// Parse parses value into a base media type and subtype.
+//
+// Parameters are ignored because content negotiation only uses the base media type.
+func Parse(value string) (string, string, error) {
+	mediaType, _, _ := strings.Cut(value, ";")
+	mediaType = strings.TrimSpace(mediaType)
+
+	_, subtype, ok := strings.Cut(mediaType, "/")
+	if !ok || strings.IsEmpty(subtype) {
+		return strings.Empty, strings.Empty, ErrInvalidType
+	}
+
+	return mediaType, subtype, nil
+}
+
 // Error is the media type used for plain-text error bodies.
 //
 // This is intended for responses where the body is a human-readable error message.

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -1,0 +1,16 @@
+package media_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInvalidMediaType(t *testing.T) {
+	_, _, err := media.Parse("json")
+
+	require.ErrorIs(t, err, media.ErrInvalidType)
+	require.True(t, errors.Is(err, media.ErrInvalidType))
+}


### PR DESCRIPTION
## What

- Moved media type parsing into `net/http/media`.
- Added exported `media.ErrInvalidType` so parse failures can be checked with `errors.Is`.
- Changed content media resolution to ignore parameters like `charset` and use the base media type for encoder lookup.
- Updated tests to expect normalized base media types in error messages and parameterized content type handling.

## Why

Keep media parsing owned by the media package while avoiding unnecessary MIME parameter parsing allocations for content negotiation.

## Testing

- `make dep`
- `go test ./net/http/media ./net/http/content`
- `go test -mod=mod -run=^$ -bench='BenchmarkNewFrom' -benchmem -count=10 ./net/http/content`
- `make lint` passed with `0 issues` after the existing `gomodguard` deprecation warning.