### PR TITLE
feat(http): expose chained middleware alias

### DIFF
--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -16,7 +16,6 @@ import (
 	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
-	"github.com/urfave/negroni/v3"
 )
 
 // Server bundles the dependencies required to build HTTP, gRPC, and debug servers for tests.
@@ -60,7 +59,7 @@ func (s *Server) Register() error {
 			Config:   s.TransportConfig.HTTP,
 			Logger:   s.Logger,
 			Limiter:  s.HTTPLimiter,
-			Handlers: []negroni.Handler{&EmptyHandler{}},
+			Handlers: []http.ChainedHandler{&EmptyHandler{}},
 			Verifier: s.Verifier, ID: s.Generator, UserID: UserID,
 			UserAgent: UserAgent, Version: Version,
 		}
@@ -112,10 +111,10 @@ func (s *Server) Register() error {
 	return nil
 }
 
-// EmptyHandler is a no-op Negroni middleware used in server tests.
+// EmptyHandler is a no-op chained middleware used in server tests.
 type EmptyHandler struct{}
 
-// ServeHTTP implements negroni.Handler and just calls the next handler.
+// ServeHTTP implements http.ChainedHandler and just calls the next handler.
 func (*EmptyHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	next(rw, r)
 }

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/urfave/negroni/v3"
 )
 
 // MethodDelete is an alias of http.MethodDelete.
@@ -66,6 +67,9 @@ type MaxBytesError = http.MaxBytesError
 
 // Handler is an alias for net/http.Handler.
 type Handler = http.Handler
+
+// ChainedHandler is an alias for negroni.Handler.
+type ChainedHandler = negroni.Handler
 
 // HandlerFunc is an alias for net/http.HandlerFunc.
 type HandlerFunc = http.HandlerFunc

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -34,7 +34,7 @@ import (
 //   - `Logger`: enables server-side request logging middleware when non-nil.
 //   - `Limiter`: enables server-side rate limiting middleware when non-nil.
 //   - `Verifier`: enables server-side token verification middleware when non-nil.
-//   - `Handlers`: allows callers to inject additional Negroni middleware (and is optional in DI).
+//   - `Handlers`: allows callers to inject additional chained middleware (and is optional in DI).
 type ServerParams struct {
 	di.In
 
@@ -71,10 +71,10 @@ type ServerParams struct {
 	// Verifier enables server-side token verification middleware when non-nil.
 	Verifier token.Verifier
 
-	// Handlers are additional Negroni handlers to insert into the middleware chain.
+	// Handlers are additional chained handlers to insert into the middleware chain.
 	//
 	// These handlers are applied in the order provided.
-	Handlers []negroni.Handler `optional:"true"`
+	Handlers []ChainedHandler `optional:"true"`
 }
 
 // NewServer constructs an HTTP transport `Server` when the transport is enabled.


### PR DESCRIPTION
## What

- Added a transport `ChainedHandler` alias for Negroni chained middleware.
- Updated server params and internal test wiring to use the alias instead of exposing `negroni.Handler` directly.

## Why

- Keeps the transport package API readable while avoiding confusion with the existing standard `Handler` alias.

## Testing

- `go test ./transport/http ./internal/test` - passed
- `make lint` - passed
