### PR TITLE
feat(mvc): render typed not-found pages

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -55,6 +55,9 @@ const StatusRequestEntityTooLarge = http.StatusRequestEntityTooLarge
 // StatusInternalServerError is an alias of http.StatusInternalServerError.
 const StatusInternalServerError = http.StatusInternalServerError
 
+// StatusMethodNotAllowed is an alias of http.StatusMethodNotAllowed.
+const StatusMethodNotAllowed = http.StatusMethodNotAllowed
+
 // StatusNotFound is an alias of http.StatusNotFound.
 const StatusNotFound = http.StatusNotFound
 

--- a/net/http/mvc/controller.go
+++ b/net/http/mvc/controller.go
@@ -17,3 +17,8 @@ import "github.com/alexfalkowski/go-service/v2/context"
 // error (via net/http/status.Code) and renders the returned view using the error value as the template model.
 // Implementations should therefore ensure view is non-nil even in error cases, or accept that rendering may panic.
 type Controller[Model any] func(ctx context.Context) (*View, *Model, error)
+
+// NotFoundController returns the view and model used to render an MVC not-found response.
+//
+// It is used by Handler for unmatched routes.
+type NotFoundController[Model any] func(ctx context.Context) (*View, *Model)

--- a/net/http/mvc/example_test.go
+++ b/net/http/mvc/example_test.go
@@ -1,0 +1,77 @@
+package mvc_test
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http/httptest"
+	"testing/fstest"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
+	sync "github.com/alexfalkowski/go-sync"
+)
+
+func ExampleGet() {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  exampleFileSystem(),
+		Pool:        sync.NewBufferPool(),
+		Layout:      mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	mvc.Get("/hello", func(_ context.Context) (*mvc.View, *examplePage, error) {
+		return mvc.NewFullView("views/page.tmpl"), &examplePage{Title: "Hello"}, nil
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/hello", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	fmt.Println(res.Code)
+	fmt.Println(res.Body.String())
+	// Output:
+	// 200
+	// Hello
+}
+
+func ExampleNotFound() {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  exampleFileSystem(),
+		Pool:        sync.NewBufferPool(),
+		Layout:      mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	mvc.NotFound(func(_ context.Context) (*mvc.View, *examplePage) {
+		return mvc.NewFullView("views/page.tmpl"), &examplePage{Title: "Not Found"}
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mvc.NewHandler(mux).ServeHTTP(res, req)
+
+	fmt.Println(res.Code)
+	fmt.Println(res.Body.String())
+	// Output:
+	// 404
+	// Not Found
+}
+
+type examplePage struct {
+	Title string
+}
+
+func exampleFileSystem() fstest.MapFS {
+	return fstest.MapFS{
+		"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+		"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+		"views/page.tmpl":    &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Title }}{{ end }}`)},
+	}
+}

--- a/net/http/mvc/handler.go
+++ b/net/http/mvc/handler.go
@@ -1,0 +1,55 @@
+package mvc
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	snoop "github.com/felixge/httpsnoop"
+)
+
+// NewHandler wraps mux with MVC error handling when MVC is defined.
+//
+// When MVC is not defined, it returns mux unchanged. When no NotFoundController has been registered, the
+// returned handler preserves the mux's default behavior until one is registered.
+func NewHandler(mux *http.ServeMux) http.Handler {
+	if !IsDefined() {
+		return mux
+	}
+
+	return &Handler{mux: mux}
+}
+
+// Handler wraps an HTTP mux and renders MVC error pages for unmatched routes.
+type Handler struct {
+	mux *http.ServeMux
+}
+
+// ServeHTTP serves req through the wrapped mux.
+//
+// If the mux has no matching route and the generated response is a 404, ServeHTTP renders the registered
+// MVC error view instead of the mux's default plain-text response.
+func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	if !IsDefined() || notFoundController == nil {
+		h.mux.ServeHTTP(res, req)
+		return
+	}
+
+	handler, pattern := h.mux.Handler(req)
+	if !strings.IsEmpty(pattern) {
+		h.mux.ServeHTTP(res, req)
+		return
+	}
+
+	buffer := pool.Get()
+	defer pool.Put(buffer)
+
+	response := &bufferedWriter{response: res, buffer: buffer, header: http.Header{}}
+	metrics := snoop.CaptureMetricsFn(response, func(res http.ResponseWriter) {
+		handler.ServeHTTP(res, req)
+	})
+	if metrics.Code != http.StatusNotFound {
+		response.Flush()
+		return
+	}
+
+	writeNotFound(req, res)
+}

--- a/net/http/mvc/mvc.go
+++ b/net/http/mvc/mvc.go
@@ -3,6 +3,7 @@ package mvc
 import (
 	"io/fs"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-sync"
@@ -10,11 +11,12 @@ import (
 )
 
 var (
-	mux        *http.ServeMux
-	fmap       sprout.FunctionMap
-	fileSystem fs.FS
-	layout     *Layout
-	pool       *sync.BufferPool
+	mux                *http.ServeMux
+	fmap               sprout.FunctionMap
+	fileSystem         fs.FS
+	layout             *Layout
+	pool               *sync.BufferPool
+	notFoundController func(ctx context.Context) (*View, any)
 )
 
 // RegisterParams defines dependencies used to register MVC package globals.
@@ -66,6 +68,7 @@ func Register(params RegisterParams) {
 	fileSystem = params.FileSystem
 	pool = params.Pool
 	layout = params.Layout
+	notFoundController = nil
 }
 
 // IsDefined reports whether MVC routing and rendering has been configured.

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -16,6 +16,21 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
+// NotFound registers controller as the MVC not-found renderer.
+//
+// It returns false when MVC is not defined (see IsDefined).
+func NotFound[Model any](controller NotFoundController[Model]) bool {
+	if !IsDefined() {
+		return false
+	}
+
+	notFoundController = func(ctx context.Context) (*View, any) {
+		view, model := controller(ctx)
+		return view, model
+	}
+	return true
+}
+
 // Delete registers an HTTP DELETE route that invokes controller.
 func Delete[Model any](pattern string, controller Controller[Model]) bool {
 	return Route(strings.Join(strings.Space, http.MethodDelete, pattern), controller)
@@ -88,14 +103,12 @@ func StaticFile(pattern, name string) bool {
 		buffer := pool.Get()
 		defer pool.Put(buffer)
 
-		ctx := req.Context()
-
 		if err := writeFile(name, buffer); err != nil {
-			writeHeader(ctx, res, staticStatusCode(err))
+			res.WriteHeader(staticStatusCode(err))
 			return
 		}
 
-		writeBuffer(ctx, res, http.StatusOK, buffer)
+		writeBuffer(res, http.StatusOK, buffer)
 	}
 
 	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
@@ -117,20 +130,19 @@ func StaticPathValue(pattern, value, prefix string) bool {
 		buffer := pool.Get()
 		defer pool.Put(buffer)
 
-		ctx := req.Context()
 		cleaned := path.Clean(req.PathValue(value))
 		if cleaned == "." || cleaned != req.PathValue(value) || !fs.ValidPath(cleaned) || strings.Contains(cleaned, `\`) {
-			writeHeader(ctx, res, staticStatusCode(status.BadRequestError(fs.ErrInvalid)))
+			res.WriteHeader(staticStatusCode(status.BadRequestError(fs.ErrInvalid)))
 			return
 		}
 
 		name := path.Join(prefix, cleaned)
 		if err := writeFile(name, buffer); err != nil {
-			writeHeader(ctx, res, staticStatusCode(err))
+			res.WriteHeader(staticStatusCode(err))
 			return
 		}
 
-		writeBuffer(ctx, res, http.StatusOK, buffer)
+		writeBuffer(res, http.StatusOK, buffer)
 	}
 
 	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
@@ -156,30 +168,46 @@ func staticStatusCode(err error) int {
 }
 
 func writeView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) {
+	if err := renderView(ctx, res, view, model, code); err != nil {
+		res.WriteHeader(status.Code(err))
+	}
+}
+
+func writeNotFound(req *http.Request, res http.ResponseWriter) {
+	if notFoundController == nil {
+		res.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
+	res.Header().Set(content.TypeKey, media.WithUTF8(media.HTML))
+	ctx := req.Context()
+	ctx = meta.WithContent(ctx, req, res, nil)
+	ctx = meta.WithAttributes(ctx, meta.NewPair("mvcModelError", meta.Error(err)))
+
+	view, model := notFoundController(ctx)
+	if err := renderView(ctx, res, view, model, http.StatusNotFound); err != nil {
+		res.WriteHeader(status.Code(err))
+	}
+}
+
+func renderView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) error {
+	if view == nil {
+		return ErrMissingView
+	}
+
 	buffer := pool.Get()
 	defer pool.Put(buffer)
 
 	if err := view.render(ctx, buffer, model); err != nil {
-		writeHeader(ctx, res, status.Code(err))
-		return
+		return err
 	}
 
-	writeBuffer(ctx, res, code, buffer)
+	writeBuffer(res, code, buffer)
+	return nil
 }
 
-func writeBuffer(ctx context.Context, res http.ResponseWriter, code int, buffer *bytes.Buffer) {
-	if !writeHeader(ctx, res, code) {
-		return
-	}
-
-	_, _ = buffer.WriteTo(res)
-}
-
-func writeHeader(ctx context.Context, res http.ResponseWriter, code int) bool {
-	if ctx.Err() != nil {
-		return false
-	}
-
+func writeBuffer(res http.ResponseWriter, code int, buffer *bytes.Buffer) {
 	res.WriteHeader(code)
-	return true
+	_, _ = buffer.WriteTo(res)
 }

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -1,7 +1,6 @@
 package mvc_test
 
 import (
-	"io"
 	"io/fs"
 	"log/slog"
 	"net/http/httptest"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -133,6 +133,39 @@ func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
 	require.Empty(t, res.Body.String())
 }
 
+func TestRouteRenderErrorDoesNotUseNotFoundController(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/bad.tmpl":     &fstest.MapFile{Data: []byte(`{{ define "content" }}hello {{ index .Model 0 }}{{ end }}`)},
+			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}error {{ index .Meta "mvcModelError" }}{{ end }}`)},
+		},
+		Pool:   test.Pool,
+		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *test.Page) {
+		return mvc.NewFullView("views/error.tmpl"), nil
+	}))
+	require.True(t, mvc.Get("/hello", func(_ context.Context) (*mvc.View, *test.Page, error) {
+		return mvc.NewFullView("views/bad.tmpl"), &test.Model, nil
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.TypeKey, media.HTML)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Empty(t, res.Body.String())
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header().Get(content.TypeKey))
+}
+
 func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
@@ -159,6 +192,141 @@ func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	require.Empty(t, res.Body.String())
+}
+
+func TestNotFoundHandlesNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Err }}{{ end }}`)},
+		},
+		Pool:   test.Pool,
+		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *errorModel) {
+		return mvc.NewFullView("views/error.tmpl"), &errorModel{
+			Code: http.StatusNotFound,
+			Err:  status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound)),
+		}
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mvc.NewHandler(mux).ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header().Get(content.TypeKey))
+	require.Contains(t, res.Body.String(), "404 Not Found")
+}
+
+func TestNotFoundIncludesRequestMeta(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Method }} {{ .Model.Path }}{{ end }}`)},
+		},
+		Pool:   test.Pool,
+		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	require.True(t, mvc.NotFound(func(ctx context.Context) (*mvc.View, *requestModel) {
+		req := meta.Request(ctx)
+		return mvc.NewFullView("views/error.tmpl"), &requestModel{
+			Method: req.Method,
+			Path:   req.URL.Path,
+		}
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mvc.NewHandler(mux).ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+	require.Contains(t, res.Body.String(), "PUT /missing")
+}
+
+func TestNotFoundUsesDefaultWhenControllerMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  test.FileSystem,
+		Pool:        test.Pool,
+		Layout:      test.Layout,
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mvc.NewHandler(mux).ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+	require.Contains(t, res.Body.String(), "404 page not found")
+}
+
+func TestNotFoundWritesRenderStatusWhenViewMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  test.FileSystem,
+		Pool:        test.Pool,
+		Layout:      test.Layout,
+	})
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *test.Page) {
+		return nil, &test.Model
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mvc.NewHandler(mux).ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Empty(t, res.Body.String())
+}
+
+func TestNotFoundDoesNotReplaceMethodNotAllowed(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}custom {{ .Model.Code }}{{ end }}`)},
+			"views/hello.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}hello{{ end }}`)},
+		},
+		Pool:   test.Pool,
+		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *errorModel) {
+		return mvc.NewFullView("views/error.tmpl"), &errorModel{Code: http.StatusNotFound}
+	}))
+	require.True(t, mvc.Get("/hello", func(_ context.Context) (*mvc.View, *test.Page, error) {
+		return mvc.NewFullView("views/hello.tmpl"), &test.Model, nil
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mvc.NewHandler(mux).ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, res.Code)
+	require.NotContains(t, res.Body.String(), "custom")
 }
 
 func TestStaticFileDoesNotWritePartialBodyWhenReadFails(t *testing.T) {
@@ -239,4 +407,14 @@ func (errFileInfo) IsDir() bool {
 
 func (errFileInfo) Sys() any {
 	return nil
+}
+
+type errorModel struct {
+	Err  error
+	Code int
+}
+
+type requestModel struct {
+	Method string
+	Path   string
 }

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -6,10 +6,14 @@ import (
 	"path/filepath"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	hm "github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
+
+// ErrMissingView is returned when MVC rendering is requested without a view.
+var ErrMissingView = errors.New("mvc: missing view")
 
 // NewLayout constructs a Layout that defines the base templates used for rendering views.
 //

--- a/net/http/mvc/writer.go
+++ b/net/http/mvc/writer.go
@@ -1,0 +1,50 @@
+package mvc
+
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+)
+
+// bufferedWriter captures a mux-generated response until Handler decides whether to replay it.
+//
+// The MVC not-found handler needs to inspect generated mux responses without committing the client
+// response early: non-404 responses are flushed unchanged, while 404 responses are replaced with the
+// configured MVC not-found view.
+type bufferedWriter struct {
+	header   http.Header
+	response http.ResponseWriter
+	buffer   *bytes.Buffer
+	code     int
+}
+
+func (w *bufferedWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *bufferedWriter) Write(p []byte) (int, error) {
+	if w.code == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	return w.buffer.Write(p)
+}
+
+func (w *bufferedWriter) WriteHeader(code int) {
+	w.code = code
+}
+
+func (w *bufferedWriter) Flush() {
+	header := w.response.Header()
+	for key, values := range w.header {
+		header.Del(key)
+		for _, value := range values {
+			header.Add(key, value)
+		}
+	}
+
+	if w.code != 0 {
+		w.response.WriteHeader(w.code)
+	}
+
+	_, _ = w.buffer.WriteTo(w.response)
+}

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -92,6 +92,28 @@ func TestRouteError(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNotFound(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *notFoundModel) {
+		return mvc.NewFullView("views/error.tmpl"), &notFoundModel{Error: http.StatusText(http.StatusNotFound)}
+	}))
+
+	header := http.Header{}
+	header.Set(content.TypeKey, media.HTML)
+
+	url := world.PathServerURL("http", "missing")
+
+	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, header, http.NoBody)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+
+	_, err = html.Parse(strings.NewReader(body))
+	require.NoError(t, err)
+}
+
 func TestStaticFileSuccess(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
@@ -163,6 +185,9 @@ func TestMissingViews(t *testing.T) {
 	require.False(t, mvc.Get("/hello", func(_ context.Context) (*mvc.View, *test.Page, error) {
 		return mvc.NewFullView("views/hello.tmpl"), &test.Model, nil
 	}))
+	require.False(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *test.Page) {
+		return mvc.NewFullView("views/error.tmpl"), nil
+	}))
 	require.False(t, mvc.StaticFile("/robots.txt", "static/robots.txt"))
 	require.False(t, mvc.StaticPathValue("/{file}", "file", "static"))
 
@@ -176,6 +201,13 @@ func TestMissingViews(t *testing.T) {
 	require.False(t, mvc.Get("/hello", func(_ context.Context) (*mvc.View, *test.Page, error) {
 		return mvc.NewFullView("views/hello.tmpl"), &test.Model, nil
 	}))
+	require.False(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *test.Page) {
+		return mvc.NewFullView("views/error.tmpl"), nil
+	}))
 	require.False(t, mvc.StaticFile("/robots.txt", "static/robots.txt"))
 	require.False(t, mvc.StaticPathValue("/{file}", "file", "static"))
+}
+
+type notFoundModel struct {
+	Error string
 }

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/transport/http/body"
@@ -127,7 +128,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(limiter.NewHandler(params.Limiter))
 	}
 
-	neg.UseHandler(gzhttp.GzipHandler(params.Mux))
+	neg.UseHandler(gzhttp.GzipHandler(mvc.NewHandler(params.Mux)))
 
 	httpServer := http.NewServer(params.Config.Options, params.Config.Timeout, neg)
 


### PR DESCRIPTION
## What
- add a typed MVC not-found registration API and handler wrapper that renders configured 404 pages for unmatched mux routes
- preserve default mux behavior for non-404 generated responses and status-only behavior for route render failures
- wire HTTP transport to wrap the mux and add package/transport coverage

## Why
- MVC apps can provide custom 404 pages without catch-all routes that interfere with existing routes or method handling

## Testing
- go test ./net/http/mvc ./transport/http
- make lint (passes with existing gomodguard deprecation warning)

AI-assisted-by: [Codex](https://openai.com/codex/)
