### PR TITLE
feat(http): treat internal error payloads as plain text

### DIFF
--- a/io/doc.go
+++ b/io/doc.go
@@ -4,7 +4,7 @@
 // io primitives while preserving the exact semantics of the standard library `io` package.
 //
 // Most identifiers in this package are thin aliases/wrappers (for example `Reader`, `Writer`,
-// `ReaderFrom`, `WriterTo`, `ReadCloser`, `Resetter`, and `NopCloser`). They exist so packages within
+// `ReaderFrom`, `WriterTo`, `ReadCloser`, `Resetter`, `NopCloser`, and `WriteString`). They exist so packages within
 // go-service and downstream services can consistently
 // import `github.com/alexfalkowski/go-service/v2/io` without mixing direct stdlib imports across the
 // codebase.

--- a/io/io.go
+++ b/io/io.go
@@ -61,6 +61,13 @@ func LimitReader(r Reader, n int64) Reader {
 	return io.LimitReader(r, n)
 }
 
+// WriteString writes the contents of s to w.
+//
+// This is a thin wrapper around io.WriteString.
+func WriteString(w Writer, s string) (int, error) {
+	return io.WriteString(w, s)
+}
+
 // ReadAll reads all remaining bytes from r and returns:
 //
 //   - the captured bytes, and

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -1,0 +1,19 @@
+package io_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteString(t *testing.T) {
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	n, err := io.WriteString(buffer, "hello")
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", buffer.String())
+}

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -3,6 +3,7 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-sync"
 )
@@ -43,20 +44,22 @@ type Content struct {
 // If Content-Type is not set, it falls back to the first media type in Accept.
 //
 // If parsing fails, it falls back to JSON.
+// If the internal error media type is selected, it falls back to plain text.
 func (c *Content) NewFromRequest(req *http.Request) Media {
 	mediaType := req.Header.Get(TypeKey)
 	if strings.IsEmpty(mediaType) {
 		mediaType = firstMediaType(req.Header.Get(AcceptKey))
 	}
 
-	return NewMedia(mediaType, c.enc)
+	return c.newRequestMedia(mediaType)
 }
 
 // NewFromContentType parses the request Content-Type header and returns a matching Media.
 //
 // If parsing fails, it falls back to JSON.
+// If the internal error media type is selected, it falls back to plain text.
 func (c *Content) NewFromContentType(req *http.Request) Media {
-	return NewMedia(req.Header.Get(TypeKey), c.enc)
+	return c.newRequestMedia(req.Header.Get(TypeKey))
 }
 
 // NewFromMedia parses mediaType and returns a matching Media.
@@ -69,4 +72,13 @@ func (c *Content) NewFromMedia(mediaType string) Media {
 func firstMediaType(value string) string {
 	mediaType, _, _ := strings.Cut(value, ",")
 	return strings.TrimSpace(mediaType)
+}
+
+func (c *Content) newRequestMedia(mediaType string) Media {
+	m := NewMedia(mediaType, c.enc)
+	if m.IsError() {
+		return newMedia(media.Text, "plain", c.enc)
+	}
+
+	return m
 }

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -56,6 +56,16 @@ func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
 }
 
+func TestNewFromRequestFallsBackFromInternalErrorMedia(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.AcceptKey, media.Error)
+
+	media := test.Content.NewFromRequest(req)
+
+	require.Equal(t, "plain", media.Subtype)
+	require.Same(t, test.Encoder.Get("plain"), media.Encoder)
+}
+
 func TestNewFromContentType(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
@@ -70,12 +80,29 @@ func TestNewFromContentType(t *testing.T) {
 	}
 }
 
+func TestNewFromContentTypeFallsBackFromInternalErrorMedia(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.TypeKey, media.Error)
+
+	media := test.Content.NewFromContentType(req)
+
+	require.Equal(t, "plain", media.Subtype)
+	require.Same(t, test.Encoder.Get("plain"), media.Encoder)
+}
+
 func TestNewFromMediaWithParameters(t *testing.T) {
 	media := test.Content.NewFromMedia("application/json; profile=test")
 
 	require.Equal(t, "application/json", media.Type)
 	require.Equal(t, "json", media.Subtype)
 	require.Same(t, test.Encoder.Get("json"), media.Encoder)
+}
+
+func TestNewFromMediaPreservesInternalErrorMedia(t *testing.T) {
+	media := test.Content.NewFromMedia(media.Error)
+
+	require.Equal(t, "error", media.Subtype)
+	require.Nil(t, media.Encoder)
 }
 
 type mediaTest struct {

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -1,13 +1,14 @@
 package content_test
 
 import (
-	"io"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -30,6 +31,38 @@ func TestNewRequestHandlerPrefersContentType(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, media.WithUTF8(media.JSON), res.Header().Get(content.TypeKey))
 	require.JSONEq(t, `{"Greeting":"Hello Bob","Meta":null}`, res.Body.String())
+}
+
+func TestNewRequestHandlerTreatsInternalErrorContentTypeAsText(t *testing.T) {
+	handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *bytes.Buffer) (*bytes.Buffer, error) {
+		return bytes.NewBufferString("Hello " + req.String()), nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("Bob"))
+	req.Header.Set(content.TypeKey, media.Error)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.WithUTF8(media.Text), res.Header().Get(content.TypeKey))
+	require.Equal(t, "Hello Bob", res.Body.String())
+}
+
+func TestNewHandlerTreatsInternalErrorAcceptAsText(t *testing.T) {
+	handler := content.NewHandler(test.Content, func(_ context.Context) (*bytes.Buffer, error) {
+		return bytes.NewBufferString("Hello Bob"), nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.Error)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.WithUTF8(media.Text), res.Header().Get(content.TypeKey))
+	require.Equal(t, "Hello Bob", res.Body.String())
 }
 
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {


### PR DESCRIPTION
## What

- Normalize request-side `text/error` negotiation to `text/plain` so normal content handlers use the plain encoder.
- Preserve `text/error` as the internal error-response marker for client-side response handling.
- Add `io.WriteString` as a go-service I/O wrapper and cover it with a unit test.
- Add regression coverage for `text/error` in request `Accept` and `Content-Type` headers.

## Why

- `text/error` is internal to error responses, but it is still a text payload when encountered during request negotiation.
- Normal handlers should not select the internal nil encoder path from request headers.

## Testing

- `go test ./io ./net/http/content ./net/...` - passed
- `gmake lint` - passed
- `gmake specs` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
