### PR TITLE
feat(telemetry): require explicit tracer kind

### DIFF
--- a/cache/driver/benchmark_test.go
+++ b/cache/driver/benchmark_test.go
@@ -59,7 +59,7 @@ func (noopLifecycle) Append(di.Hook) {}
 func resetTelemetry(tb testing.TB) {
 	tb.Helper()
 
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
 }
 
@@ -80,14 +80,14 @@ func enableMetrics(tb testing.TB) {
 func enableTracer(tb testing.TB) {
 	tb.Helper()
 
-	tracer.Register(tracer.TracerParams{
+	require.NoError(tb, tracer.Register(tracer.TracerParams{
 		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{},
+		Config:      &tracer.Config{Kind: "otlp"},
 		ID:          test.ID,
 		Name:        test.Name,
 		Version:     test.Version,
 		Environment: test.Environment,
-	})
+	}))
 }
 
 func enableTelemetry(tb testing.TB) {

--- a/database/sql/driver/benchmark_test.go
+++ b/database/sql/driver/benchmark_test.go
@@ -91,7 +91,7 @@ func (benchmarkRows) Next([]driver.Value) error {
 func resetTelemetry(tb testing.TB) {
 	tb.Helper()
 
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
 }
 
@@ -112,14 +112,14 @@ func enableMetrics(tb testing.TB) {
 func enableTracer(tb testing.TB) {
 	tb.Helper()
 
-	tracer.Register(tracer.TracerParams{
+	require.NoError(tb, tracer.Register(tracer.TracerParams{
 		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{},
+		Config:      &tracer.Config{Kind: "otlp"},
 		ID:          test.ID,
 		Name:        test.Name,
 		Version:     test.Version,
 		Environment: test.Environment,
-	})
+	}))
 }
 
 func enableTelemetry(tb testing.TB) {

--- a/internal/test/tracer.go
+++ b/internal/test/tracer.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 )
 
@@ -15,5 +16,5 @@ func RegisterTracer(lc di.Lifecycle, config *tracer.Config) {
 		Config:      config,
 	}
 
-	tracer.Register(params)
+	runtime.Must(tracer.Register(params))
 }

--- a/net/http/benchmark_test.go
+++ b/net/http/benchmark_test.go
@@ -50,7 +50,7 @@ func BenchmarkClientTelemetry(b *testing.B) {
 func resetTelemetry(tb testing.TB) {
 	tb.Helper()
 
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
 }
 
@@ -71,12 +71,12 @@ func enableMetrics(tb testing.TB) {
 func enableTracer(tb testing.TB) {
 	tb.Helper()
 
-	tracer.Register(tracer.TracerParams{
+	require.NoError(tb, tracer.Register(tracer.TracerParams{
 		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{},
+		Config:      &tracer.Config{Kind: "otlp"},
 		ID:          test.ID,
 		Name:        test.Name,
 		Version:     test.Version,
 		Environment: test.Environment,
-	})
+	}))
 }

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -31,7 +31,7 @@ func TestMaxBytesHandler(t *testing.T) {
 }
 
 func TestHandleWhenTelemetryDisabled(t *testing.T) {
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 
 	mux := http.NewServeMux()
@@ -54,11 +54,11 @@ func TestHandleWhenTelemetryDisabled(t *testing.T) {
 
 func TestHandleWhenMetricsEnabled(t *testing.T) {
 	t.Cleanup(func() {
-		tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	})
 
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{
 		Lifecycle: fxtest.NewLifecycle(t),
 		Config:    &metrics.Config{},

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -17,8 +17,8 @@ type Config struct {
 
 	// Kind selects the tracer/exporter implementation.
 	//
-	// Supported kinds depend on what the service links in. This package wires an
-	// OTLP/HTTP exporter when tracing is enabled.
+	// An empty kind means tracing is not configured. This package supports "otlp" and
+	// wires an OTLP/HTTP exporter for that kind.
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
 
 	// URL is the destination endpoint for the selected Kind, when applicable.
@@ -28,9 +28,9 @@ type Config struct {
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`
 }
 
-// IsEnabled reports whether tracing configuration is present.
+// IsEnabled reports whether tracing is configured.
 //
-// A nil *Config indicates tracing is disabled.
+// A nil *Config or empty Kind indicates tracing is disabled.
 func (c *Config) IsEnabled() bool {
-	return c != nil
+	return c != nil && c.Kind != ""
 }

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -2,8 +2,9 @@
 //
 // # What it does
 //
-// When enabled via Config, Register configures and installs a process-wide OpenTelemetry
-// TracerProvider (via otel.SetTracerProvider) backed by an OTLP/HTTP exporter.
+// When configured with kind "otlp", Register configures and installs a process-wide
+// OpenTelemetry TracerProvider (via otel.SetTracerProvider) backed by an OTLP/HTTP
+// exporter.
 //
 // The provider is configured with a Resource describing the running service instance,
 // including standard service identity attributes (host ID, service name, service version,
@@ -11,9 +12,9 @@
 //
 // # Enablement model
 //
-// Tracing is enabled by presence: a nil *Config indicates tracing is disabled.
-// When disabled, Register installs this package's noop provider. IsEnabled reports
-// whether the current global provider is not that noop provider.
+// Tracing is enabled by kind: a nil *Config or an empty Config.Kind indicates tracing
+// is not configured. When disabled, Register installs this package's noop provider.
+// IsEnabled reports whether the current global provider is not that noop provider.
 //
 // # Global provider installation
 //
@@ -35,6 +36,9 @@
 // Shutdown errors are intentionally ignored to avoid blocking other lifecycle stop hooks.
 //
 // # Configuration
+//
+// The supported kind is "otlp". Unknown non-empty kinds cause Register to return
+// ErrNotFound.
 //
 // The exporter request headers are provided by Config.Headers. Header values may be
 // configured as go-service “source strings” (for example "env:NAME", "file:/path", or a

--- a/telemetry/tracer/errors.go
+++ b/telemetry/tracer/errors.go
@@ -2,6 +2,9 @@ package tracer
 
 import "github.com/alexfalkowski/go-service/v2/errors"
 
+// ErrNotFound is returned when the configured tracer kind is unknown.
+var ErrNotFound = errors.New("tracer: not found")
+
 func prefix(err error) error {
 	return errors.Prefix("tracer", err)
 }

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -45,7 +45,7 @@ type TracerParams struct {
 
 // Register configures and installs a global OpenTelemetry TracerProvider.
 //
-// When tracing is enabled (`params.Config != nil`), Register:
+// When tracing is configured with kind "otlp", Register:
 //
 //  1. Creates an OTLP/HTTP trace exporter using `Config.URL` and `Config.Headers`.
 //  2. Creates an OpenTelemetry resource describing the running service.
@@ -53,39 +53,49 @@ type TracerParams struct {
 //  4. Appends lifecycle hooks to start the exporter on application start and to
 //     shut down the provider/exporter on application stop.
 //
+// If Config is nil or Kind is empty, Register installs the noop provider. Unknown
+// non-empty kinds return ErrNotFound.
+//
 // Shutdown errors are intentionally ignored to avoid blocking other stop hooks.
-func Register(params TracerParams) {
+func Register(params TracerParams) error {
 	if !params.Config.IsEnabled() {
 		otel.SetTracerProvider(noopProvider)
-		return
+		return nil
 	}
 
-	client := otlp.NewClient(otlp.WithEndpointURL(params.Config.URL), otlp.WithHeaders(params.Config.Headers))
-	exporter := otlptrace.NewUnstarted(client)
-	attrs := resource.NewWithAttributes(
-		attributes.SchemaURL,
-		attributes.HostID(params.ID.String()),
-		attributes.ServiceName(params.Name.String()),
-		attributes.ServiceVersion(params.Version.String()),
-		attributes.DeploymentEnvironmentName(params.Environment.String()),
-	)
+	switch params.Config.Kind {
+	case "otlp":
+		client := otlp.NewClient(otlp.WithEndpointURL(params.Config.URL), otlp.WithHeaders(params.Config.Headers))
+		exporter := otlptrace.NewUnstarted(client)
+		attrs := resource.NewWithAttributes(
+			attributes.SchemaURL,
+			attributes.HostID(params.ID.String()),
+			attributes.ServiceName(params.Name.String()),
+			attributes.ServiceVersion(params.Version.String()),
+			attributes.DeploymentEnvironmentName(params.Environment.String()),
+		)
 
-	provider := sdk.NewTracerProvider(sdk.WithResource(attrs), sdk.WithBatcher(exporter))
-	otel.SetTracerProvider(provider)
+		provider := sdk.NewTracerProvider(sdk.WithResource(attrs), sdk.WithBatcher(exporter))
+		otel.SetTracerProvider(provider)
 
-	params.Lifecycle.Append(di.Hook{
-		OnStart: func(ctx context.Context) error {
-			return prefix(exporter.Start(ctx))
-		},
-		OnStop: func(ctx context.Context) error {
-			// Do not return error as this will stop all others.
-			_ = provider.Shutdown(ctx)
-			_ = exporter.Shutdown(ctx)
-			otel.SetTracerProvider(noopProvider)
+		params.Lifecycle.Append(di.Hook{
+			OnStart: func(ctx context.Context) error {
+				return prefix(exporter.Start(ctx))
+			},
+			OnStop: func(ctx context.Context) error {
+				// Do not return error as this will stop all others.
+				_ = provider.Shutdown(ctx)
+				_ = exporter.Shutdown(ctx)
+				otel.SetTracerProvider(noopProvider)
 
-			return nil
-		},
-	})
+				return nil
+			},
+		})
+
+		return nil
+	default:
+		return ErrNotFound
+	}
 }
 
 // IsEnabled reports whether tracing is backed by a non-noop provider installed by this package.

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -11,19 +11,40 @@ import (
 
 func TestIsEnabled(t *testing.T) {
 	t.Cleanup(func() {
-		tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})
 
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)})
+	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	require.False(t, tracer.IsEnabled())
 
-	tracer.Register(tracer.TracerParams{
+	require.NoError(t, tracer.Register(tracer.TracerParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config:    &tracer.Config{},
+	}))
+	require.False(t, tracer.IsEnabled())
+
+	require.NoError(t, tracer.Register(tracer.TracerParams{
 		Lifecycle:   fxtest.NewLifecycle(t),
-		Config:      &tracer.Config{},
+		Config:      &tracer.Config{Kind: "otlp"},
 		ID:          test.ID,
 		Name:        test.Name,
 		Version:     test.Version,
 		Environment: test.Environment,
-	})
+	}))
 	require.True(t, tracer.IsEnabled())
+}
+
+func TestConfigIsEnabled(t *testing.T) {
+	require.False(t, (*tracer.Config)(nil).IsEnabled())
+	require.False(t, (&tracer.Config{}).IsEnabled())
+	require.True(t, (&tracer.Config{Kind: "otlp"}).IsEnabled())
+}
+
+func TestRegisterInvalidKind(t *testing.T) {
+	err := tracer.Register(tracer.TracerParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config:    &tracer.Config{Kind: "wrong"},
+	})
+
+	require.ErrorIs(t, err, tracer.ErrNotFound)
 }

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -197,6 +197,6 @@ func BenchmarkGRPC(b *testing.B) {
 func disableTelemetry(b *testing.B) {
 	b.Helper()
 
-	tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(b)})
+	require.NoError(b, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(b)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(b)})
 }


### PR DESCRIPTION
## What

- return an error for unknown configured tracer kinds
- treat nil tracer config or empty tracer kind as not configured
- require explicit `otlp` kind before wiring the OTLP tracer provider
- update tests and benchmark helpers to check tracer registration errors

## Why

- avoid silently enabling tracing from a blank kind while still allowing empty tracer config to mean disabled
- make unsupported configured tracer kinds fail clearly

## Testing

- `go test ./telemetry/...`
- `go test ./net/http ./cache/driver ./database/sql/driver ./transport/grpc`
- `go test ./config`
- `make lint`
