### PR TITLE
feat(errors): avoid leaking internal status details

### DIFF
--- a/errors/safe.go
+++ b/errors/safe.go
@@ -1,0 +1,47 @@
+package errors
+
+// SafeMessenger allows an error to expose a message that is safe to send outside the process.
+//
+// Error implementations can use this when Error contains diagnostic details that should be retained for
+// logs or wrapping, but clients should receive a smaller, non-sensitive message.
+type SafeMessenger interface {
+	// SafeMessage returns a non-sensitive message suitable for clients.
+	SafeMessage() string
+}
+
+// SafeMessage returns the first safe message in err's chain, or fallback when none is available.
+//
+// Empty safe messages are ignored so callers can always rely on a non-empty fallback.
+func SafeMessage(err error, fallback string) string {
+	if msg := safeMessage(err); msg != "" {
+		return msg
+	}
+
+	return fallback
+}
+
+func safeMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if messenger, ok := err.(SafeMessenger); ok {
+		if msg := messenger.SafeMessage(); msg != "" {
+			return msg
+		}
+	}
+
+	if unwrapper, ok := err.(interface{ Unwrap() error }); ok {
+		return safeMessage(unwrapper.Unwrap())
+	}
+
+	if unwrapper, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, err := range unwrapper.Unwrap() {
+			if msg := safeMessage(err); msg != "" {
+				return msg
+			}
+		}
+	}
+
+	return ""
+}

--- a/errors/safe_test.go
+++ b/errors/safe_test.go
@@ -1,0 +1,55 @@
+package errors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeMessage(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		name string
+		want string
+	}{
+		{name: "nil", want: "fallback"},
+		{name: "plain", err: errors.New("internal"), want: "fallback"},
+		{name: "wrapped", err: fmt.Errorf("wrapped: %w", safeError{msg: "safe"}), want: "safe"},
+		{name: "empty", err: emptySafeError{err: safeError{msg: "safe"}}, want: "safe"},
+		{name: "joined", err: errors.Join(errors.New("internal"), safeError{msg: "safe"}), want: "safe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, errors.SafeMessage(tc.err, "fallback"))
+		})
+	}
+}
+
+type safeError struct {
+	msg string
+}
+
+func (s safeError) Error() string {
+	return "internal"
+}
+
+func (s safeError) SafeMessage() string {
+	return s.msg
+}
+
+type emptySafeError struct {
+	err error
+}
+
+func (e emptySafeError) Error() string {
+	return "internal"
+}
+
+func (e emptySafeError) SafeMessage() string {
+	return ""
+}
+
+func (e emptySafeError) Unwrap() error {
+	return e.err
+}

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -61,18 +61,16 @@
 //
 // # Client-visible messages
 //
-// gRPC status messages are sent to clients. This package intentionally preserves
-// the message provided to Error or Errorf instead of replacing it with a generic
-// response. That keeps the framework useful for diagnostics while leaving
-// application-specific redaction policy to callers. Services that must hide
-// internal details should pass a public message here and record the internal
-// cause through their own logging or observability path.
+// gRPC status messages are sent to clients. Error and Errorf treat their message
+// as client-visible. SafeError lets callers attach a safe client message while
+// preserving an internal cause through Unwrap for inspection with errors.Is and
+// errors.As.
 //
 // # Non-goals
 //
 // This package intentionally exposes only the small subset of the upstream
-// status API that go-service uses broadly: Code, FromError, Error, Errorf, and
-// the Status type alias. Higher-level code that needs additional constructors or
-// richer structured-detail helpers should use the upstream status package
-// directly.
+// status API that go-service uses broadly: Code, FromError, Error, Errorf,
+// SafeError, and the Status type alias. Higher-level code that needs additional
+// constructors or richer structured-detail helpers should use the upstream status
+// package directly.
 package status

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -1,6 +1,8 @@
 package status
 
 import (
+	"fmt"
+
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -49,28 +51,77 @@ func FromError(err error) (*Status, bool) {
 
 // Error constructs a gRPC status error with code c and message msg.
 //
-// This is a thin wrapper around google.golang.org/grpc/status.Error. The
-// returned error is suitable to be returned from a gRPC handler so the runtime
-// can send the corresponding status code and message to the client.
-// The message is client-visible by design. Callers that need redaction should
-// pass a public message and record the internal cause separately.
+// The returned error is suitable to be returned from a gRPC handler so the runtime can send the
+// corresponding status code and message to the client. The message is client-visible by design.
 //
 // For structured status details (protobuf Any details), use the upstream status
 // API directly (for example status.New(...).WithDetails(...)).
 func Error(c codes.Code, msg string) error {
-	return status.Error(c, msg)
+	return SafeError(c, msg, nil)
+}
+
+// SafeError wraps err with c and a message that is safe to send to clients.
+//
+// The wrapped error remains available through Unwrap for internal inspection, while gRPC sends msg instead
+// of err.Error(). If c is codes.OK, SafeError returns nil to preserve upstream gRPC status invariants.
+func SafeError(c codes.Code, msg string, err error) error {
+	if c == codes.OK {
+		return nil
+	}
+
+	return &statusError{code: c, msg: msg, err: err}
 }
 
 // Errorf constructs a formatted gRPC status error with code c.
 //
-// This is a thin wrapper around google.golang.org/grpc/status.Errorf. It formats
-// the message using fmt-style formatting rules and returns an error suitable to
-// be returned from a gRPC handler.
-// The formatted message is client-visible by design. Callers that need redaction
-// should pass a public format string and record the internal cause separately.
+// It formats the message using fmt-style formatting rules and returns an error suitable to be returned
+// from a gRPC handler. The formatted message is client-visible by design.
 //
 // For structured status details (protobuf Any details), use the upstream status
 // API directly (for example status.New(...).WithDetails(...)).
 func Errorf(c codes.Code, format string, a ...any) error {
-	return status.Errorf(c, format, a...)
+	return Error(c, fmt.Sprintf(format, a...))
+}
+
+type statusError struct {
+	err  error
+	msg  string
+	code codes.Code
+}
+
+// Error returns the gRPC status error string with the safe message.
+func (s *statusError) Error() string {
+	return status.New(s.code, s.msg).Err().Error()
+}
+
+// SafeMessage returns the message that is safe to send to clients.
+func (s *statusError) SafeMessage() string {
+	return s.msg
+}
+
+// GRPCStatus returns the status sent by gRPC.
+//
+// The method name is part of google.golang.org/grpc/status.FromError's contract: gRPC detects custom
+// status errors by looking for GRPCStatus() *Status.
+func (s *statusError) GRPCStatus() *Status {
+	return status.New(s.code, s.msg)
+}
+
+// Is reports whether target has the same gRPC status code and message.
+func (s *statusError) Is(target error) bool {
+	type grpcStatus interface {
+		GRPCStatus() *Status
+	}
+
+	if target, ok := target.(grpcStatus); ok {
+		t := target.GRPCStatus()
+		return t != nil && s.code == t.Code() && s.msg == t.Message()
+	}
+
+	return false
+}
+
+// Unwrap returns the wrapped cause, if any.
+func (s *statusError) Unwrap() error {
+	return s.err
 }

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -33,3 +33,33 @@ func TestFromErrorUnknown(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, codes.Unknown, s.Code())
 }
+
+func TestSafeError(t *testing.T) {
+	cause := errors.New("secret database failure")
+	err := status.SafeError(codes.Internal, "internal server error", cause)
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, s.Code())
+	require.Equal(t, "internal server error", s.Message())
+	require.ErrorIs(t, err, cause)
+}
+
+func TestSafeErrorWrapped(t *testing.T) {
+	cause := errors.New("secret database failure")
+	err := fmt.Errorf("wrapped: %w", status.SafeError(codes.Internal, "internal server error", cause))
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, s.Code())
+	require.Contains(t, s.Message(), "wrapped:")
+	require.Contains(t, s.Message(), "internal server error")
+	require.NotContains(t, s.Message(), "secret database failure")
+}
+
+func TestErrorIs(t *testing.T) {
+	err := status.Error(codes.NotFound, "missing")
+	target := status.Error(codes.NotFound, "missing")
+
+	require.ErrorIs(t, err, target)
+}

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -49,7 +49,7 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
-	require.Equal(t, test.ErrFailed.Error()+"\n", res.Body.String())
+	require.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
 	require.NotContains(t, res.Body.String(), "partial")
 }
 

--- a/net/http/status/doc.go
+++ b/net/http/status/doc.go
@@ -3,7 +3,8 @@
 // This package defines a Coder interface, error constructors (Error/Errorf and helpers like BadRequestError),
 // and utilities to classify and extract status codes from errors (including mapping gRPC status errors to HTTP codes).
 //
-// Status error messages are diagnostic and client-visible when passed to WriteError. This is intentional for a
-// framework package: callers should pass the concrete error they want clients to see, or map/wrap internal failures
-// to sanitized status errors before writing the response.
+// Status error messages created with Error/Errorf are client-visible when passed to WriteError. Wrapped
+// internal failures created with FromError keep their diagnostic Error text, but WriteError sends a safe
+// status message instead. Callers can use SafeError to attach a specific safe client message to an internal
+// cause.
 package status

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -3,6 +3,7 @@ package status
 import (
 	"fmt"
 
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 )
@@ -21,10 +22,9 @@ import (
 //   - gRPC status errors mapped to HTTP codes.
 //
 // Write behavior:
-// The error message is written as a single line (via fmt.Fprintln) containing err.Error(). This is a
-// deliberate framework-level diagnostic contract: WriteError does not replace the message with a generic
-// response body. Applications that need sanitized client output should map the internal error to a public
-// status error before calling WriteError.
+// The error message is written as a single line (via fmt.Fprintln) containing the first SafeMessage in
+// err's chain. If no safe message is available, WriteError uses the standard HTTP status text for Code(err).
+// Use SafeError when callers need to provide a more specific safe client message for an internal cause.
 // If writing the body fails, WriteError returns the write error and does not attempt to write a
 // secondary error response.
 //
@@ -36,9 +36,10 @@ func WriteError(res http.ResponseWriter, err error) error {
 	header.Set("Content-Type", media.WithUTF8(media.Error))
 	header.Set("X-Content-Type-Options", "nosniff")
 
-	res.WriteHeader(Code(err))
+	code := Code(err)
+	res.WriteHeader(code)
 
-	_, writeErr := fmt.Fprintln(res, err.Error())
+	_, writeErr := fmt.Fprintln(res, errors.SafeMessage(err, defaultSafeMessage(code)))
 	return writeErr
 }
 

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -11,10 +11,25 @@ import (
 // Error constructs an error that carries an HTTP status code and a message.
 //
 // The returned error implements the Coder interface so handlers and helpers can extract the HTTP
-// status code via Code(err). The message is diagnostic and may be sent to clients by WriteError,
-// so callers should provide the public message they want exposed.
+// status code via Code(err). The message is considered safe to send to clients by WriteError.
 func Error(code int, msg string) error {
-	return &statusError{code: code, msg: msg}
+	return SafeError(code, msg, nil)
+}
+
+// SafeError wraps err with code and a message that is safe to send to clients.
+//
+// The wrapped error remains available through Unwrap for internal inspection, while WriteError sends msg
+// instead of err.Error(). If err already carries a status code, it is returned unchanged.
+func SafeError(code int, msg string, err error) error {
+	if err == nil {
+		return &statusError{code: code, error: msg, msg: msg}
+	}
+
+	if IsError(err) {
+		return err
+	}
+
+	return &statusError{code: normalizeCode(code, err), error: err.Error(), msg: msg, err: err}
 }
 
 // InternalServerError wraps err with StatusInternalServerError (500) unless err already carries a status code.
@@ -51,21 +66,13 @@ func BadRequestError(err error) error {
 // implementing Coder): calling FromError on such errors does not overwrite the original status code.
 // Raw *http.MaxBytesError values are normalized to StatusRequestEntityTooLarge (413) regardless of the
 // provided code so oversized request bodies surface consistently.
-// The wrapped error message remains diagnostic and may be sent to clients by WriteError. Callers that need
-// a sanitized response body should create a public status error explicitly instead of passing the internal
-// cause to FromError.
+// The wrapped error message remains diagnostic through Error, but WriteError sends a safe message instead
+// of err.Error(). Use SafeError when callers need to provide a more specific safe client message.
 //
-// Note: err must be non-nil. Passing a nil error will panic because err.Error() will be called.
+// Passing nil returns a status error with the default safe message for code.
 func FromError(code int, err error) error {
-	if IsError(err) {
-		return err
-	}
-
-	if isMaxBytesError(err) {
-		code = http.StatusRequestEntityTooLarge
-	}
-
-	return &statusError{code: code, msg: err.Error(), err: err}
+	code = normalizeCode(code, err)
+	return SafeError(code, defaultSafeMessage(code), err)
 }
 
 // Errorf formats a message and returns an error with the provided status code.
@@ -127,10 +134,19 @@ func isMaxBytesError(err error) bool {
 	return ok
 }
 
+func normalizeCode(code int, err error) int {
+	if isMaxBytesError(err) {
+		return http.StatusRequestEntityTooLarge
+	}
+
+	return code
+}
+
 type statusError struct {
-	err  error
-	msg  string
-	code int
+	err   error
+	error string
+	msg   string
+	code  int
 }
 
 // Code returns the HTTP status code carried by the error.
@@ -138,12 +154,25 @@ func (s *statusError) Code() int {
 	return s.code
 }
 
-// Error returns the status message.
+// Error returns the diagnostic error message.
 func (s *statusError) Error() string {
+	return s.error
+}
+
+// SafeMessage returns the status message that is safe to send to clients.
+func (s *statusError) SafeMessage() string {
 	return s.msg
 }
 
 // Unwrap returns the wrapped cause, if any.
 func (s *statusError) Unwrap() error {
 	return s.err
+}
+
+func defaultSafeMessage(code int) string {
+	if msg := http.StatusText(code); msg != "" {
+		return msg
+	}
+
+	return http.StatusText(http.StatusInternalServerError)
 }

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -2,6 +2,7 @@ package status_test
 
 import (
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -33,6 +34,64 @@ func TestFromErrorWrapsCause(t *testing.T) {
 	require.ErrorIs(t, err, test.ErrInvalid)
 	require.True(t, httpstatus.IsError(err))
 	require.Equal(t, http.StatusBadRequest, httpstatus.Code(err))
+	require.Equal(t, test.ErrInvalid.Error(), err.Error())
+}
+
+func TestFromErrorAllowsNil(t *testing.T) {
+	err := httpstatus.FromError(http.StatusBadRequest, nil)
+
+	require.Equal(t, http.StatusText(http.StatusBadRequest), err.Error())
+	require.Equal(t, http.StatusBadRequest, httpstatus.Code(err))
+}
+
+func TestWriteErrorUsesSafeMessageForFromError(t *testing.T) {
+	res := httptest.NewRecorder()
+
+	err := httpstatus.WriteError(res, httpstatus.BadRequestError(test.ErrInvalid))
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, http.StatusText(http.StatusBadRequest)+"\n", res.Body.String())
+}
+
+func TestWriteErrorUsesSafeMessage(t *testing.T) {
+	res := httptest.NewRecorder()
+
+	err := httpstatus.WriteError(res, httpstatus.SafeError(http.StatusUnauthorized, "invalid authorization", test.ErrInvalid))
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, res.Code)
+	require.Equal(t, "invalid authorization\n", res.Body.String())
+}
+
+func TestSafeErrorAllowsNilCause(t *testing.T) {
+	err := httpstatus.SafeError(http.StatusUnauthorized, "invalid authorization", nil)
+
+	require.Equal(t, "invalid authorization", err.Error())
+	require.Equal(t, http.StatusUnauthorized, httpstatus.Code(err))
+}
+
+func TestSafeErrorKeepsWrappedCoder(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
+
+	require.Same(t, err, httpstatus.SafeError(http.StatusBadRequest, "invalid", err))
+}
+
+func TestSafeErrorUsesRequestEntityTooLargeForMaxBytesError(t *testing.T) {
+	err := httpstatus.SafeError(http.StatusBadRequest, "too large", &http.MaxBytesError{Limit: 1})
+
+	require.True(t, httpstatus.IsError(err))
+	require.Equal(t, http.StatusRequestEntityTooLarge, httpstatus.Code(err))
+}
+
+func TestWriteErrorUsesDefaultSafeMessageForUnknownStatusCode(t *testing.T) {
+	res := httptest.NewRecorder()
+
+	err := httpstatus.WriteError(res, &customCoderError{code: 999})
+
+	require.NoError(t, err)
+	require.Equal(t, 999, res.Code)
+	require.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
 }
 
 func TestCodeRecognizesMaxBytesError(t *testing.T) {

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -64,7 +64,7 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Contains(t, body, "token: invalid config")
+	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
 }
 
 func TestValidAuthUnary(t *testing.T) {
@@ -99,7 +99,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Contains(t, body, `token: invalid match`)
+	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
 }
 
 func TestAuthUnaryWithAppend(t *testing.T) {
@@ -152,7 +152,7 @@ func TestMissingAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Contains(t, body, "invalid match")
+	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
 }
 
 func TestEmptyAuthUnary(t *testing.T) {
@@ -185,7 +185,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Contains(t, body, "invalid match")
+	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
 }
 
 func TestTokenErrorAuthUnary(t *testing.T) {

--- a/transport/http/body/body_test.go
+++ b/transport/http/body/body_test.go
@@ -35,5 +35,5 @@ func TestHandlerWritesBadRequestWhenBodyReadFails(t *testing.T) {
 	})
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, test.ErrFailed.Error()+"\n", res.Body.String())
+	require.Equal(t, http.StatusText(http.StatusBadRequest)+"\n", res.Body.String())
 }

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -71,7 +71,7 @@ func TestInvalidHealth(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-	require.Equal(t, "http: http checker: invalid status code", body)
+	require.Equal(t, http.StatusText(http.StatusServiceUnavailable), body)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
 }
 

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -164,7 +164,11 @@ func TestErrorRPC(t *testing.T) {
 
 					res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, b)
 					require.NoError(t, err)
-					require.Equal(t, "failed", body)
+					if handler.name == "mapped" {
+						require.Equal(t, "failed", body)
+					} else {
+						require.Equal(t, http.StatusText(http.StatusInternalServerError), body)
+					}
 					require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 				})
 			}
@@ -229,7 +233,7 @@ func TestDisallowedRPC(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, status.IsError(err))
 			require.Equal(t, http.StatusUnauthorized, status.Code(err))
-			require.Equal(t, "token: invalid match", err.Error())
+			require.Equal(t, http.StatusText(http.StatusUnauthorized), err.Error())
 		})
 	}
 }

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -53,7 +53,7 @@ func TestServerMaxReceiveSize(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
-	require.Contains(t, body, "http: request body too large")
+	require.Equal(t, http.StatusText(http.StatusRequestEntityTooLarge), body)
 }
 
 func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
@@ -77,7 +77,7 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
-	require.Contains(t, body, "http: request body too large")
+	require.Equal(t, http.StatusText(http.StatusRequestEntityTooLarge), body)
 }
 
 type unknownLengthReader struct {


### PR DESCRIPTION
## What

- Added shared safe-message support for errors and status errors.
- Added HTTP and gRPC `SafeError` constructors that preserve internal causes while sending safe client messages.
- Updated HTTP error rendering and transport expectations so wrapped internal failures return generic status text by default.

## Why

- Prevent internal diagnostic messages from leaking to HTTP and gRPC clients while keeping wrapped causes available for logging, `errors.Is`, and `errors.As`.
- Preserve important gRPC status compatibility, including OK handling and `errors.Is` matching by code/message.

## Testing

- `go test ./...` - passed
- `make lint` - passed; reported an existing `gomodguard` deprecation warning and 0 issues.

AI-assisted-by: [Codex](https://openai.com/codex/)
