### PR TITLE
feat(transport): sanitize transport status messages

### DIFF
--- a/net/grpc/codes/codes.go
+++ b/net/grpc/codes/codes.go
@@ -18,6 +18,11 @@ import "google.golang.org/grpc/codes"
 // consult the upstream gRPC documentation.
 type Code = codes.Code
 
+// StatusText returns the standard gRPC status text for the code.
+func StatusText(code Code) string {
+	return code.String()
+}
+
 const (
 	// Aborted indicates the operation was aborted, typically due to a concurrency
 	// issue such as sequencer check failures, transaction aborts, etc.

--- a/net/grpc/codes/codes_test.go
+++ b/net/grpc/codes/codes_test.go
@@ -1,0 +1,12 @@
+package codes_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusText(t *testing.T) {
+	require.Equal(t, codes.Unauthenticated.String(), codes.StatusText(codes.Unauthenticated))
+}

--- a/net/grpc/codes/doc.go
+++ b/net/grpc/codes/doc.go
@@ -23,7 +23,7 @@
 //	type Code = codes.Code
 //
 // and re-exports selected code constants (for example OK, NotFound, Unavailable,
-// etc.).
+// etc.). It also provides StatusText for the standard string form of a code.
 //
 // # Usage
 //
@@ -35,8 +35,7 @@
 //
 // # Notes
 //
-// This package intentionally contains aliases/constants only. It does not define
-// new semantics, mapping logic, or wrappers beyond naming and import
-// consolidation. For detailed behavioral descriptions of each code, consult the
-// upstream gRPC documentation.
+// This package intentionally keeps to the upstream code representation. For
+// detailed behavioral descriptions of each code, consult the upstream gRPC
+// documentation.
 package codes

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/net"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -138,6 +139,11 @@ type UnaryServerInterceptor = grpc.UnaryServerInterceptor
 
 // TransportCredentials is an alias of credentials.TransportCredentials.
 type TransportCredentials = credentials.TransportCredentials
+
+// StatusText returns the standard gRPC status text for the code.
+func StatusText(code codes.Code) string {
+	return codes.StatusText(code)
+}
 
 // StatsHandler returns a ServerOption that installs h as the server stats handler.
 //

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -5,9 +5,14 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStatusText(t *testing.T) {
+	require.Equal(t, codes.Unauthenticated.String(), grpc.StatusText(codes.Unauthenticated))
+}
 
 func TestNewServerWithAdvancedOptions(t *testing.T) {
 	opts := options.Map{

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -51,7 +51,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 
 		auth, err := serverAuthorization(ctx)
 		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, status.SafeError(codes.InvalidArgument, codes.StatusText(codes.InvalidArgument), err)
 		}
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
@@ -93,7 +93,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 
 		auth, err := serverAuthorization(ctx)
 		if err != nil {
-			return status.Error(codes.InvalidArgument, err.Error())
+			return status.SafeError(codes.InvalidArgument, codes.StatusText(codes.InvalidArgument), err)
 		}
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -29,14 +29,16 @@
 //
 // # Constructing errors
 //
-// Use Error or Errorf to create an error with a specific gRPC code:
+// Use Error to create an error with a specific gRPC code:
 //
 //	err := status.Error(codes.NotFound, "widget does not exist")
 //
-//	err := status.Errorf(codes.InvalidArgument, "bad widget id: %q", id)
+// Use Errorf when the client-visible message should be formatted:
 //
-// These functions delegate to google.golang.org/grpc/status.Error and
-// google.golang.org/grpc/status.Errorf.
+//	err := status.Errorf(codes.NotFound, "widget %q does not exist", name)
+//
+// Use SafeError when the internal cause should remain available through
+// unwrapping but the client should receive a separate safe message.
 //
 // # Inspecting errors
 //
@@ -61,16 +63,16 @@
 //
 // # Client-visible messages
 //
-// gRPC status messages are sent to clients. Error and Errorf treat their message
-// as client-visible. SafeError lets callers attach a safe client message while
-// preserving an internal cause through Unwrap for inspection with errors.Is and
-// errors.As.
+// gRPC status messages are sent to clients. Error and Errorf treat their
+// messages as client-visible. SafeError lets callers attach a safe client
+// message while preserving an internal cause through Unwrap for inspection with
+// errors.Is and errors.As.
 //
 // # Non-goals
 //
 // This package intentionally exposes only the small subset of the upstream
 // status API that go-service uses broadly: Code, FromError, Error, Errorf,
 // SafeError, and the Status type alias. Higher-level code that needs additional
-// constructors or richer structured-detail helpers should use the upstream status
-// package directly.
+// constructors or richer structured-detail helpers should use the upstream
+// status package directly.
 package status

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -60,6 +60,13 @@ func Error(c codes.Code, msg string) error {
 	return SafeError(c, msg, nil)
 }
 
+// Errorf formats a message and returns an error with the provided status code.
+//
+// This is a convenience wrapper over Error(c, fmt.Sprintf(...)).
+func Errorf(c codes.Code, format string, a ...any) error {
+	return Error(c, fmt.Sprintf(format, a...))
+}
+
 // SafeError wraps err with c and a message that is safe to send to clients.
 //
 // The wrapped error remains available through Unwrap for internal inspection, while gRPC sends msg instead
@@ -70,17 +77,6 @@ func SafeError(c codes.Code, msg string, err error) error {
 	}
 
 	return &statusError{code: c, msg: msg, err: err}
-}
-
-// Errorf constructs a formatted gRPC status error with code c.
-//
-// It formats the message using fmt-style formatting rules and returns an error suitable to be returned
-// from a gRPC handler. The formatted message is client-visible by design.
-//
-// For structured status details (protobuf Any details), use the upstream status
-// API directly (for example status.New(...).WithDetails(...)).
-func Errorf(c codes.Code, format string, a ...any) error {
-	return Error(c, fmt.Sprintf(format, a...))
 }
 
 type statusError struct {

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -34,6 +34,15 @@ func TestFromErrorUnknown(t *testing.T) {
 	require.Equal(t, codes.Unknown, s.Code())
 }
 
+func TestErrorf(t *testing.T) {
+	err := status.Errorf(codes.InvalidArgument, "invalid %s", "name")
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, s.Code())
+	require.Equal(t, "invalid name", s.Message())
+}
+
 func TestSafeError(t *testing.T) {
 	cause := errors.New("secret database failure")
 	err := status.SafeError(codes.Internal, "internal server error", cause)

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
@@ -178,7 +179,7 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 
 	_, err := client.SayHello(t.Context(), req)
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
-	require.Contains(t, err.Error(), "token: invalid config")
+	require.Contains(t, err.Error(), grpc.StatusText(codes.Unauthenticated))
 }
 
 func TestBreakerAuthUnary(t *testing.T) {

--- a/transport/grpc/breaker/breaker.go
+++ b/transport/grpc/breaker/breaker.go
@@ -55,7 +55,7 @@ func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
 		})
 		if err != nil {
 			if errors.Is(err, breaker.ErrOpenState) || errors.Is(err, breaker.ErrTooManyRequests) {
-				return status.Error(codes.ResourceExhausted, err.Error())
+				return status.SafeError(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted), err)
 			}
 
 			return err

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-health/v2/subscriber"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
@@ -54,7 +55,7 @@ type Server struct {
 func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response, error) {
 	observer, err := s.server.Observer(req.GetService(), "grpc")
 	if err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, status.SafeError(codes.NotFound, grpc.StatusText(codes.NotFound), err)
 	}
 
 	return &health.Response{Status: s.status(observer)}, nil
@@ -97,7 +98,7 @@ func (s *Server) Watch(req *health.Request, w health.WatchServer) error {
 
 		select {
 		case <-w.Context().Done():
-			return status.Error(codes.Canceled, w.Context().Err().Error())
+			return status.SafeError(codes.Canceled, grpc.StatusText(codes.Canceled), w.Context().Err())
 		case <-ticker.C:
 		}
 	}

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -61,13 +61,13 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 
 		ok, header, err := limiter.Take(ctx)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "limiter: %s", err.Error())
+			return nil, status.SafeError(codes.Internal, grpc.StatusText(codes.Internal), err)
 		}
 
 		_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", header))
 
 		if !ok {
-			return nil, status.Errorf(codes.ResourceExhausted, "limiter: resource exhausted, %s", header)
+			return nil, status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
 		}
 
 		return handler(ctx, req)
@@ -109,13 +109,13 @@ type Client struct {
 // Callers should only install this interceptor when limiter is non-nil.
 func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		ok, header, err := limiter.Take(ctx)
+		ok, _, err := limiter.Take(ctx)
 		if err != nil {
-			return status.Errorf(codes.Internal, "limiter: %s", err.Error())
+			return status.SafeError(codes.Internal, grpc.StatusText(codes.Internal), err)
 		}
 
 		if !ok {
-			return status.Errorf(codes.ResourceExhausted, "limiter: resource exhausted, %s", header)
+			return status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
 		}
 
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -97,7 +97,7 @@ func UnaryServerInterceptor(id env.UserID, verifier Verifier) grpc.UnaryServerIn
 
 		sub, err := verifier.Verify(strings.Bytes(auth), info.FullMethod)
 		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, err.Error())
+			return nil, status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
 		}
 
 		ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
@@ -130,7 +130,7 @@ func StreamServerInterceptor(id env.UserID, verifier Verifier) grpc.StreamServer
 
 		sub, err := verifier.Verify(strings.Bytes(auth), info.FullMethod)
 		if err != nil {
-			return status.Error(codes.Unauthenticated, err.Error())
+			return status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
 		}
 
 		ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
@@ -177,11 +177,11 @@ func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClient
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		token, err := generator.Generate(fullMethod, id.String())
 		if err != nil {
-			return status.Error(codes.Unauthenticated, err.Error())
+			return status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
 		}
 
 		if len(token) == 0 {
-			return status.Error(codes.Unauthenticated, header.ErrInvalidAuthorization.Error())
+			return status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), header.ErrInvalidAuthorization)
 		}
 
 		auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))
@@ -215,11 +215,11 @@ func StreamClientInterceptor(id env.UserID, generator Generator) grpc.StreamClie
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		token, err := generator.Generate(fullMethod, id.String())
 		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, err.Error())
+			return nil, status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
 		}
 
 		if len(token) == 0 {
-			return nil, status.Error(codes.Unauthenticated, header.ErrInvalidAuthorization.Error())
+			return nil, status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), header.ErrInvalidAuthorization)
 		}
 
 		auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -76,7 +76,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	res.Header().Add("RateLimit", header)
 
 	if !ok {
-		_ = status.WriteError(res, status.Errorf(http.StatusTooManyRequests, "limiter: too many requests, %s", header))
+		_ = status.WriteError(res, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests)))
 		return
 	}
 
@@ -130,13 +130,13 @@ type RoundTripper struct {
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	ok, header, err := r.limiter.Take(ctx)
+	ok, _, err := r.limiter.Take(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if !ok {
-		return nil, status.Errorf(http.StatusTooManyRequests, "limiter: too many requests, %s", header)
+		return nil, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests))
 	}
 
 	return r.RoundTripper.RoundTrip(req)


### PR DESCRIPTION
## What

- Replaced transport gRPC status responses that exposed internal error text with `SafeError` and safe client messages.
- Removed diagnostic rate-limit/header details from HTTP and gRPC limiter response messages.
- Updated the gRPC auth test to assert the safe authorization message.

## Why

- Keep transport error responses from leaking internal token, limiter, breaker, health, metadata, or cancellation details to clients.
- Preserve status codes and wrapped causes for internal inspection while making response messages intentionally client-safe.

## Testing

- `go test ./net/grpc/meta ./transport/grpc ./transport/grpc/token ./transport/grpc/limiter ./transport/grpc/breaker ./transport/grpc/health ./transport/http ./transport/http/limiter` - passed
- `go test ./...` - passed
- `make lint` - passed; reported an existing `gomodguard` deprecation warning and 0 issues.

AI-assisted-by: [Codex](https://openai.com/codex/)
