### PR TITLE
feat(http): handle nil request headers in http middleware

### DIFF
--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -49,6 +49,9 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	)
 
 	cloned := req.Clone(ctx)
+	if cloned.Header == nil {
+		cloned.Header = http.Header{}
+	}
 	clientSetRequestHeaders(cloned.Header, userAgent.Value(), requestID.Value())
 
 	return r.RoundTripper.RoundTrip(cloned)

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -55,6 +55,27 @@ func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 	require.Empty(t, req.Header.Values("Request-Id"))
 }
 
+func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
+	roundTripper := meta.NewRoundTripper(
+		env.UserAgent("agent"),
+		staticGenerator("request-id"),
+		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "agent", req.Header.Get("User-Agent"))
+			require.Equal(t, "request-id", req.Header.Get("Request-Id"))
+
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+	req.Header = nil
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Nil(t, req.Header)
+}
+
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 	handler := meta.NewHandler(env.UserAgent("agent"), env.Version("v1"), staticGenerator("request-id"))
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -66,6 +66,9 @@ func (h *Webhook) Sign(req *http.Request) error {
 	}
 
 	req.Body = body
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
 	now := time.Now()
 	id := h.generator.Generate()
 	signature, _ := h.hook.Sign(id, now, payload)

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -55,6 +55,20 @@ func TestSignAndVerifyNilBody(t *testing.T) {
 	require.NotNil(t, verifyReq.Body)
 }
 
+func TestSignHandlesNilRequestHeader(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
+	req := &http.Request{Body: http.NoBody}
+
+	require.NoError(t, hook.Sign(req))
+	require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookID))
+	require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookSignature))
+	require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookTimestamp))
+	require.NoError(t, hook.Verify(req))
+}
+
 func TestRoundTripper(t *testing.T) {
 	hook := hooks.NewWebhook(nil, nil)
 	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -87,6 +101,27 @@ func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
 	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookID))
 	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookSignature))
 	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookTimestamp))
+}
+
+func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
+	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookID))
+		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookSignature))
+		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookTimestamp))
+
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	}))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
+	req.Header = nil
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Nil(t, req.Header)
 }
 
 func TestHandler(t *testing.T) {

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -170,6 +170,9 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := meta.WithAttributes(req.Context(), meta.WithAuthorization(auth))
 
 	cloned := req.Clone(ctx)
+	if cloned.Header == nil {
+		cloned.Header = http.Header{}
+	}
 	cloned.Header.Set("Authorization", auth.Value())
 	return r.RoundTripper.RoundTrip(cloned)
 }

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -28,6 +28,26 @@ func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
 	require.Empty(t, req.Header.Values("Authorization"))
 }
 
+func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
+	roundTripper := token.NewRoundTripper(
+		env.UserID("service-user"),
+		staticGenerator("fresh-token"),
+		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "Bearer fresh-token", req.Header.Get("Authorization"))
+
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	req.Header = nil
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Nil(t, req.Header)
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## What

- Initialize cloned or signed request headers before setting metadata, authorization, or webhook signature headers.
- Add regression coverage for nil request header maps in HTTP metadata, token, and webhook middleware.

## Why

- Go allows manually constructed requests to have a nil Header map, and http.Request.Clone preserves that nil map.
- These middleware paths write headers, so they should avoid panicking on caller-supplied requests while preserving normal behavior and original request immutability.

## Testing

- `git diff --check` - passed
- `go test ./net/http/meta ./transport/http/token ./transport/http/hooks` - passed
- `go test ./...` - passed
- `make lint` - passed
