### PR TITLE
feat(ssh): bind signed tokens to audience and expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ transport:
     token:
       kind: ssh
       ssh:
+        exp: 5m
         keys:
           - name: active
             public: file:/keys/active.pub
@@ -610,6 +611,7 @@ transport:
     token:
       kind: ssh
       ssh:
+        exp: 5m
         key:
           name: active
           private: file:/keys/active
@@ -624,6 +626,7 @@ Notes:
 
 - `ssh.key` is used for minting tokens (requires private key).
 - `ssh.keys` is used for verification (public keys).
+- `ssh.exp` sets the token validity window; SSH keys remain long-lived, while generated tokens are short-lived.
 - The config does not enforce that the signing key name exists in the verification set; include it if you want round-trip.
 
 ---

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -80,6 +80,7 @@ func NewToken(kind string) *token.Config {
 			Expiration: time.Hour,
 		},
 		SSH: &ssh.Config{
+			Expiration: time.Hour,
 			Key: &ssh.Key{
 				Name:   UserID.String(),
 				Config: NewSSH("secrets/ssh_public", "secrets/ssh_private"),

--- a/token/ssh/claims.go
+++ b/token/ssh/claims.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
+	"github.com/alexfalkowski/go-service/v2/encoding/base64"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	token "github.com/alexfalkowski/go-service/v2/token/errors"
+)
+
+type claims struct {
+	Version   string `json:"ver"`
+	KeyID     string `json:"kid"`
+	Audience  string `json:"aud"`
+	IssuedAt  int64  `json:"iat"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+func parseClaims(tkn string) (*claims, []byte, string, error) {
+	rawClaims, rawSignature, ok := strings.Cut(tkn, tokenSeparator)
+	if !ok || strings.IsEmpty(rawClaims) || strings.IsEmpty(rawSignature) || strings.Contains(rawSignature, tokenSeparator) {
+		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
+	}
+
+	encoded, err := base64.Decode(rawClaims)
+	if err != nil {
+		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
+	}
+
+	data := &claims{}
+	if err := json.Unmarshal(encoded, data); err != nil {
+		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
+	}
+
+	if strings.IsEmpty(data.KeyID) {
+		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
+	}
+
+	return data, encoded, rawSignature, nil
+}
+
+func validateClaims(c *claims, aud string, now int64) error {
+	if c.Audience != aud {
+		return token.ErrInvalidAudience
+	}
+	if c.Version != tokenVersion {
+		return crypto.ErrInvalidMatch
+	}
+	if c.IssuedAt > now || c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt {
+		return token.ErrInvalidTime
+	}
+
+	return nil
+}

--- a/token/ssh/config.go
+++ b/token/ssh/config.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"github.com/alexfalkowski/go-service/v2/crypto/ssh"
 	"github.com/alexfalkowski/go-service/v2/slices"
+	"github.com/alexfalkowski/go-service/v2/time"
 )
 
 // Config configures the SSH-style token implementation.
@@ -16,12 +17,13 @@ import (
 //
 //   - Key is the single signing key used by Token.Generate.
 //   - Keys is the set of verification keys that Token.Verify may use.
+//   - Expiration is how long newly generated tokens are valid.
 //
 // # Key rotation and multi-key verification
 //
-// Verification is name-based: the token embeds a key name prefix, and verification selects
-// a matching public key config from Keys (via Keys.Get(name)). This design supports key
-// rotation by allowing you to:
+// Verification is name-based: the signed token claims embed a key id, and
+// verification selects a matching public key config from Keys (via Keys.Get(name)).
+// This design supports key rotation by allowing you to:
 //
 //   - mint new tokens with the active signing key name, and
 //   - continue verifying older tokens by keeping historical public keys in Keys.
@@ -45,11 +47,16 @@ type Config struct {
 
 	// Keys is the set of verification keys that may be used to validate SSH-style tokens.
 	//
-	// Verification uses the token's embedded name to select a key from this set. If Keys
-	// is empty or does not contain the token's name, verification fails.
+	// Verification uses the token's embedded key id to select a key from this set. If Keys
+	// is empty or does not contain the token's key id, verification fails.
 	//
 	// If Keys is nil/empty, Token.Verify will not be usable.
 	Keys Keys `yaml:"keys,omitempty" json:"keys,omitempty" toml:"keys,omitempty"`
+
+	// Expiration is the duration used to set token expiration.
+	//
+	// In config files it is encoded as a Go duration string, for example "15m" or "1h".
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
 }
 
 // IsEnabled reports whether SSH token configuration is enabled.
@@ -71,7 +78,7 @@ type Key struct {
 
 	// Name is the logical key name used to select a key (for example via Keys.Get).
 	//
-	// For signing, this name is embedded into minted tokens as the "<name>-" prefix.
+	// For signing, this name is embedded into the signed token claims as the key id.
 	// For verification, this name is used as the lookup key into Keys.
 	Name string `yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty"`
 }

--- a/token/ssh/doc.go
+++ b/token/ssh/doc.go
@@ -2,24 +2,24 @@
 //
 // This package implements a simple signed token scheme using SSH public key
 // cryptography. It is intentionally different from claim-based tokens (JWT/PASETO):
-// it does not encode audiences, issuers, expiration, or other claims. Instead, it
-// provides a compact token that binds a key name to a signature.
+// it does not encode issuers or arbitrary claims. Instead, it provides a compact
+// token that binds a key name, audience, issued-at time, and expiration claims
+// to a signature.
 //
 // # Token format
 //
 // Tokens are ASCII strings of the form:
 //
-//	<name>-<base64(signature)>
+//	<base64(json-claims)>.<base64(signature)>
 //
 // Where:
 //
-//   - <name> is the logical name of the signing key (for example "primary").
-//   - signature is produced by signing the bytes of <name> with the configured SSH
-//     private key.
+//   - json-claims contains "kid" (the logical signing key name) and "aud"
+//     (the expected audience, such as an HTTP path or gRPC method), plus "iat"
+//     and "exp" Unix nanosecond timestamps.
+//   - signature is produced by signing the exact JSON claims bytes with the
+//     configured SSH private key.
 //   - base64(signature) is the standard base64 encoding of the raw signature bytes.
-//
-// The separator is the last "-" in the token string. Anything before the last "-"
-// is treated as the key name, which allows names themselves to contain "-".
 //
 // # Signing keys and verification keys
 //
@@ -27,10 +27,11 @@
 //
 //   - Config.Key is the single signing key used for Generate.
 //   - Config.Keys is a set of named public keys used for Verify.
+//   - Config.Expiration controls how long generated tokens remain valid.
 //
-// Verification is “name-based”: Verify extracts <name> from the token and then
-// looks up a matching public key configuration in Config.Keys (via Keys.Get(name)).
-// If no key with that name exists, verification fails.
+// Verification is “name-based”: Verify extracts kid from the signed claims and
+// then looks up a matching public key configuration in Config.Keys (via
+// Keys.Get(kid)). If no key with that name exists, verification fails.
 //
 // This design supports key rotation and multi-key verification: you can mint tokens
 // with the active signing key name while allowing verification against multiple
@@ -47,11 +48,13 @@
 //
 // # Error handling expectations
 //
-// Verify returns the key name on success (the <name> prefix from the token).
+// Verify returns the key name on success (the kid field from the signed claims).
 // On failure, it returns an empty name plus an error. Common failure modes include:
 //
-//   - token does not contain the "-" separator,
+//   - token does not contain the "." separator,
 //   - no verification key exists for the extracted name,
+//   - the signed audience does not match the expected audience,
+//   - the token is expired or not yet valid,
 //   - base64 decoding fails,
 //   - signature verification fails,
 //   - key material cannot be loaded.
@@ -64,10 +67,10 @@
 // # Security notes
 //
 // This scheme authenticates possession of a key (via signature verification) and binds
-// that to a logical name. It does not provide expiration or replay protection by
-// itself. If your use case requires time-bounded validity, nonce/jti semantics, or
-// audience restrictions, prefer JWT or PASETO token kinds or layer additional checks
-// at a higher level.
+// that to a logical name, audience, and validity window. It does not provide
+// nonce/jti replay protection for repeated calls to the same audience inside the
+// validity window. If your use case requires one-time-use tokens, prefer JWT or
+// PASETO token kinds with jti tracking or layer additional checks at a higher level.
 //
 // # Relationship to the top-level token facade
 //

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -4,9 +4,16 @@ import (
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/ssh"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	token "github.com/alexfalkowski/go-service/v2/token/errors"
+)
+
+const (
+	tokenSeparator = "."
+	tokenVersion   = "v1"
 )
 
 // Signer is an alias for crypto/ssh.Signer.
@@ -34,8 +41,8 @@ func NewToken(cfg *Config, fs *os.FS) *Token {
 
 // Token generates and verifies SSH-style tokens.
 //
-// This token kind is intentionally simple and does not carry claims (audience, issuer,
-// expiration, etc.). Instead, it binds a logical key name to a signature.
+// This token kind is intentionally simple. It binds a logical key name and audience
+// to a signature.
 //
 // Missing per-operation key material is treated as invalid configuration and
 // reported via token/errors.ErrInvalidConfig.
@@ -44,25 +51,41 @@ type Token struct {
 	fs  *os.FS
 }
 
-// Generate creates an SSH-style token.
+// Generate creates an SSH-style token for the given audience.
 //
 // Token format:
 //
-//	<name>-<base64(signature)>
+//	<base64(json-claims)>.<base64(signature)>
 //
-// Where <name> is t.cfg.Key.Name and signature is produced by signing the bytes of
-// <name> using the configured signing key material. Because the signature uses
-// standard base64 encoding, key names may themselves contain "-" characters.
+// Where json-claims contains:
+//   - ver: the token format version ("v1")
+//   - kid: t.cfg.Key.Name
+//   - aud: aud
+//   - iat: the issued-at Unix nanosecond timestamp
+//   - exp: the expiration Unix nanosecond timestamp
+//
+// The sub parameter is accepted to match the other token implementations; SSH
+// tokens identify the signing key instead of carrying a subject.
+//
+// The signature is produced by signing the exact JSON claims bytes using the
+// configured signing key material. Because the key name and audience are both in
+// the signed claims, a token minted for one audience cannot be replayed for
+// another audience.
 //
 // High-level algorithm:
 //  1. Load an SSH signer from the configured signing key (t.cfg.Key) using fs.
-//  2. Compute signature = Sign(<name>).
-//  3. Return "<name>-<base64(signature)>".
+//  2. Marshal claims = {"ver": "v1", "kid": <name>, "aud": <aud>, "iat": <now>, "exp": <expiration>}.
+//  3. Compute signature = Sign(claims).
+//  4. Return "<base64(claims)>.<base64(signature)>".
 //
 // Errors are returned when the signing key configuration is missing/partial,
-// key material cannot be loaded, or signature generation fails.
-func (t *Token) Generate() (string, error) {
+// key material cannot be loaded, claims encoding fails, or signature generation
+// fails.
+func (t *Token) Generate(aud, sub string) (string, error) {
 	if t.cfg.Key == nil || t.cfg.Key.Config == nil || strings.IsEmpty(t.cfg.Key.Name) {
+		return strings.Empty, token.ErrInvalidConfig
+	}
+	if t.cfg.Expiration <= 0 {
 		return strings.Empty, token.ErrInvalidConfig
 	}
 
@@ -71,49 +94,64 @@ func (t *Token) Generate() (string, error) {
 		return strings.Empty, err
 	}
 
-	signature, err := sig.Sign(strings.Bytes(t.cfg.Key.Name))
+	now := time.Now()
+	c, err := json.Marshal(claims{
+		Version:   tokenVersion,
+		KeyID:     t.cfg.Key.Name,
+		Audience:  aud,
+		IssuedAt:  now.UnixNano(),
+		ExpiresAt: now.Add(t.cfg.Expiration.Duration()).UnixNano(),
+	})
 	if err != nil {
 		return strings.Empty, err
 	}
 
-	return strings.Join("-", t.cfg.Key.Name, base64.Encode(signature)), nil
+	signature, err := sig.Sign(c)
+	if err != nil {
+		return strings.Empty, err
+	}
+
+	return strings.Join(tokenSeparator, base64.Encode(c), base64.Encode(signature)), nil
 }
 
-// Verify validates token and returns the embedded key name if it is valid.
+// Verify validates token for aud and returns the embedded key name if it is valid.
 //
 // Token format:
 //
-//	<name>-<base64(signature)>
+//	<base64(json-claims)>.<base64(signature)>
 //
-// Verification is name-based: Verify extracts <name> and then selects the matching
-// verification key configuration from t.cfg.Keys using Keys.Get(name). It verifies
-// the signature over the bytes of <name> with that key.
+// Verification is name-based and audience-bound: Verify decodes the signed claims,
+// checks claims.aud against aud, selects the matching verification key
+// configuration from t.cfg.Keys using Keys.Get(claims.kid), and verifies the
+// signature over the exact claims bytes with that key.
 //
 // High-level algorithm:
-//  1. Split token into (name, encodedSignature) on the last "-".
-//  2. Look up a verification key config for name in t.cfg.Keys.
-//  3. Load an SSH verifier from the selected key material using fs.
-//  4. Decode the signature from base64.
-//  5. Verify(signature, <name>).
+//  1. Split token into (encodedClaims, encodedSignature) on ".".
+//  2. Decode and unmarshal the claims.
+//  3. Look up a verification key config for claims.kid in t.cfg.Keys.
+//  4. Load an SSH verifier from the selected key material using fs.
+//  5. Decode the signature from base64.
+//  6. Verify(signature, claims).
+//  7. Check claims.ver, claims.aud, claims.iat, and claims.exp.
 //
 // Security-oriented error behavior:
-//   - If the token cannot be split or no key exists for the name, Verify returns
-//     crypto/errors.ErrInvalidMatch. This intentionally collapses multiple invalid-token
-//     cases into a single class to avoid leaking whether a given key name exists.
+//   - If the token cannot be split, the claims cannot be decoded, or no key
+//     exists for the name, Verify returns crypto/errors.ErrInvalidMatch.
+//     This intentionally collapses multiple invalid-token cases into a single
+//     class to avoid leaking whether a given key name exists.
 //   - If a matching key name exists but its verification config is missing/partial,
 //     Verify returns token/errors.ErrInvalidConfig.
 //   - Base64 decode errors and verifier loading errors are returned as-is.
 //
-// On success, Verify returns the extracted name. On failure, it always returns an
-// empty name alongside the error.
-func (t *Token) Verify(tkn string) (string, error) {
-	index := strings.LastIndex(tkn, "-")
-	if index <= 0 || index == len(tkn)-1 {
-		return strings.Empty, crypto.ErrInvalidMatch
+// On success, Verify returns the extracted key name. On failure, it always
+// returns an empty name alongside the error.
+func (t *Token) Verify(tkn, aud string) (string, error) {
+	data, encoded, key, err := parseClaims(tkn)
+	if err != nil {
+		return strings.Empty, err
 	}
-	name, key := tkn[:index], tkn[index+1:]
 
-	cfg := t.cfg.Keys.Get(name)
+	cfg := t.cfg.Keys.Get(data.KeyID)
 	if cfg == nil {
 		return strings.Empty, crypto.ErrInvalidMatch
 	}
@@ -132,9 +170,13 @@ func (t *Token) Verify(tkn string) (string, error) {
 		return strings.Empty, err
 	}
 
-	if err := verifier.Verify(sig, strings.Bytes(name)); err != nil {
+	if err := verifier.Verify(sig, encoded); err != nil {
 		return strings.Empty, err
 	}
 
-	return name, nil
+	if err := validateClaims(data, aud, time.Now().UnixNano()); err != nil {
+		return strings.Empty, err
+	}
+
+	return data.KeyID, nil
 }

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -3,9 +3,11 @@ package ssh_test
 import (
 	"testing"
 
+	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/ssh"
 	"github.com/stretchr/testify/require"
@@ -14,16 +16,56 @@ import (
 func TestValid(t *testing.T) {
 	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 
-	tkn, err := token.Generate()
+	tkn, err := token.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
 	require.NotEmpty(t, tkn)
 
-	sub, err := token.Verify(tkn)
+	sub, err := token.Verify(tkn, strings.Empty)
 	require.NoError(t, err)
 	require.Equal(t, test.UserID.String(), sub)
 
 	ssh := ssh.NewToken(nil, nil)
 	require.Nil(t, ssh)
+}
+
+func TestValidForAudience(t *testing.T) {
+	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
+
+	tkn, err := token.Generate("/service.Method", strings.Empty)
+	require.NoError(t, err)
+	require.NotEmpty(t, tkn)
+
+	sub, err := token.Verify(tkn, "/service.Method")
+	require.NoError(t, err)
+	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestInvalidAudience(t *testing.T) {
+	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
+
+	tkn, err := token.Generate("/service.Method", strings.Empty)
+	require.NoError(t, err)
+	require.NotEmpty(t, tkn)
+
+	sub, err := token.Verify(tkn, "/service.Other")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidAudience)
+}
+
+func TestInvalidExpired(t *testing.T) {
+	cfg := test.NewToken("ssh").SSH
+	cfg.Expiration = time.Nanosecond
+	token := ssh.NewToken(cfg, test.FS)
+
+	tkn, err := token.Generate("/service.Method", strings.Empty)
+	require.NoError(t, err)
+	require.NotEmpty(t, tkn)
+
+	time.Sleep(time.Millisecond)
+
+	sub, err := token.Verify(tkn, "/service.Method")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
 func TestValidNameWithDash(t *testing.T) {
@@ -33,11 +75,11 @@ func TestValidNameWithDash(t *testing.T) {
 
 	token := ssh.NewToken(cfg, test.FS)
 
-	tkn, err := token.Generate()
+	tkn, err := token.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
 	require.NotEmpty(t, tkn)
 
-	sub, err := token.Verify(tkn)
+	sub, err := token.Verify(tkn, strings.Empty)
 	require.NoError(t, err)
 	require.Equal(t, "test-user", sub)
 }
@@ -49,13 +91,13 @@ func TestInvalid(t *testing.T) {
 			Config: test.NewSSH("secrets/ssh_public", "secrets/none"),
 		},
 	}, test.FS)
-	_, err := token.Generate()
+	_, err := token.Generate(strings.Empty, strings.Empty)
 	require.Error(t, err)
 
 	for _, tkn := range []string{strings.Empty, "none-", "test-", "test-bob"} {
 		t.Run(tkn, func(t *testing.T) {
 			token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
-			sub, err := token.Verify(tkn)
+			sub, err := token.Verify(tkn, strings.Empty)
 			require.Error(t, err)
 			require.Empty(t, sub)
 		})
@@ -69,18 +111,30 @@ func TestInvalid(t *testing.T) {
 			},
 		},
 	}, test.FS)
-	sub, err := token.Verify("test-bob")
+	sub, err := token.Verify("test-bob", strings.Empty)
 	require.Error(t, err)
 	require.Empty(t, sub)
 
 	valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
-	tkn, err := valid.Generate()
+	tkn, err := valid.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
 
-	index := strings.LastIndex(tkn, "-")
-	require.NotEqual(t, -1, index)
+	token = ssh.NewToken(&ssh.Config{
+		Keys: ssh.Keys{
+			&ssh.Key{
+				Name:   "other",
+				Config: test.NewSSH("secrets/ssh_public", "secrets/ssh_private"),
+			},
+		},
+	}, test.FS)
+	sub, err = token.Verify(tkn, strings.Empty)
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
 
-	sub, err = valid.Verify(tkn[:index+1] + base64.Encode([]byte("bad")))
+	encoded, _, ok := strings.Cut(tkn, ".")
+	require.True(t, ok)
+
+	sub, err = valid.Verify(encoded+"."+base64.Encode([]byte("bad")), strings.Empty)
 	require.Error(t, err)
 	require.Empty(t, sub)
 
@@ -99,7 +153,7 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 			},
 		}, test.FS)
 
-		tkn, err := token.Generate()
+		tkn, err := token.Generate(strings.Empty, strings.Empty)
 		require.Empty(t, tkn)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
 	})
@@ -110,19 +164,34 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 
 		token := ssh.NewToken(cfg, test.FS)
 
-		tkn, err := token.Generate()
+		tkn, err := token.Generate(strings.Empty, strings.Empty)
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("generate with empty expiration", func(t *testing.T) {
+		cfg := test.NewToken("ssh").SSH
+		cfg.Expiration = 0
+
+		token := ssh.NewToken(cfg, test.FS)
+
+		tkn, err := token.Generate(strings.Empty, strings.Empty)
 		require.Empty(t, tkn)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
 	})
 
 	t.Run("verify with matching key missing config", func(t *testing.T) {
+		valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
+		tkn, err := valid.Generate(strings.Empty, strings.Empty)
+		require.NoError(t, err)
+
 		token := ssh.NewToken(&ssh.Config{
 			Keys: ssh.Keys{
-				&ssh.Key{Name: "test"},
+				&ssh.Key{Name: test.UserID.String()},
 			},
 		}, test.FS)
 
-		sub, err := token.Verify("test-bob")
+		sub, err := token.Verify(tkn, strings.Empty)
 		require.Empty(t, sub)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
 	})

--- a/token/token.go
+++ b/token/token.go
@@ -62,8 +62,8 @@ type Token struct {
 //   - "jwt" and "paseto": the token is minted for the provided audience (aud) and
 //     subject (sub).
 //
-//   - "ssh": audience and subject are ignored; the SSH token kind uses its own
-//     encoding/signature format and typically identifies a key rather than a subject.
+//   - "ssh": the token is minted for the provided audience (aud), while subject
+//     is ignored. The SSH token kind typically identifies a key rather than a subject.
 //
 // If the configured kind is unknown, Generate returns token/errors.ErrInvalidConfig.
 func (t *Token) Generate(aud, sub string) ([]byte, error) {
@@ -84,7 +84,7 @@ func (t *Token) Generate(aud, sub string) ([]byte, error) {
 		if t.ssh == nil {
 			return nil, errors.ErrInvalidConfig
 		}
-		token, err := t.ssh.Generate()
+		token, err := t.ssh.Generate(aud, sub)
 		return strings.Bytes(token), err
 	default:
 		return nil, errors.ErrInvalidConfig
@@ -98,8 +98,8 @@ func (t *Token) Generate(aud, sub string) ([]byte, error) {
 //   - "jwt" and "paseto": verifies the token for the provided audience (aud) and
 //     returns the subject ("sub") claim.
 //
-//   - "ssh": audience is ignored and the returned string is the selected key name
-//     (not a JWT/PASETO "sub" claim).
+//   - "ssh": verifies the token for the provided audience (aud), and the
+//     returned string is the selected key name (not a JWT/PASETO "sub" claim).
 //
 // If the configured kind is unknown, Verify returns token/errors.ErrInvalidConfig.
 func (t *Token) Verify(token []byte, aud string) (string, error) {
@@ -118,7 +118,7 @@ func (t *Token) Verify(token []byte, aud string) (string, error) {
 		if t.ssh == nil {
 			return strings.Empty, errors.ErrInvalidConfig
 		}
-		return t.ssh.Verify(bytes.String(token))
+		return t.ssh.Verify(bytes.String(token), aud)
 	default:
 		return strings.Empty, errors.ErrInvalidConfig
 	}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -52,11 +52,14 @@ func TestVerify(t *testing.T) {
 			cfg := test.NewToken(kind)
 			tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
 
-			gen, err := tkn.Generate(strings.Empty, strings.Empty)
+			gen, err := tkn.Generate("hello", strings.Empty)
 			require.NoError(t, err)
 
-			_, err = tkn.Verify(gen, strings.Empty)
+			_, err = tkn.Verify(gen, "hello")
 			require.NoError(t, err)
+
+			_, err = tkn.Verify(gen, "other")
+			require.ErrorIs(t, err, errors.ErrInvalidAudience)
 		})
 	}
 }


### PR DESCRIPTION
## What

- Change SSH tokens from name-only signatures to signed JSON claims with `ver`, `kid`, `aud`, `iat`, and `exp`.
- Add SSH token expiration config and thread audience-bound SSH generation and verification through the token facade.
- Document SSH token expiration and cover audience, expiry, malformed token, and config validation cases.

## Why

- Prevent a captured SSH-style bearer token from being replayed across audiences while keeping SSH keys long-lived.
- Align SSH token generation and verification APIs with JWT and PASETO.

## Testing

- `go test ./token/... ./transport/http ./transport/grpc` - passed
- `make lint` - passed
- `git diff --check` - passed
