### PR TITLE
fix(http): pass client options by value

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -113,19 +113,14 @@ type Options struct {
 }
 
 // HasRequest reports whether a request payload is set.
-func (o *Options) HasRequest() bool {
+func (o Options) HasRequest() bool {
 	return o.Request != nil
 }
 
 // HasResponse reports whether a response payload is set.
-func (o *Options) HasResponse() bool {
+func (o Options) HasResponse() bool {
 	return o.Response != nil
 }
-
-// NoOptions is a reusable empty Options value.
-//
-// It can be passed when no request/response bodies are needed and defaults are acceptable.
-var NoOptions = &Options{}
 
 // Client wraps *http.Client with content-aware encoding and decoding helpers.
 //
@@ -140,35 +135,35 @@ type Client struct {
 // Delete issues an HTTP DELETE request to url using opts.
 //
 // It is a convenience wrapper around Do.
-func (c *Client) Delete(ctx context.Context, url string, opts *Options) error {
+func (c *Client) Delete(ctx context.Context, url string, opts Options) error {
 	return c.Do(ctx, http.MethodDelete, url, opts)
 }
 
 // Get issues an HTTP GET request to url using opts.
 //
 // It is a convenience wrapper around Do.
-func (c *Client) Get(ctx context.Context, url string, opts *Options) error {
+func (c *Client) Get(ctx context.Context, url string, opts Options) error {
 	return c.Do(ctx, http.MethodGet, url, opts)
 }
 
 // Post issues an HTTP POST request to url using opts.
 //
 // It is a convenience wrapper around Do.
-func (c *Client) Post(ctx context.Context, url string, opts *Options) error {
+func (c *Client) Post(ctx context.Context, url string, opts Options) error {
 	return c.Do(ctx, http.MethodPost, url, opts)
 }
 
 // Put issues an HTTP PUT request to url using opts.
 //
 // It is a convenience wrapper around Do.
-func (c *Client) Put(ctx context.Context, url string, opts *Options) error {
+func (c *Client) Put(ctx context.Context, url string, opts Options) error {
 	return c.Do(ctx, http.MethodPut, url, opts)
 }
 
 // Patch issues an HTTP PATCH request to url using opts.
 //
 // It is a convenience wrapper around Do.
-func (c *Client) Patch(ctx context.Context, url string, opts *Options) error {
+func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 	return c.Do(ctx, http.MethodPatch, url, opts)
 }
 
@@ -190,11 +185,11 @@ func (c *Client) Patch(ctx context.Context, url string, opts *Options) error {
 //     selected by the response Content-Type (falling back to opts.ContentType if absent).
 //
 // Notes:
-//   - opts must be non-nil; callers may pass NoOptions.
+//   - callers may pass the zero Options value when no request/response bodies are needed.
 //   - This method buffers the entire response body in memory.
 //
 //nolint:cyclop
-func (c *Client) Do(ctx context.Context, method, url string, opts *Options) error {
+func (c *Client) Do(ctx context.Context, method, url string, opts Options) error {
 	buffer := c.pool.Get()
 	defer c.pool.Put(buffer)
 

--- a/net/http/rest/client.go
+++ b/net/http/rest/client.go
@@ -6,9 +6,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-// NoOptions is an alias for client.NoOptions.
-var NoOptions = client.NoOptions
-
 // Options is an alias for client.Options.
 type Options = client.Options
 

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -113,7 +113,7 @@ func (c *Client) Post(ctx context.Context, path string, req, res any) error {
 		return ErrInvalidResponse
 	}
 
-	opts := &client.Options{ContentType: c.contentType, Request: req, Response: res}
+	opts := client.Options{ContentType: c.contentType, Request: req, Response: res}
 	return c.client.Post(ctx, c.url+path, opts)
 }
 

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -369,7 +369,7 @@ func BenchmarkRest(b *testing.B) {
 				for b.Loop() {
 					req := &test.Request{Name: "Bob"}
 					res := &test.Response{}
-					opts := &rest.Options{
+					opts := rest.Options{
 						ContentType: "application/" + mt,
 						Request:     req,
 						Response:    res,
@@ -392,7 +392,7 @@ func BenchmarkRest(b *testing.B) {
 
 			for b.Loop() {
 				buffer := test.Pool.Get()
-				opts := &rest.Options{
+				opts := rest.Options{
 					ContentType: media.Text,
 					Response:    buffer,
 				}
@@ -431,7 +431,7 @@ func BenchmarkRest(b *testing.B) {
 				for b.Loop() {
 					req := &v1.SayHelloRequest{Name: "Bob"}
 					res := &v1.SayHelloResponse{}
-					opts := &rest.Options{
+					opts := rest.Options{
 						ContentType: "application/" + mt,
 						Request:     req,
 						Response:    res,

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -18,7 +18,7 @@ func TestRestNoContent(t *testing.T) {
 			test.RegisterHandlers("/hello", test.RestNoContent)
 
 			url := world.NamedServerURL("http", "hello")
-			err := world.Rest.Do(t.Context(), method, url, rest.NoOptions)
+			err := world.Rest.Do(t.Context(), method, url, rest.Options{})
 			require.NoError(t, err)
 		})
 	}
@@ -33,7 +33,7 @@ func TestRestRequestNoContent(t *testing.T) {
 
 			url := world.NamedServerURL("http", "hello")
 			req := &test.Request{Name: "test"}
-			opts := &rest.Options{
+			opts := rest.Options{
 				ContentType: media.JSON,
 				Request:     req,
 			}
@@ -51,7 +51,7 @@ func TestRestError(t *testing.T) {
 			test.RegisterHandlers("/hello", test.RestError)
 
 			url := world.NamedServerURL("http", "hello")
-			err := world.Rest.Do(t.Context(), method, url, rest.NoOptions)
+			err := world.Rest.Do(t.Context(), method, url, rest.Options{})
 			require.Error(t, err)
 		})
 	}
@@ -66,7 +66,7 @@ func TestRestRequestError(t *testing.T) {
 
 			url := world.NamedServerURL("http", "hello")
 			req := &test.Request{Name: "test"}
-			opts := &rest.Options{
+			opts := rest.Options{
 				ContentType: media.JSON,
 				Request:     req,
 			}
@@ -85,7 +85,7 @@ func TestRestWithContent(t *testing.T) {
 
 			url := world.NamedServerURL("http", "hello")
 			resp := &test.Response{}
-			opts := &rest.Options{
+			opts := rest.Options{
 				Response: resp,
 			}
 			err := world.Rest.Do(t.Context(), method, url, opts)
@@ -105,7 +105,7 @@ func TestRestRequestWithContent(t *testing.T) {
 			url := world.NamedServerURL("http", "hello")
 			req := &test.Request{Name: "test"}
 			resp := &test.Response{}
-			opts := &rest.Options{
+			opts := rest.Options{
 				ContentType: media.JSON,
 				Request:     req,
 				Response:    resp,
@@ -123,17 +123,17 @@ func TestRestInvalidStatusCode(t *testing.T) {
 	test.RegisterHandlers("/hello", test.RestInvalidStatusCode)
 
 	url := world.NamedServerURL("http", "hello")
-	err := world.Rest.Get(t.Context(), url, rest.NoOptions)
+	err := world.Rest.Get(t.Context(), url, rest.Options{})
 	require.Error(t, err)
 
-	err = world.Rest.Delete(t.Context(), url, rest.NoOptions)
+	err = world.Rest.Delete(t.Context(), url, rest.Options{})
 	require.Error(t, err)
 
 	test.RegisterRequestHandlers("/hello", test.RestRequestInvalidStatusCode)
 
 	url = world.NamedServerURL("http", "hello")
 	req := &test.Request{}
-	opts := &rest.Options{Request: req}
+	opts := rest.Options{Request: req}
 
 	err = world.Rest.Post(t.Context(), url, opts)
 	require.Error(t, err)


### PR DESCRIPTION
## What
- Change HTTP client call options from pointer parameters to value parameters.
- Remove the exported `NoOptions` helpers and use the zero `Options` value instead.
- Update REST/RPC call sites, tests, and benchmarks to pass `Options` values.

## Why
- Avoid nil `*Options` panics in the HTTP client API.
- Keep the empty-options path idiomatic through the zero value instead of an extra exported variable.

## Testing
- `go test ./net/http/... ./transport/http/...`
- `go test ./...`
- `make lint`
