### PR TITLE
feat(retry): preserve http attempts without configured timeout

### DIFF
--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -91,15 +91,15 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	attempt := &roundTripAttempt{}
 
 	operation := func(ctx context.Context) (*http.Response, error) {
-		return r.attempt(req, ctx, attempt)
+		return r.attempt(ctx, req, attempt)
 	}
 
 	res, err := retry.DoValue(req.Context(), r.backoff, operation)
 	return attempt.finalize(res, err)
 }
 
-func (r *RoundTripper) attempt(req *http.Request, ctx context.Context, attempt *roundTripAttempt) (*http.Response, error) {
-	ctx, cancel := context.WithTimeoutCause(ctx, r.timeout, ErrAttemptTimeout)
+func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *roundTripAttempt) (*http.Response, error) {
+	ctx, cancel := r.withAttemptTimeout(ctx)
 	defer cancel()
 
 	attemptReq, err := attempt.request(req, ctx)
@@ -113,6 +113,14 @@ func (r *RoundTripper) attempt(req *http.Request, ctx context.Context, attempt *
 	}
 
 	return res, err
+}
+
+func (r *RoundTripper) withAttemptTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if r.timeout <= 0 {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeoutCause(ctx, r.timeout, ErrAttemptTimeout)
 }
 
 func request(req *http.Request, ctx context.Context, attempt int) (*http.Request, error) {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -194,11 +194,28 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	require.Equal(t, []int{1, 1}, rt.authCounts)
 }
 
-func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {
+func TestRoundTripperDoesNotSetAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
 	transport := &causeRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
 		Timeout:  0,
+		Backoff:  time.Millisecond,
+	}, transport)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NoError(t, transport.err)
+	require.NoError(t, transport.cause)
+}
+
+func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {
+	transport := &causeRoundTripper{wait: true}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 1,
+		Timeout:  time.Nanosecond,
 		Backoff:  time.Millisecond,
 	}, transport)
 
@@ -331,9 +348,14 @@ func (r *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 type causeRoundTripper struct {
 	cause error
 	err   error
+	wait  bool
 }
 
 func (r *causeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.wait {
+		<-req.Context().Done()
+	}
+
 	r.cause = context.Cause(req.Context())
 	r.err = req.Context().Err()
 


### PR DESCRIPTION
## What

- Skip per-attempt timeout wrapping when HTTP retry timeout is unset or non-positive.
- Cover zero-timeout and positive-timeout behavior in HTTP retry tests.

## Why

- Avoid immediately canceling HTTP retry attempts when retry.timeout is omitted.

## Testing

- `go test ./transport/http/retry` - passed
- `go test ./transport/http/retry ./transport/http ./config ./transport/retry` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
