### PR TITLE
feat(http): return typed not-found responses

### DIFF
--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -56,6 +56,7 @@ func (s *Server) Register() error {
 	if s.RegisterHTTP {
 		params := http.ServerParams{
 			Shutdowner: sh, Mux: s.Mux,
+			Pool:     Pool,
 			Config:   s.TransportConfig.HTTP,
 			Logger:   s.Logger,
 			Limiter:  s.HTTPLimiter,

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -65,6 +65,16 @@ func NewHandler[Res any](cont *Content, handler Handler[Res]) http.HandlerFunc {
 	})
 }
 
+// NotFoundHandler returns a not-found handler that writes the standard content error response.
+func NotFoundHandler() http.NotFoundHandler {
+	return func(res http.ResponseWriter, _ *http.Request) bool {
+		err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
+		_ = status.WriteError(res, err)
+
+		return true
+	}
+}
+
 func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res, error)) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -81,6 +81,16 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	require.NotContains(t, res.Body.String(), "partial")
 }
 
+func TestNotFoundHandlerWritesStatusError(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	require.True(t, content.NotFoundHandler()(res, req))
+	require.Equal(t, http.StatusNotFound, res.Code)
+	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
+	require.Equal(t, "Not Found\n", res.Body.String())
+}
+
 type partialEncoder struct{}
 
 func (partialEncoder) Encode(w io.Writer, _ any) error {

--- a/net/http/handler.go
+++ b/net/http/handler.go
@@ -1,0 +1,62 @@
+package http
+
+import (
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-sync"
+	snoop "github.com/felixge/httpsnoop"
+)
+
+// NotFoundHandler handles an unmatched mux request.
+//
+// It returns true when it has written a response. Returning false lets the next handler decide.
+type NotFoundHandler func(res ResponseWriter, req *Request) bool
+
+// NewNotFoundHandler wraps mux and lets handlers replace generated 404 responses.
+//
+// Non-404 mux responses are flushed unchanged. This preserves method handling such as 405 Method Not
+// Allowed while still allowing MVC, REST, or RPC packages to provide typed not-found responses.
+func NewNotFoundHandler(mux *ServeMux, pool *sync.BufferPool, handlers ...NotFoundHandler) Handler {
+	if len(handlers) == 0 {
+		return mux
+	}
+
+	return &notFoundHandler{mux: mux, pool: pool, handlers: handlers}
+}
+
+type notFoundHandler struct {
+	mux      *ServeMux
+	pool     *sync.BufferPool
+	handlers []NotFoundHandler
+}
+
+func (h *notFoundHandler) ServeHTTP(res ResponseWriter, req *Request) {
+	handler, pattern := h.mux.Handler(req)
+	if !strings.IsEmpty(pattern) {
+		h.mux.ServeHTTP(res, req)
+		return
+	}
+
+	response := &bufferedWriter{
+		header:   Header{},
+		response: res,
+		buffer:   h.pool.Get(),
+		pool:     h.pool,
+	}
+	metrics := snoop.CaptureMetricsFn(response, func(res ResponseWriter) {
+		handler.ServeHTTP(res, req)
+	})
+	defer response.Close()
+
+	if metrics.Code != StatusNotFound {
+		response.Flush()
+		return
+	}
+
+	for _, handler := range h.handlers {
+		if handler(res, req) {
+			return
+		}
+	}
+
+	response.Flush()
+}

--- a/net/http/handler_test.go
+++ b/net/http/handler_test.go
@@ -1,0 +1,89 @@
+package http_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNotFoundHandler(t *testing.T) {
+	tests := []notFoundHandlerTest{
+		{
+			name:   "handles mux not found",
+			method: http.MethodGet,
+			path:   "/missing",
+			handle: true,
+			code:   http.StatusNotFound,
+			body:   "fallback",
+		},
+		{
+			name:     "flushes mux not found when unhandled",
+			method:   http.MethodGet,
+			path:     "/missing",
+			code:     http.StatusNotFound,
+			contains: "404 page not found",
+		},
+		{
+			name:          "does not handle method not allowed",
+			method:        http.MethodPost,
+			path:          "/hello",
+			registerRoute: true,
+			handle:        true,
+			code:          http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testNotFoundHandler(t, tt)
+		})
+	}
+}
+
+type notFoundHandlerTest struct {
+	name          string
+	method        string
+	path          string
+	body          string
+	contains      string
+	registerRoute bool
+	handle        bool
+	code          int
+}
+
+func testNotFoundHandler(t *testing.T, tt notFoundHandlerTest) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	if tt.registerRoute {
+		http.HandleFunc(mux, "GET /hello", func(res http.ResponseWriter, _ *http.Request) {
+			res.WriteHeader(http.StatusOK)
+		})
+	}
+
+	handler := http.NewNotFoundHandler(mux, test.Pool, func(res http.ResponseWriter, _ *http.Request) bool {
+		if !tt.handle {
+			return false
+		}
+
+		res.WriteHeader(http.StatusNotFound)
+		_, _ = res.Write([]byte("fallback"))
+		return true
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, http.NoBody)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, tt.code, res.Code)
+	if tt.body != "" {
+		require.Equal(t, tt.body, res.Body.String())
+	}
+	if tt.contains != "" {
+		require.Contains(t, res.Body.String(), tt.contains)
+	}
+}

--- a/net/http/mvc/handler.go
+++ b/net/http/mvc/handler.go
@@ -2,9 +2,31 @@ package mvc
 
 import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	snoop "github.com/felixge/httpsnoop"
 )
+
+// NotFoundHandler returns the MVC not-found handler for mixed HTTP transports.
+//
+// The handler only handles requests that explicitly accept HTML or come from HTMX, allowing API clients
+// to receive the transport's content error fallback instead.
+func NotFoundHandler() http.NotFoundHandler {
+	return func(res http.ResponseWriter, req *http.Request) bool {
+		if !IsDefined() || notFoundController == nil {
+			return false
+		}
+
+		acceptsHTML := strings.Contains(req.Header.Get("Accept"), media.HTML)
+		isHTMX := req.Header.Get("Hx-Request") == "true"
+		if !acceptsHTML && !isHTMX {
+			return false
+		}
+
+		writeNotFound(req, res)
+		return true
+	}
+}
 
 // NewHandler wraps mux with MVC error handling when MVC is defined.
 //

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -275,6 +275,56 @@ func TestNotFoundUsesDefaultWhenControllerMissing(t *testing.T) {
 	require.Contains(t, res.Body.String(), "404 page not found")
 }
 
+func TestFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		accept  string
+		hx      string
+		handled bool
+	}{
+		{name: "accepts html", accept: media.HTML, handled: true},
+		{name: "accepts htmx", accept: "*/*", hx: "true", handled: true},
+		{name: "ignores api", accept: media.JSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mvc.Register(mvc.RegisterParams{
+				Mux:         http.NewServeMux(),
+				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+				FileSystem: fstest.MapFS{
+					"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+					"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+					"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Err }}{{ end }}`)},
+				},
+				Pool:   test.Pool,
+				Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+			})
+
+			require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *errorModel) {
+				return mvc.NewPartialView("views/error.tmpl"), &errorModel{
+					Code: http.StatusNotFound,
+					Err:  status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound)),
+				}
+			}))
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+			req.Header.Set("Accept", tt.accept)
+			req.Header.Set("Hx-Request", tt.hx)
+			res := httptest.NewRecorder()
+
+			require.Equal(t, tt.handled, mvc.NotFoundHandler()(res, req))
+			if !tt.handled {
+				return
+			}
+
+			require.Equal(t, http.StatusNotFound, res.Code)
+			require.Equal(t, media.WithUTF8(media.HTML), res.Header().Get(content.TypeKey))
+			require.Contains(t, res.Body.String(), "404 Not Found")
+		})
+	}
+}
+
 func TestNotFoundWritesRenderStatusWhenViewMissing(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{

--- a/net/http/writer.go
+++ b/net/http/writer.go
@@ -1,0 +1,64 @@
+package http
+
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-sync"
+)
+
+// bufferedWriter captures a mux-generated response until notFoundHandler decides whether to replay it.
+//
+// The not-found handler needs to inspect generated mux responses without committing the client response
+// early: non-404 responses are flushed unchanged, while 404 responses can be replaced by a package-specific
+// handler such as MVC not-found rendering or content status errors.
+type bufferedWriter struct {
+	header   Header
+	response ResponseWriter
+	buffer   *bytes.Buffer
+	pool     *sync.BufferPool
+	code     int
+}
+
+func (w *bufferedWriter) Header() Header {
+	return w.header
+}
+
+func (w *bufferedWriter) Write(p []byte) (int, error) {
+	if w.code == 0 {
+		w.WriteHeader(StatusOK)
+	}
+
+	return w.buffer.Write(p)
+}
+
+func (w *bufferedWriter) WriteHeader(code int) {
+	if w.code != 0 {
+		return
+	}
+
+	w.code = code
+}
+
+func (w *bufferedWriter) Flush() {
+	header := w.response.Header()
+	for key, values := range w.header {
+		if len(values) == 0 {
+			header.Del(key)
+			continue
+		}
+
+		header.Set(key, values[0])
+		for _, value := range values[1:] {
+			header.Add(key, value)
+		}
+	}
+
+	if w.code != 0 {
+		w.response.WriteHeader(w.code)
+	}
+
+	_, _ = w.buffer.WriteTo(w.response)
+}
+
+func (w *bufferedWriter) Close() {
+	w.pool.Put(w.buffer)
+}

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -77,6 +77,7 @@ func BenchmarkHTTP(b *testing.B) {
 		h, err := transporthttp.NewServer(transporthttp.ServerParams{
 			Shutdowner: test.NewShutdowner(),
 			Mux:        mux,
+			Pool:       test.Pool,
 			Config:     cfg.HTTP,
 			UserAgent:  test.UserAgent,
 			Version:    test.Version,
@@ -124,6 +125,7 @@ func BenchmarkHTTP(b *testing.B) {
 		h, err := transporthttp.NewServer(transporthttp.ServerParams{
 			Shutdowner: test.NewShutdowner(),
 			Mux:        mux,
+			Pool:       test.Pool,
 			Config:     cfg.HTTP,
 			Logger:     logger,
 			UserAgent:  test.UserAgent,
@@ -175,6 +177,7 @@ func BenchmarkHTTP(b *testing.B) {
 		h, err := transporthttp.NewServer(transporthttp.ServerParams{
 			Shutdowner: test.NewShutdowner(),
 			Mux:        mux,
+			Pool:       test.Pool,
 			Config:     cfg.HTTP,
 			Logger:     logger,
 			UserAgent:  test.UserAgent,

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -100,6 +100,50 @@ func TestNotFound(t *testing.T) {
 	}))
 
 	header := http.Header{}
+	header.Set("Accept", media.HTML)
+	header.Set(content.TypeKey, media.HTML)
+
+	url := world.PathServerURL("http", "missing")
+
+	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, header, http.NoBody)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+
+	_, err = html.Parse(strings.NewReader(body))
+	require.NoError(t, err)
+}
+
+func TestNotFoundUsesContentFallbackWithoutHTMLAccept(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *notFoundModel) {
+		return mvc.NewFullView("views/error.tmpl"), &notFoundModel{Error: http.StatusText(http.StatusNotFound)}
+	}))
+
+	header := http.Header{}
+	header.Set(content.TypeKey, media.JSON)
+
+	url := world.PathServerURL("http", "missing")
+
+	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, header, http.NoBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, http.StatusText(http.StatusNotFound), body)
+}
+
+func TestNotFoundHandlesHTMXRequest(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *notFoundModel) {
+		return mvc.NewPartialView("views/error.tmpl"), &notFoundModel{Error: http.StatusText(http.StatusNotFound)}
+	}))
+
+	header := http.Header{}
+	header.Set("Accept", "*/*")
+	header.Set("Hx-Request", "true")
 	header.Set(content.TypeKey, media.HTML)
 
 	url := world.PathServerURL("http", "missing")

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,19 @@ func TestRestError(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestRestNotFound(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
+
+	header := http.Header{}
+	header.Set(content.TypeKey, media.JSON)
+
+	res, body, err := world.GetBody(t.Context(), world.NamedServerURL("http", "missing"), header)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, http.StatusText(http.StatusNotFound), body)
 }
 
 func TestRestRequestError(t *testing.T) {

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -172,6 +172,19 @@ func TestErrorRPC(t *testing.T) {
 	}
 }
 
+func TestRPCNotFound(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+
+	header := http.Header{}
+	header.Set(content.TypeKey, media.JSON)
+
+	res, body, err := world.ResponseWithBody(t.Context(), world.PathServerURL("http", "missing"), http.MethodPost, header, http.NoBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, http.StatusText(http.StatusNotFound), body)
+}
+
 func TestAllowedRPC(t *testing.T) {
 	for _, mt := range []string{"json", "hjson", "yaml", "yml", "toml", "gob"} {
 		t.Run(mt, func(t *testing.T) {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
@@ -19,6 +20,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
+	sync "github.com/alexfalkowski/go-sync"
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/urfave/negroni/v3"
 )
@@ -41,6 +43,9 @@ type ServerParams struct {
 
 	// Mux is the HTTP request multiplexer that holds registered routes/handlers.
 	Mux *http.ServeMux
+
+	// Pool is the shared buffer pool used to inspect mux 404s without committing the response early.
+	Pool *sync.BufferPool
 
 	// Config controls HTTP server enablement, address, timeouts, TLS, and low-level HTTP options.
 	Config *Config
@@ -85,7 +90,7 @@ type ServerParams struct {
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - optional token verification (`transport/http/token`) when `params.Verifier` is non-nil
 //   - optional rate limiting (`transport/http/limiter`) when `params.Limiter` is non-nil
-//   - gzip compression wrapping the mux handler (`gzhttp.GzipHandler(params.Mux)`)
+//   - gzip compression wrapping the mux not-found handler (`gzhttp.GzipHandler(http.NewNotFoundHandler(...))`)
 //
 // Token verification and rate limiting middleware typically treat "ignorable" paths (health/metrics/etc.)
 // as bypassable, so those endpoints do not require auth and do not consume limiter capacity by default.
@@ -128,7 +133,8 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(limiter.NewHandler(params.Limiter))
 	}
 
-	neg.UseHandler(gzhttp.GzipHandler(mvc.NewHandler(params.Mux)))
+	handler := http.NewNotFoundHandler(params.Mux, params.Pool, mvc.NotFoundHandler(), content.NotFoundHandler())
+	neg.UseHandler(gzhttp.GzipHandler(handler))
 
 	httpServer := http.NewServer(params.Config.Options, params.Config.Timeout, neg)
 


### PR DESCRIPTION
## What
- Added a shared mux fallback handler that can replace generated 404 responses while preserving non-404 mux responses such as 405.
- Added content and MVC fallbacks so API requests receive status.WriteError responses while HTML and HTMX requests can render the MVC not-found view.
- Wired the HTTP transport through the fallback chain and covered REST, RPC, MVC, HTMX, and mux fallback behavior with tests.

## Why
- Mixed MVC and API services need missing API routes to return the same typed error payloads as REST/RPC handlers, without taking away MVC not-found pages for browser-style requests.

## Testing
- go test ./net/http ./net/http/content ./net/http/mvc ./transport/http
- make lint
