### PR TITLE
test(ssh): guard signature checks before claim validation

### DIFF
--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -134,9 +134,9 @@ func TestInvalid(t *testing.T) {
 	encoded, _, ok := strings.Cut(tkn, ".")
 	require.True(t, ok)
 
-	sub, err = valid.Verify(encoded+"."+base64.Encode([]byte("bad")), strings.Empty)
-	require.Error(t, err)
+	sub, err = valid.Verify(encoded+"."+base64.Encode([]byte("bad")), "other")
 	require.Empty(t, sub)
+	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
 
 	token = ssh.NewToken(nil, test.FS)
 	require.Nil(t, token)


### PR DESCRIPTION
## What

- Strengthen the SSH token invalid-token test to use both a bad signature and a mismatched audience.
- Assert that verification returns `crypto.ErrInvalidMatch` before any audience-specific error.

## Why

- Protect the security-sensitive ordering where SSH token signatures are verified before signed claims are validated.
- Prevent future refactors from exposing claim-specific validation errors for unauthenticated claim bytes.

## Testing

- `go test ./token/ssh` - passed
- `make lint` - passed
- `git diff --check` - passed
