### PR TITLE
feat(http): hide negroni behind chained aliases

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/urfave/negroni/v3"
 )
 
 // MethodDelete is an alias of http.MethodDelete.
@@ -93,6 +94,12 @@ type (
 	// It is provided so go-service code can depend on a consistent import path while preserving
 	// standard library semantics.
 	Handler = http.Handler
+
+	// ChainedHandler is an alias for negroni.Handler.
+	ChainedHandler = negroni.Handler
+
+	// ChainedHandlers is an alias for negroni.Negroni.
+	ChainedHandlers = negroni.Negroni
 
 	// HandlerFunc is an alias for net/http.HandlerFunc.
 	//
@@ -200,6 +207,11 @@ func NewRequestWithContext(ctx context.Context, method, url string, body io.Read
 // This is a thin wrapper around net/http.NewServeMux.
 func NewServeMux() *ServeMux {
 	return http.NewServeMux()
+}
+
+// NewChainedHandlers constructs an HTTP middleware chain.
+func NewChainedHandlers(handlers ...ChainedHandler) *ChainedHandlers {
+	return negroni.New(handlers...)
 }
 
 // MaxBytesHandler wraps h so inbound request bodies are limited to n bytes.

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -5,7 +5,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/urfave/negroni/v3"
 )
 
 // MethodDelete is an alias of http.MethodDelete.
@@ -68,8 +67,11 @@ type MaxBytesError = http.MaxBytesError
 // Handler is an alias for net/http.Handler.
 type Handler = http.Handler
 
-// ChainedHandler is an alias for negroni.Handler.
-type ChainedHandler = negroni.Handler
+// ChainedHandler is an alias for net/http.ChainedHandler.
+type ChainedHandler = http.ChainedHandler
+
+// ChainedHandlers is an alias for net/http.ChainedHandlers.
+type ChainedHandlers = http.ChainedHandlers
 
 // HandlerFunc is an alias for net/http.HandlerFunc.
 type HandlerFunc = http.HandlerFunc
@@ -112,6 +114,11 @@ func NewRequestWithContext(ctx context.Context, method, url string, body io.Read
 // NewServeMux constructs a new HTTP request multiplexer.
 func NewServeMux() *ServeMux {
 	return http.NewServeMux()
+}
+
+// NewChainedHandlers constructs an HTTP middleware chain.
+func NewChainedHandlers(handlers ...ChainedHandler) *ChainedHandlers {
+	return http.NewChainedHandlers(handlers...)
 }
 
 // MaxBytesHandler wraps h so inbound request bodies are limited to n bytes.

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -22,7 +22,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	sync "github.com/alexfalkowski/go-sync"
 	"github.com/klauspost/compress/gzhttp"
-	"github.com/urfave/negroni/v3"
 )
 
 // ServerParams defines dependencies for constructing an HTTP transport `Server`.
@@ -112,7 +111,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, nil
 	}
 
-	neg := negroni.New()
+	neg := NewChainedHandlers()
 	neg.Use(meta.NewHandler(params.UserAgent, params.Version, params.ID))
 
 	if params.Logger != nil {


### PR DESCRIPTION
## What

- Added `ChainedHandler`, `ChainedHandlers`, and `NewChainedHandlers` to `net/http` as the Negroni-backed chain surface.
- Re-exported the chained handler API from `transport/http` so transport server configuration can keep using the transport package surface.
- Updated HTTP server construction to call `NewChainedHandlers()` instead of importing Negroni directly.

## Why

- Keeps direct Negroni usage centralized in the lower-level HTTP package while preserving a convenient transport API for middleware injection.

## Testing

- `go test ./net/http ./transport/http ./internal/test` - passed
- `make lint` - passed
