### PR TITLE
test(health): cover db checker ping paths

### DIFF
--- a/health/checker/db_test.go
+++ b/health/checker/db_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/database/sql"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/health/checker"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
@@ -14,6 +16,20 @@ func TestDBCheckerWithoutConnections(t *testing.T) {
 	require.Empty(t, errs)
 
 	check := checker.NewDBChecker(db, time.Second)
-	err := check.Check(t.Context())
-	require.ErrorIs(t, err, checker.ErrNoConnections)
+	require.ErrorIs(t, check.Check(t.Context()), checker.ErrNoConnections)
+}
+
+func TestDBCheckerPingsWorldDB(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
+
+	check := checker.NewDBChecker(world.DB, time.Second)
+	require.NoError(t, check.Check(t.Context()))
+}
+
+func TestDBCheckerReturnsPingError(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
+
+	check := checker.NewDBChecker(world.DB, time.Second)
+	require.NoError(t, errors.Join(world.DB.Destroy()...))
+	require.Error(t, check.Check(t.Context()))
 }


### PR DESCRIPTION
## What

- add DB checker coverage that uses the shared test world Postgres connection
- verify checker success against the world DB and ping failure after closing the pool

## Why

- exercises the real DB ping path instead of only the no-connection case
- keeps the checker tests aligned with the repository world fixture pattern

## Testing

- go test ./health/checker
- make lint
