### PR TITLE
feat(server): drop inbound retry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,16 @@ import (
 
 func main() {
     app := cli.NewApplication(func(commander cli.Commander) {
-       server := commander.AddServer("serve", "Run the service", module.Server)
-       server.AddInput("file:./config.yml") // enables the `-i` flag used by config.NewDecoder
+        serve := commander.AddServer("serve", "Run the service", module.Server)
+        serve.AddInput("file:./config.yml") // adds the `-i` config input flag with this default
     })
 
     os.Exit(app.RunCode(context.Background()))
 }
 ```
 
-Use `app.Run(context.Background())` when the caller should receive the execution error directly, or
-`app.RunCode(context.Background())` when the caller wants a process exit code. Applications can pass
-`cli.WithExitCodeFunc` to `cli.NewApplication` to map specific errors to specific exit codes.
+Use `app.RunCode(context.Background())` from `main` when exiting the process. Use
+`app.Run(context.Background())` in tests or embedding code that needs to inspect the returned error.
 
 ---
 
@@ -702,19 +701,36 @@ Built-in text/object payload media types include:
 - `application/yml`
 - `application/toml`
 - `application/gob`
+- `application/octet-stream`
+- `text/plain`
+- `text/markdown`
 
 Built-in protobuf-oriented media type aliases include:
 
 - `application/proto`
+- `application/pb`
 - `application/protobuf`
+- `application/protobin`
+- `application/pbbin`
 - `application/protojson`
+- `application/pbjson`
 - `application/prototext`
+- `application/prototxt`
+- `application/pbtxt`
 
 Notes:
 
 - `application/hjson` maps to the built-in `hjson` encoder kind.
 - Unknown or invalid request media types fall back to JSON selection.
 - `text/error` is reserved for error responses and should not be sent by clients as a request content type.
+
+### HTTP route misses
+
+The HTTP transport wraps the mux with `net/http.NewNotFoundHandler` so generated 404 responses can be rendered consistently while preserving other mux responses such as 405 Method Not Allowed.
+
+- REST/RPC-style missing routes use `net/http/content.NotFoundHandler`, which writes the standard `status.WriteError` response.
+- MVC missing routes can use `net/http/mvc.NotFoundHandler` to render the registered MVC not-found view when the request accepts HTML (`Accept: text/html`) or is an HTMX request (`Hx-Request: true`).
+- Routes that match and write their own status are not replaced by this mux-level not-found handler.
 
 ### Transport configuration (servers)
 
@@ -752,17 +768,13 @@ transport:
     max_receive_size: 3MB
 ```
 
-With retry + low-level options map:
+With low-level server options:
 
 ```yaml
 transport:
   http:
     address: tcp://localhost:8000
     timeout: 10s
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     options:
       read_timeout: 10s
       write_timeout: 10s
@@ -771,10 +783,6 @@ transport:
   grpc:
     address: tcp://localhost:9000
     timeout: 10s
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     options:
       keepalive_enforcement_policy_ping_min_time: 10s
       keepalive_max_connection_idle: 10s

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -281,8 +281,6 @@ func verifyConfig(t *testing.T, config *config.Config) {
 		},
 		config.Transport.GRPC.Options,
 	)
-	require.Equal(t, 3, int(config.Transport.GRPC.Retry.Attempts))
-	require.Equal(t, time.Second, config.Transport.GRPC.Retry.Timeout)
 	require.False(t, config.Transport.GRPC.TLS.IsEnabled())
 	require.True(t, config.Transport.HTTP.Token.IsEnabled())
 	require.Equal(t, "file:../test/configs/rbac.conf", config.Transport.HTTP.Token.Access.Model)
@@ -307,7 +305,5 @@ func verifyConfig(t *testing.T, config *config.Config) {
 		},
 		config.Transport.HTTP.Options,
 	)
-	require.Equal(t, 3, int(config.Transport.HTTP.Retry.Attempts))
-	require.Equal(t, time.Second, config.Transport.HTTP.Retry.Timeout)
 	require.False(t, config.Transport.HTTP.TLS.IsEnabled())
 }

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
-	"github.com/alexfalkowski/go-service/v2/transport/retry"
 )
 
 // DefaultMaxReceiveSize is the default inbound payload limit applied when MaxReceiveSize is omitted or zero.
@@ -19,9 +18,6 @@ const DefaultMaxReceiveSize bytes.Size = 4 * bytes.MB
 type Config struct {
 	// Limiter configures server-side request limiting.
 	Limiter *limiter.Config `yaml:"limiter,omitempty" json:"limiter,omitempty" toml:"limiter,omitempty"`
-
-	// Retry configures server-side retry behavior where applicable.
-	Retry *retry.Config `yaml:"retry,omitempty" json:"retry,omitempty" toml:"retry,omitempty"`
 
 	// TLS configures server-side TLS (certificate and key material).
 	TLS *tlsconfig.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	httpbreaker "github.com/alexfalkowski/go-service/v2/transport/http/breaker"
 	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
+	"github.com/alexfalkowski/go-service/v2/transport/retry"
 )
 
 // Client bundles the dependencies needed to construct instrumented HTTP and gRPC clients for tests.
@@ -30,6 +31,7 @@ type Client struct {
 	RoundTripper http.RoundTripper
 	Meter        metrics.Meter
 	Generator    token.Generator
+	Retry        *retry.Config
 	HTTPLimiter  *httplimiter.Client
 	GRPCLimiter  *grpclimiter.Client
 	Compression  bool
@@ -42,7 +44,7 @@ func (c *Client) NewHTTP(os ...httpbreaker.Option) (*http.Client, error) {
 		http.WithClientLogger(c.Logger),
 		http.WithClientRoundTripper(c.RoundTripper),
 		http.WithClientBreaker(os...),
-		http.WithClientRetry(c.Transport.HTTP.Retry),
+		http.WithClientRetry(c.Retry),
 		http.WithClientUserAgent(UserAgent),
 		http.WithClientTokenGenerator(UserID, c.Generator),
 		http.WithClientTimeout(time.Minute),
@@ -66,7 +68,7 @@ func (c *Client) NewGRPC(os ...grpcbreaker.Option) (*grpc.ClientConn, error) {
 		grpc.WithClientStreamInterceptors(),
 		grpc.WithClientLogger(c.Logger),
 		grpc.WithClientBreaker(os...),
-		grpc.WithClientRetry(c.Transport.GRPC.Retry),
+		grpc.WithClientRetry(c.Retry),
 		grpc.WithClientUserAgent(UserAgent),
 		grpc.WithClientTokenGenerator(UserID, c.Generator),
 		grpc.WithClientTimeout(time.Minute),

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -174,14 +174,12 @@ func NewInsecureTransportConfig() *transport.Config {
 			Config: &server.Config{
 				Timeout: timeout,
 				Address: RandomAddress(),
-				Retry:   NewRetry(),
 			},
 		},
 		GRPC: &grpc.Config{
 			Config: &server.Config{
 				Timeout: timeout,
 				Address: RandomAddress(),
-				Retry:   NewRetry(),
 			},
 		},
 	}
@@ -200,7 +198,6 @@ func NewGRPCTransportConfig() *grpc.Config {
 // NewSecureTransportConfig returns HTTP and gRPC transport configs wired with the shared TLS server fixtures on ephemeral local addresses.
 func NewSecureTransportConfig() *transport.Config {
 	config := NewTLSServerConfig()
-	retry := NewRetry()
 
 	return &transport.Config{
 		HTTP: &http.Config{
@@ -208,7 +205,6 @@ func NewSecureTransportConfig() *transport.Config {
 				Timeout: timeout,
 				TLS:     config,
 				Address: RandomAddress(),
-				Retry:   retry,
 			},
 		},
 		GRPC: &grpc.Config{
@@ -216,7 +212,6 @@ func NewSecureTransportConfig() *transport.Config {
 				Timeout: timeout,
 				TLS:     config,
 				Address: RandomAddress(),
-				Retry:   retry,
 			},
 		},
 	}
@@ -306,7 +301,6 @@ func NewInsecureDebugConfig() *debug.Config {
 		Config: &server.Config{
 			Timeout: 5 * time.Second,
 			Address: RandomAddress(),
-			Retry:   NewRetry(),
 		},
 	}
 }
@@ -318,7 +312,6 @@ func NewSecureDebugConfig() *debug.Config {
 			Timeout: 5 * time.Second,
 			TLS:     NewTLSServerConfig(),
 			Address: RandomAddress(),
-			Retry:   NewRetry(),
 		},
 	}
 }

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -90,7 +90,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	client := &Client{
 		Lifecycle: lc, Logger: logger, Tracer: tracer, Transport: transportCfg,
 		Meter: meter, TLS: tlsCfg, Generator: os.generator,
-		Compression: os.compression, RoundTripper: os.rt,
+		Retry: NewRetry(), Compression: os.compression, RoundTripper: os.rt,
 		HTTPLimiter: httpClientLimiter,
 		GRPCLimiter: grpcClientLimiter,
 	}

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -102,11 +102,6 @@
         read_header_timeout: "10s"
         max_header_bytes: "32KB"
       }
-      retry: {
-        backoff: "100ms"
-        timeout: "1s"
-        attempts: 3
-      }
       timeout: "10s"
       token: {
         access: {
@@ -141,11 +136,6 @@
         initial_window_size: "1MB"
         initial_conn_window_size: "2MB"
         max_send_msg_size: "8MB"
-      }
-      retry: {
-        backoff: "100ms"
-        timeout: "1s"
-        attempts: 3
       }
       timeout: "10s"
       token: {

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -71,10 +71,6 @@ transport:
       idle_timeout: 10s
       read_header_timeout: 10s
       max_header_bytes: 32KB
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     timeout: 10s
     token:
       access:
@@ -104,10 +100,6 @@ transport:
       initial_window_size: 1MB
       initial_conn_window_size: 2MB
       max_send_msg_size: 8MB
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     timeout: 10s
     token:
       access:

--- a/test/configs/invalid_grpc.config.yml
+++ b/test/configs/invalid_grpc.config.yml
@@ -5,10 +5,6 @@ transport:
   http:
     address: "tcp://localhost:0"
     timeout: 10s
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
   grpc:
     address: "tcp://localhost:invalid"
     timeout: 10s

--- a/test/configs/invalid_trace.yml
+++ b/test/configs/invalid_trace.yml
@@ -63,10 +63,6 @@ transport:
       kind: user-agent
       tokens: 10
       interval: 1s
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     timeout: 10s
   grpc:
     address: tcp://localhost:12000
@@ -74,8 +70,4 @@ transport:
       kind: user-agent
       tokens: 10
       interval: 1s
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     timeout: 10s

--- a/test/status.yml
+++ b/test/status.yml
@@ -11,8 +11,4 @@ telemetry:
 transport:
   http:
     address: tcp://:6000
-    retry:
-      backoff: 100ms
-      timeout: 1s
-      attempts: 3
     timeout: 10s


### PR DESCRIPTION
## What
- removed retry from the shared server config shape
- removed transport-level retry entries from config fixtures and assertions
- kept integration test clients on an explicit client retry config
- updated README transport docs and HTTP content/not-found notes

## Why
- retry behavior is applied by outbound HTTP/gRPC clients, while inbound constructors do not consume retry config
- keeping retry under server config made the public config surface imply unsupported behavior

## Testing
- go test -count=1 ./config ./config/server ./internal/test ./transport/http ./transport/grpc
- go test -count=1 ./internal/test ./transport/http ./transport/grpc
- go test ./module ./cli ./config ./config/server ./internal/test ./transport/http ./transport/grpc ./net/http ./net/http/content ./net/http/mvc
- make lint
