### PR TITLE
docs(http): clarify redirect handling

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -60,9 +60,7 @@ func WithTimeout(timeout time.Duration) ClientOption {
 // WithIgnoreRedirect disables automatic redirect following.
 //
 // When set, the underlying http.Client.CheckRedirect is configured to return http.ErrUseLastResponse,
-// causing the client to return the redirect response (3xx) instead of following it.
-//
-// This can be useful when you want to inspect Location headers or preserve redirect responses as-is.
+// causing the underlying client to use the last response instead of following the redirect.
 func WithIgnoreRedirect() ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.ignoreRedirect = true


### PR DESCRIPTION
## What
- Update `WithIgnoreRedirect` documentation to describe the exact `http.Client.CheckRedirect` behavior.
- Remove wording that implied this wrapper exposes redirect headers for inspection.

## Why
- The option configures `CheckRedirect` to return `http.ErrUseLastResponse`, but `Client.Do` still exposes only decoded bodies and errors.
- The docs should describe the behavior precisely without promising response metadata access.

## Testing
- `go test ./net/http/...`
