### PR TITLE
feat(http): remove charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ Notes:
 
 - `application/hjson` maps to the built-in `hjson` encoder kind.
 - Unknown or invalid request media types fall back to JSON selection.
-- `text/error; charset=utf-8` is reserved for error responses and should not be sent by clients as a request content type.
+- `text/error` is reserved for error responses and should not be sent by clients as a request content type.
 
 ### Transport configuration (servers)
 

--- a/net/http/content/benchmark_test.go
+++ b/net/http/content/benchmark_test.go
@@ -29,9 +29,9 @@ func BenchmarkNewFromRequestJSON(b *testing.B) {
 	}
 }
 
-func BenchmarkNewFromMediaWithCharset(b *testing.B) {
+func BenchmarkNewFromMediaWithParameters(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkMedia = test.Content.NewFromMedia("application/json; charset=utf-8")
+		benchmarkMedia = test.Content.NewFromMedia("application/json; profile=test")
 	}
 }

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -36,7 +36,7 @@ func TestNewFromRequest(t *testing.T) {
 }
 
 func TestNewFromMediaWithParameters(t *testing.T) {
-	media := test.Content.NewFromMedia("application/json; charset=utf-8")
+	media := test.Content.NewFromMedia("application/json; profile=test")
 
 	require.Equal(t, "application/json", media.Type)
 	require.Equal(t, "json", media.Subtype)

--- a/net/http/media/doc.go
+++ b/net/http/media/doc.go
@@ -3,14 +3,11 @@
 // This package centralizes the media types used across go-service HTTP components for consistent
 // Content-Type negotiation and response encoding.
 //
-// The constants in this package represent full media type strings (sometimes including charset
-// parameters), suitable for use in HTTP headers such as:
+// The constants in this package represent media type strings suitable for use in HTTP headers such as:
 //
 //	Content-Type: application/json
 //
-// or:
-//
-//	Content-Type: text/plain; charset=utf-8
+//	Content-Type: text/plain
 //
 // Start with constants such as JSON, Protobuf, and Text.
 package media

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -28,12 +28,12 @@ func Parse(value string) (string, string, error) {
 // This is intended for responses where the body is a human-readable error message.
 // Note: "text/error" is not a standard IANA media type, but is used within go-service
 // for consistent internal error rendering.
-const Error = "text/error; charset=utf-8"
+const Error = "text/error"
 
-// HTML is the media type for HTML documents encoded as UTF-8.
+// HTML is the media type for HTML documents.
 //
 // This is typically used for HTML responses or debug pages.
-const HTML = "text/html; charset=utf-8"
+const HTML = "text/html"
 
 // JPEG is the media type for JPEG images.
 const JPEG = "image/jpeg"
@@ -48,8 +48,8 @@ const JSON = "application/json"
 // This is commonly used as the Content-Type for HJSON request/response bodies.
 const HJSON = "application/hjson"
 
-// Markdown is the media type for Markdown documents encoded as UTF-8.
-const Markdown = "text/markdown; charset=utf-8"
+// Markdown is the media type for Markdown documents.
+const Markdown = "text/markdown"
 
 // Protobuf is the media type for protobuf binary payloads.
 //
@@ -68,8 +68,8 @@ const ProtobufJSON = "application/pbjson"
 // in content negotiation.
 const ProtobufText = "application/pbtxt"
 
-// Text is the media type for plain text encoded as UTF-8.
-const Text = "text/plain; charset=utf-8"
+// Text is the media type for plain text.
+const Text = "text/plain"
 
 // TOML is the media type for TOML documents.
 const TOML = "application/toml"

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -11,7 +11,7 @@ import (
 //
 // Content-Type:
 // WriteError always writes the response as a plain-text error payload using the go-service specific
-// error media type "text/error; charset=utf-8" and sets "X-Content-Type-Options: nosniff".
+// error media type "text/error" and sets "X-Content-Type-Options: nosniff".
 //
 // Status code selection:
 // The HTTP status code is derived from err using Code(err), which understands:


### PR DESCRIPTION
## What

- Removed `charset=utf-8` from HTTP media constants.
- Updated media docs and README references to use base media types.
- Kept parameter-stripping coverage with `application/json; profile=test`.
- Renamed the parameterized content benchmark to avoid charset-specific wording.

## Why

Use consistent base media types across HTTP content negotiation and response headers, while still supporting request media type parameters.

## Testing

- `make dep`
- `rg 'charset=utf-8' -n`
- `go test ./net/http/media ./net/http/content ./net/http/status ./net/http/mvc`
- `go test -run=^$ -bench='BenchmarkNewFrom' -benchmem -count=5 ./net/http/content`
- `make lint` passed with `0 issues` after the existing `gomodguard` deprecation warning.