### PR TITLE
feat(transport): treat empty tls config as disabled

### DIFF
--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -114,7 +114,11 @@ func TestNewConfigInvalidKeyPair(t *testing.T) {
 }
 
 func TestNewConfigInvalidCA(t *testing.T) {
-	_, err := server.NewConfig(test.FS, &config.Config{CA: "invalid ca"})
+	_, err := server.NewConfig(test.FS, &config.Config{
+		Cert: test.FilePath("certs/cert.pem"),
+		Key:  test.FilePath("certs/key.pem"),
+		CA:   "invalid ca",
+	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, config.ErrInvalidCA))
 }

--- a/crypto/tls/config/certificate.go
+++ b/crypto/tls/config/certificate.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"github.com/alexfalkowski/go-service/v2/crypto/tls"
+	"github.com/alexfalkowski/go-service/v2/os"
+)
+
+// NewKeyPair resolves and parses cfg's configured leaf certificate/private-key pair.
+func NewKeyPair(fs *os.FS, cfg *Config) (tls.Certificate, error) {
+	cert, err := cfg.GetCert(fs)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	key, err := cfg.GetKey(fs)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	pair, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return pair, nil
+}

--- a/crypto/tls/config/certificate_test.go
+++ b/crypto/tls/config/certificate_test.go
@@ -1,0 +1,45 @@
+package config_test
+
+import (
+	"testing"
+
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKeyPair(t *testing.T) {
+	validTests := []struct {
+		config *tls.Config
+		name   string
+	}{
+		{name: "nil config", config: nil},
+		{name: "empty config", config: &tls.Config{}},
+		{name: "valid config", config: test.NewTLSConfig("certs/cert.pem", "certs/key.pem")},
+	}
+
+	for _, tt := range validTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.config.HasKeyPair() {
+				_, err := tls.NewKeyPair(test.FS, tt.config)
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	invalidTests := []struct {
+		config *tls.Config
+		name   string
+	}{
+		{name: "invalid key", config: test.NewTLSConfig("certs/client-cert.pem", "secrets/none")},
+		{name: "invalid cert", config: test.NewTLSConfig("secrets/none", "certs/client-key.pem")},
+		{name: "invalid pair", config: test.NewTLSConfig("secrets/hooks", "certs/client-key.pem")},
+	}
+
+	for _, tt := range invalidTests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tls.NewKeyPair(test.FS, tt.config)
+			require.Error(t, err)
+		})
+	}
+}

--- a/crypto/tls/config/config.go
+++ b/crypto/tls/config/config.go
@@ -1,9 +1,6 @@
 package config
 
 import (
-	"crypto/x509"
-
-	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -53,13 +50,17 @@ type Config struct {
 	ServerName string `yaml:"server_name,omitempty" json:"server_name,omitempty" toml:"server_name,omitempty"`
 }
 
-// IsEnabled reports whether TLS configuration is present.
+// IsEnabled reports whether TLS configuration has any configured TLS material.
 //
-// By convention across go-service config types, a nil *Config is treated as
-// "disabled", so callers can omit TLS config entirely to leave transports in
-// plain-text mode.
+// By convention across go-service config types, a nil *Config is treated as "disabled".
+// An empty *Config is also disabled so decoders that allocate an empty TLS block do not
+// accidentally enable TLS without key material.
 func (c *Config) IsEnabled() bool {
-	return c != nil
+	if c == nil {
+		return false
+	}
+
+	return c.hasKeyMaterial() || c.HasCA() || !strings.IsEmpty(c.ServerName)
 }
 
 // HasKeyPair reports whether both certificate and key sources are configured.
@@ -69,6 +70,10 @@ func (c *Config) IsEnabled() bool {
 // valid X.509 key pair.
 func (c *Config) HasKeyPair() bool {
 	return c != nil && !strings.IsEmpty(c.Cert) && !strings.IsEmpty(c.Key)
+}
+
+func (c *Config) hasKeyMaterial() bool {
+	return !strings.IsEmpty(c.Cert) || !strings.IsEmpty(c.Key)
 }
 
 // HasCA reports whether a peer CA source is configured.
@@ -104,39 +109,4 @@ func (c *Config) GetKey(fs *os.FS) ([]byte, error) {
 // from that operation.
 func (c *Config) GetCA(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.CA)
-}
-
-// NewKeyPair resolves and parses cfg's configured leaf certificate/private-key pair.
-func NewKeyPair(fs *os.FS, cfg *Config) (tls.Certificate, error) {
-	cert, err := cfg.GetCert(fs)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	key, err := cfg.GetKey(fs)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	pair, err := tls.X509KeyPair(cert, key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	return pair, nil
-}
-
-// NewCertPool resolves and parses cfg's configured CA bundle.
-func NewCertPool(fs *os.FS, cfg *Config) (*x509.CertPool, error) {
-	ca, err := cfg.GetCA(fs)
-	if err != nil {
-		return nil, err
-	}
-
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(ca) {
-		return nil, ErrInvalidCA
-	}
-
-	return pool, nil
 }

--- a/crypto/tls/config/config_test.go
+++ b/crypto/tls/config/config_test.go
@@ -1,78 +1,30 @@
 package config_test
 
 import (
-	"crypto/x509"
-	"encoding/pem"
 	"testing"
 
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig(t *testing.T) {
-	validTests := []struct {
+func TestIsEnabled(t *testing.T) {
+	tests := []struct {
 		config *tls.Config
 		name   string
+		want   bool
 	}{
-		{name: "nil config", config: nil},
-		{name: "empty config", config: &tls.Config{}},
-		{name: "valid config", config: test.NewTLSConfig("certs/cert.pem", "certs/key.pem")},
+		{name: "nil"},
+		{name: "empty", config: &tls.Config{}},
+		{name: "cert", config: &tls.Config{Cert: test.FilePath("certs/cert.pem")}, want: true},
+		{name: "key", config: &tls.Config{Key: test.FilePath("certs/key.pem")}, want: true},
+		{name: "ca", config: &tls.Config{CA: test.FilePath("certs/rootCA.pem")}, want: true},
+		{name: "server name", config: &tls.Config{ServerName: "localhost"}, want: true},
 	}
 
-	for _, tt := range validTests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.config.HasKeyPair() {
-				_, err := tls.NewKeyPair(test.FS, tt.config)
-				require.NoError(t, err)
-			}
+			require.Equal(t, tt.want, tt.config.IsEnabled())
 		})
 	}
-
-	invalidTests := []struct {
-		config *tls.Config
-		name   string
-	}{
-		{name: "invalid key", config: test.NewTLSConfig("certs/client-cert.pem", "secrets/none")},
-		{name: "invalid cert", config: test.NewTLSConfig("secrets/none", "certs/client-key.pem")},
-		{name: "invalid pair", config: test.NewTLSConfig("secrets/hooks", "certs/client-key.pem")},
-	}
-
-	for _, tt := range invalidTests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := tls.NewKeyPair(test.FS, tt.config)
-			require.Error(t, err)
-		})
-	}
-}
-
-func TestNewCertPool(t *testing.T) {
-	pool, err := tls.NewCertPool(test.FS, test.NewTLSServerConfig())
-	require.NoError(t, err)
-	require.NotNil(t, pool)
-
-	data, err := test.FS.ReadSource(test.FilePath("certs/client-cert.pem"))
-	require.NoError(t, err)
-
-	block, _ := pem.Decode(data)
-	require.NotNil(t, block)
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	require.NoError(t, err)
-
-	_, err = cert.Verify(x509.VerifyOptions{Roots: pool})
-	require.NoError(t, err)
-}
-
-func TestNewCertPoolInvalid(t *testing.T) {
-	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: "invalid ca"})
-	require.Error(t, err)
-	require.True(t, errors.Is(err, tls.ErrInvalidCA))
-}
-
-func TestNewCertPoolSourceError(t *testing.T) {
-	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: test.FilePath("certs/missing.pem")})
-	require.Error(t, err)
-	require.False(t, errors.Is(err, tls.ErrInvalidCA))
 }

--- a/crypto/tls/config/pool.go
+++ b/crypto/tls/config/pool.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"crypto/x509"
+
+	"github.com/alexfalkowski/go-service/v2/os"
+)
+
+// NewCertPool resolves and parses cfg's configured CA bundle.
+func NewCertPool(fs *os.FS, cfg *Config) (*x509.CertPool, error) {
+	ca, err := cfg.GetCA(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca) {
+		return nil, ErrInvalidCA
+	}
+
+	return pool, nil
+}

--- a/crypto/tls/config/pool_test.go
+++ b/crypto/tls/config/pool_test.go
@@ -1,0 +1,42 @@
+package config_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCertPool(t *testing.T) {
+	pool, err := tls.NewCertPool(test.FS, test.NewTLSServerConfig())
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+
+	data, err := test.FS.ReadSource(test.FilePath("certs/client-cert.pem"))
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	_, err = cert.Verify(x509.VerifyOptions{Roots: pool})
+	require.NoError(t, err)
+}
+
+func TestNewCertPoolInvalid(t *testing.T) {
+	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: "invalid ca"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, tls.ErrInvalidCA))
+}
+
+func TestNewCertPoolSourceError(t *testing.T) {
+	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: test.FilePath("certs/missing.pem")})
+	require.Error(t, err)
+	require.False(t, errors.Is(err, tls.ErrInvalidCA))
+}

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -145,7 +145,7 @@ func NewTLSClientConfig() *tls.Config {
 	return NewTLSConfig("certs/client-cert.pem", "certs/client-key.pem")
 }
 
-// NewInsecureConfig returns an empty TLS config, which the transport treats as insecure mode.
+// NewInsecureConfig returns an empty TLS config for client tests that do not load key material.
 func NewInsecureConfig() *tls.Config {
 	return &tls.Config{}
 }

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/config/server"
-	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -26,8 +25,6 @@ func TestServer(t *testing.T) {
 	require.NoError(t, err)
 
 	c := test.NewInsecureTransportConfig()
-	c.GRPC.TLS = &tls.Config{}
-
 	s := &test.Server{Lifecycle: lc, Logger: logger, TransportConfig: c, Meter: meter, Mux: mux}
 	require.NoError(t, s.Register())
 


### PR DESCRIPTION
## What
- treat an empty TLS config as disabled instead of configured
- keep server TLS setup opportunistic: load cert/key only when both are present and load CA when present
- remove the missing-key-pair sentinel and strict server constructor rejection tests

## Why
- configs that omit TLS material should continue to behave like TLS is not configured
- server config should not fail only because a decoded TLS block is empty

## Testing
- go test ./crypto/tls/config ./config/server ./transport/http ./transport/grpc ./config/client
- make lint

AI-assisted-by: [Codex](https://openai.com/codex/)