### PR TITLE
feat(transport): harden transport server controls

### DIFF
--- a/config/server/config.go
+++ b/config/server/config.go
@@ -14,6 +14,9 @@ import (
 // DefaultMaxReceiveSize is the default inbound payload limit applied when MaxReceiveSize is omitted or zero.
 const DefaultMaxReceiveSize bytes.Size = 4 * bytes.MB
 
+// DefaultTimeout is the default server timeout applied when Timeout is omitted or zero.
+const DefaultTimeout time.Duration = 30 * time.Second
+
 // Config configures server-side behavior shared across transports.
 type Config struct {
 	// Limiter configures server-side request limiting.
@@ -34,6 +37,8 @@ type Config struct {
 	// Timeout is the server request timeout duration.
 	//
 	// In config files it is encoded as a Go duration string (for example "30s", "5m").
+	//
+	// A zero value applies DefaultTimeout.
 	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
 
 	// MaxReceiveSize limits inbound request payload size.
@@ -58,6 +63,17 @@ func (c *Config) GetMaxReceiveSize() bytes.Size {
 	}
 
 	return c.MaxReceiveSize
+}
+
+// GetTimeout returns the configured server timeout.
+//
+// A nil receiver or a zero value falls back to DefaultTimeout.
+func (c *Config) GetTimeout() time.Duration {
+	if c == nil || c.Timeout == 0 {
+		return DefaultTimeout
+	}
+
+	return c.Timeout
 }
 
 // NewConfig constructs a server-side runtime TLS config from cfg.

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +29,24 @@ func TestGetMaxReceiveSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, tt.cfg.GetMaxReceiveSize())
+		})
+	}
+}
+
+func TestGetTimeout(t *testing.T) {
+	tests := []struct {
+		cfg  *server.Config
+		name string
+		want time.Duration
+	}{
+		{name: "nil", want: server.DefaultTimeout},
+		{name: "zero", cfg: &server.Config{}, want: server.DefaultTimeout},
+		{name: "explicit", cfg: &server.Config{Timeout: 5 * time.Second}, want: 5 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.cfg.GetTimeout())
 		})
 	}
 }

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -198,8 +198,8 @@ func WithClientID(generator id.Generator) ClientOption {
 
 // WithClientLimiter enables client-side rate limiting interceptors.
 //
-// When configured, unary client calls are rate-limited before being sent. If limiter is nil, rate limiting
-// is not enabled.
+// When configured, unary client calls and streams are rate-limited before being sent. If limiter is nil,
+// rate limiting is not enabled.
 func WithClientLimiter(limiter *limiter.Client) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.limiter = limiter
@@ -339,6 +339,10 @@ func streamDialOption(opts *clientOpts) grpc.DialOption {
 	}
 
 	stream = append(stream, meta.StreamClientInterceptor(opts.userAgent, opts.generator))
+	if opts.limiter != nil {
+		stream = append(stream, limiter.StreamClientInterceptor(opts.limiter))
+	}
+
 	return grpc.WithChainStreamInterceptor(stream...)
 }
 

--- a/transport/grpc/limiter/doc.go
+++ b/transport/grpc/limiter/doc.go
@@ -3,5 +3,6 @@
 // This package integrates rate limiting into gRPC servers (server-side interceptors) and gRPC clients
 // (client-side interceptors).
 //
-// Start with `UnaryServerInterceptor` for server-side limiting and `UnaryClientInterceptor` for client-side limiting.
+// Start with `UnaryServerInterceptor` or `StreamServerInterceptor` for server-side limiting and
+// `UnaryClientInterceptor` or `StreamClientInterceptor` for client-side limiting.
 package limiter

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -74,6 +74,39 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 	}
 }
 
+// StreamServerInterceptor returns a gRPC stream server interceptor that enforces rate limiting.
+//
+// Ignorable RPC methods (health/metrics/etc.) bypass limiting (see `net/grpc/strings.IsIgnorable`).
+//
+// On every stream, the interceptor calls `limiter.Take(ctx)` to determine whether the stream is allowed:
+//
+//   - If `Take` returns an error, the interceptor returns `codes.Internal`.
+//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
+//   - If the stream is not allowed, the interceptor returns `codes.ResourceExhausted`.
+//   - Otherwise, it invokes the handler.
+//
+// Callers should only install this interceptor when limiter is non-nil.
+func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if strings.IsIgnorable(info.FullMethod) {
+			return handler(srv, stream)
+		}
+
+		ok, header, err := limiter.Take(stream.Context())
+		if err != nil {
+			return status.SafeError(codes.Internal, err)
+		}
+
+		_ = stream.SetHeader(meta.Pairs("ratelimit", header))
+
+		if !ok {
+			return status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
+		}
+
+		return handler(srv, stream)
+	}
+}
+
 // NewClientLimiter constructs a gRPC client-side rate limiter.
 //
 // If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
@@ -119,5 +152,29 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 		}
 
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
+	}
+}
+
+// StreamClientInterceptor returns a gRPC stream client interceptor that enforces rate limiting.
+//
+// The interceptor calls `limiter.Take(ctx)` before opening the stream:
+//
+//   - If `Take` returns an error, it returns `codes.Internal`.
+//   - If the stream is not allowed, it returns `codes.ResourceExhausted`.
+//   - Otherwise, it invokes the underlying `streamer`.
+//
+// Callers should only install this interceptor when limiter is non-nil.
+func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ok, _, err := limiter.Take(ctx)
+		if err != nil {
+			return nil, status.SafeError(codes.Internal, err)
+		}
+
+		if !ok {
+			return nil, status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
+		}
+
+		return streamer(ctx, desc, conn, fullMethod, opts...)
 	}
 }

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -26,6 +26,20 @@ func TestServerLimiterUnary(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
+func TestServerLimiterStream(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	_ = sayStreamHello(t, client)
+	err := sayStreamHello(t, client)
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
 func TestClientLimiterUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
 
@@ -37,6 +51,20 @@ func TestClientLimiterUnary(t *testing.T) {
 
 	_, _ = client.SayHello(t.Context(), req)
 	_, err := client.SayHello(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestClientLimiterStream(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	_ = sayStreamHello(t, client)
+	err := sayStreamHello(t, client)
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
@@ -60,6 +88,23 @@ func TestClientLimiterUsesGeneratedTokenUnary(t *testing.T) {
 
 	_, err = client.SayHello(t.Context(), req)
 	require.NoError(t, err)
+}
+
+func TestClientLimiterUsesGeneratedTokenStream(t *testing.T) {
+	world := test.NewStartedWorld(t,
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
+		test.WithWorldToken(&sequenceGenerator{}, acceptingVerifier{}),
+		test.WithWorldGRPC(),
+	)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	require.NoError(t, sayStreamHello(t, client))
+	require.NoError(t, sayStreamHello(t, client))
 }
 
 func TestLimiterUnlimitedUnary(t *testing.T) {
@@ -134,6 +179,22 @@ func TestClientClosedLimiterUnary(t *testing.T) {
 	_, err := client.SayHello(t.Context(), req)
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+func sayStreamHello(t *testing.T, client v1.GreeterServiceClient) error {
+	t.Helper()
+
+	stream, err := client.SayStreamHello(t.Context())
+	if err != nil {
+		return err
+	}
+
+	if err := stream.Send(&v1.SayStreamHelloRequest{Name: "test"}); err != nil {
+		return err
+	}
+
+	_, err = stream.Recv()
+	return err
 }
 
 type sequenceGenerator struct {

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -30,7 +30,7 @@ import (
 //
 // Optional fields:
 //   - `Logger`: enables server-side RPC outcome logging when non-nil.
-//   - `Limiter`: enables server-side unary rate limiting when non-nil.
+//   - `Limiter`: enables server-side rate limiting when non-nil.
 //   - `Verifier`: enables server-side token verification when non-nil.
 //   - `Unary`/`Stream`: allow callers to inject additional interceptors (and are optional in DI).
 type ServerParams struct {
@@ -57,7 +57,7 @@ type ServerParams struct {
 	// ID generates request IDs when one is not already present.
 	ID id.Generator
 
-	// Limiter enables server-side unary rate limiting when non-nil.
+	// Limiter enables server-side rate limiting when non-nil.
 	Limiter *limiter.Server
 
 	// Verifier enables server-side token verification when non-nil.
@@ -80,7 +80,7 @@ type ServerParams struct {
 //   - A unary interceptor chain that performs metadata extraction/injection, and optionally logging,
 //     token verification, and rate limiting, followed by any user-provided interceptors.
 //   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging
-//     and token verification, followed by any user-provided interceptors.
+//     token verification, and rate limiting, followed by any user-provided interceptors.
 //
 // TLS:
 // If TLS is enabled in config, server credentials are built from `params.Config.TLS`. Certificate/key
@@ -112,7 +112,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		options = append(options, grpc.StatsHandler(telemetry.NewServerHandler()))
 	}
 
-	grpcServer := grpc.NewServer(params.Config.Options, params.Config.Timeout, options...)
+	grpcServer := grpc.NewServer(params.Config.Options, params.Config.GetTimeout(), options...)
 	cfg := &config.Config{Address: cmp.Or(params.Config.Address, net.DefaultAddress("9090"))}
 
 	service, err := grpcserver.NewService("grpc", grpcServer, cfg, params.Logger, params.Shutdowner)
@@ -185,6 +185,10 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 
 	if params.Verifier != nil {
 		sis = append(sis, token.StreamServerInterceptor(params.UserID, params.Verifier))
+	}
+
+	if params.Limiter != nil {
+		sis = append(sis, limiter.StreamServerInterceptor(params.Limiter))
 	}
 
 	sis = append(sis, interceptors...)

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -25,6 +25,8 @@ type Settings = breaker.Settings
 //
 // A separate circuit breaker is maintained per request key: "<METHOD> <HOST>". The host is derived from
 // `req.URL.Host`, falling back to `req.Host` (and finally "unknown"). This isolates failures per upstream.
+// Breaker keys are retained for the lifetime of the RoundTripper, so this wrapper is intended for a small,
+// bounded set of service-to-service upstream hosts rather than arbitrary user-supplied destinations.
 //
 // # Failure accounting and error semantics
 //
@@ -53,6 +55,7 @@ func NewRoundTripper(hrt http.RoundTripper, options ...Option) *RoundTripper {
 //
 // Breakers are cached per request key (method + host) so each upstream is isolated. Breakers are created lazily
 // on first use and then reused for subsequent requests to the same key.
+// The cache does not evict entries; callers should use this wrapper with bounded upstream host sets.
 //
 // Use `NewRoundTripper` to construct instances with the desired settings and failure classification behavior.
 type RoundTripper struct {
@@ -109,5 +112,8 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 }
 
 func requestKey(req *http.Request) string {
+	// Breaker keys are intentionally stable per method and upstream host. They
+	// are retained for the RoundTripper lifetime, so callers should avoid using
+	// breaker-enabled clients for arbitrary high-cardinality destinations.
 	return strings.Join(" ", req.Method, cmp.Or(req.URL.Host, req.Host, "unknown"))
 }

--- a/transport/http/breaker/doc.go
+++ b/transport/http/breaker/doc.go
@@ -5,6 +5,9 @@
 // # Breaker scope
 //
 // Breakers are maintained per request key (method + host), so each upstream is isolated.
+// Breaker keys are retained for the lifetime of the RoundTripper. This is intended for service-to-service
+// clients with a small, bounded set of configured upstream hosts. Avoid enabling this wrapper for clients that
+// call arbitrary user-supplied or otherwise high-cardinality hosts unless the caller bounds that host set.
 //
 // # Failure accounting vs caller behavior
 //

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -86,9 +86,10 @@ type ServerParams struct {
 // The server is built using Negroni and composes middleware in this order (first listed runs first):
 //   - metadata extraction/injection and response headers (`net/http/meta`)
 //   - optional logging (`transport/http/telemetry/logger`) when `params.Logger` is non-nil
-//   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - optional token verification (`transport/http/token`) when `params.Verifier` is non-nil
 //   - optional rate limiting (`transport/http/limiter`) when `params.Limiter` is non-nil
+//   - inbound request body size limiting (`transport/http/body`)
+//   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - gzip compression wrapping the mux not-found handler (`gzhttp.GzipHandler(http.NewNotFoundHandler(...))`)
 //
 // Token verification and rate limiting middleware typically treat "ignorable" paths (health/metrics/etc.)
@@ -118,12 +119,6 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(logger.NewHandler(params.Logger))
 	}
 
-	neg.Use(body.NewHandler(params.Config.GetMaxReceiveSize().Bytes()))
-
-	for _, hd := range params.Handlers {
-		neg.Use(hd)
-	}
-
 	if params.Verifier != nil {
 		neg.Use(token.NewHandler(params.UserID, params.Verifier))
 	}
@@ -132,10 +127,16 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(limiter.NewHandler(params.Limiter))
 	}
 
+	neg.Use(body.NewHandler(params.Config.GetMaxReceiveSize().Bytes()))
+
+	for _, hd := range params.Handlers {
+		neg.Use(hd)
+	}
+
 	handler := http.NewNotFoundHandler(params.Mux, params.Pool, mvc.NotFoundHandler(), content.NotFoundHandler())
 	neg.UseHandler(gzhttp.GzipHandler(handler))
 
-	httpServer := http.NewServer(params.Config.Options, params.Config.Timeout, neg)
+	httpServer := http.NewServer(params.Config.Options, params.Config.GetTimeout(), neg)
 
 	cfg, err := newConfig(fs, params.Config)
 	if err != nil {


### PR DESCRIPTION
## What

- Apply the configured server timeout through a shared `DefaultTimeout`/`GetTimeout` fallback so enabled HTTP and gRPC servers do not run with zero timeouts when config omits `timeout`.
- Move HTTP token verification and rate limiting before request body buffering while keeping body limits before custom handlers and mux handling.
- Extend gRPC rate limiting to streaming RPCs on both server and client paths.
- Document that HTTP breaker keys are retained for the RoundTripper lifetime and are intended for bounded upstream host sets.

## Why

- Reduce avoidable DoS exposure from slow clients, unauthenticated body buffering, and unbounded streaming calls.
- Make the HTTP breaker cardinality assumption explicit so dynamic-host callers do not mistake it for an evicting cache.

## Testing

- `go test ./config/server ./transport/http ./transport/grpc` - passed
- `go test ./transport/...` - passed
- `go test ./transport/grpc ./transport/grpc/limiter` - passed
- `go test ./transport/http/breaker` - passed
- `gmake lint` - passed
- `gmake specs` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
