### PR TITLE
test(slices): cover non-nil append helper

### DIFF
--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -45,7 +45,7 @@ func TestAppendNil(t *testing.T) {
 
 	for _, elem := range []*int{&integer} {
 		t.Run("non-nil pointer", func(t *testing.T) {
-			require.NotEmpty(t, slices.AppendNotZero([]*int{}, elem))
+			require.NotEmpty(t, slices.AppendNotNil([]*int{}, elem))
 		})
 	}
 }


### PR DESCRIPTION
## What
- corrected the non-nil append helper test to exercise AppendNotNil instead of AppendNotZero

## Why
- ensures the intended positive path for AppendNotNil is covered

## Testing
- git diff --check
- go test ./slices
