### PR TITLE
fix(http): fallback for unmapped grpc statuses

### DIFF
--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -99,7 +99,11 @@ func Code(err error) int {
 
 	s, ok := status.FromError(err)
 	if ok {
-		return statusCodes[s.Code()]
+		if code, ok := statusCodes[s.Code()]; ok {
+			return code
+		}
+
+		return http.StatusInternalServerError
 	}
 
 	return http.StatusInternalServerError

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -87,6 +87,12 @@ func TestCodeMapsGRPCStatusCodes(t *testing.T) {
 	}
 }
 
+func TestCodeMapsUnknownGRPCStatusCodeToInternalServerError(t *testing.T) {
+	err := grpcstatus.Error(codes.Code(999), "unknown")
+
+	require.Equal(t, http.StatusInternalServerError, httpstatus.Code(err))
+}
+
 func TestWriteErrorReturnsWriteFailure(t *testing.T) {
 	res := &test.ErrResponseWriter{}
 


### PR DESCRIPTION
## What
- return 500 when a gRPC status code is not present in the HTTP mapping table
- add a regression test for an unmapped gRPC status code

## Why
- avoid returning an invalid status code when malformed, custom, or future gRPC codes reach HTTP status conversion

## Testing
- go test ./net/http/status
- go test ./net/...
- make lint
