### PR TITLE
feat(net): require bearer authorization scheme

### DIFF
--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -181,7 +181,7 @@ func serverAuthorization(ctx context.Context) (meta.Value, error) {
 		return meta.Blank(), nil
 	}
 
-	_, value, err := header.ParseAuthorization(a)
+	value, err := header.ParseBearer(a)
 	if err != nil {
 		return meta.Blank(), err
 	}

--- a/net/header/doc.go
+++ b/net/header/doc.go
@@ -1,7 +1,7 @@
 // Package header provides shared helpers for working with network protocol headers in go-service.
 //
-// This package currently focuses on Authorization header parsing and shared forwarding header names so
+// This package currently focuses on Bearer Authorization header parsing and shared forwarding header names so
 // HTTP and gRPC integrations can use the same metadata semantics.
 //
-// Start with `ParseAuthorization` and `ForwardedIPs`.
+// Start with `ParseBearer` and `ForwardedIPs`.
 package header

--- a/net/header/header.go
+++ b/net/header/header.go
@@ -5,32 +5,16 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
-const (
-	// BasicAuthorization is the HTTP Authorization scheme name for Basic authentication.
-	//
-	// When used in an Authorization header, it is typically formatted as:
-	//
-	//	Authorization: Basic <credentials>
-	//
-	// where <credentials> is usually a base64-encoded `username:password` value.
-	BasicAuthorization = "Basic"
-
-	// BearerAuthorization is the HTTP Authorization scheme name for Bearer token authentication.
-	//
-	// When used in an Authorization header, it is typically formatted as:
-	//
-	//	Authorization: Bearer <token>
-	//
-	// where <token> is an opaque access token (for example, a JWT).
-	BearerAuthorization = "Bearer"
-)
+// BearerAuthorization is the HTTP Authorization scheme name for Bearer token authentication.
+//
+// When used in an Authorization header, it is typically formatted as:
+//
+//	Authorization: Bearer <token>
+//
+// where <token> is an opaque access token (for example, a JWT).
+const BearerAuthorization = "Bearer"
 
 var (
-	// AllAuthorizations lists the supported Authorization schemes for ParseAuthorization.
-	//
-	// Values are matched case-insensitively against the parsed scheme token.
-	AllAuthorizations = []string{BasicAuthorization, BearerAuthorization}
-
 	// ForwardedIPs lists the forwarding headers used to derive a client IP address.
 	//
 	// The order reflects the preferred source when multiple headers are present.
@@ -49,7 +33,7 @@ var (
 
 	// ErrNotSupportedAuthorization is returned when the Authorization scheme is not supported.
 	//
-	// This is returned when the parsed scheme is not present in AllAuthorizations.
+	// This is returned when the parsed scheme is not Bearer.
 	ErrNotSupportedAuthorization = errors.New("header: authorization is not supported")
 )
 
@@ -67,44 +51,28 @@ type ForwardedIP struct {
 	GRPC string
 }
 
-// ParseAuthorization parses an HTTP Authorization header into scheme and value.
+// ParseBearer parses an HTTP Authorization header and returns its bearer token value.
 //
 // The expected format is:
 //
-//	<scheme><space><value>
+//	Bearer <token>
 //
-// Supported schemes are listed in AllAuthorizations (for example Basic and Bearer) and are
-// matched case-insensitively.
+// The Bearer scheme is matched case-insensitively.
 //
 // Error behavior:
 //   - If the header cannot be split into two parts on the first ASCII space, it returns ErrInvalidAuthorization.
-//   - If the parsed scheme is not supported, it returns ErrNotSupportedAuthorization.
+//   - If the parsed scheme is not Bearer, it returns ErrNotSupportedAuthorization.
 //
-// On error, the returned scheme and value are empty strings.
-func ParseAuthorization(header string) (string, string, error) {
+// On error, the returned value is an empty string.
+func ParseBearer(header string) (string, error) {
 	key, value, ok := strings.Cut(header, strings.Space)
 	if !ok {
-		return strings.Empty, strings.Empty, ErrInvalidAuthorization
+		return strings.Empty, ErrInvalidAuthorization
 	}
 
-	// Design note: this parser intentionally accepts all supported Authorization schemes.
-	// Token middleware consumes only the credential value, so scheme-specific enforcement belongs
-	// at the middleware/policy layer rather than in this shared parser.
-	key, ok = canonicalAuthorization(key)
-	if !ok {
-		return strings.Empty, strings.Empty, ErrNotSupportedAuthorization
+	if strings.ToLower(key) != strings.ToLower(BearerAuthorization) {
+		return strings.Empty, ErrNotSupportedAuthorization
 	}
 
-	return key, value, nil
-}
-
-func canonicalAuthorization(scheme string) (string, bool) {
-	switch strings.ToLower(scheme) {
-	case strings.ToLower(BasicAuthorization):
-		return BasicAuthorization, true
-	case strings.ToLower(BearerAuthorization):
-		return BearerAuthorization, true
-	default:
-		return strings.Empty, false
-	}
+	return value, nil
 }

--- a/net/header/header_test.go
+++ b/net/header/header_test.go
@@ -8,10 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidParseAuthorization(t *testing.T) {
-	key, value, err := header.ParseAuthorization("Bearer token")
+func TestValidParseBearer(t *testing.T) {
+	value, err := header.ParseBearer("Bearer token")
 	require.NoError(t, err)
-	require.Equal(t, "Bearer", key)
 	require.Equal(t, "token", value)
 }
 
@@ -24,30 +23,23 @@ func TestForwardedIPs(t *testing.T) {
 	}, header.ForwardedIPs)
 }
 
-func TestValidParseAuthorizationWithLowercaseScheme(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		value  string
-		scheme string
-	}{
-		{name: "bearer", value: "bearer token", scheme: header.BearerAuthorization},
-		{name: "basic", value: "basic token", scheme: header.BasicAuthorization},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			key, value, err := header.ParseAuthorization(tc.value)
-			require.NoError(t, err)
-			require.Equal(t, tc.scheme, key)
-			require.Equal(t, "token", value)
-		})
-	}
+func TestValidParseBearerWithLowercaseScheme(t *testing.T) {
+	value, err := header.ParseBearer("bearer token")
+	require.NoError(t, err)
+	require.Equal(t, "token", value)
 }
 
-func TestMissingParseAuthorization(t *testing.T) {
-	_, _, err := header.ParseAuthorization(strings.Empty)
+func TestMissingParseBearer(t *testing.T) {
+	_, err := header.ParseBearer(strings.Empty)
 	require.ErrorIs(t, err, header.ErrInvalidAuthorization)
 }
 
-func TestNotSupportedParseAuthorization(t *testing.T) {
-	_, _, err := header.ParseAuthorization("Bob token")
+func TestNotSupportedParseBearer(t *testing.T) {
+	_, err := header.ParseBearer("Bob token")
+	require.ErrorIs(t, err, header.ErrNotSupportedAuthorization)
+}
+
+func TestParseBearerRejectsBasic(t *testing.T) {
+	_, err := header.ParseBearer("Basic token")
 	require.ErrorIs(t, err, header.ErrNotSupportedAuthorization)
 }

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -138,7 +138,7 @@ func serverAuthorization(req *http.Request) (meta.Value, error) {
 		return meta.Blank(), nil
 	}
 
-	_, value, err := header.ParseAuthorization(a)
+	value, err := header.ParseBearer(a)
 	if err != nil {
 		return meta.Blank(), err
 	}


### PR DESCRIPTION
## What
- Replaced the generic authorization parser with a bearer-only parser.
- Updated HTTP and gRPC metadata extraction to use the bearer parser.
- Updated header package docs and tests, including explicit rejection coverage for Basic authorization.

## Why
- Transport token auth only issues and verifies bearer-style JWT, PASETO, and SSH tokens.
- Rejecting non-bearer schemes prevents valid tokens from being accepted under the wrong Authorization scheme.

## Testing
- go test ./net/header ./net/http/meta ./net/grpc/meta
- go test ./net/header ./net/http/meta ./net/grpc/meta ./transport/http ./transport/grpc
- go test ./net/... ./transport/...
- make lint
