### PR TITLE
fix(http): status error wrapping

### DIFF
--- a/net/http/status/codes.go
+++ b/net/http/status/codes.go
@@ -33,6 +33,6 @@ var statusCodes = map[codes.Code]int{
 	codes.OutOfRange:         http.StatusBadRequest,
 	codes.Unimplemented:      http.StatusNotImplemented,
 	codes.Internal:           http.StatusInternalServerError,
-	codes.Unavailable:        http.StatusInternalServerError,
+	codes.Unavailable:        http.StatusServiceUnavailable,
 	codes.DataLoss:           http.StatusInternalServerError,
 }

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -61,7 +61,7 @@ func FromError(code int, err error) error {
 		code = http.StatusRequestEntityTooLarge
 	}
 
-	return Error(code, err.Error())
+	return &statusError{code: code, msg: err.Error(), err: err}
 }
 
 // Errorf formats a message and returns an error with the provided status code.
@@ -120,6 +120,7 @@ func isMaxBytesError(err error) bool {
 }
 
 type statusError struct {
+	err  error
 	msg  string
 	code int
 }
@@ -132,4 +133,9 @@ func (s *statusError) Code() int {
 // Error returns the status message.
 func (s *statusError) Error() string {
 	return s.msg
+}
+
+// Unwrap returns the wrapped cause, if any.
+func (s *statusError) Unwrap() error {
+	return s.err
 }

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -5,43 +5,92 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	grpcstatus "github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	httpstatus "github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsErrorRecognizesWrappedCoder(t *testing.T) {
 	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
-	require.True(t, status.IsError(err))
+	require.True(t, httpstatus.IsError(err))
 }
 
 func TestCodeRecognizesWrappedCoder(t *testing.T) {
 	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
-	require.Equal(t, http.StatusConflict, status.Code(err))
+	require.Equal(t, http.StatusConflict, httpstatus.Code(err))
 }
 
 func TestFromErrorKeepsWrappedCoder(t *testing.T) {
 	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
-	require.Same(t, err, status.FromError(http.StatusBadRequest, err))
+	require.Same(t, err, httpstatus.FromError(http.StatusBadRequest, err))
+}
+
+func TestFromErrorWrapsCause(t *testing.T) {
+	err := httpstatus.BadRequestError(test.ErrInvalid)
+
+	require.ErrorIs(t, err, test.ErrInvalid)
+	require.True(t, httpstatus.IsError(err))
+	require.Equal(t, http.StatusBadRequest, httpstatus.Code(err))
 }
 
 func TestCodeRecognizesMaxBytesError(t *testing.T) {
 	err := &http.MaxBytesError{Limit: 1}
 
-	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+	require.Equal(t, http.StatusRequestEntityTooLarge, httpstatus.Code(err))
 }
 
 func TestBadRequestErrorUsesRequestEntityTooLargeForMaxBytesError(t *testing.T) {
-	err := status.BadRequestError(&http.MaxBytesError{Limit: 1})
+	err := httpstatus.BadRequestError(&http.MaxBytesError{Limit: 1})
 
-	require.True(t, status.IsError(err))
-	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+	require.True(t, httpstatus.IsError(err))
+	require.Equal(t, http.StatusRequestEntityTooLarge, httpstatus.Code(err))
+}
+
+func TestBadRequestErrorWrapsMaxBytesError(t *testing.T) {
+	maxBytesErr := &http.MaxBytesError{Limit: 1}
+	err := httpstatus.BadRequestError(maxBytesErr)
+
+	require.ErrorIs(t, err, maxBytesErr)
+}
+
+func TestCodeMapsGRPCStatusCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code codes.Code
+		want int
+	}{
+		{name: "ok", code: codes.OK, want: http.StatusOK},
+		{name: "canceled", code: codes.Canceled, want: 499},
+		{name: "unknown", code: codes.Unknown, want: http.StatusInternalServerError},
+		{name: "invalid argument", code: codes.InvalidArgument, want: http.StatusBadRequest},
+		{name: "deadline exceeded", code: codes.DeadlineExceeded, want: http.StatusGatewayTimeout},
+		{name: "not found", code: codes.NotFound, want: http.StatusNotFound},
+		{name: "already exists", code: codes.AlreadyExists, want: http.StatusConflict},
+		{name: "permission denied", code: codes.PermissionDenied, want: http.StatusForbidden},
+		{name: "unauthenticated", code: codes.Unauthenticated, want: http.StatusUnauthorized},
+		{name: "resource exhausted", code: codes.ResourceExhausted, want: http.StatusTooManyRequests},
+		{name: "failed precondition", code: codes.FailedPrecondition, want: http.StatusBadRequest},
+		{name: "aborted", code: codes.Aborted, want: http.StatusConflict},
+		{name: "out of range", code: codes.OutOfRange, want: http.StatusBadRequest},
+		{name: "unimplemented", code: codes.Unimplemented, want: http.StatusNotImplemented},
+		{name: "internal", code: codes.Internal, want: http.StatusInternalServerError},
+		{name: "unavailable", code: codes.Unavailable, want: http.StatusServiceUnavailable},
+		{name: "data loss", code: codes.DataLoss, want: http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := grpcstatus.Error(tc.code, tc.name)
+
+			require.Equal(t, tc.want, httpstatus.Code(err))
+		})
+	}
 }
 
 func TestWriteErrorReturnsWriteFailure(t *testing.T) {
 	res := &test.ErrResponseWriter{}
 
-	err := status.WriteError(res, status.BadRequestError(test.ErrInvalid))
+	err := httpstatus.WriteError(res, httpstatus.BadRequestError(test.ErrInvalid))
 
 	require.ErrorIs(t, err, test.ErrFailed)
 	require.Equal(t, http.StatusBadRequest, res.Code)
@@ -50,7 +99,7 @@ func TestWriteErrorReturnsWriteFailure(t *testing.T) {
 func TestWriteTextReturnsWriteFailure(t *testing.T) {
 	res := &test.ErrResponseWriter{}
 
-	err := status.WriteText(res, "hello")
+	err := httpstatus.WriteText(res, "hello")
 
 	require.ErrorIs(t, err, test.ErrFailed)
 	require.Equal(t, http.StatusOK, res.Code)


### PR DESCRIPTION
## What
- map gRPC unavailable errors to HTTP 503 instead of HTTP 500
- preserve the original cause when wrapping errors with HTTP status codes
- add tests for wrapped causes, max body errors, and gRPC-to-HTTP status mappings

## Why
- keep transient gRPC unavailable failures visible to HTTP retry and breaker logic as service unavailable responses
- allow callers to continue using errors.Is and errors.As after converting plain errors into HTTP status errors

## Testing
- go test ./net/http/status
- go test ./net/...

AI-assisted-by: [Codex](https://openai.com/codex/)
