### PR TITLE
feat(net): standardize safe status messages

### DIFF
--- a/meta/meta.go
+++ b/meta/meta.go
@@ -3,15 +3,12 @@ package meta
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/strings"
-	"github.com/iancoleman/strcase"
 )
 
-const (
-	// NoPrefix is a convenience constant for passing an empty prefix to export helpers.
-	NoPrefix = strings.Empty
+// NoPrefix is a convenience constant for passing an empty prefix to export helpers.
+const NoPrefix = strings.Empty
 
-	meta = context.Key("meta")
-)
+const meta = context.Key("meta")
 
 // WithAttributes returns a copy of ctx with all provided attributes stored.
 //
@@ -44,7 +41,7 @@ type Map map[string]string
 // The prefix parameter is prepended to each exported key (if non-empty).
 // Attributes whose rendered value is empty are skipped.
 func SnakeStrings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix, strcase.ToSnake)
+	return attributes(ctx).Strings(prefix, strings.ToSnake)
 }
 
 // CamelStrings returns all stored attributes as a string map with lowerCamelCased keys.
@@ -52,7 +49,7 @@ func SnakeStrings(ctx context.Context, prefix string) Map {
 // The prefix parameter is prepended to each exported key (if non-empty).
 // Attributes whose rendered value is empty are skipped.
 func CamelStrings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix, strcase.ToLowerCamel)
+	return attributes(ctx).Strings(prefix, strings.ToLowerCamel)
 }
 
 // Strings returns all stored attributes as a string map with keys unchanged.

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -39,7 +39,8 @@
 //	err := status.Errorf(codes.NotFound, "widget %q does not exist", name)
 //
 // Use SafeError when the internal cause should remain available through
-// unwrapping but the client should receive the standard status text.
+// unwrapping but the client should receive a lowercase "grpc: " prefixed
+// status message.
 //
 // # Inspecting errors
 //
@@ -65,9 +66,9 @@
 // # Client-visible messages
 //
 // gRPC status messages are sent to clients. Error and Errorf treat their
-// messages as client-visible. SafeError sends the standard status text while
-// preserving an internal cause through Unwrap for inspection with errors.Is and
-// errors.As.
+// messages as client-visible. SafeError sends a lowercase "grpc: " prefixed
+// status message while preserving an internal cause through Unwrap for
+// inspection with errors.Is and errors.As.
 //
 // # Non-goals
 //

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"google.golang.org/grpc/status"
 )
 
@@ -71,16 +72,16 @@ func Errorf(c codes.Code, format string, a ...any) error {
 	return Error(c, fmt.Sprintf(format, a...))
 }
 
-// SafeError wraps err with c and the standard status text that is safe to send to clients.
+// SafeError wraps err with c and a safe gRPC-prefixed status message that is safe to send to clients.
 //
-// The wrapped error remains available through Unwrap for internal inspection, while gRPC sends StatusText(c) instead
+// The wrapped error remains available through Unwrap for internal inspection, while gRPC sends the safe message instead
 // of err.Error(). If c is codes.OK, SafeError returns nil to preserve upstream gRPC status invariants.
 func SafeError(c codes.Code, err error) error {
 	if c == codes.OK {
 		return nil
 	}
 
-	return &statusError{code: c, msg: codes.StatusText(c), err: err}
+	return &statusError{code: c, msg: defaultSafeMessage(c), err: err}
 }
 
 type statusError struct {
@@ -124,4 +125,8 @@ func (s *statusError) Is(target error) bool {
 // Unwrap returns the wrapped cause, if any.
 func (s *statusError) Unwrap() error {
 	return s.err
+}
+
+func defaultSafeMessage(c codes.Code) string {
+	return "grpc: " + strings.ToLower(strings.ToDelimited(codes.StatusText(c), ' '))
 }

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -50,7 +50,7 @@ func TestSafeError(t *testing.T) {
 	s, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, codes.Internal, s.Code())
-	require.Equal(t, codes.StatusText(codes.Internal), s.Message())
+	require.Equal(t, "grpc: internal", s.Message())
 	require.ErrorIs(t, err, cause)
 }
 
@@ -68,7 +68,7 @@ func TestSafeErrorWrapped(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, codes.Internal, s.Code())
 	require.Contains(t, s.Message(), "wrapped:")
-	require.Contains(t, s.Message(), codes.StatusText(codes.Internal))
+	require.Contains(t, s.Message(), "grpc: internal")
 	require.NotContains(t, s.Message(), "secret database failure")
 }
 

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -264,7 +264,7 @@ func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {
 	}
 
 	if int64(buffer.Len()) > c.maxResponseSize {
-		return errors.Prefix("http: response", status.Error(http.StatusRequestEntityTooLarge, strings.ToLower(http.StatusText(http.StatusRequestEntityTooLarge))))
+		return status.SafeError(http.StatusRequestEntityTooLarge, nil)
 	}
 
 	return nil

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -39,7 +39,7 @@ func TestDoRejectsResponseOverMaxResponseSize(t *testing.T) {
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.Error(t, err)
-	require.EqualError(t, err, "http: response: request entity too large")
+	require.EqualError(t, err, "http: request entity too large")
 	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
 }
 
@@ -55,7 +55,7 @@ func TestDoRejectsErrorResponseOverMaxResponseSize(t *testing.T) {
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.Error(t, err)
-	require.EqualError(t, err, "http: response: request entity too large")
+	require.EqualError(t, err, "http: request entity too large")
 	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
 }
 

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -62,7 +62,7 @@ func NewHandler[Res any](cont *Content, handler Handler[Res]) http.HandlerFunc {
 // NotFoundHandler returns a not-found handler that writes the standard content error response.
 func NotFoundHandler() http.NotFoundHandler {
 	return func(res http.ResponseWriter, _ *http.Request) bool {
-		err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
+		err := status.SafeError(http.StatusNotFound, nil)
 		_ = status.WriteError(res, err)
 
 		return true

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -82,7 +82,7 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
-	require.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
+	require.Equal(t, "http: internal server error", strings.TrimSpace(res.Body.String()))
 	require.NotContains(t, res.Body.String(), "partial")
 }
 
@@ -93,7 +93,7 @@ func TestNotFoundHandlerWritesStatusError(t *testing.T) {
 	require.True(t, content.NotFoundHandler()(res, req))
 	require.Equal(t, http.StatusNotFound, res.Code)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
-	require.Equal(t, "Not Found\n", res.Body.String())
+	require.Equal(t, "http: not found", strings.TrimSpace(res.Body.String()))
 }
 
 type partialEncoder struct{}

--- a/net/http/status/doc.go
+++ b/net/http/status/doc.go
@@ -5,5 +5,5 @@
 //
 // Status error messages created with Error/Errorf are client-visible when passed to WriteError. Wrapped
 // internal failures created with FromError or SafeError keep their diagnostic Error text, but WriteError
-// sends the standard status text instead.
+// sends a lowercase "http: " prefixed status message instead.
 package status

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -23,8 +23,8 @@ import (
 //
 // Write behavior:
 // The error message is written as a single line (via fmt.Fprintln) containing the first SafeMessage in
-// err's chain. If no safe message is available, WriteError uses the standard HTTP status text for Code(err).
-// Use SafeError to preserve an internal cause while returning the standard HTTP status text to the client.
+// err's chain. If no safe message is available, WriteError uses the default safe HTTP status message for Code(err).
+// Use SafeError to preserve an internal cause while returning the default safe HTTP status message to the client.
 // If writing the body fails, WriteError returns the write error and does not attempt to write a
 // secondary error response.
 //

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // Error constructs an error that carries an HTTP status code and a message.
@@ -16,9 +17,9 @@ func Error(code int, msg string) error {
 	return &statusError{code: code, error: msg, msg: msg}
 }
 
-// SafeError wraps err with code and the standard status text that is safe to send to clients.
+// SafeError wraps err with code and a safe HTTP-prefixed status message that is safe to send to clients.
 //
-// The wrapped error remains available through Unwrap for internal inspection, while WriteError sends StatusText(code)
+// The wrapped error remains available through Unwrap for internal inspection, while WriteError sends the safe message
 // instead of err.Error(). If err already carries a status code, it is returned unchanged.
 func SafeError(code int, err error) error {
 	code = normalizeCode(code, err)
@@ -173,8 +174,8 @@ func (s *statusError) Unwrap() error {
 
 func defaultSafeMessage(code int) string {
 	if msg := http.StatusText(code); msg != "" {
-		return msg
+		return "http: " + strings.ToLower(msg)
 	}
 
-	return http.StatusText(http.StatusInternalServerError)
+	return "http: " + strings.ToLower(http.StatusText(http.StatusInternalServerError))
 }

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -10,6 +10,7 @@ import (
 	grpcstatus "github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	httpstatus "github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +41,7 @@ func TestFromErrorWrapsCause(t *testing.T) {
 func TestFromErrorAllowsNil(t *testing.T) {
 	err := httpstatus.FromError(http.StatusBadRequest, nil)
 
-	require.Equal(t, http.StatusText(http.StatusBadRequest), err.Error())
+	require.Equal(t, "http: bad request", err.Error())
 	require.Equal(t, http.StatusBadRequest, httpstatus.Code(err))
 }
 
@@ -51,7 +52,7 @@ func TestWriteErrorUsesSafeMessageForFromError(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, http.StatusText(http.StatusBadRequest)+"\n", res.Body.String())
+	require.Equal(t, "http: bad request", strings.TrimSpace(res.Body.String()))
 }
 
 func TestWriteErrorUsesSafeMessage(t *testing.T) {
@@ -61,13 +62,13 @@ func TestWriteErrorUsesSafeMessage(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.Code)
-	require.Equal(t, http.StatusText(http.StatusUnauthorized)+"\n", res.Body.String())
+	require.Equal(t, "http: unauthorized", strings.TrimSpace(res.Body.String()))
 }
 
 func TestSafeErrorAllowsNilCause(t *testing.T) {
 	err := httpstatus.SafeError(http.StatusUnauthorized, nil)
 
-	require.Equal(t, http.StatusText(http.StatusUnauthorized), err.Error())
+	require.Equal(t, "http: unauthorized", err.Error())
 	require.Equal(t, http.StatusUnauthorized, httpstatus.Code(err))
 }
 
@@ -91,7 +92,7 @@ func TestWriteErrorUsesDefaultSafeMessageForUnknownStatusCode(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 999, res.Code)
-	require.Equal(t, http.StatusText(http.StatusInternalServerError)+"\n", res.Body.String())
+	require.Equal(t, "http: internal server error", strings.TrimSpace(res.Body.String()))
 }
 
 func TestCodeRecognizesMaxBytesError(t *testing.T) {

--- a/strings/doc.go
+++ b/strings/doc.go
@@ -12,7 +12,8 @@
 //
 // Most functions in this package are thin wrappers around the corresponding
 // functions in the standard library strings package (for example Contains,
-// HasPrefix, ReplaceAll, TrimSpace). These wrappers do not change semantics.
+// HasPrefix, ReplaceAll, TrimSpace) or the strcase package (for example
+// ToSnake, ToLowerCamel, ToDelimited). These wrappers do not change semantics.
 //
 // # Convenience helpers
 //
@@ -27,6 +28,9 @@
 //   - CutColon: a small helper that splits on the first ":" using strings.Cut,
 //     returning the part before and after. If ":" is not present, the "after"
 //     return value is empty.
+//
+//   - ToSnake / ToLowerCamel / ToDelimited: common string case conversion
+//     helpers delegated to strcase.
 //
 // # Constants
 //

--- a/strings/strcase.go
+++ b/strings/strcase.go
@@ -1,0 +1,24 @@
+package strings
+
+import "github.com/iancoleman/strcase"
+
+// ToDelimited converts s to a delimiter-separated string.
+//
+// This is a thin wrapper around strcase.ToDelimited and does not change semantics.
+func ToDelimited(s string, delimiter uint8) string {
+	return strcase.ToDelimited(s, delimiter)
+}
+
+// ToLowerCamel converts s to lower camel case.
+//
+// This is a thin wrapper around strcase.ToLowerCamel and does not change semantics.
+func ToLowerCamel(s string) string {
+	return strcase.ToLowerCamel(s)
+}
+
+// ToSnake converts s to snake case.
+//
+// This is a thin wrapper around strcase.ToSnake and does not change semantics.
+func ToSnake(s string) string {
+	return strcase.ToSnake(s)
+}

--- a/strings/strcase_test.go
+++ b/strings/strcase_test.go
@@ -1,0 +1,20 @@
+package strings_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDelimited(t *testing.T) {
+	require.Equal(t, "invalid argument", strings.ToDelimited("InvalidArgument", ' '))
+}
+
+func TestToLowerCamel(t *testing.T) {
+	require.Equal(t, "requestId", strings.ToLowerCamel("request_id"))
+}
+
+func TestToSnake(t *testing.T) {
+	require.Equal(t, "request_id", strings.ToSnake("requestID"))
+}

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -64,7 +64,7 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
+	require.Equal(t, "http: unauthorized", body)
 }
 
 func TestValidAuthUnary(t *testing.T) {
@@ -99,7 +99,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
+	require.Equal(t, "http: unauthorized", body)
 }
 
 func TestAuthUnaryWithAppend(t *testing.T) {
@@ -152,7 +152,7 @@ func TestMissingAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
+	require.Equal(t, "http: unauthorized", body)
 }
 
 func TestEmptyAuthUnary(t *testing.T) {
@@ -185,7 +185,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusUnauthorized), body)
+	require.Equal(t, "http: unauthorized", body)
 }
 
 func TestTokenErrorAuthUnary(t *testing.T) {

--- a/transport/http/body/body_test.go
+++ b/transport/http/body/body_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/body"
 	"github.com/stretchr/testify/require"
 )
@@ -35,5 +36,5 @@ func TestHandlerWritesBadRequestWhenBodyReadFails(t *testing.T) {
 	})
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, http.StatusText(http.StatusBadRequest)+"\n", res.Body.String())
+	require.Equal(t, "http: bad request", strings.TrimSpace(res.Body.String()))
 }

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -71,7 +71,7 @@ func TestInvalidHealth(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusServiceUnavailable), body)
+	require.Equal(t, "http: service unavailable", body)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
 }
 

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -136,11 +136,6 @@ func Handle(mux *ServeMux, pattern string, handler Handler) {
 	http.Handle(mux, pattern, handler)
 }
 
-// StatusText returns the standard HTTP status text for the given status code.
-func StatusText(code int) string {
-	return http.StatusText(code)
-}
-
 // ParseServiceMethod derives a logical "service" and "method" name from an HTTP request.
 func ParseServiceMethod(req *Request) (string, string) {
 	return http.ParseServiceMethod(req)

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -131,7 +131,7 @@ func TestNotFoundUsesContentFallbackWithoutHTMLAccept(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
-	require.Equal(t, http.StatusText(http.StatusNotFound), body)
+	require.Equal(t, "http: not found", body)
 }
 
 func TestNotFoundHandlesHTMXRequest(t *testing.T) {

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -68,7 +68,7 @@ func TestRestNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
-	require.Equal(t, http.StatusText(http.StatusNotFound), body)
+	require.Equal(t, "http: not found", body)
 }
 
 func TestRestRequestError(t *testing.T) {

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -167,7 +167,7 @@ func TestErrorRPC(t *testing.T) {
 					if handler.name == "mapped" {
 						require.Equal(t, "failed", body)
 					} else {
-						require.Equal(t, http.StatusText(http.StatusInternalServerError), body)
+						require.Equal(t, "http: internal server error", body)
 					}
 					require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 				})
@@ -186,7 +186,7 @@ func TestRPCNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
-	require.Equal(t, http.StatusText(http.StatusNotFound), body)
+	require.Equal(t, "http: not found", body)
 }
 
 func TestAllowedRPC(t *testing.T) {
@@ -233,7 +233,7 @@ func TestDisallowedRPC(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, status.IsError(err))
 			require.Equal(t, http.StatusUnauthorized, status.Code(err))
-			require.Equal(t, http.StatusText(http.StatusUnauthorized), err.Error())
+			require.Equal(t, "http: unauthorized", err.Error())
 		})
 	}
 }

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -53,7 +53,7 @@ func TestServerMaxReceiveSize(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusRequestEntityTooLarge), body)
+	require.Equal(t, "http: request entity too large", body)
 }
 
 func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
@@ -77,7 +77,7 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
-	require.Equal(t, http.StatusText(http.StatusRequestEntityTooLarge), body)
+	require.Equal(t, "http: request entity too large", body)
 }
 
 type unknownLengthReader struct {


### PR DESCRIPTION
## What

- Normalize HTTP and gRPC SafeError text to lowercase protocol-prefixed messages.
- Centralize strcase helpers behind the local strings package and update metadata/status callers to use it.
- Update HTTP client and transport expectations for the normalized safe status text.

## Why

- Keeps client-visible status text consistent across HTTP and gRPC paths.
- Avoids scattered direct strcase imports outside the local strings package.

## Testing

- `make specs` - passed
- `make lint` - passed
