### PR TITLE
docs(http): clarify forwarded ip trust boundary

### DIFF
--- a/net/grpc/meta/doc.go
+++ b/net/grpc/meta/doc.go
@@ -21,11 +21,21 @@
 // Server interceptors also emit response header metadata such as
 // "service-version" and "request-id".
 //
-// Server metadata extraction intentionally prefers common forwarding metadata such
-// as "x-forwarded-for", "x-real-ip", "cf-connecting-ip", and
-// "true-client-ip" over peer addresses. Deployments that use the extracted IP for
-// access logs, policy, or rate limiting should place the service behind trusted
-// proxies that strip or overwrite spoofed forwarding metadata.
+// # Forwarded IP trust boundary
+//
+// Server metadata extraction intentionally treats common forwarding metadata,
+// such as "x-forwarded-for", "x-real-ip", "cf-connecting-ip", and
+// "true-client-ip", as trusted inputs and prefers them over peer addresses.
+//
+// This package does not fetch CDN provider IP ranges, maintain trusted proxy
+// CIDR lists, or decide whether a request came through a trusted edge. That
+// policy belongs at the infrastructure boundary: CDN, ingress, load balancer,
+// firewall, service mesh, or application-specific middleware.
+//
+// Deployments that use the extracted IP for access logs, policy, or rate
+// limiting should ensure direct origin access is blocked and the trusted edge
+// strips or overwrites client-supplied forwarding metadata before traffic
+// reaches the service.
 //
 // Start with `UnaryServerInterceptor` / `StreamServerInterceptor` for
 // server-side extraction and `UnaryClientInterceptor` /

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -25,11 +25,21 @@
 // `net/http/content.NewHandler` / `NewRequestHandler`), which populate the context before invoking
 // downstream logic.
 //
-// HTTP server metadata extraction intentionally prefers common forwarding headers
-// such as X-Forwarded-For, X-Real-IP, CF-Connecting-IP, and True-Client-IP over
-// RemoteAddr. Deployments that use the extracted IP for access logs, policy, or
-// rate limiting should place the service behind trusted proxies that strip or
-// overwrite spoofed forwarding headers.
+// # Forwarded IP trust boundary
+//
+// HTTP server metadata extraction intentionally treats common forwarding
+// headers, such as X-Forwarded-For, X-Real-IP, CF-Connecting-IP, and
+// True-Client-IP, as trusted inputs and prefers them over RemoteAddr.
+//
+// This package does not fetch CDN provider IP ranges, maintain trusted proxy
+// CIDR lists, or decide whether a request came through a trusted edge. That
+// policy belongs at the infrastructure boundary: CDN, ingress, load balancer,
+// firewall, service mesh, or application-specific middleware.
+//
+// Deployments that use the extracted IP for access logs, policy, or rate
+// limiting should ensure direct origin access is blocked and the trusted edge
+// strips or overwrites client-supplied forwarding headers before traffic reaches
+// the service.
 //
 // This package also provides HTTP metadata middleware via `NewHandler` and `NewRoundTripper`.
 package meta

--- a/transport/limiter/doc.go
+++ b/transport/limiter/doc.go
@@ -18,9 +18,16 @@
 // limiter construction fails with ErrMissingKey.
 //
 // The "ip" key uses IP metadata populated by transport metadata middleware. That
-// middleware intentionally trusts common forwarding headers such as X-Forwarded-For
-// and CF-Connecting-IP. Use this key only when requests first pass through trusted
-// proxies that strip or overwrite client-supplied forwarding headers.
+// middleware intentionally trusts common forwarding headers such as
+// X-Forwarded-For and CF-Connecting-IP. The limiter does not validate CDN or
+// proxy source ranges itself; it consumes the metadata provided by the transport
+// stack.
+//
+// Use the "ip" key when the service is only reachable through trusted edge
+// infrastructure that strips or overwrites client-supplied forwarding headers.
+// If direct origin access is possible, prefer a different key such as "token" or
+// add application-specific trusted proxy validation before relying on IP-based
+// limits.
 //
 // # In-memory behavior and lifecycle
 //


### PR DESCRIPTION
## What

- Document that HTTP and gRPC metadata extraction intentionally trusts forwarded IP headers.
- Clarify that CDN/provider IP range validation and direct-origin protection belong at the infrastructure boundary.
- Update limiter docs to explain when the `ip` key is appropriate and when to prefer `token` or app-specific proxy validation.

## Why

- Keep framework behavior simple while making the deployment contract explicit.
- Avoid adding Cloudflare-specific CIDR management to generic metadata and limiter packages.

## Testing

- `go test ./net/http/meta ./net/grpc/meta ./transport/limiter` - passed
- `make lint` - passed
- `git diff --check` - passed
