### PR TITLE
feat(compress): enforce cache value size budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ cache:
   kind: redis
   compressor: zstd
   encoder: json
+  max_size: 4MB
   options:
     url: env:CACHE_URL
 ```
@@ -263,6 +264,7 @@ Notes:
 
 - Built-in driver kinds in this repo are `redis` and `sync`.
 - `kind` is still wiring-dependent in practice: services can register additional drivers.
+- `max_size` limits encoded cache values before compression and after decompression. A zero value uses the default `4MB`.
 - `options` is backend-specific and decoded as `map[string]any`.
 
 ---

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -139,7 +139,11 @@ func (c *Cache) encode(value any) (string, error) {
 	}
 
 	data := buf.Bytes()
-	compressed := c.compressor().Compress(data)
+	compressed, err := c.compressor().Compress(data, c.cfg.GetMaxSize())
+	if err != nil {
+		return strings.Empty, err
+	}
+
 	encoded := base64.Encode(compressed)
 
 	return encoded, nil
@@ -151,7 +155,7 @@ func (c *Cache) decode(value string, field any) error {
 		return err
 	}
 
-	decompressed, err := c.compressor().Decompress(decoded)
+	decompressed, err := c.compressor().Decompress(decoded, c.cfg.GetMaxSize())
 	if err != nil {
 		return err
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/cache"
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/ptr"
@@ -96,6 +97,27 @@ func TestGenericDisabledCache(t *testing.T) {
 	value, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
 	require.Equal(t, strings.Empty, *value)
+}
+
+func TestMaxSizeOnPersist(t *testing.T) {
+	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
+	cfg.MaxSize = 4
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	err := world.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestMaxSizeOnGet(t *testing.T) {
+	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	require.NoError(t, world.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute))
+
+	cfg.MaxSize = 4
+
+	err := world.Get(t.Context(), "test", ptr.Zero[string]())
+	require.ErrorIs(t, err, errors.ErrTooLarge)
 }
 
 func TestExpiredCache(t *testing.T) {

--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -1,5 +1,10 @@
 package config
 
+import "github.com/alexfalkowski/go-service/v2/bytes"
+
+// DefaultMaxSize is the default cache value limit applied when MaxSize is omitted or zero.
+const DefaultMaxSize bytes.Size = 4 * bytes.MB
+
 // Config configures the cache subsystem.
 type Config struct {
 	// Options contains implementation-specific configuration for the selected Kind.
@@ -16,9 +21,27 @@ type Config struct {
 
 	// Encoder selects the value encoding used when storing objects in the cache (if applicable).
 	Encoder string `yaml:"encoder,omitempty" json:"encoder,omitempty" toml:"encoder,omitempty"`
+
+	// MaxSize limits encoded cache value size before compression and after decompression.
+	//
+	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
+	//
+	// A zero value applies DefaultMaxSize. Negative values are invalid.
+	MaxSize bytes.Size `yaml:"max_size,omitempty" json:"max_size,omitempty" toml:"max_size,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether caching is enabled.
 func (c *Config) IsEnabled() bool {
 	return c != nil
+}
+
+// GetMaxSize returns the configured cache value limit.
+//
+// A nil receiver or a zero value falls back to DefaultMaxSize.
+func (c *Config) GetMaxSize() bytes.Size {
+	if c == nil || c.MaxSize == 0 {
+		return DefaultMaxSize
+	}
+
+	return c.MaxSize
 }

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -1,0 +1,26 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/cache/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMaxSize(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var cfg *config.Config
+		require.Equal(t, config.DefaultMaxSize, cfg.GetMaxSize())
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		cfg := &config.Config{}
+		require.Equal(t, config.DefaultMaxSize, cfg.GetMaxSize())
+	})
+
+	t.Run("explicit", func(t *testing.T) {
+		cfg := &config.Config{MaxSize: 64}
+		require.Equal(t, bytes.Size(64), cfg.GetMaxSize())
+	})
+}

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -3,6 +3,9 @@ package compress_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/zstd"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
@@ -14,9 +17,10 @@ func TestMap(t *testing.T) {
 			cmp := test.Compressor.Get(kind)
 
 			data := strings.Bytes("hello")
-			d := cmp.Compress(data)
+			d, err := cmp.Compress(data, bytes.KB)
+			require.NoError(t, err)
 
-			ns, err := cmp.Decompress(d)
+			ns, err := cmp.Decompress(d, bytes.KB)
 			require.NoError(t, err)
 			require.Equal(t, data, ns)
 		})
@@ -28,4 +32,72 @@ func TestMap(t *testing.T) {
 			require.Nil(t, cmp)
 		})
 	}
+}
+
+func TestCompressRejectsTooLarge(t *testing.T) {
+	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+		t.Run(kind, func(t *testing.T) {
+			cmp := test.Compressor.Get(kind)
+
+			_, err := cmp.Compress(strings.Bytes("hello"), 4)
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+		})
+	}
+}
+
+func TestDecompressRejectsTooLarge(t *testing.T) {
+	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+		t.Run(kind, func(t *testing.T) {
+			cmp := test.Compressor.Get(kind)
+
+			data := strings.Bytes("hello")
+			d, err := cmp.Compress(data, bytes.KB)
+			require.NoError(t, err)
+
+			_, err = cmp.Decompress(d, bytes.Size(len(data)-1))
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+		})
+	}
+}
+
+func TestDecompressRejectsInvalidData(t *testing.T) {
+	for _, kind := range []string{"zstd", "s2", "snappy"} {
+		t.Run(kind, func(t *testing.T) {
+			cmp := test.Compressor.Get(kind)
+
+			_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, errors.ErrTooLarge)
+		})
+	}
+}
+
+func TestS2DecompressReturnsDecodedLenError(t *testing.T) {
+	cmp := test.Compressor.Get("s2")
+	data := []byte{0x80}
+
+	_, err := cmp.Decompress(data, bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestSnappyDecompressReturnsDecodedLenError(t *testing.T) {
+	cmp := test.Compressor.Get("snappy")
+	data := []byte{0x80}
+
+	_, err := cmp.Decompress(data, bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestZstdDecompressPreservesDecoderSizeError(t *testing.T) {
+	cmp := zstd.NewCompressor()
+
+	data := make([]byte, zstd.MinWindowSize+1)
+	encoded, err := cmp.Compress(data, bytes.Size(len(data)))
+	require.NoError(t, err)
+
+	_, err = cmp.Decompress(encoded, zstd.MinWindowSize)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+	require.ErrorIs(t, err, zstd.ErrDecoderSizeExceeded)
 }

--- a/compress/compressor.go
+++ b/compress/compressor.go
@@ -1,13 +1,19 @@
 package compress
 
+import "github.com/alexfalkowski/go-service/v2/bytes"
+
 // Compressor provides a common interface for compressing and decompressing byte slices.
 //
 // Implementations may use different algorithms and may return errors during decompression if the input
 // is invalid or corrupted.
 type Compressor interface {
 	// Compress returns a compressed representation of data.
-	Compress(data []byte) []byte
+	//
+	// The input data must not exceed size.
+	Compress(data []byte, size bytes.Size) ([]byte, error)
 
 	// Decompress returns the decompressed representation of data.
-	Decompress(data []byte) ([]byte, error)
+	//
+	// The returned data must not exceed size.
+	Decompress(data []byte, size bytes.Size) ([]byte, error)
 }

--- a/compress/errors/doc.go
+++ b/compress/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors provides shared errors for compression packages.
+package errors

--- a/compress/errors/errors.go
+++ b/compress/errors/errors.go
@@ -1,0 +1,6 @@
+package errors
+
+import "github.com/alexfalkowski/go-service/v2/errors"
+
+// ErrTooLarge is returned when data exceeds the configured size.
+var ErrTooLarge = errors.New("compress: too large")

--- a/compress/none/none.go
+++ b/compress/none/none.go
@@ -1,5 +1,10 @@
 package none
 
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+)
+
 // NewCompressor constructs a no-op compressor implementation.
 //
 // The returned value implements `github.com/alexfalkowski/go-service/v2/compress.Compressor` and is
@@ -16,11 +21,23 @@ func NewCompressor() *Compressor {
 type Compressor struct{}
 
 // Compress returns data unchanged.
-func (c *Compressor) Compress(data []byte) []byte {
-	return data
+//
+// An error is returned if data exceeds size.
+func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
+	if int64(len(data)) > size.Bytes() {
+		return nil, errors.ErrTooLarge
+	}
+
+	return data, nil
 }
 
 // Decompress returns data unchanged.
-func (c *Compressor) Decompress(data []byte) ([]byte, error) {
+//
+// An error is returned if data exceeds size.
+func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
+	if int64(len(data)) > size.Bytes() {
+		return nil, errors.ErrTooLarge
+	}
+
 	return data, nil
 }

--- a/compress/s2/s2.go
+++ b/compress/s2/s2.go
@@ -1,6 +1,10 @@
 package s2
 
-import "github.com/klauspost/compress/s2"
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/klauspost/compress/s2"
+)
 
 // NewCompressor constructs an S2 compressor implementation.
 //
@@ -15,13 +19,27 @@ func NewCompressor() *Compressor {
 type Compressor struct{}
 
 // Compress returns the S2-compressed representation of data.
-func (c *Compressor) Compress(data []byte) []byte {
-	return s2.Encode(nil, data)
+//
+// An error is returned if data exceeds size.
+func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
+	if int64(len(data)) > size.Bytes() {
+		return nil, errors.ErrTooLarge
+	}
+
+	return s2.Encode(nil, data), nil
 }
 
 // Decompress returns the decompressed representation of data.
 //
-// An error is returned if data is not valid S2-encoded content.
-func (c *Compressor) Decompress(data []byte) ([]byte, error) {
+// An error is returned if data is not valid S2-encoded content or the decompressed data exceeds size.
+func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
+	decodedLen, err := s2.DecodedLen(data)
+	if err != nil {
+		return nil, err
+	}
+	if int64(decodedLen) > size.Bytes() {
+		return nil, errors.ErrTooLarge
+	}
+
 	return s2.Decode(nil, data)
 }

--- a/compress/snappy/snappy.go
+++ b/compress/snappy/snappy.go
@@ -1,6 +1,10 @@
 package snappy
 
-import "github.com/klauspost/compress/snappy"
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/klauspost/compress/snappy"
+)
 
 // NewCompressor constructs a Snappy compressor implementation.
 //
@@ -15,13 +19,27 @@ func NewCompressor() *Compressor {
 type Compressor struct{}
 
 // Compress returns the Snappy-compressed representation of data.
-func (c *Compressor) Compress(data []byte) []byte {
-	return snappy.Encode(nil, data)
+//
+// An error is returned if data exceeds size.
+func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
+	if int64(len(data)) > size.Bytes() {
+		return nil, errors.ErrTooLarge
+	}
+
+	return snappy.Encode(nil, data), nil
 }
 
 // Decompress returns the decompressed representation of data.
 //
-// An error is returned if data is not valid Snappy-encoded content.
-func (c *Compressor) Decompress(data []byte) ([]byte, error) {
+// An error is returned if data is not valid Snappy-encoded content or the decompressed data exceeds size.
+func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
+	decodedLen, err := snappy.DecodedLen(data)
+	if err != nil {
+		return nil, err
+	}
+	if int64(decodedLen) > size.Bytes() {
+		return nil, errors.ErrTooLarge
+	}
+
 	return snappy.Decode(nil, data)
 }

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -1,6 +1,20 @@
 package zstd
 
-import "github.com/klauspost/compress/zstd"
+import (
+	"fmt"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	compress "github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/klauspost/compress/zstd"
+)
+
+// MinWindowSize is the minimum decoder window size used by the underlying Zstandard implementation.
+const MinWindowSize = zstd.MinWindowSize
+
+// ErrDecoderSizeExceeded is returned by the underlying Zstandard decoder when decoded size exceeds its limit.
+var ErrDecoderSizeExceeded = zstd.ErrDecoderSizeExceeded
 
 // NewCompressor constructs a Zstandard (zstd) compressor implementation.
 //
@@ -17,19 +31,48 @@ type Compressor struct{}
 // Compress returns the zstd-compressed representation of data.
 //
 // This method uses the klauspost/compress zstd encoder.
-func (c *Compressor) Compress(data []byte) []byte {
-	e, _ := zstd.NewWriter(nil)
+//
+// An error is returned if data exceeds size.
+func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
+	if int64(len(data)) > size.Bytes() {
+		return nil, compress.ErrTooLarge
+	}
+
+	e, err := zstd.NewWriter(nil)
+	if err != nil {
+		return nil, err
+	}
 	defer e.Close()
 
-	return e.EncodeAll(data, nil)
+	return e.EncodeAll(data, nil), nil
 }
 
 // Decompress returns the decompressed representation of data.
 //
-// An error is returned if data is not valid zstd-encoded content.
-func (c *Compressor) Decompress(data []byte) ([]byte, error) {
-	d, _ := zstd.NewReader(nil)
+// An error is returned if data is not valid zstd-encoded content or the decompressed data exceeds size.
+func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
+	limit := size.Bytes()
+	maxMemory := uint64(max(limit, int64(MinWindowSize)))
+	d, err := zstd.NewReader(
+		bytes.NewReader(data),
+		zstd.WithDecoderMaxMemory(maxMemory),
+	)
+	if err != nil {
+		return nil, err
+	}
 	defer d.Close()
 
-	return d.DecodeAll(data, nil)
+	decoded, _, err := io.ReadAll(io.LimitReader(d, limit+1))
+	if err != nil {
+		if errors.Is(err, ErrDecoderSizeExceeded) {
+			return nil, fmt.Errorf("%w: %w", compress.ErrTooLarge, err)
+		}
+
+		return nil, err
+	}
+	if int64(len(decoded)) > limit {
+		return nil, compress.ErrTooLarge
+	}
+
+	return decoded, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -216,6 +216,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "redis", config.Cache.Kind)
 	require.Equal(t, "snappy", config.Cache.Compressor)
 	require.Equal(t, "proto", config.Cache.Encoder)
+	require.Equal(t, 4*bytes.MB, config.Cache.MaxSize)
 	require.Equal(t, "file:../test/secrets/redis", config.Cache.Options["url"])
 	require.True(t, config.Crypto.IsEnabled())
 	require.True(t, config.Crypto.AES.IsEnabled())

--- a/internal/test/compress.go
+++ b/internal/test/compress.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/compress"
 	"github.com/alexfalkowski/go-service/v2/compress/none"
 	"github.com/alexfalkowski/go-service/v2/compress/s2"
@@ -26,11 +27,11 @@ type compressor struct {
 }
 
 // Compress implements compress.Compressor for tests.
-func (c *compressor) Compress(_ []byte) []byte {
-	return nil
+func (c *compressor) Compress(_ []byte, _ bytes.Size) ([]byte, error) {
+	return nil, c.err
 }
 
 // Decompress implements compress.Compressor for tests.
-func (c *compressor) Decompress(_ []byte) ([]byte, error) {
+func (c *compressor) Decompress(_ []byte, _ bytes.Size) ([]byte, error) {
 	return nil, c.err
 }

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -9,6 +9,7 @@
     kind: redis
     encoder: proto
     compressor: snappy
+    max_size: 4MB
     options: {
       url: "file:../test/secrets/redis"
     }

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -8,6 +8,7 @@ timeout = "10s"
 kind = "redis"
 encoder = "proto"
 compressor = "snappy"
+max_size = "4MB"
 [cache.options]
 url = "file:../test/secrets/redis"
 

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -6,6 +6,7 @@ cache:
   kind: redis
   encoder: proto
   compressor: snappy
+  max_size: 4MB
   options:
     url: file:../test/secrets/redis
 crypto:


### PR DESCRIPTION
## What
- require compressors to receive a size budget when compressing and decompressing
- add cache max_size config with a 4MB default and pass it into cache encode/decode paths
- return compress ErrTooLarge when values exceed the configured budget
- document max_size and cover config fixtures, cache paths, and codec limit behavior

## Why
- keep cache values bounded before storing and after loading
- avoid relying on codec defaults for allocation and decoded output limits

## Testing
- go test ./compress/... ./cache/... ./config
- make lint
- git diff --check
