### PR TITLE
feat(transport): account for upstream failures and generated token keys

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -289,22 +289,18 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 // Order matters. Interceptors are appended in the following sequence:
 //   - any custom interceptors provided via `WithClientUnaryInterceptors`
 //   - a timeout interceptor
-//   - optional limiter interceptor (when configured)
 //   - optional retry interceptor (when configured)
 //   - optional circuit breaker interceptor (when enabled via `WithClientBreaker`)
 //   - optional logging interceptor (when configured)
 //   - optional token injection interceptor (when configured)
 //   - metadata propagation interceptor (user-agent and request-id)
+//   - optional limiter interceptor (when configured)
 func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor {
 	os := options(opts...)
 	unary := []grpc.UnaryClientInterceptor{}
 
 	unary = append(unary, os.unary...)
 	unary = append(unary, grpc.TimeoutUnaryClientInterceptor(os.timeout))
-
-	if os.limiter != nil {
-		unary = append(unary, limiter.UnaryClientInterceptor(os.limiter))
-	}
 
 	if os.retry != nil {
 		unary = append(unary, retry.UnaryClientInterceptor(os.retry))
@@ -323,6 +319,10 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 	}
 
 	unary = append(unary, meta.UnaryClientInterceptor(os.userAgent, os.generator))
+	if os.limiter != nil {
+		unary = append(unary, limiter.UnaryClientInterceptor(os.limiter))
+	}
+
 	return unary
 }
 

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -41,6 +41,27 @@ func TestClientLimiterUnary(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
+func TestClientLimiterUsesGeneratedTokenUnary(t *testing.T) {
+	world := test.NewStartedWorld(t,
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
+		test.WithWorldToken(&sequenceGenerator{}, acceptingVerifier{}),
+		test.WithWorldGRPC(),
+	)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+	req := &v1.SayHelloRequest{Name: "test"}
+
+	_, err := client.SayHello(t.Context(), req)
+	require.NoError(t, err)
+
+	_, err = client.SayHello(t.Context(), req)
+	require.NoError(t, err)
+}
+
 func TestLimiterUnlimitedUnary(t *testing.T) {
 	cfg := test.NewLimiterConfig("user-agent", "1s", 10)
 	world := test.NewStartedWorld(t,
@@ -113,4 +134,20 @@ func TestClientClosedLimiterUnary(t *testing.T) {
 	_, err := client.SayHello(t.Context(), req)
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+type sequenceGenerator struct {
+	next int
+}
+
+func (g *sequenceGenerator) Generate(_, _ string) ([]byte, error) {
+	g.next++
+
+	return []byte("token-" + strconv.Itoa(g.next)), nil
+}
+
+type acceptingVerifier struct{}
+
+func (acceptingVerifier) Verify([]byte, string) (string, error) {
+	return test.UserID.String(), nil
 }

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -102,14 +102,6 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 
 	s := r.opts.settings
 	s.Name = key
-	s.IsSuccessful = func(err error) bool {
-		if err == nil {
-			return true
-		}
-
-		_, ok := errors.AsType[responseError](err)
-		return !ok
-	}
 
 	cb := breaker.NewCircuitBreaker(s)
 	actual, _ := r.breakers.LoadOrStore(key, cb)

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -1,0 +1,41 @@
+package breaker_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	base "github.com/alexfalkowski/go-service/v2/transport/breaker"
+	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripperOpensOnTransportError(t *testing.T) {
+	transportErr := errors.New("transport unavailable")
+	rt := breaker.NewRoundTripper(
+		errorRoundTripper{err: transportErr},
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts base.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, transportErr)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, base.ErrOpenState)
+}
+
+type errorRoundTripper struct {
+	err error
+}
+
+func (r errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, r.err
+}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -195,14 +195,14 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //   - logger (optional)
 //   - breaker (optional)
 //   - retry (optional)
+//   - token injection (optional)
 //   - limiter (optional)
 //   - compression (optional)
-//   - token injection (optional)
 //   - base transport
 //
 // Notes:
 //   - `WithClientRoundTripper` short-circuits base transport selection and TLS config construction.
-//   - Token injection is applied closest to the base transport so subsequent wrappers see the Authorization header.
+//   - Token injection remains inside retry so a fresh token is generated for each retry attempt.
 func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 	os := options(opts...)
 
@@ -211,16 +211,16 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 		return nil, err
 	}
 
-	if os.gen != nil {
-		hrt = token.NewRoundTripper(os.id, os.gen, hrt)
-	}
-
 	if os.compression {
 		hrt = gzhttp.Transport(hrt, gzhttp.TransportEnableGzip(true))
 	}
 
 	if os.limiter != nil {
 		hrt = limiter.NewRoundTripper(os.limiter, hrt)
+	}
+
+	if os.gen != nil {
+		hrt = token.NewRoundTripper(os.id, os.gen, hrt)
 	}
 
 	if os.retry != nil {

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -1,6 +1,7 @@
 package http_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -75,6 +76,28 @@ func TestClientLimiter(t *testing.T) {
 	}
 }
 
+func TestClientLimiterUsesGeneratedToken(t *testing.T) {
+	world := test.NewStartedWorld(t,
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
+		test.WithWorldToken(&sequenceGenerator{}, acceptingVerifier{}),
+		test.WithWorldHTTP(),
+		test.WithWorldHello(),
+	)
+
+	url := world.PathServerURL("http", "hello")
+
+	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "hello!", body)
+
+	res, body, err = world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "hello!", body)
+}
+
 func TestServerClosedLimiter(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
@@ -109,4 +132,20 @@ func TestClientClosedLimiter(t *testing.T) {
 	_, _, err = world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
 	require.Error(t, err)
 	require.Equal(t, http.StatusInternalServerError, status.Code(err))
+}
+
+type sequenceGenerator struct {
+	next int
+}
+
+func (g *sequenceGenerator) Generate(_, _ string) ([]byte, error) {
+	g.next++
+
+	return []byte("token-" + strconv.Itoa(g.next)), nil
+}
+
+type acceptingVerifier struct{}
+
+func (acceptingVerifier) Verify([]byte, string) (string, error) {
+	return test.UserID.String(), nil
 }

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -166,10 +166,10 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, status.UnauthorizedError(header.ErrInvalidAuthorization)
 	}
 
-	cloned := req.Clone(req.Context())
-	cloned.Header.Set(
-		"Authorization",
-		strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)),
-	)
+	auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))
+	ctx := meta.WithAttributes(req.Context(), meta.WithAuthorization(auth))
+
+	cloned := req.Clone(ctx)
+	cloned.Header.Set("Authorization", auth.Value())
 	return r.RoundTripper.RoundTrip(cloned)
 }


### PR DESCRIPTION
## What

- rely on the default breaker failure accounting so HTTP transport errors open circuit breakers
- expose generated HTTP authorization values through request context metadata for downstream middleware
- move HTTP and gRPC client limiters after token metadata injection while keeping HTTP token generation inside retries
- add regression coverage for breaker transport errors and token-keyed client limiting

## Why

Client-side token limiters derive their keys from context metadata, so generated tokens need to be present before limiting runs. HTTP breaker accounting also needs transport-level errors to count as failures, not successes.

## Testing

- `go test ./transport/http/breaker ./transport/http ./transport/grpc`
- `go test ./net/... ./transport/...`
- `make lint`
- `make specs`

AI-assisted-by: [Codex](https://openai.com/codex/)
