### PR TITLE
feat(crypto): return missing key for empty material

### DIFF
--- a/config/client/config.go
+++ b/config/client/config.go
@@ -57,7 +57,7 @@ func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
 		return config, nil
 	}
 
-	if cfg.HasKeyPair() {
+	if cfg.HasKeyMaterial() {
 		pair, err := tlsconfig.NewKeyPair(fs, cfg)
 		if err != nil {
 			return config, err

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -74,11 +74,11 @@ func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	if !cfg.IsEnabled() {
+	if !cfg.HasKeyMaterial() && !cfg.HasCA() {
 		return config, nil
 	}
 
-	if cfg.HasKeyPair() {
+	if cfg.HasKeyMaterial() {
 		pair, err := tlsconfig.NewKeyPair(fs, cfg)
 		if err != nil {
 			return config, err

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -71,6 +71,7 @@ func TestNewConfigDefaults(t *testing.T) {
 	}{
 		{name: "nil"},
 		{name: "empty", config: &config.Config{}},
+		{name: "server name", config: &config.Config{ServerName: "localhost"}},
 	}
 
 	for _, tt := range tests {

--- a/crypto/aes/aes.go
+++ b/crypto/aes/aes.go
@@ -4,9 +4,11 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // ErrInvalidLength is returned when a ciphertext is too short to contain the required nonce prefix.
@@ -25,9 +27,19 @@ func NewCipher(gen *rand.Generator, fs *os.FS, cfg *Config) (*Cipher, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
+	if strings.IsEmpty(cfg.Key) {
+		return nil, crypto.ErrMissingKey
+	}
 
 	k, err := cfg.GetKey(fs)
-	return &Cipher{gen: gen, key: k}, err
+	if err != nil {
+		return nil, err
+	}
+	if len(k) == 0 {
+		return nil, crypto.ErrMissingKey
+	}
+
+	return &Cipher{gen: gen, key: k}, nil
 }
 
 // Cipher provides AES-GCM encryption and decryption using a configured key.

--- a/crypto/aes/aes_test.go
+++ b/crypto/aes/aes_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/crypto/aes"
+	"github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -45,7 +46,17 @@ func TestValidCipher(t *testing.T) {
 func TestInvalidCipher(t *testing.T) {
 	gen := rand.NewGenerator(rand.NewReader())
 
-	cipher, err := aes.NewCipher(gen, test.FS, &aes.Config{Key: test.FilePath("secrets/aes_invalid")})
+	cipher, err := aes.NewCipher(gen, test.FS, &aes.Config{})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+	require.Nil(t, cipher)
+
+	t.Setenv("AES_EMPTY", "")
+
+	cipher, err = aes.NewCipher(gen, test.FS, &aes.Config{Key: "env:AES_EMPTY"})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+	require.Nil(t, cipher)
+
+	cipher, err = aes.NewCipher(gen, test.FS, &aes.Config{Key: test.FilePath("secrets/aes_invalid")})
 	require.NoError(t, err)
 
 	_, err = cipher.Encrypt(strings.Bytes("test"))

--- a/crypto/ed25519/doc.go
+++ b/crypto/ed25519/doc.go
@@ -18,6 +18,6 @@
 //
 // If the decoded key material is valid but not Ed25519, key parsing helpers
 // return crypto/errors.ErrInvalidKeyType instead of panicking. Callers can use
-// errors.Is(err, cryptoerrors.ErrInvalidKeyType) to detect that case while still
+// errors.Is(err, crypto.ErrInvalidKeyType) to detect that case while still
 // receiving wrapped context about the actual decoded type.
 package ed25519

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -58,13 +58,20 @@ func TestInvalidConfig(t *testing.T) {
 		name   string
 	}{
 		{name: "empty signer config", config: &ed25519.Config{}},
+		{name: "empty signer private key", config: &ed25519.Config{Private: "env:ED25519_EMPTY"}},
 		{name: "invalid signer private key", config: &ed25519.Config{Public: test.FilePath("secrets/ed25519_public"), Private: test.FilePath("secrets/ed25519_private_invalid")}},
 	}
+
+	t.Setenv("ED25519_EMPTY", "")
 
 	for _, tt := range signerTests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ed25519.NewSigner(test.PEM, tt.config)
-			require.Error(t, err)
+			if tt.name == "invalid signer private key" {
+				require.Error(t, err)
+				return
+			}
+			require.ErrorIs(t, err, errors.ErrMissingKey)
 		})
 	}
 
@@ -73,13 +80,18 @@ func TestInvalidConfig(t *testing.T) {
 		name   string
 	}{
 		{name: "empty verifier config", config: &ed25519.Config{}},
+		{name: "empty verifier public key", config: &ed25519.Config{Public: "env:ED25519_EMPTY"}},
 		{name: "invalid verifier public key", config: &ed25519.Config{Public: test.FilePath("secrets/ed25519_public_invalid"), Private: test.FilePath("secrets/ed25519_private")}},
 	}
 
 	for _, tt := range verifierTests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ed25519.NewVerifier(test.PEM, tt.config)
-			require.Error(t, err)
+			if tt.name == "invalid verifier public key" {
+				require.Error(t, err)
+				return
+			}
+			require.ErrorIs(t, err, errors.ErrMissingKey)
 		})
 	}
 }

--- a/crypto/ed25519/signer.go
+++ b/crypto/ed25519/signer.go
@@ -3,7 +3,9 @@ package ed25519
 import (
 	"crypto/ed25519"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewSigner constructs an Ed25519 Signer when configuration is enabled.
@@ -15,6 +17,9 @@ import (
 func NewSigner(decoder *pem.Decoder, cfg *Config) (*Signer, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
+	}
+	if strings.IsEmpty(cfg.Private) {
+		return nil, crypto.ErrMissingKey
 	}
 
 	pri, err := cfg.PrivateKey(decoder)

--- a/crypto/ed25519/verifier.go
+++ b/crypto/ed25519/verifier.go
@@ -5,6 +5,7 @@ import (
 
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewVerifier constructs an Ed25519 Verifier when configuration is enabled.
@@ -16,6 +17,9 @@ import (
 func NewVerifier(decoder *pem.Decoder, cfg *Config) (*Verifier, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
+	}
+	if strings.IsEmpty(cfg.Public) {
+		return nil, crypto.ErrMissingKey
 	}
 
 	pub, err := cfg.PublicKey(decoder)

--- a/crypto/errors/errors.go
+++ b/crypto/errors/errors.go
@@ -8,6 +8,10 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // signature/hash does not match the expected value for the input message.
 var ErrInvalidMatch = errors.New("crypto: invalid match")
 
+// ErrMissingKey indicates that required cryptographic key material was not configured
+// or resolved to empty bytes.
+var ErrMissingKey = errors.New("crypto: missing key")
+
 // ErrInvalidKeyType indicates that parsed key material was valid, but not of the
 // key type expected by the caller.
 //

--- a/crypto/hmac/hmac.go
+++ b/crypto/hmac/hmac.go
@@ -4,8 +4,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha512"
 
-	"github.com/alexfalkowski/go-service/v2/crypto/errors"
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewSigner constructs an HMAC-SHA-512 Signer when configuration is enabled.
@@ -20,9 +21,19 @@ func NewSigner(fs *os.FS, cfg *Config) (*Signer, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
+	if strings.IsEmpty(cfg.Key) {
+		return nil, crypto.ErrMissingKey
+	}
 
 	k, err := cfg.GetKey(fs)
-	return &Signer{key: k}, err
+	if err != nil {
+		return nil, err
+	}
+	if len(k) == 0 {
+		return nil, crypto.ErrMissingKey
+	}
+
+	return &Signer{key: k}, nil
 }
 
 // Signer signs and verifies messages using HMAC-SHA-512.
@@ -53,7 +64,7 @@ func (s *Signer) Verify(sig, msg []byte) error {
 	mac.Write(msg)
 
 	if !hmac.Equal(sig, mac.Sum(nil)) {
-		return errors.ErrInvalidMatch
+		return crypto.ErrInvalidMatch
 	}
 
 	return nil

--- a/crypto/hmac/hmac_test.go
+++ b/crypto/hmac/hmac_test.go
@@ -23,6 +23,12 @@ func TestGenerator(t *testing.T) {
 	require.Empty(t, key)
 }
 
+func TestIsEnabled(t *testing.T) {
+	require.False(t, (*hmac.Config)(nil).IsEnabled())
+	require.True(t, (&hmac.Config{}).IsEnabled())
+	require.True(t, test.NewHMAC().IsEnabled())
+}
+
 func TestValidSigner(t *testing.T) {
 	signer, err := hmac.NewSigner(test.FS, test.NewHMAC())
 	require.NoError(t, err)
@@ -37,6 +43,18 @@ func TestValidSigner(t *testing.T) {
 
 	signer, err = hmac.NewSigner(nil, nil)
 	require.NoError(t, err)
+	require.Nil(t, signer)
+}
+
+func TestSignerMissingKey(t *testing.T) {
+	signer, err := hmac.NewSigner(test.FS, &hmac.Config{})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+	require.Nil(t, signer)
+
+	t.Setenv("HMAC_EMPTY", "")
+
+	signer, err = hmac.NewSigner(test.FS, &hmac.Config{Key: "env:HMAC_EMPTY"})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
 	require.Nil(t, signer)
 }
 

--- a/crypto/pem/pem.go
+++ b/crypto/pem/pem.go
@@ -3,8 +3,10 @@ package pem
 import (
 	"encoding/pem"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 var (
@@ -46,9 +48,16 @@ type Decoder struct {
 //   - returns ErrInvalidKind if a PEM block is decoded but its Type does not equal kind.
 //   - returns any error from fs.ReadSource if the input cannot be resolved/read.
 func (d *Decoder) Decode(path, kind string) ([]byte, error) {
+	if strings.IsEmpty(path) {
+		return nil, crypto.ErrMissingKey
+	}
+
 	data, err := d.fs.ReadSource(path)
 	if err != nil {
 		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, crypto.ErrMissingKey
 	}
 
 	block, _ := pem.Decode(data)

--- a/crypto/pem/pem_test.go
+++ b/crypto/pem/pem_test.go
@@ -3,6 +3,7 @@ package pem_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,14 @@ import (
 func TestDecode(t *testing.T) {
 	_, err := test.PEM.Decode(test.FilePath("none"), "n/a")
 	require.Error(t, err)
+
+	_, err = test.PEM.Decode("", "n/a")
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+
+	t.Setenv("PEM_EMPTY", "")
+
+	_, err = test.PEM.Decode("env:PEM_EMPTY", "n/a")
+	require.ErrorIs(t, err, errors.ErrMissingKey)
 
 	_, err = test.PEM.Decode(test.FilePath("secrets/redis"), "n/a")
 	require.ErrorIs(t, err, pem.ErrInvalidBlock)

--- a/crypto/rsa/decryptor.go
+++ b/crypto/rsa/decryptor.go
@@ -4,8 +4,10 @@ import (
 	"crypto/rsa"
 	"crypto/sha512"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewDecryptor constructs an RSA Decryptor when configuration is enabled.
@@ -19,6 +21,9 @@ import (
 func NewDecryptor(generator *rand.Generator, decoder *pem.Decoder, cfg *Config) (*Decryptor, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
+	}
+	if strings.IsEmpty(cfg.Private) {
+		return nil, crypto.ErrMissingKey
 	}
 
 	pri, err := cfg.PrivateKey(decoder)

--- a/crypto/rsa/encryptor.go
+++ b/crypto/rsa/encryptor.go
@@ -4,8 +4,10 @@ import (
 	"crypto/rsa"
 	"crypto/sha512"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewEncryptor constructs an RSA Encryptor when configuration is enabled.
@@ -19,6 +21,9 @@ import (
 func NewEncryptor(generator *rand.Generator, decoder *pem.Decoder, cfg *Config) (*Encryptor, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
+	}
+	if strings.IsEmpty(cfg.Public) {
+		return nil, crypto.ErrMissingKey
 	}
 
 	pub, err := cfg.PublicKey(decoder)

--- a/crypto/rsa/rsa_test.go
+++ b/crypto/rsa/rsa_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
 	"github.com/alexfalkowski/go-service/v2/crypto/rsa"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -58,11 +59,21 @@ func TestInvalid(t *testing.T) {
 	rand := rand.NewGenerator(rand.NewReader())
 
 	enc, err := rsa.NewEncryptor(rand, test.PEM, &rsa.Config{})
-	require.Error(t, err)
+	require.ErrorIs(t, err, errors.ErrMissingKey)
 	require.Nil(t, enc)
 
 	dec, err := rsa.NewDecryptor(rand, test.PEM, &rsa.Config{})
-	require.Error(t, err)
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+	require.Nil(t, dec)
+
+	t.Setenv("RSA_EMPTY", "")
+
+	enc, err = rsa.NewEncryptor(rand, test.PEM, &rsa.Config{Public: "env:RSA_EMPTY"})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+	require.Nil(t, enc)
+
+	dec, err = rsa.NewDecryptor(rand, test.PEM, &rsa.Config{Private: "env:RSA_EMPTY"})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
 	require.Nil(t, dec)
 
 	cfg := test.NewRSA()

--- a/crypto/ssh/config.go
+++ b/crypto/ssh/config.go
@@ -54,6 +54,9 @@ func (c *Config) PublicKey(fs *os.FS) (ed25519.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(data) == 0 {
+		return nil, errors.ErrMissingKey
+	}
 
 	//nolint:dogsled
 	parsed, _, _, _, err := ssh.ParseAuthorizedKey(data)
@@ -88,6 +91,9 @@ func (c *Config) PrivateKey(fs *os.FS) (ed25519.PrivateKey, error) {
 	data, err := fs.ReadSource(c.Private)
 	if err != nil {
 		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, errors.ErrMissingKey
 	}
 
 	key, err := ssh.ParseRawPrivateKey(data)

--- a/crypto/ssh/doc.go
+++ b/crypto/ssh/doc.go
@@ -19,7 +19,7 @@
 //
 // If the provided key material is valid SSH key data but not an Ed25519 key,
 // key parsing helpers return crypto/errors.ErrInvalidKeyType instead of
-// panicking. Callers can use errors.Is(err, cryptoerrors.ErrInvalidKeyType) to
+// panicking. Callers can use errors.Is(err, crypto.ErrInvalidKeyType) to
 // detect that case while still receiving wrapped context about the actual
 // decoded type.
 package ssh

--- a/crypto/ssh/signer.go
+++ b/crypto/ssh/signer.go
@@ -3,7 +3,9 @@ package ssh
 import (
 	"crypto/ed25519"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewSigner constructs an SSH Signer when configuration is enabled.
@@ -17,6 +19,9 @@ import (
 func NewSigner(fs *os.FS, cfg *Config) (*Signer, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
+	}
+	if strings.IsEmpty(cfg.Private) {
+		return nil, crypto.ErrMissingKey
 	}
 
 	pri, err := cfg.PrivateKey(fs)

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -53,10 +53,18 @@ func TestValid(t *testing.T) {
 
 func TestInvalidConfig(t *testing.T) {
 	_, err := ssh.NewSigner(test.FS, &ssh.Config{})
-	require.Error(t, err)
+	require.ErrorIs(t, err, errors.ErrMissingKey)
 
 	_, err = ssh.NewVerifier(test.FS, &ssh.Config{})
-	require.Error(t, err)
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+
+	t.Setenv("SSH_EMPTY", "")
+
+	_, err = ssh.NewSigner(test.FS, &ssh.Config{Private: "env:SSH_EMPTY"})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
+
+	_, err = ssh.NewVerifier(test.FS, &ssh.Config{Public: "env:SSH_EMPTY"})
+	require.ErrorIs(t, err, errors.ErrMissingKey)
 
 	_, err = ssh.NewVerifier(test.FS, &ssh.Config{Public: test.FilePath("secrets/redis")})
 	require.Error(t, err)

--- a/crypto/ssh/verifier.go
+++ b/crypto/ssh/verifier.go
@@ -5,6 +5,7 @@ import (
 
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewVerifier constructs an SSH Verifier when configuration is enabled.
@@ -18,6 +19,9 @@ import (
 func NewVerifier(fs *os.FS, cfg *Config) (*Verifier, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
+	}
+	if strings.IsEmpty(cfg.Public) {
+		return nil, crypto.ErrMissingKey
 	}
 
 	pub, err := cfg.PublicKey(fs)

--- a/crypto/tls/config/certificate.go
+++ b/crypto/tls/config/certificate.go
@@ -1,20 +1,32 @@
 package config
 
 import (
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewKeyPair resolves and parses cfg's configured leaf certificate/private-key pair.
 func NewKeyPair(fs *os.FS, cfg *Config) (tls.Certificate, error) {
+	if cfg == nil || strings.IsEmpty(cfg.Cert) || strings.IsEmpty(cfg.Key) {
+		return tls.Certificate{}, crypto.ErrMissingKey
+	}
+
 	cert, err := cfg.GetCert(fs)
 	if err != nil {
 		return tls.Certificate{}, err
+	}
+	if len(cert) == 0 {
+		return tls.Certificate{}, crypto.ErrMissingKey
 	}
 
 	key, err := cfg.GetKey(fs)
 	if err != nil {
 		return tls.Certificate{}, err
+	}
+	if len(key) == 0 {
+		return tls.Certificate{}, crypto.ErrMissingKey
 	}
 
 	pair, err := tls.X509KeyPair(cert, key)

--- a/crypto/tls/config/certificate_test.go
+++ b/crypto/tls/config/certificate_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/crypto/errors"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
@@ -28,17 +29,30 @@ func TestNewKeyPair(t *testing.T) {
 	}
 
 	invalidTests := []struct {
-		config *tls.Config
-		name   string
+		config        *tls.Config
+		name          string
+		errMissingKey bool
 	}{
+		{name: "nil config", errMissingKey: true},
+		{name: "empty config", config: &tls.Config{}, errMissingKey: true},
+		{name: "missing cert", config: &tls.Config{Key: test.FilePath("certs/key.pem")}, errMissingKey: true},
+		{name: "missing key", config: &tls.Config{Cert: test.FilePath("certs/cert.pem")}, errMissingKey: true},
+		{name: "empty cert source", config: &tls.Config{Cert: "env:TLS_EMPTY", Key: test.FilePath("certs/key.pem")}, errMissingKey: true},
+		{name: "empty key source", config: &tls.Config{Cert: test.FilePath("certs/cert.pem"), Key: "env:TLS_EMPTY"}, errMissingKey: true},
 		{name: "invalid key", config: test.NewTLSConfig("certs/client-cert.pem", "secrets/none")},
 		{name: "invalid cert", config: test.NewTLSConfig("secrets/none", "certs/client-key.pem")},
 		{name: "invalid pair", config: test.NewTLSConfig("secrets/hooks", "certs/client-key.pem")},
 	}
 
+	t.Setenv("TLS_EMPTY", "")
+
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tls.NewKeyPair(test.FS, tt.config)
+			if tt.errMissingKey {
+				require.ErrorIs(t, err, errors.ErrMissingKey)
+				return
+			}
 			require.Error(t, err)
 		})
 	}

--- a/crypto/tls/config/config.go
+++ b/crypto/tls/config/config.go
@@ -50,17 +50,11 @@ type Config struct {
 	ServerName string `yaml:"server_name,omitempty" json:"server_name,omitempty" toml:"server_name,omitempty"`
 }
 
-// IsEnabled reports whether TLS configuration has any configured TLS material.
+// IsEnabled reports whether TLS configuration has any configured TLS field.
 //
-// By convention across go-service config types, a nil *Config is treated as "disabled".
-// An empty *Config is also disabled so decoders that allocate an empty TLS block do not
-// accidentally enable TLS without key material.
+// By convention, nil and empty configs are disabled.
 func (c *Config) IsEnabled() bool {
-	if c == nil {
-		return false
-	}
-
-	return c.hasKeyMaterial() || c.HasCA() || !strings.IsEmpty(c.ServerName)
+	return c.HasKeyMaterial() || c.HasCA() || c.HasServerName()
 }
 
 // HasKeyPair reports whether both certificate and key sources are configured.
@@ -72,8 +66,9 @@ func (c *Config) HasKeyPair() bool {
 	return c != nil && !strings.IsEmpty(c.Cert) && !strings.IsEmpty(c.Key)
 }
 
-func (c *Config) hasKeyMaterial() bool {
-	return !strings.IsEmpty(c.Cert) || !strings.IsEmpty(c.Key)
+// HasKeyMaterial reports whether certificate or private key source is configured.
+func (c *Config) HasKeyMaterial() bool {
+	return c != nil && (!strings.IsEmpty(c.Cert) || !strings.IsEmpty(c.Key))
 }
 
 // HasCA reports whether a peer CA source is configured.
@@ -82,6 +77,11 @@ func (c *Config) hasKeyMaterial() bool {
 // that the resolved contents are readable or contain PEM-encoded certificates.
 func (c *Config) HasCA() bool {
 	return c != nil && !strings.IsEmpty(c.CA)
+}
+
+// HasServerName reports whether a client-side server name override is configured.
+func (c *Config) HasServerName() bool {
+	return c != nil && !strings.IsEmpty(c.ServerName)
 }
 
 // GetCert resolves and returns the certificate bytes from the configured source

--- a/crypto/tls/config/config_test.go
+++ b/crypto/tls/config/config_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHasKeyMaterial(t *testing.T) {
+	tests := []struct {
+		config *tls.Config
+		name   string
+		want   bool
+	}{
+		{name: "nil"},
+		{name: "empty", config: &tls.Config{}},
+		{name: "cert", config: &tls.Config{Cert: test.FilePath("certs/cert.pem")}, want: true},
+		{name: "key", config: &tls.Config{Key: test.FilePath("certs/key.pem")}, want: true},
+		{name: "ca", config: &tls.Config{CA: test.FilePath("certs/rootCA.pem")}},
+		{name: "server name", config: &tls.Config{ServerName: "localhost"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.config.HasKeyMaterial())
+		})
+	}
+}
+
 func TestIsEnabled(t *testing.T) {
 	tests := []struct {
 		config *tls.Config

--- a/debug/server.go
+++ b/debug/server.go
@@ -94,7 +94,7 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 	config := &config.Config{
 		Address: cmp.Or(cfg.Address, net.DefaultAddress("6060")),
 	}
-	if !cfg.TLS.IsEnabled() {
+	if !cfg.TLS.HasKeyMaterial() && !cfg.TLS.HasCA() {
 		return config, nil
 	}
 

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -1,12 +1,12 @@
 package ssh
 
 import (
-	cryptoerrors "github.com/alexfalkowski/go-service/v2/crypto/errors"
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/ssh"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
-	tokenerrors "github.com/alexfalkowski/go-service/v2/token/errors"
+	token "github.com/alexfalkowski/go-service/v2/token/errors"
 )
 
 // Signer is an alias for crypto/ssh.Signer.
@@ -63,7 +63,7 @@ type Token struct {
 // key material cannot be loaded, or signature generation fails.
 func (t *Token) Generate() (string, error) {
 	if t.cfg.Key == nil || t.cfg.Key.Config == nil {
-		return strings.Empty, tokenerrors.ErrInvalidConfig
+		return strings.Empty, token.ErrInvalidConfig
 	}
 
 	sig, err := ssh.NewSigner(t.fs, t.cfg.Key.Config)
@@ -106,20 +106,20 @@ func (t *Token) Generate() (string, error) {
 //
 // On success, Verify returns the extracted name. On failure, it always returns an
 // empty name alongside the error.
-func (t *Token) Verify(token string) (string, error) {
-	index := strings.LastIndex(token, "-")
-	if index <= 0 || index == len(token)-1 {
-		return strings.Empty, cryptoerrors.ErrInvalidMatch
+func (t *Token) Verify(tkn string) (string, error) {
+	index := strings.LastIndex(tkn, "-")
+	if index <= 0 || index == len(tkn)-1 {
+		return strings.Empty, crypto.ErrInvalidMatch
 	}
-	name, key := token[:index], token[index+1:]
+	name, key := tkn[:index], tkn[index+1:]
 
 	cfg := t.cfg.Keys.Get(name)
 	if cfg == nil {
-		return strings.Empty, cryptoerrors.ErrInvalidMatch
+		return strings.Empty, crypto.ErrInvalidMatch
 	}
 
 	if cfg.Config == nil {
-		return strings.Empty, tokenerrors.ErrInvalidConfig
+		return strings.Empty, token.ErrInvalidConfig
 	}
 
 	verifier, err := ssh.NewVerifier(t.fs, cfg.Config)

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -199,7 +199,7 @@ func maxReceiveSizeOption(cfg *Config) grpc.ServerOption {
 }
 
 func credsServerOption(fs *os.FS, cfg *Config) (grpc.ServerOption, error) {
-	if !cfg.TLS.IsEnabled() {
+	if !cfg.TLS.HasKeyMaterial() && !cfg.TLS.HasCA() {
 		return grpc.EmptyServerOption{}, nil
 	}
 

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -168,7 +168,7 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 	config := &config.Config{
 		Address: cmp.Or(cfg.Address, net.DefaultAddress("8080")),
 	}
-	if !cfg.TLS.IsEnabled() {
+	if !cfg.TLS.HasKeyMaterial() && !cfg.TLS.HasCA() {
 		return config, nil
 	}
 


### PR DESCRIPTION
## What

- Add a shared missing-key sentinel and return it consistently when configured key material is absent or resolves empty.
- Cover AES, HMAC, RSA, Ed25519, SSH, PEM decoding, and TLS keypair loading with focused tests.
- Keep TLS client enablement on `Config.IsEnabled()` while server paths only enable TLS for server-relevant key material or CA config.
- Rename local `crypto/errors` aliases to `crypto` for consistency.

## Why

- Avoid silently accepting empty secrets or surfacing provider-specific parse errors for missing key material.
- Preserve optional TLS config behavior while keeping client-only `server_name` from enabling server TLS.

## Testing

- `go test ./crypto/... ./config ./debug ./transport/... ./token/...`
- `make lint`
- `git diff --check`
