### PR TITLE
docs(grpc): explain method validation

### DIFF
--- a/net/grpc/strings/strings.go
+++ b/net/grpc/strings/strings.go
@@ -61,6 +61,8 @@ func IsIgnorable(name string) bool {
 // This is the canonical shape of gRPC full method names as they appear in interceptors (for example
 // "/helloworld.Greeter/SayHello").
 func IsFullMethod(name string) bool {
+	// Buf-managed protos in this repo require a package, so service names are
+	// expected to include a package-qualified dot, e.g. "/greet.v1.Greeter/SayHello".
 	return strings.HasPrefix(name, "/") && strings.Count(name, "/") == 2 && strings.Count(name, ".") > 0
 }
 


### PR DESCRIPTION
## What
- Add a comment explaining why `IsFullMethod` expects a package-qualified service name with a dot.

## Why
- Buf-managed protos in this repo require packages, so generated gRPC full method names are expected to use package-qualified service names.
- The comment documents that local convention and avoids treating the dot check as accidental generic gRPC validation.

## Testing
- `go test ./net/grpc/...`
