### PR TITLE
docs(http): document status error exposure policy

### DIFF
--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -59,6 +59,15 @@
 //   - google.golang.org/grpc/status is the upstream implementation; this package
 //     forwards directly to it.
 //
+// # Client-visible messages
+//
+// gRPC status messages are sent to clients. This package intentionally preserves
+// the message provided to Error or Errorf instead of replacing it with a generic
+// response. That keeps the framework useful for diagnostics while leaving
+// application-specific redaction policy to callers. Services that must hide
+// internal details should pass a public message here and record the internal
+// cause through their own logging or observability path.
+//
 // # Non-goals
 //
 // This package intentionally exposes only the small subset of the upstream

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -52,6 +52,8 @@ func FromError(err error) (*Status, bool) {
 // This is a thin wrapper around google.golang.org/grpc/status.Error. The
 // returned error is suitable to be returned from a gRPC handler so the runtime
 // can send the corresponding status code and message to the client.
+// The message is client-visible by design. Callers that need redaction should
+// pass a public message and record the internal cause separately.
 //
 // For structured status details (protobuf Any details), use the upstream status
 // API directly (for example status.New(...).WithDetails(...)).
@@ -64,6 +66,8 @@ func Error(c codes.Code, msg string) error {
 // This is a thin wrapper around google.golang.org/grpc/status.Errorf. It formats
 // the message using fmt-style formatting rules and returns an error suitable to
 // be returned from a gRPC handler.
+// The formatted message is client-visible by design. Callers that need redaction
+// should pass a public format string and record the internal cause separately.
 //
 // For structured status details (protobuf Any details), use the upstream status
 // API directly (for example status.New(...).WithDetails(...)).

--- a/net/http/status/doc.go
+++ b/net/http/status/doc.go
@@ -2,4 +2,8 @@
 //
 // This package defines a Coder interface, error constructors (Error/Errorf and helpers like BadRequestError),
 // and utilities to classify and extract status codes from errors (including mapping gRPC status errors to HTTP codes).
+//
+// Status error messages are diagnostic and client-visible when passed to WriteError. This is intentional for a
+// framework package: callers should pass the concrete error they want clients to see, or map/wrap internal failures
+// to sanitized status errors before writing the response.
 package status

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -21,7 +21,10 @@ import (
 //   - gRPC status errors mapped to HTTP codes.
 //
 // Write behavior:
-// The error message is written as a single line (via fmt.Fprintln) containing err.Error().
+// The error message is written as a single line (via fmt.Fprintln) containing err.Error(). This is a
+// deliberate framework-level diagnostic contract: WriteError does not replace the message with a generic
+// response body. Applications that need sanitized client output should map the internal error to a public
+// status error before calling WriteError.
 // If writing the body fails, WriteError returns the write error and does not attempt to write a
 // secondary error response.
 //

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -11,7 +11,8 @@ import (
 // Error constructs an error that carries an HTTP status code and a message.
 //
 // The returned error implements the Coder interface so handlers and helpers can extract the HTTP
-// status code via Code(err).
+// status code via Code(err). The message is diagnostic and may be sent to clients by WriteError,
+// so callers should provide the public message they want exposed.
 func Error(code int, msg string) error {
 	return &statusError{code: code, msg: msg}
 }
@@ -50,6 +51,9 @@ func BadRequestError(err error) error {
 // implementing Coder): calling FromError on such errors does not overwrite the original status code.
 // Raw *http.MaxBytesError values are normalized to StatusRequestEntityTooLarge (413) regardless of the
 // provided code so oversized request bodies surface consistently.
+// The wrapped error message remains diagnostic and may be sent to clients by WriteError. Callers that need
+// a sanitized response body should create a public status error explicitly instead of passing the internal
+// cause to FromError.
 //
 // Note: err must be non-nil. Passing a nil error will panic because err.Error() will be called.
 func FromError(code int, err error) error {

--- a/token/ssh/claims.go
+++ b/token/ssh/claims.go
@@ -27,16 +27,16 @@ func parseClaims(tkn string) (*claims, []byte, string, error) {
 		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
 	}
 
-	data := &claims{}
-	if err := json.Unmarshal(encoded, data); err != nil {
+	c := &claims{}
+	if err := json.Unmarshal(encoded, c); err != nil {
 		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
 	}
 
-	if strings.IsEmpty(data.KeyID) {
+	if strings.IsEmpty(c.KeyID) {
 		return nil, nil, strings.Empty, crypto.ErrInvalidMatch
 	}
 
-	return data, encoded, rawSignature, nil
+	return c, encoded, rawSignature, nil
 }
 
 func validateClaims(c *claims, aud string, now int64) error {


### PR DESCRIPTION
## What

- Document that HTTP status errors passed to WriteError preserve err.Error() as the client-visible response body.
- Document that gRPC status Error and Errorf messages are client-visible by design.
- Clarify that applications needing redaction should pass public status messages and record internal causes separately.
- Rename a local SSH claims variable from data to c to match the surrounding claims terminology.

## Why

- This framework intentionally exposes concrete status error messages for diagnostics instead of replacing them with generic responses.
- The docs now make the application-level redaction responsibility explicit for consumers with stricter public error requirements.

## Testing

- ok  	github.com/alexfalkowski/go-service/v2/net/http/status	(cached)
ok  	github.com/alexfalkowski/go-service/v2/net/grpc/status	(cached)
ok  	github.com/alexfalkowski/go-service/v2/token/ssh	(cached) - passed
- 0 issues. - passed
-  - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
