### PR TITLE
feat(http): add utf8 media header

### DIFF
--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -3,6 +3,7 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/types/ptr"
@@ -68,15 +69,15 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		media := cont.NewFromRequest(req)
-		if media.Encoder == nil {
-			_ = status.WriteError(res, status.Errorf(http.StatusBadRequest, "content: invalid request media type %q", media.Type))
+		mediaType := cont.NewFromRequest(req)
+		if mediaType.Encoder == nil {
+			_ = status.WriteError(res, status.Errorf(http.StatusBadRequest, "content: invalid request media type %q", mediaType.Type))
 
 			return
 		}
 
-		ctx = meta.WithContent(ctx, req, res, media.Encoder)
-		res.Header().Add(TypeKey, media.Type)
+		ctx = meta.WithContent(ctx, req, res, mediaType.Encoder)
+		res.Header().Add(TypeKey, media.WithUTF8(mediaType.Type))
 
 		data, err := handler(ctx)
 		if err != nil {
@@ -88,7 +89,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 		buffer := cont.pool.Get()
 		defer cont.pool.Put(buffer)
 
-		if err := media.Encoder.Encode(buffer, data); err != nil {
+		if err := mediaType.Encoder.Encode(buffer, data); err != nil {
 			_ = status.WriteError(res, err)
 
 			return

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -34,7 +34,7 @@ func TestNewRequestHandlerRejectsErrorContentType(t *testing.T) {
 
 	require.False(t, called)
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, media.Error, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
 	require.Contains(t, res.Body.String(), `content: invalid request media type "text/error"`)
 }
 
@@ -56,7 +56,7 @@ func TestNewHandlerRejectsErrorContentType(t *testing.T) {
 	})
 	require.False(t, called)
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, media.Error, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
 	require.Contains(t, res.Body.String(), `content: invalid request media type "text/error"`)
 }
 
@@ -76,7 +76,7 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
-	require.Equal(t, media.Error, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
 	require.Equal(t, test.ErrFailed.Error()+"\n", res.Body.String())
 	require.NotContains(t, res.Body.String(), "partial")
 }

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -5,24 +5,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
-// ErrInvalidType is returned when a media type cannot be parsed.
-var ErrInvalidType = errors.New("media: invalid type")
-
-// Parse parses value into a base media type and subtype.
-//
-// Parameters are ignored because content negotiation only uses the base media type.
-func Parse(value string) (string, string, error) {
-	mediaType, _, _ := strings.Cut(value, ";")
-	mediaType = strings.TrimSpace(mediaType)
-
-	_, subtype, ok := strings.Cut(mediaType, "/")
-	if !ok || strings.IsEmpty(subtype) {
-		return strings.Empty, strings.Empty, ErrInvalidType
-	}
-
-	return mediaType, subtype, nil
-}
-
 // Error is the media type used for plain-text error bodies.
 //
 // This is intended for responses where the body is a human-readable error message.
@@ -76,3 +58,33 @@ const TOML = "application/toml"
 
 // YAML is the media type for YAML documents.
 const YAML = "application/yaml"
+
+// ErrInvalidType is returned when a media type cannot be parsed.
+var ErrInvalidType = errors.New("media: invalid type")
+
+// Parse parses value into a base media type and subtype.
+//
+// Parameters are ignored because content negotiation only uses the base media type.
+func Parse(value string) (string, string, error) {
+	mediaType, _, _ := strings.Cut(value, ";")
+	mediaType = strings.TrimSpace(mediaType)
+
+	_, subtype, ok := strings.Cut(mediaType, "/")
+	if !ok || strings.IsEmpty(subtype) {
+		return strings.Empty, strings.Empty, ErrInvalidType
+	}
+
+	return mediaType, subtype, nil
+}
+
+// WithUTF8 appends a UTF-8 charset parameter to text media types.
+//
+// Non-text media types and media types that already contain a charset parameter are returned unchanged.
+func WithUTF8(mediaType string) string {
+	value, _, err := Parse(mediaType)
+	if err != nil || !strings.HasPrefix(value, "text/") || strings.Contains(mediaType, "charset=") {
+		return mediaType
+	}
+
+	return strings.Concat(mediaType, "; ", "charset=utf-8")
+}

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -14,3 +14,22 @@ func TestParseInvalidMediaType(t *testing.T) {
 	require.ErrorIs(t, err, media.ErrInvalidType)
 	require.True(t, errors.Is(err, media.ErrInvalidType))
 }
+
+func TestWithUTF8(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mediaType string
+		expected  string
+	}{
+		{name: "text", mediaType: media.Text, expected: "text/plain; charset=utf-8"},
+		{name: "html", mediaType: media.HTML, expected: "text/html; charset=utf-8"},
+		{name: "existing charset", mediaType: "text/plain; charset=utf-8", expected: "text/plain; charset=utf-8"},
+		{name: "parameter", mediaType: "text/plain; profile=test", expected: "text/plain; profile=test; charset=utf-8"},
+		{name: "json", mediaType: media.JSON, expected: media.JSON},
+		{name: "invalid", mediaType: "json", expected: "json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, media.WithUTF8(tc.mediaType))
+		})
+	}
+}

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -57,7 +57,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 	}
 
 	handler := func(res http.ResponseWriter, req *http.Request) {
-		res.Header().Set(content.TypeKey, media.HTML)
+		res.Header().Set(content.TypeKey, media.WithUTF8(media.HTML))
 
 		ctx := req.Context()
 		ctx = meta.WithContent(ctx, req, res, nil)

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -11,7 +11,7 @@ import (
 //
 // Content-Type:
 // WriteError always writes the response as a plain-text error payload using the go-service specific
-// error media type "text/error" and sets "X-Content-Type-Options: nosniff".
+// error media type "text/error; charset=utf-8" and sets "X-Content-Type-Options: nosniff".
 //
 // Status code selection:
 // The HTTP status code is derived from err using Code(err), which understands:
@@ -30,7 +30,7 @@ import (
 func WriteError(res http.ResponseWriter, err error) error {
 	header := res.Header()
 	header.Del("Content-Length")
-	header.Set("Content-Type", media.Error)
+	header.Set("Content-Type", media.WithUTF8(media.Error))
 	header.Set("X-Content-Type-Options", "nosniff")
 
 	res.WriteHeader(Code(err))
@@ -41,7 +41,7 @@ func WriteError(res http.ResponseWriter, err error) error {
 
 // WriteText writes a plain-text success response to res.
 //
-// It clears any precomputed Content-Length, sets "Content-Type" to media.Text,
+// It clears any precomputed Content-Length, sets "Content-Type" to media.Text with UTF-8 charset,
 // sets "X-Content-Type-Options: nosniff", writes HTTP 200 OK, and emits text followed by
 // a trailing newline via fmt.Fprintln.
 //
@@ -50,7 +50,7 @@ func WriteError(res http.ResponseWriter, err error) error {
 func WriteText(res http.ResponseWriter, text string) error {
 	header := res.Header()
 	header.Del("Content-Length")
-	header.Set("Content-Type", media.Text)
+	header.Set("Content-Type", media.WithUTF8(media.Text))
 	header.Set("X-Content-Type-Options", "nosniff")
 
 	res.WriteHeader(http.StatusOK)

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -55,7 +55,7 @@ func TestReadinessNoop(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, "SERVING", body)
-	require.Equal(t, media.Text, res.Header.Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.Text), res.Header.Get(content.TypeKey))
 }
 
 func TestInvalidHealth(t *testing.T) {
@@ -72,7 +72,7 @@ func TestInvalidHealth(t *testing.T) {
 
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.Equal(t, "http: http checker: invalid status code", body)
-	require.Equal(t, media.Error, res.Header.Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
 }
 
 func TestMissingHealth(t *testing.T) {

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -40,7 +40,7 @@ func TestRouteSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.HTML, res.Header.Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestRoutePartialViewSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.HTML, res.Header.Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestRouteError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-	require.Equal(t, media.HTML, res.Header.Get(content.TypeKey))
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestStaticFileSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Contains(t, res.Header.Get(content.TypeKey), media.Text)
+	require.Equal(t, media.WithUTF8(media.Text), res.Header.Get(content.TypeKey))
 }
 
 func TestStaticFileError(t *testing.T) {
@@ -136,7 +136,7 @@ func TestStaticPathValueSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Contains(t, res.Header.Get(content.TypeKey), media.Text)
+	require.Equal(t, media.WithUTF8(media.Text), res.Header.Get(content.TypeKey))
 }
 
 func TestStaticPathValueError(t *testing.T) {


### PR DESCRIPTION
## What

- Added `media.WithUTF8` to append `charset=utf-8` for `text/*` response media types.
- Kept base media constants parameter-free for parsing and content negotiation.
- Updated content, status, MVC, and transport response header writes/tests to use UTF-8 text headers where appropriate.
- Added coverage for `media.WithUTF8`.

## Why

Keep media type constants clean while making text response headers match Go’s default UTF-8 behavior at write boundaries.

## Testing

- `make dep`
- `go test ./net/http/media ./net/http/content ./net/http/status ./net/http/mvc ./transport/http`
- `go test -run=^$ -bench='BenchmarkNewFrom' -benchmem -count=5 ./net/http/content`
- `go test -run '^TestStatic(PathValue|File)Success$' ./transport/http`
- `make lint` passed with `0 issues` after the existing `gomodguard` warning.