### PR TITLE
fix(database): reject empty dsn sources

### DIFF
--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -48,6 +48,9 @@ var ErrSkip = driver.ErrSkip
 // ErrNoDSNs is returned when SQL configuration enables a driver without any master or slave DSNs.
 var ErrNoDSNs = errors.New("driver: no database DSNs configured")
 
+// ErrEmptyDSN is returned when a configured DSN source resolves to an empty string.
+var ErrEmptyDSN = errors.New("driver: empty database DSN")
+
 // Register registers a `database/sql` driver under name.
 //
 // This function registers the driver with the global `database/sql` driver registry. It is therefore intended
@@ -104,6 +107,9 @@ func Connect(name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(u) == 0 {
+			return nil, ErrEmptyDSN
+		}
 
 		masters[i] = bytes.String(u)
 	}
@@ -114,6 +120,9 @@ func Connect(name string, fs *os.FS, cfg *config.Config) (*mssqlx.DBs, error) {
 		u, err := s.GetURL(fs)
 		if err != nil {
 			return nil, err
+		}
+		if len(u) == 0 {
+			return nil, ErrEmptyDSN
 		}
 
 		slaves[i] = bytes.String(u)

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -17,31 +17,6 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func up(ctx context.Context, db *sql.DBs) error {
-	ctx, cancel := test.Timeout(ctx)
-	defer cancel()
-
-	query := `CREATE TABLE IF NOT EXISTS accounts (
-		user_id serial PRIMARY KEY,
-		created_at TIMESTAMP NOT NULL
-	);`
-
-	_, err := db.ExecContext(ctx, query)
-
-	return err
-}
-
-func down(ctx context.Context, db *sql.DBs) error {
-	ctx, cancel := test.Timeout(ctx)
-	defer cancel()
-
-	query := "DROP TABLE IF EXISTS accounts;"
-
-	_, err := db.ExecContext(ctx, query)
-
-	return err
-}
-
 func TestConnect(t *testing.T) {
 	cfg := test.NewPGConfig()
 
@@ -57,42 +32,44 @@ func TestInvalidOpen(t *testing.T) {
 	}{
 		{
 			name: "invalid masters",
-			config: &pg.Config{
-				Config: &config.Config{
-					Masters:         []config.DSN{{URL: test.FilePath("secrets/none")}},
-					Slaves:          []config.DSN{{URL: test.FilePath("secrets/pg")}},
-					MaxOpenConns:    5,
-					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour,
-				},
-			},
+			config: pgConfig(
+				[]config.DSN{{URL: test.FilePath("secrets/none")}},
+				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
+			),
 			wantErr: fs.ErrNotExist,
 		},
 		{
 			name: "invalid slaves",
-			config: &pg.Config{
-				Config: &config.Config{
-					Masters:         []config.DSN{{URL: test.FilePath("secrets/pg")}},
-					Slaves:          []config.DSN{{URL: test.FilePath("secrets/none")}},
-					MaxOpenConns:    5,
-					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour,
-				},
-			},
+			config: pgConfig(
+				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
+				[]config.DSN{{URL: test.FilePath("secrets/none")}},
+			),
 			wantErr: fs.ErrNotExist,
 		},
 		{
-			name: "empty dsn configuration",
-			config: &pg.Config{
-				Config: &config.Config{
-					MaxOpenConns:    5,
-					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour,
-				},
-			},
+			name:    "empty dsn configuration",
+			config:  pgConfig(nil, nil),
 			wantErr: driver.ErrNoDSNs,
 		},
+		{
+			name: "empty master dsn",
+			config: pgConfig(
+				[]config.DSN{{}},
+				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
+			),
+			wantErr: driver.ErrEmptyDSN,
+		},
+		{
+			name: "empty slave dsn",
+			config: pgConfig(
+				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
+				[]config.DSN{{URL: "env:PG_EMPTY_DSN"}},
+			),
+			wantErr: driver.ErrEmptyDSN,
+		},
 	}
+
+	t.Setenv("PG_EMPTY_DSN", "")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -352,4 +329,41 @@ func TestInvalidSQLPort(t *testing.T) {
 	lc.RequireStart()
 	require.Error(t, errors.Join(db.Ping()...))
 	lc.RequireStop()
+}
+
+func up(ctx context.Context, db *sql.DBs) error {
+	ctx, cancel := test.Timeout(ctx)
+	defer cancel()
+
+	query := `CREATE TABLE IF NOT EXISTS accounts (
+		user_id serial PRIMARY KEY,
+		created_at TIMESTAMP NOT NULL
+	);`
+
+	_, err := db.ExecContext(ctx, query)
+
+	return err
+}
+
+func down(ctx context.Context, db *sql.DBs) error {
+	ctx, cancel := test.Timeout(ctx)
+	defer cancel()
+
+	query := "DROP TABLE IF EXISTS accounts;"
+
+	_, err := db.ExecContext(ctx, query)
+
+	return err
+}
+
+func pgConfig(masters, slaves []config.DSN) *pg.Config {
+	return &pg.Config{
+		Config: &config.Config{
+			Masters:         masters,
+			Slaves:          slaves,
+			MaxOpenConns:    5,
+			MaxIdleConns:    5,
+			ConnMaxLifetime: time.Hour,
+		},
+	}
 }


### PR DESCRIPTION
## What

- Add `driver.ErrEmptyDSN` for configured datasource entries that resolve to empty strings.
- Reject empty master and slave DSNs before opening database pools.
- Add PostgreSQL wiring tests for blank DSN entries and env-backed DSNs that resolve empty.

## Why

- Prevent missing or empty DSN secrets from falling through to driver defaults such as pgx/libpq environment or local connection settings.
- Keep the existing no-DSNs case distinct from configured-but-empty DSN entries.

## Testing

- `go test ./config ./database/...`
- `make lint`
- `git diff --check`
