### PR TITLE
docs(agents): record module wiring review assumptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ matching skill for the task.
 - Default file lookup checks the executable directory, `$XDG_CONFIG_HOME/<serviceName>/`, and `/etc/<serviceName>/`.
 - Many config fields use source strings through `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
 - Nil pointer sub-configs usually mean "disabled".
+- Standard module wiring is the supported path. Do not flag hypothetical failures that require hand-wiring an incomplete DI graph unless the public API explicitly promises that custom construction mode.
 
 ## Gotchas
 


### PR DESCRIPTION
## What

- document that standard module wiring is the supported path for this repository
- tell reviewers not to flag hypothetical failures that require incomplete hand-wired DI graphs unless an API explicitly supports that construction mode

## Why

- keep code reviews focused on realistic repo contracts instead of unsupported manual wiring scenarios

## Testing

- not run; docs-only guidance change
