### PR TITLE
feat(http): preserve retry bodies and accept empty webhooks

### DIFF
--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -60,7 +60,7 @@ func (h *Webhook) Sign(req *http.Request) error {
 		return nil
 	}
 
-	payload, body, err := io.ReadAll(req.Body)
+	payload, body, err := readBody(req)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (h *Webhook) Verify(req *http.Request) error {
 		return nil
 	}
 
-	payload, body, err := io.ReadAll(req.Body)
+	payload, body, err := readBody(req)
 	if err != nil {
 		return err
 	}
@@ -103,6 +103,14 @@ func (h *Webhook) Verify(req *http.Request) error {
 	}
 
 	return nil
+}
+
+func readBody(req *http.Request) ([]byte, io.ReadCloser, error) {
+	if req.Body == nil {
+		req.Body = http.NoBody
+	}
+
+	return io.ReadAll(req.Body)
 }
 
 // Handler verifies webhook signatures on inbound requests.

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -40,6 +40,21 @@ func TestSignOverwritesHeaders(t *testing.T) {
 	require.NoError(t, hook.Verify(req))
 }
 
+func TestSignAndVerifyNilBody(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
+	req := &http.Request{Header: make(http.Header)}
+
+	require.NoError(t, hook.Sign(req))
+	require.NotNil(t, req.Body)
+
+	verifyReq := &http.Request{Header: req.Header.Clone()}
+	require.NoError(t, hook.Verify(verifyReq))
+	require.NotNil(t, verifyReq.Body)
+}
+
 func TestRoundTripper(t *testing.T) {
 	hook := hooks.NewWebhook(nil, nil)
 	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -116,7 +116,7 @@ func (r *RoundTripper) attempt(req *http.Request, ctx context.Context, attempt *
 }
 
 func request(req *http.Request, ctx context.Context, attempt int) (*http.Request, error) {
-	if attempt == 0 && req.GetBody == nil {
+	if attempt == 0 {
 		return req.WithContext(ctx), nil
 	}
 

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -117,6 +117,30 @@ func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
 	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
 }
 
+func TestRoundTripperUsesOriginalBodyOnFirstAttempt(t *testing.T) {
+	body := &trackedBody{Reader: strings.NewReader("hello")}
+	rt := &originalBodyRoundTripper{original: body}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+	require.NoError(t, err)
+	req.Body = body
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("hello")), nil
+	}
+
+	res, roundTripErr := retrying.RoundTrip(req)
+	require.NoError(t, roundTripErr)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.True(t, rt.firstUsedOriginal)
+	require.True(t, body.closed)
+	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
+}
+
 func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
 	rt := &requestRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
@@ -242,6 +266,37 @@ func (r *requestRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}, nil
 }
 
+type originalBodyRoundTripper struct {
+	original          io.ReadCloser
+	bodies            []string
+	calls             int
+	firstUsedOriginal bool
+}
+
+func (r *originalBodyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.calls == 0 {
+		r.firstUsedOriginal = req.Body == r.original
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	r.calls++
+	r.bodies = append(r.bodies, string(body))
+
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Status:     fmt.Sprintf("%d %s", http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)),
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}, nil
+}
+
 type errorRoundTripper struct {
 	err   error
 	calls int
@@ -312,4 +367,14 @@ func (r *nonReplayableReader) Read(p []byte) (int, error) {
 	r.read = true
 	copy(p, r.value)
 	return len(r.value), io.EOF
+}
+
+type trackedBody struct {
+	*strings.Reader
+	closed bool
+}
+
+func (b *trackedBody) Close() error {
+	b.closed = true
+	return nil
 }


### PR DESCRIPTION
## What

- use the original request body for the first retry attempt and reserve `GetBody` for later attempts
- handle nil webhook request bodies as empty payloads during signing and verification
- add regression coverage for retry body ownership and empty webhook bodies

## Why

- avoid leaking the original request body when retry middleware wraps replayable requests
- prevent webhook signing or verification from panicking on valid empty-body requests

## Testing

- `go test ./transport/http/retry ./transport/http/hooks ./transport/...`
- `make lint` (passes with the existing gomodguard deprecation warning)
