### PR TITLE
fix(env): avoid eager service id generation

### DIFF
--- a/env/env_test.go
+++ b/env/env_test.go
@@ -27,4 +27,5 @@ func TestID(t *testing.T) {
 
 	t.Setenv("SERVICE_ID", "new_id")
 	require.Equal(t, "new_id", env.NewID(generator).String())
+	require.Equal(t, "new_id", env.NewID(nil).String())
 }

--- a/env/id.go
+++ b/env/id.go
@@ -1,8 +1,6 @@
 package env
 
 import (
-	"cmp"
-
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/os"
 )
@@ -15,7 +13,11 @@ import (
 // This is commonly used to distinguish service instances in logs/metrics/traces when multiple replicas
 // are running.
 func NewID(generator id.Generator) ID {
-	return ID(cmp.Or(os.Getenv("SERVICE_ID"), generator.Generate()))
+	if id := os.Getenv("SERVICE_ID"); id != "" {
+		return ID(id)
+	}
+
+	return ID(generator.Generate())
 }
 
 // ID is the service instance identifier.

--- a/id/config.go
+++ b/id/config.go
@@ -8,9 +8,8 @@ package id
 //
 // # Optional pointers and "enabled" semantics
 //
-// This config is intentionally optional. By convention across go-service configuration types, a nil
-// *Config is treated as "ID generation disabled". When disabled, wiring that depends on this config
-// often returns (nil, nil) rather than failing.
+// This config is intentionally optional. When nil, generator selection falls back to the default
+// "uuid" generator.
 type Config struct {
 	// Kind selects the ID generator implementation.
 	//

--- a/id/doc.go
+++ b/id/doc.go
@@ -12,9 +12,8 @@
 //
 // # Configuration and enablement
 //
-// ID generation configuration is optional. By convention across go-service config types, a nil
-// `*id.Config` is treated as "disabled" and `NewGenerator` returns (nil, nil) when disabled.
-// If configuration is enabled but the configured kind is unknown, `NewGenerator` returns ErrNotFound.
+// ID generation configuration is optional. A nil `*id.Config` selects the default "uuid" generator.
+// If configuration is present but the configured kind is unknown, `NewGenerator` returns ErrNotFound.
 //
 // Start with `Generator`, `Config`, `NewGenerator`, `Map`, and `Module`.
 package id

--- a/id/id.go
+++ b/id/id.go
@@ -77,13 +77,13 @@ func (f *Map) Get(kind string) Generator {
 
 // NewGenerator selects a Generator based on config.Kind from the provided registry.
 //
-// Disabled behavior: if config is nil/disabled, NewGenerator returns (nil, nil).
+// Default behavior: if config is nil/disabled, NewGenerator returns the "uuid" generator.
 //
 // Enabled behavior: if config is enabled, NewGenerator looks up the generator for config.Kind in m.
 // If the kind is registered, it returns that generator. If the kind is not registered, it returns ErrNotFound.
 func NewGenerator(config *Config, m *Map) (Generator, error) {
 	if !config.IsEnabled() {
-		return nil, nil
+		return m.Get("uuid"), nil
 	}
 
 	g := m.Get(config.Kind)

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -27,10 +27,11 @@ func TestValidID(t *testing.T) {
 	}
 }
 
-func TestNilID(t *testing.T) {
+func TestDefaultID(t *testing.T) {
 	gen, err := id.NewGenerator(nil, test.Generators)
 	require.NoError(t, err)
-	require.Nil(t, gen)
+	require.NotNil(t, gen)
+	require.NotEmpty(t, gen.Generate())
 }
 
 func TestInvalidID(t *testing.T) {

--- a/id/module.go
+++ b/id/module.go
@@ -21,8 +21,8 @@ import (
 // It then constructs a generator registry (*id.Map) via NewMap and finally selects a concrete
 // Generator via NewGenerator using Config.Kind.
 //
-// Disabled behavior: when *id.Config is nil/disabled, NewGenerator returns (nil, nil) so downstream
-// consumers can treat ID generation as optional.
+// Default behavior: when *id.Config is nil/disabled, NewGenerator returns the "uuid" generator so
+// downstream consumers always have a usable ID source.
 var Module = di.Module(
 	di.Constructor(ksuid.NewGenerator),
 	di.Constructor(nanoid.NewGenerator),


### PR DESCRIPTION
## What

- make `env.NewID` return `SERVICE_ID` without generating an unused ID
- default missing ID config to the registered `uuid` generator
- update ID docs and tests to reflect the default generator behavior

## Why

- keep service instance IDs non-empty even when ID config is omitted
- avoid panics or unnecessary generation when `SERVICE_ID` is already configured

## Testing

- `go test ./id/...`
- `go test ./env`
- `go test -count=1 ./cli -run ^TestApplicationDisabled`
- `make lint`
