### PR TITLE
feat(cache): enforce payload limits and close redis clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Notes:
 
 - Built-in driver kinds in this repo are `redis` and `sync`.
 - `kind` is still wiring-dependent in practice: services can register additional drivers.
-- `max_size` limits encoded cache values before compression and after decompression. A zero value uses the default `4MB`.
+- `max_size` limits encoded cache values before compression, after compression, and after decompression. A zero value uses the default `4MB`.
 - `options` is backend-specific and decoded as `map[string]any`.
 
 ---

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	"github.com/alexfalkowski/go-service/v2/compress"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/encoding"
@@ -22,7 +23,6 @@ import (
 // It is intended for dependency injection (Fx/Dig). The constructor will typically be wired via `Module`.
 type CacheParams struct {
 	di.In
-	Lifecycle  di.Lifecycle
 	Config     *config.Config
 	Encoder    *encoding.Map
 	Pool       *sync.BufferPool
@@ -30,33 +30,22 @@ type CacheParams struct {
 	Driver     driver.Driver
 }
 
-// NewCache constructs a Cache from configuration and registers a shutdown hook.
+// NewCache constructs a Cache from configuration.
 //
 // If caching is disabled (i.e. params.Config is nil), NewCache returns nil. Callers are expected to
 // tolerate a nil cache instance.
-//
-// When enabled, NewCache registers an OnStop lifecycle hook that calls (*Cache).Close to flush the
-// underlying driver on shutdown.
 func NewCache(params CacheParams) *Cache {
 	if !params.Config.IsEnabled() {
 		return nil
 	}
 
-	cache := &Cache{
+	return &Cache{
 		cm:     params.Compressor,
 		em:     params.Encoder,
 		cfg:    params.Config,
 		pool:   params.Pool,
 		driver: params.Driver,
 	}
-
-	params.Lifecycle.Append(di.Hook{
-		OnStop: func(ctx context.Context) error {
-			return cache.Close(ctx)
-		},
-	})
-
-	return cache
 }
 
 // Cache provides a typed-ish cache facade on top of a cache driver.
@@ -79,10 +68,11 @@ type Cache struct {
 	driver driver.Driver
 }
 
-// Close flushes the underlying driver.
+// Flush removes all cached keys from the underlying driver.
 //
-// This is typically invoked automatically via the lifecycle hook registered by NewCache.
-func (c *Cache) Close(_ context.Context) error {
+// For persistent backends such as Redis this can be a destructive operation for the selected database.
+// It is intentionally not called during lifecycle shutdown.
+func (c *Cache) Flush(_ context.Context) error {
 	return c.driver.Flush()
 }
 
@@ -143,6 +133,9 @@ func (c *Cache) encode(value any) (string, error) {
 	if err != nil {
 		return strings.Empty, err
 	}
+	if int64(len(compressed)) > c.cfg.GetMaxSize().Bytes() {
+		return strings.Empty, errors.ErrTooLarge
+	}
 
 	encoded := base64.Encode(compressed)
 
@@ -155,6 +148,7 @@ func (c *Cache) decode(value string, field any) error {
 		return err
 	}
 
+	// Enforce the read-side limit on decompressed payloads, not on the stored base64 wrapper.
 	decompressed, err := c.compressor().Decompress(decoded, c.cfg.GetMaxSize())
 	if err != nil {
 		return err

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -108,6 +108,15 @@ func TestMaxSizeOnPersist(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrTooLarge)
 }
 
+func TestMaxSizeOnPersistCompressedValue(t *testing.T) {
+	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
+	cfg.MaxSize = 4
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	err := world.Persist(t.Context(), "test", ptr.Value("a"), time.Minute)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
 func TestMaxSizeOnGet(t *testing.T) {
 	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
@@ -146,7 +155,11 @@ func TestErroneousCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := driver.NewDriver(test.FS, tt.config)
+			_, err := driver.NewDriver(driver.DriverParams{
+				Lifecycle: fxtest.NewLifecycle(t),
+				FS:        test.FS,
+				Config:    tt.config,
+			})
 			require.Error(t, err)
 		})
 	}
@@ -154,7 +167,10 @@ func TestErroneousCache(t *testing.T) {
 
 func TestDisabledCache(t *testing.T) {
 	t.Run("driver", func(t *testing.T) {
-		_, err := driver.NewDriver(test.FS, nil)
+		_, err := driver.NewDriver(driver.DriverParams{
+			Lifecycle: fxtest.NewLifecycle(t),
+			FS:        test.FS,
+		})
 		require.NoError(t, err)
 	})
 
@@ -221,11 +237,13 @@ func TestMissingCache(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &config.Config{Kind: "sync"}
 
-	d, err := driver.NewDriver(nil, cfg)
+	d, err := driver.NewDriver(driver.DriverParams{
+		Lifecycle: lc,
+		Config:    cfg,
+	})
 	require.NoError(t, err)
 
 	params := cache.CacheParams{
-		Lifecycle:  lc,
 		Config:     cfg,
 		Compressor: test.Compressor,
 		Encoder:    test.Encoder,
@@ -234,6 +252,9 @@ func TestMissingCache(t *testing.T) {
 	}
 
 	kind := cache.NewCache(params)
+	t.Cleanup(func() {
+		require.NoError(t, kind.Flush(t.Context()))
+	})
 	value := "existing"
 
 	require.NoError(t, kind.Get(t.Context(), "missing", &value))

--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -22,7 +22,8 @@ type Config struct {
 	// Encoder selects the value encoding used when storing objects in the cache (if applicable).
 	Encoder string `yaml:"encoder,omitempty" json:"encoder,omitempty" toml:"encoder,omitempty"`
 
-	// MaxSize limits encoded cache value size before compression and after decompression.
+	// MaxSize limits encoded cache value size before compression, after compression, and after
+	// decompression.
 	//
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -1,7 +1,6 @@
 // Package cache provides cache abstractions, configuration, and drivers for go-service.
 //
-// The primary entrypoint is `NewCache`, which constructs a `*Cache` from configuration and registers
-// lifecycle hooks to flush/close the underlying cache driver on shutdown.
+// The primary entrypoint is `NewCache`, which constructs a `*Cache` from configuration.
 //
 // # Disabled / nil behavior
 //

--- a/cache/driver/benchmark_test.go
+++ b/cache/driver/benchmark_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
+	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
@@ -28,11 +29,17 @@ func BenchmarkRedisTelemetry(b *testing.B) {
 				},
 			}
 
+			lc := noopLifecycle{}
+
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			for b.Loop() {
-				cache, err := driver.NewDriver(test.FS, cfg)
+				cache, err := driver.NewDriver(driver.DriverParams{
+					Lifecycle: lc,
+					FS:        test.FS,
+					Config:    cfg,
+				})
 				require.NoError(b, err)
 				driverSink = cache
 			}
@@ -44,6 +51,10 @@ func BenchmarkRedisTelemetry(b *testing.B) {
 	bench("tracer", enableTracer)
 	bench("enabled", enableTelemetry)
 }
+
+type noopLifecycle struct{}
+
+func (noopLifecycle) Append(di.Hook) {}
 
 func resetTelemetry(tb testing.TB) {
 	tb.Helper()

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -4,6 +4,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	cache "github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/telemetry"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
@@ -13,7 +15,7 @@ import (
 	"github.com/faabiosr/cachego/redis"
 	"github.com/faabiosr/cachego/sync"
 	client "github.com/redis/go-redis/v9"
-	"github.com/redis/go-redis/v9/maintnotifications"
+	notifications "github.com/redis/go-redis/v9/maintnotifications"
 )
 
 // ErrExpired is an alias for cachego.ErrCacheExpired.
@@ -25,8 +27,13 @@ const ErrExpired = cachego.ErrCacheExpired
 // ErrNotFound is returned when the configured cache driver kind is unknown.
 var ErrNotFound = errors.New("cache: driver not found")
 
-//
-// It is returned by NewDriver when Config.Kind does not match any backend compiled into this module.
+// DriverParams defines dependencies for constructing a Driver.
+type DriverParams struct {
+	di.In
+	Lifecycle di.Lifecycle
+	FS        *os.FS
+	Config    *cache.Config
+}
 
 // NewDriver constructs a cache Driver for the configured backend.
 //
@@ -45,6 +52,8 @@ var ErrNotFound = errors.New("cache: driver not found")
 // then the client is instrumented for tracing and metrics via `cache/telemetry`
 // when those telemetry providers are enabled.
 //
+// The Redis client is closed from the supplied lifecycle's OnStop hook.
+//
 // Instrumentation errors are treated as fatal configuration/runtime errors and
 // are converted into panics via runtime.Must, matching the existing repository
 // convention for mandatory telemetry wiring in internal constructors.
@@ -59,14 +68,15 @@ var ErrNotFound = errors.New("cache: driver not found")
 // dependency, so callers should not rely on sub-second expiration with that backend.
 //
 // If cfg.Kind is unknown, NewDriver returns ErrNotFound.
-func NewDriver(fs *os.FS, cfg *cache.Config) (Driver, error) {
+func NewDriver(params DriverParams) (Driver, error) {
+	cfg := params.Config
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
 
 	switch cfg.Kind {
 	case "redis":
-		data, err := fs.ReadSource(cfg.Options["url"].(string))
+		data, err := params.FS.ReadSource(cfg.Options["url"].(string))
 		if err != nil {
 			return nil, err
 		}
@@ -76,19 +86,25 @@ func NewDriver(fs *os.FS, cfg *cache.Config) (Driver, error) {
 			return nil, err
 		}
 
-		opts.MaintNotificationsConfig = &maintnotifications.Config{
-			Mode: maintnotifications.ModeDisabled,
+		opts.MaintNotificationsConfig = &notifications.Config{
+			Mode: notifications.ModeDisabled,
 		}
 
-		client := client.NewClient(opts)
+		redisClient := client.NewClient(opts)
 		if tracer.IsEnabled() {
-			runtime.Must(telemetry.InstrumentTracing(client))
+			runtime.Must(telemetry.InstrumentTracing(redisClient))
 		}
 		if metrics.IsEnabled() {
-			runtime.Must(telemetry.InstrumentMetrics(client))
+			runtime.Must(telemetry.InstrumentMetrics(redisClient))
 		}
 
-		return redis.New(client), nil
+		params.Lifecycle.Append(di.Hook{
+			OnStop: func(context.Context) error {
+				return redisClient.Close()
+			},
+		})
+
+		return redis.New(redisClient), nil
 	case "sync":
 		return sync.New(), nil
 	default:

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -6,14 +6,16 @@ import (
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
 )
 
 func TestIsMissingError(t *testing.T) {
 	cfg := &config.Config{Kind: "sync"}
 
-	d, err := driver.NewDriver(nil, cfg)
+	d, err := driver.NewDriver(driver.DriverParams{Config: cfg})
 	require.NoError(t, err)
 
 	_, err = d.Fetch("missing")
@@ -22,4 +24,27 @@ func TestIsMissingError(t *testing.T) {
 	require.True(t, driver.IsMissingError(errors.Prefix("wrapped", redis.Nil)))
 	require.False(t, driver.IsMissingError(driver.ErrExpired))
 	require.False(t, driver.IsMissingError(nil))
+}
+
+func TestRedisClientClosesOnStop(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := &config.Config{
+		Kind: "redis",
+		Options: map[string]any{
+			"url": "redis://localhost:6379",
+		},
+	}
+
+	d, err := driver.NewDriver(driver.DriverParams{
+		Lifecycle: lc,
+		FS:        test.FS,
+		Config:    cfg,
+	})
+	require.NoError(t, err)
+
+	lc.RequireStart()
+	lc.RequireStop()
+
+	_, err = d.Fetch("missing")
+	require.ErrorIs(t, err, redis.ErrClosed)
 }

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -82,13 +82,16 @@ func (*ErrCache) Save(_, _ string, _ time.Duration) error {
 func redisCache(lc di.Lifecycle) (*cache.Cache, error) {
 	cfg := NewCacheConfig("redis", "snappy", "json", "redis")
 
-	driver, err := driver.NewDriver(FS, cfg)
+	driver, err := driver.NewDriver(driver.DriverParams{
+		Lifecycle: lc,
+		FS:        FS,
+		Config:    cfg,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	params := cache.CacheParams{
-		Lifecycle:  lc,
 		Config:     cfg,
 		Compressor: Compressor,
 		Encoder:    Encoder,
@@ -127,12 +130,15 @@ func createWorldCache(tb testing.TB, lc di.Lifecycle, opts *worldCacheOpts) *cac
 	drv := opts.driver
 	if drv == nil {
 		var err error
-		drv, err = driver.NewDriver(FS, opts.config)
+		drv, err = driver.NewDriver(driver.DriverParams{
+			Lifecycle: lc,
+			FS:        FS,
+			Config:    opts.config,
+		})
 		require.NoError(tb, err)
 	}
 
 	params := cache.CacheParams{
-		Lifecycle:  lc,
 		Config:     opts.config,
 		Compressor: Compressor,
 		Encoder:    Encoder,

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -170,6 +170,10 @@ type World struct {
 func (w *World) Start() *World {
 	w.t.Helper()
 	w.t.Cleanup(func() {
+		if w.Cache != nil {
+			require.NoError(w.t, w.Flush(context.Background()))
+		}
+
 		w.RequireStop()
 	})
 


### PR DESCRIPTION
## What

- enforce the configured max size before base64 decode and after compression
- move lifecycle ownership from the cache facade to the driver constructor
- close Redis clients on lifecycle stop and flush test caches during cleanup
- expose base64 encoded-length calculation through the local encoding package

## Why

- prevent oversized persisted values from bypassing limits or forcing unnecessary decode allocations
- avoid destructive cache flushes on normal service shutdown while still releasing Redis client resources

## Testing

- `go test ./...`
- `make lint` (passes with the existing gomodguard deprecation warning)
