### PR TITLE
feat(http): preserve client requests in transport middleware

### DIFF
--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -43,13 +43,15 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	userAgent := clientUserAgent(ctx, req, r.userAgent)
 	requestID := clientRequestID(ctx, r.generator, req)
 
-	clientSetRequestHeaders(req.Header, userAgent.Value(), requestID.Value())
 	ctx = meta.WithAttributes(ctx,
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
 	)
 
-	return r.RoundTripper.RoundTrip(req.WithContext(ctx))
+	cloned := req.Clone(ctx)
+	clientSetRequestHeaders(cloned.Header, userAgent.Value(), requestID.Value())
+
+	return r.RoundTripper.RoundTrip(cloned)
 }
 
 func clientSetRequestHeaders(header http.Header, userAgent, requestID string) {

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -51,6 +51,8 @@ func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 	res, err := roundTripper.RoundTrip(req)
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
+	require.Empty(t, req.Header.Values("User-Agent"))
+	require.Empty(t, req.Header.Values("Request-Id"))
 }
 
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -170,9 +170,20 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return r.RoundTripper.RoundTrip(req)
 	}
 
-	if err := r.hook.Sign(req); err != nil {
+	cloned := req.Clone(req.Context())
+	body := cloned.Body
+	if err := r.hook.Sign(cloned); err != nil {
+		closeBody(body)
+
 		return nil, err
 	}
+	closeBody(body)
 
-	return r.RoundTripper.RoundTrip(req)
+	return r.RoundTripper.RoundTrip(cloned)
+}
+
+func closeBody(body io.ReadCloser) {
+	if body != nil && body != http.NoBody {
+		_ = body.Close()
+	}
 }

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -52,6 +52,28 @@ func TestRoundTripper(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.StatusCode)
 }
 
+func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
+	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookID))
+		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookSignature))
+		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookTimestamp))
+
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	}))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookID))
+	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookSignature))
+	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookTimestamp))
+}
+
 func TestHandler(t *testing.T) {
 	handler := hooks.NewHandler(nil)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -166,9 +166,10 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, status.UnauthorizedError(header.ErrInvalidAuthorization)
 	}
 
-	req.Header.Set(
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set(
 		"Authorization",
 		strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)),
 	)
-	return r.RoundTripper.RoundTrip(req)
+	return r.RoundTripper.RoundTrip(cloned)
 }

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -1,0 +1,41 @@
+package token_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/transport/http/token"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
+	roundTripper := token.NewRoundTripper(
+		env.UserID("service-user"),
+		staticGenerator("fresh-token"),
+		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "Bearer fresh-token", req.Header.Get("Authorization"))
+
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Empty(t, req.Header.Values("Authorization"))
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type staticGenerator string
+
+func (g staticGenerator) Generate(_, _ string) ([]byte, error) {
+	return []byte(g), nil
+}


### PR DESCRIPTION
## What
- clone outbound request objects before adding metadata, authorization, or webhook signature headers
- keep signed/generated headers visible to the wrapped transport while leaving the caller-owned request unchanged
- add regression coverage for metadata, token, and webhook RoundTrippers

## Why
- RoundTripper implementations should not mutate caller-owned requests beyond body consumption
- defensive cloning avoids leaking generated headers back to reused or inspected request values

## Testing
- go test ./net/http/... ./transport/...
- make lint

AI-assisted-by: [Codex](https://openai.com/codex/)
