### PR TITLE
feat(telemetry): track provider enablement explicitly

### DIFF
--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-sync"
 	"go.opentelemetry.io/contrib/instrumentation/host"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
@@ -15,7 +16,10 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-var noopProvider metric.MeterProvider = noop.NewMeterProvider()
+var (
+	enabled      sync.Bool
+	noopProvider metric.MeterProvider = noop.NewMeterProvider()
+)
 
 // MeterProviderParams declares the dependencies required by NewMeterProvider.
 //
@@ -66,6 +70,7 @@ type MeterProviderParams struct {
 // If metrics are disabled or Reader is nil, it installs and returns the package noop provider.
 func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	if !params.Config.IsEnabled() || params.Reader == nil {
+		enabled.Store(false)
 		otel.SetMeterProvider(noopProvider)
 		return noopProvider
 	}
@@ -80,6 +85,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	)
 	provider := sdk.NewMeterProvider(sdk.WithReader(reader), sdk.WithResource(attrs))
 	otel.SetMeterProvider(provider)
+	enabled.Store(true)
 
 	params.Lifecycle.Append(di.Hook{
 		OnStart: func(_ context.Context) error {
@@ -91,6 +97,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 			// Do not return error as this will stop all others.
 			_ = provider.Shutdown(ctx)
 			otel.SetMeterProvider(noopProvider)
+			enabled.Store(false)
 
 			return nil
 		},
@@ -99,9 +106,9 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	return provider
 }
 
-// IsEnabled reports whether metrics are backed by a non-noop provider installed by this package.
+// IsEnabled reports whether this package has registered metrics as enabled.
 func IsEnabled() bool {
-	return otel.GetMeterProvider() != noopProvider
+	return enabled.Load()
 }
 
 // NewManualReader constructs an OpenTelemetry SDK manual metric reader.

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -13,6 +15,9 @@ func TestIsEnabled(t *testing.T) {
 	t.Cleanup(func() {
 		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	})
+
+	otel.SetMeterProvider(noop.NewMeterProvider())
+	require.False(t, metrics.IsEnabled())
 
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	require.False(t, metrics.IsEnabled())
@@ -28,4 +33,7 @@ func TestIsEnabled(t *testing.T) {
 	})
 	require.NotNil(t, provider)
 	require.True(t, metrics.IsEnabled())
+
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	require.False(t, metrics.IsEnabled())
 }

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-sync"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	otlp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -14,7 +15,10 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
-var noopProvider trace.TracerProvider = noop.NewTracerProvider()
+var (
+	enabled      sync.Bool
+	noopProvider trace.TracerProvider = noop.NewTracerProvider()
+)
 
 // TracerParams declares the dependencies required by Register.
 //
@@ -59,6 +63,7 @@ type TracerParams struct {
 // Shutdown errors are intentionally ignored to avoid blocking other stop hooks.
 func Register(params TracerParams) error {
 	if !params.Config.IsEnabled() {
+		enabled.Store(false)
 		otel.SetTracerProvider(noopProvider)
 		return nil
 	}
@@ -77,6 +82,7 @@ func Register(params TracerParams) error {
 
 		provider := sdk.NewTracerProvider(sdk.WithResource(attrs), sdk.WithBatcher(exporter))
 		otel.SetTracerProvider(provider)
+		enabled.Store(true)
 
 		params.Lifecycle.Append(di.Hook{
 			OnStart: func(ctx context.Context) error {
@@ -87,6 +93,7 @@ func Register(params TracerParams) error {
 				_ = provider.Shutdown(ctx)
 				_ = exporter.Shutdown(ctx)
 				otel.SetTracerProvider(noopProvider)
+				enabled.Store(false)
 
 				return nil
 			},
@@ -98,7 +105,7 @@ func Register(params TracerParams) error {
 	}
 }
 
-// IsEnabled reports whether tracing is backed by a non-noop provider installed by this package.
+// IsEnabled reports whether this package has registered tracing as enabled.
 func IsEnabled() bool {
-	return otel.GetTracerProvider() != noopProvider
+	return enabled.Load()
 }

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -13,6 +15,9 @@ func TestIsEnabled(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})
+
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	require.False(t, tracer.IsEnabled())
 
 	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	require.False(t, tracer.IsEnabled())
@@ -32,6 +37,9 @@ func TestIsEnabled(t *testing.T) {
 		Environment: test.Environment,
 	}))
 	require.True(t, tracer.IsEnabled())
+
+	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
+	require.False(t, tracer.IsEnabled())
 }
 
 func TestConfigIsEnabled(t *testing.T) {


### PR DESCRIPTION
## What

- Track metrics and tracing enablement with package-level sync.Bool values while keeping noop providers for disabled global state.
- Reset enablement when providers are disabled or stopped.
- Cover external noop providers and enabled-to-disabled transitions in metrics/tracer tests.

## Why

- Comparing OpenTelemetry globals against this package noop provider only checked provider identity and could treat OpenTelemetry noop providers as enabled before go-service registration.
- Cache, SQL, and transport instrumentation should only see telemetry as enabled after go-service installs configured providers.

## Testing

- `go test ./telemetry/tracer ./telemetry/metrics ./cache/driver ./database/sql/pg ./transport/http ./transport/grpc ./module` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
