### PR TITLE
feat(mvc): serve static files with extension media types

### DIFF
--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -1,6 +1,8 @@
 package media
 
 import (
+	"mime"
+
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
@@ -61,6 +63,14 @@ const YAML = "application/yaml"
 
 // ErrInvalidType is returned when a media type cannot be parsed.
 var ErrInvalidType = errors.New("media: invalid type")
+
+// TypeByExtension returns the media type associated with ext.
+//
+// It wraps mime.TypeByExtension so HTTP packages can use the shared media package
+// for media type lookup.
+func TypeByExtension(ext string) string {
+	return mime.TypeByExtension(ext)
+}
 
 // Parse parses value into a base media type and subtype.
 //

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -15,6 +15,10 @@ func TestParseInvalidMediaType(t *testing.T) {
 	require.True(t, errors.Is(err, media.ErrInvalidType))
 }
 
+func TestTypeByExtension(t *testing.T) {
+	require.Equal(t, "image/svg+xml", media.TypeByExtension(".svg"))
+}
+
 func TestWithUTF8(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -108,6 +108,7 @@ func StaticFile(pattern, name string) bool {
 			return
 		}
 
+		setStaticContentType(res, name)
 		writeBuffer(res, http.StatusOK, buffer)
 	}
 
@@ -142,6 +143,7 @@ func StaticPathValue(pattern, value, prefix string) bool {
 			return
 		}
 
+		setStaticContentType(res, name)
 		writeBuffer(res, http.StatusOK, buffer)
 	}
 
@@ -165,6 +167,13 @@ func staticStatusCode(err error) int {
 		return http.StatusNotFound
 	}
 	return status.Code(err)
+}
+
+func setStaticContentType(res http.ResponseWriter, name string) {
+	mediaType := media.TypeByExtension(path.Ext(name))
+	if !strings.IsEmpty(mediaType) {
+		res.Header().Set(content.TypeKey, media.WithUTF8(mediaType))
+	}
 }
 
 func writeView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) {

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -40,6 +40,50 @@ func TestStaticPathValueRejectsTraversal(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, res.Code)
 }
 
+func TestStaticPathValueSetsContentType(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/icon.svg": &fstest.MapFile{Data: []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`)},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticPathValue("/{file...}", "file", "static"))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/icon.svg", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "image/svg+xml", res.Header().Get(content.TypeKey))
+}
+
+func TestStaticFileSetsContentType(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/icon.svg": &fstest.MapFile{Data: []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`)},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticFile("/icon.svg", "static/icon.svg"))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/icon.svg", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "image/svg+xml", res.Header().Get(content.TypeKey))
+}
+
 func TestViewRenderReturnsContextError(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{


### PR DESCRIPTION
## What

- Added `media.TypeByExtension` as a shared wrapper around standard MIME extension lookup.
- Set static file response `Content-Type` from the served filename for `StaticFile` and `StaticPathValue`.
- Added SVG coverage for media lookup and static file/path serving.

## Why

- SVG static assets were being sniffed as `text/plain; charset=utf-8` because the static helpers wrote buffered bytes without setting a content type.

## Testing

- `go test ./net/http/media ./net/http/mvc` - passed
- `make lint` - passed
- `git diff --check` - passed
