### PR TITLE
fix(ssh): reject empty signing key names

### DIFF
--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -62,7 +62,7 @@ type Token struct {
 // Errors are returned when the signing key configuration is missing/partial,
 // key material cannot be loaded, or signature generation fails.
 func (t *Token) Generate() (string, error) {
-	if t.cfg.Key == nil || t.cfg.Key.Config == nil {
+	if t.cfg.Key == nil || t.cfg.Key.Config == nil || strings.IsEmpty(t.cfg.Key.Name) {
 		return strings.Empty, token.ErrInvalidConfig
 	}
 

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -104,6 +104,17 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
 	})
 
+	t.Run("generate with empty key name", func(t *testing.T) {
+		cfg := test.NewToken("ssh").SSH
+		cfg.Key.Name = strings.Empty
+
+		token := ssh.NewToken(cfg, test.FS)
+
+		tkn, err := token.Generate()
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
 	t.Run("verify with matching key missing config", func(t *testing.T) {
 		token := ssh.NewToken(&ssh.Config{
 			Keys: ssh.Keys{


### PR DESCRIPTION
## What
- reject SSH token signing config with an empty key name
- add regression coverage for empty SSH token key names returning invalid config

## Why
- avoid minting SSH-style tokens shaped like `-<signature>` that the verifier rejects because the embedded name is empty

## Testing
- go test ./token/ssh
- go test ./token/...
- make lint
