### PR TITLE
feat(errors): default safe errors to status text

### DIFF
--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -51,7 +51,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 
 		auth, err := serverAuthorization(ctx)
 		if err != nil {
-			return nil, status.SafeError(codes.InvalidArgument, codes.StatusText(codes.InvalidArgument), err)
+			return nil, status.SafeError(codes.InvalidArgument, err)
 		}
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
@@ -93,7 +93,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 
 		auth, err := serverAuthorization(ctx)
 		if err != nil {
-			return status.SafeError(codes.InvalidArgument, codes.StatusText(codes.InvalidArgument), err)
+			return status.SafeError(codes.InvalidArgument, err)
 		}
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -9,10 +9,11 @@
 //   - Ensure status construction and inspection uses the go-service codes.Code
 //     alias (net/grpc/codes), which is itself an alias of gRPC's codes.Code.
 //
-// The functions in this package do not add new semantics beyond forwarding to
-// the upstream gRPC status package. For authoritative behavior, edge cases, and
-// wire-level details, consult the upstream gRPC documentation for the version
-// you vend.
+// Most functions in this package forward to the upstream gRPC status package.
+// SafeError adds go-service safe-message behavior while still exposing a normal
+// gRPC status to the runtime. For authoritative upstream behavior, edge cases,
+// and wire-level details, consult the upstream gRPC documentation for the
+// version you vend.
 //
 // # Background: gRPC status errors
 //
@@ -38,7 +39,7 @@
 //	err := status.Errorf(codes.NotFound, "widget %q does not exist", name)
 //
 // Use SafeError when the internal cause should remain available through
-// unwrapping but the client should receive a separate safe message.
+// unwrapping but the client should receive the standard status text.
 //
 // # Inspecting errors
 //
@@ -64,9 +65,9 @@
 // # Client-visible messages
 //
 // gRPC status messages are sent to clients. Error and Errorf treat their
-// messages as client-visible. SafeError lets callers attach a safe client
-// message while preserving an internal cause through Unwrap for inspection with
-// errors.Is and errors.As.
+// messages as client-visible. SafeError sends the standard status text while
+// preserving an internal cause through Unwrap for inspection with errors.Is and
+// errors.As.
 //
 // # Non-goals
 //

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -57,7 +57,11 @@ func FromError(err error) (*Status, bool) {
 // For structured status details (protobuf Any details), use the upstream status
 // API directly (for example status.New(...).WithDetails(...)).
 func Error(c codes.Code, msg string) error {
-	return SafeError(c, msg, nil)
+	if c == codes.OK {
+		return nil
+	}
+
+	return &statusError{code: c, msg: msg}
 }
 
 // Errorf formats a message and returns an error with the provided status code.
@@ -67,16 +71,16 @@ func Errorf(c codes.Code, format string, a ...any) error {
 	return Error(c, fmt.Sprintf(format, a...))
 }
 
-// SafeError wraps err with c and a message that is safe to send to clients.
+// SafeError wraps err with c and the standard status text that is safe to send to clients.
 //
-// The wrapped error remains available through Unwrap for internal inspection, while gRPC sends msg instead
+// The wrapped error remains available through Unwrap for internal inspection, while gRPC sends StatusText(c) instead
 // of err.Error(). If c is codes.OK, SafeError returns nil to preserve upstream gRPC status invariants.
-func SafeError(c codes.Code, msg string, err error) error {
+func SafeError(c codes.Code, err error) error {
 	if c == codes.OK {
 		return nil
 	}
 
-	return &statusError{code: c, msg: msg, err: err}
+	return &statusError{code: c, msg: codes.StatusText(c), err: err}
 }
 
 type statusError struct {

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -45,24 +45,30 @@ func TestErrorf(t *testing.T) {
 
 func TestSafeError(t *testing.T) {
 	cause := errors.New("secret database failure")
-	err := status.SafeError(codes.Internal, "internal server error", cause)
+	err := status.SafeError(codes.Internal, cause)
 
 	s, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, codes.Internal, s.Code())
-	require.Equal(t, "internal server error", s.Message())
+	require.Equal(t, codes.StatusText(codes.Internal), s.Message())
 	require.ErrorIs(t, err, cause)
+}
+
+func TestSafeErrorOK(t *testing.T) {
+	err := status.SafeError(codes.OK, errors.New("ignored"))
+
+	require.NoError(t, err)
 }
 
 func TestSafeErrorWrapped(t *testing.T) {
 	cause := errors.New("secret database failure")
-	err := fmt.Errorf("wrapped: %w", status.SafeError(codes.Internal, "internal server error", cause))
+	err := fmt.Errorf("wrapped: %w", status.SafeError(codes.Internal, cause))
 
 	s, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, codes.Internal, s.Code())
 	require.Contains(t, s.Message(), "wrapped:")
-	require.Contains(t, s.Message(), "internal server error")
+	require.Contains(t, s.Message(), codes.StatusText(codes.Internal))
 	require.NotContains(t, s.Message(), "secret database failure")
 }
 

--- a/net/http/status/doc.go
+++ b/net/http/status/doc.go
@@ -4,7 +4,6 @@
 // and utilities to classify and extract status codes from errors (including mapping gRPC status errors to HTTP codes).
 //
 // Status error messages created with Error/Errorf are client-visible when passed to WriteError. Wrapped
-// internal failures created with FromError keep their diagnostic Error text, but WriteError sends a safe
-// status message instead. Callers can use SafeError to attach a specific safe client message to an internal
-// cause.
+// internal failures created with FromError or SafeError keep their diagnostic Error text, but WriteError
+// sends the standard status text instead.
 package status

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -24,7 +24,7 @@ import (
 // Write behavior:
 // The error message is written as a single line (via fmt.Fprintln) containing the first SafeMessage in
 // err's chain. If no safe message is available, WriteError uses the standard HTTP status text for Code(err).
-// Use SafeError when callers need to provide a more specific safe client message for an internal cause.
+// Use SafeError to preserve an internal cause while returning the standard HTTP status text to the client.
 // If writing the body fails, WriteError returns the write error and does not attempt to write a
 // secondary error response.
 //

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -13,14 +13,17 @@ import (
 // The returned error implements the Coder interface so handlers and helpers can extract the HTTP
 // status code via Code(err). The message is considered safe to send to clients by WriteError.
 func Error(code int, msg string) error {
-	return SafeError(code, msg, nil)
+	return &statusError{code: code, error: msg, msg: msg}
 }
 
-// SafeError wraps err with code and a message that is safe to send to clients.
+// SafeError wraps err with code and the standard status text that is safe to send to clients.
 //
-// The wrapped error remains available through Unwrap for internal inspection, while WriteError sends msg
+// The wrapped error remains available through Unwrap for internal inspection, while WriteError sends StatusText(code)
 // instead of err.Error(). If err already carries a status code, it is returned unchanged.
-func SafeError(code int, msg string, err error) error {
+func SafeError(code int, err error) error {
+	code = normalizeCode(code, err)
+	msg := defaultSafeMessage(code)
+
 	if err == nil {
 		return &statusError{code: code, error: msg, msg: msg}
 	}
@@ -29,7 +32,7 @@ func SafeError(code int, msg string, err error) error {
 		return err
 	}
 
-	return &statusError{code: normalizeCode(code, err), error: err.Error(), msg: msg, err: err}
+	return &statusError{code: code, error: err.Error(), msg: msg, err: err}
 }
 
 // InternalServerError wraps err with StatusInternalServerError (500) unless err already carries a status code.
@@ -66,13 +69,12 @@ func BadRequestError(err error) error {
 // implementing Coder): calling FromError on such errors does not overwrite the original status code.
 // Raw *http.MaxBytesError values are normalized to StatusRequestEntityTooLarge (413) regardless of the
 // provided code so oversized request bodies surface consistently.
-// The wrapped error message remains diagnostic through Error, but WriteError sends a safe message instead
-// of err.Error(). Use SafeError when callers need to provide a more specific safe client message.
+// The wrapped error message remains diagnostic through Error, but WriteError sends a safe status message instead
+// of err.Error().
 //
 // Passing nil returns a status error with the default safe message for code.
 func FromError(code int, err error) error {
-	code = normalizeCode(code, err)
-	return SafeError(code, defaultSafeMessage(code), err)
+	return SafeError(code, err)
 }
 
 // Errorf formats a message and returns an error with the provided status code.

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -57,28 +57,28 @@ func TestWriteErrorUsesSafeMessageForFromError(t *testing.T) {
 func TestWriteErrorUsesSafeMessage(t *testing.T) {
 	res := httptest.NewRecorder()
 
-	err := httpstatus.WriteError(res, httpstatus.SafeError(http.StatusUnauthorized, "invalid authorization", test.ErrInvalid))
+	err := httpstatus.WriteError(res, httpstatus.SafeError(http.StatusUnauthorized, test.ErrInvalid))
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.Code)
-	require.Equal(t, "invalid authorization\n", res.Body.String())
+	require.Equal(t, http.StatusText(http.StatusUnauthorized)+"\n", res.Body.String())
 }
 
 func TestSafeErrorAllowsNilCause(t *testing.T) {
-	err := httpstatus.SafeError(http.StatusUnauthorized, "invalid authorization", nil)
+	err := httpstatus.SafeError(http.StatusUnauthorized, nil)
 
-	require.Equal(t, "invalid authorization", err.Error())
+	require.Equal(t, http.StatusText(http.StatusUnauthorized), err.Error())
 	require.Equal(t, http.StatusUnauthorized, httpstatus.Code(err))
 }
 
 func TestSafeErrorKeepsWrappedCoder(t *testing.T) {
 	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
 
-	require.Same(t, err, httpstatus.SafeError(http.StatusBadRequest, "invalid", err))
+	require.Same(t, err, httpstatus.SafeError(http.StatusBadRequest, err))
 }
 
 func TestSafeErrorUsesRequestEntityTooLargeForMaxBytesError(t *testing.T) {
-	err := httpstatus.SafeError(http.StatusBadRequest, "too large", &http.MaxBytesError{Limit: 1})
+	err := httpstatus.SafeError(http.StatusBadRequest, &http.MaxBytesError{Limit: 1})
 
 	require.True(t, httpstatus.IsError(err))
 	require.Equal(t, http.StatusRequestEntityTooLarge, httpstatus.Code(err))

--- a/transport/grpc/breaker/breaker.go
+++ b/transport/grpc/breaker/breaker.go
@@ -55,7 +55,7 @@ func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
 		})
 		if err != nil {
 			if errors.Is(err, breaker.ErrOpenState) || errors.Is(err, breaker.ErrTooManyRequests) {
-				return status.SafeError(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted), err)
+				return status.SafeError(codes.ResourceExhausted, err)
 			}
 
 			return err

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -5,7 +5,6 @@ import (
 	"github.com/alexfalkowski/go-health/v2/subscriber"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
-	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
@@ -55,7 +54,7 @@ type Server struct {
 func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response, error) {
 	observer, err := s.server.Observer(req.GetService(), "grpc")
 	if err != nil {
-		return nil, status.SafeError(codes.NotFound, grpc.StatusText(codes.NotFound), err)
+		return nil, status.SafeError(codes.NotFound, err)
 	}
 
 	return &health.Response{Status: s.status(observer)}, nil
@@ -98,7 +97,7 @@ func (s *Server) Watch(req *health.Request, w health.WatchServer) error {
 
 		select {
 		case <-w.Context().Done():
-			return status.SafeError(codes.Canceled, grpc.StatusText(codes.Canceled), w.Context().Err())
+			return status.SafeError(codes.Canceled, w.Context().Err())
 		case <-ticker.C:
 		}
 	}

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -61,7 +61,7 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 
 		ok, header, err := limiter.Take(ctx)
 		if err != nil {
-			return nil, status.SafeError(codes.Internal, grpc.StatusText(codes.Internal), err)
+			return nil, status.SafeError(codes.Internal, err)
 		}
 
 		_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", header))
@@ -111,7 +111,7 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		ok, _, err := limiter.Take(ctx)
 		if err != nil {
-			return status.SafeError(codes.Internal, grpc.StatusText(codes.Internal), err)
+			return status.SafeError(codes.Internal, err)
 		}
 
 		if !ok {

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -97,7 +97,7 @@ func UnaryServerInterceptor(id env.UserID, verifier Verifier) grpc.UnaryServerIn
 
 		sub, err := verifier.Verify(strings.Bytes(auth), info.FullMethod)
 		if err != nil {
-			return nil, status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
+			return nil, status.SafeError(codes.Unauthenticated, err)
 		}
 
 		ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
@@ -130,7 +130,7 @@ func StreamServerInterceptor(id env.UserID, verifier Verifier) grpc.StreamServer
 
 		sub, err := verifier.Verify(strings.Bytes(auth), info.FullMethod)
 		if err != nil {
-			return status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
+			return status.SafeError(codes.Unauthenticated, err)
 		}
 
 		ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
@@ -177,11 +177,11 @@ func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClient
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		token, err := generator.Generate(fullMethod, id.String())
 		if err != nil {
-			return status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
+			return status.SafeError(codes.Unauthenticated, err)
 		}
 
 		if len(token) == 0 {
-			return status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), header.ErrInvalidAuthorization)
+			return status.SafeError(codes.Unauthenticated, header.ErrInvalidAuthorization)
 		}
 
 		auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))
@@ -215,11 +215,11 @@ func StreamClientInterceptor(id env.UserID, generator Generator) grpc.StreamClie
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		token, err := generator.Generate(fullMethod, id.String())
 		if err != nil {
-			return nil, status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), err)
+			return nil, status.SafeError(codes.Unauthenticated, err)
 		}
 
 		if len(token) == 0 {
-			return nil, status.SafeError(codes.Unauthenticated, grpc.StatusText(codes.Unauthenticated), header.ErrInvalidAuthorization)
+			return nil, status.SafeError(codes.Unauthenticated, header.ErrInvalidAuthorization)
 		}
 
 		auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))


### PR DESCRIPTION
## What

- Simplify HTTP and gRPC SafeError APIs to accept only a status code and internal cause.
- Default SafeError client messages to standard HTTP/gRPC status text while preserving wrapped causes for internal inspection.
- Update gRPC transport call sites to rely on SafeError for safe status text instead of passing duplicated StatusText values.
- Refresh package docs and tests for the new safe-message behavior.

## Why

- Keeps the safe-error path consistent across HTTP and gRPC.
- Reduces the chance that internal error details are accidentally reused as client-visible messages.
- Removes duplicated status-text plumbing at transport call sites.

## Testing

- `go test ./net/http ./net/http/status ./net/grpc ./net/grpc/status ./net/grpc/meta ./transport/grpc/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
