### PR TITLE
feat(http): limit response retries to selected statuses

### DIFF
--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -2,11 +2,12 @@
 //
 // The package exposes a transport-level retrying `http.RoundTripper` that:
 //   - applies a per-attempt timeout,
-//   - delegates retry classification to `retryablehttp.DefaultRetryPolicy`,
+//   - retries responses and HTTP status errors only for selected HTTP status codes,
+//   - keeps `retryablehttp.DefaultRetryPolicy` classification for transport errors,
 //   - replays request bodies on subsequent attempts when `req.GetBody` is available, and
 //   - preserves the original caller-visible response or error shape when retries are exhausted.
 //
-// In particular, when retries are triggered by HTTP responses (for example 429/5xx), the wrapper keeps
-// the first retryable response and returns that response if all retries fail. When retries are triggered
-// by transport errors, the original error is preserved.
+// In particular, when retries are triggered by HTTP responses (for example 429/503), the wrapper keeps the first
+// retryable response and returns that response if all retries fail. When retries are triggered by transport errors,
+// the original error is preserved.
 package retry

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/time"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
 	"github.com/alexfalkowski/go-sync"
@@ -26,7 +27,7 @@ type Config = config.Config
 //
 // This sentinel is used when the retry policy decides a response should be retried but does not provide
 // a more specific error value. In practice this happens for retryable HTTP response codes such as
-// `429 Too Many Requests` or retryable `5xx` responses.
+// `429 Too Many Requests` or `503 Service Unavailable`.
 var ErrInvalidStatusCode = errors.New("retry: invalid status code")
 
 // ErrAttemptTimeout is the cause recorded when a retry attempt times out.
@@ -36,7 +37,8 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 //
 // The constructed RoundTripper wraps hrt and, for each request:
 //   - applies a per-attempt timeout derived from `cfg.Timeout`, and
-//   - retries when `retryablehttp.DefaultRetryPolicy` deems the response/error retryable, and
+//   - retries responses and status errors with retryable HTTP status codes, and
+//   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`, and
 //   - waits a constant backoff derived from `cfg.Backoff` between attempts.
 //
 // Attempts/backoff:
@@ -58,7 +60,8 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper) *RoundTripper {
 // Each attempt:
 //   - runs the underlying `RoundTrip` with a derived per-attempt timeout,
 //   - re-creates the request body for subsequent attempts when `req.GetBody` is available, and
-//   - asks `retryablehttp.DefaultRetryPolicy` whether the result should be retried.
+//   - retries only selected HTTP status codes for responses and status errors.
+//   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`.
 //
 // Important:
 // Many HTTP requests are not safe to retry unless they are idempotent or the server supports safe retries.
@@ -74,7 +77,8 @@ type RoundTripper struct {
 // For each attempt:
 //   - it derives a child context with a timeout (`r.timeout`) and executes the underlying RoundTripper with it,
 //   - it clones the request and replays the body when needed,
-//   - it asks `retryablehttp.DefaultRetryPolicy` whether the response/error is retryable, and
+//   - it checks whether the response/status error carries a retryable HTTP status code, and
+//   - it uses `retryablehttp.DefaultRetryPolicy` for transport error classification, and
 //   - if retryable, it returns a retryable error (`retry.RetryableError`) so the backoff schedules another attempt.
 //
 // When the policy deems the result non-retryable, RoundTrip returns the response/error as produced by the
@@ -157,7 +161,7 @@ func (a *roundTripAttempt) request(req *http.Request, ctx context.Context) (*htt
 }
 
 func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *http.Response, err error) error {
-	ok, retryErr := retryable.DefaultRetryPolicy(ctx, res, err)
+	ok, retryErr := shouldRetryAttempt(ctx, res, err)
 	if !ok {
 		return nil
 	}
@@ -173,6 +177,34 @@ func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *ht
 
 	a.keepFirst(res)
 	return retry.RetryableError(responseError{resp: a.first, err: retryErr})
+}
+
+func shouldRetryAttempt(ctx context.Context, res *http.Response, err error) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	if isTransportError(res, err) {
+		return retryable.DefaultRetryPolicy(ctx, res, err)
+	}
+
+	if err != nil {
+		return isRetryableStatusCode(status.Code(err)), err
+	}
+
+	if res == nil {
+		return false, nil
+	}
+
+	return isRetryableStatusCode(res.StatusCode), nil
+}
+
+func isRetryableStatusCode(code int) bool {
+	return code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable
+}
+
+func isTransportError(res *http.Response, err error) bool {
+	return res == nil && err != nil && !status.IsError(err)
 }
 
 func canRetry(req *http.Request) bool {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -63,6 +63,22 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, rt.calls)
 }
 
+func TestRoundTripperDoesNotRetryUnhandledStatusCode(t *testing.T) {
+	rt := &roundTripper{codes: []int{http.StatusInternalServerError, http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, 1, rt.calls)
+}
+
 func TestRoundTripperReturnsLastRetryableResponseWhenExhausted(t *testing.T) {
 	rt := &roundTripper{codes: []int{http.StatusTooManyRequests, http.StatusTooManyRequests}}
 	retrying := retry.NewRoundTripper(&retry.Config{
@@ -113,7 +129,7 @@ func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
 
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
-	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
 }
 
@@ -135,7 +151,7 @@ func TestRoundTripperUsesOriginalBodyOnFirstAttempt(t *testing.T) {
 
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
-	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.True(t, rt.firstUsedOriginal)
 	require.True(t, body.closed)
 	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
@@ -155,11 +171,11 @@ func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
 
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
-	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.Equal(t, []string{"hello"}, rt.bodies)
 }
 
-func TestRoundTripperPreservesRetryableTransportError(t *testing.T) {
+func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
 	rt := &errorRoundTripper{err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
@@ -174,6 +190,40 @@ func TestRoundTripperPreservesRetryableTransportError(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, http.StatusTooManyRequests, status.Code(err))
 	require.Equal(t, 2, rt.calls)
+}
+
+func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
+	wantErr := io.ErrUnexpectedEOF
+	rt := &errorRoundTripper{err: wantErr}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 2, rt.calls)
+}
+
+func TestRoundTripperDoesNotRetryUnhandledTransportError(t *testing.T) {
+	rt := &errorRoundTripper{err: status.Errorf(http.StatusInternalServerError, "internal")}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.Equal(t, http.StatusInternalServerError, status.Code(err))
+	require.Equal(t, 1, rt.calls)
 }
 
 func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testing.T) {
@@ -276,8 +326,8 @@ func (r *requestRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	r.bodies = append(r.bodies, string(body))
 
 	return &http.Response{
-		StatusCode: http.StatusInternalServerError,
-		Status:     fmt.Sprintf("%d %s", http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)),
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     fmt.Sprintf("%d %s", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)),
 		Body:       http.NoBody,
 		Header:     make(http.Header),
 	}, nil
@@ -307,8 +357,8 @@ func (r *originalBodyRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	r.bodies = append(r.bodies, string(body))
 
 	return &http.Response{
-		StatusCode: http.StatusInternalServerError,
-		Status:     fmt.Sprintf("%d %s", http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)),
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     fmt.Sprintf("%d %s", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)),
 		Body:       http.NoBody,
 		Header:     make(http.Header),
 	}, nil


### PR DESCRIPTION
## What

- Limited HTTP response and HTTP status-error retries to selected status codes: 429 Too Many Requests and 503 Service Unavailable.
- Preserved go-retryablehttp transport-error classification for recoverable connection failures and its existing non-retryable transport exclusions.
- Added regression coverage for non-retryable 500 responses/status errors, recoverable transport errors, and replayable/non-replayable request bodies under the explicit retry-code policy.
- Updated HTTP retry package documentation to describe the hybrid retry policy.

## Why

- Avoid replaying non-idempotent requests for broad 5xx responses while keeping retry behavior for explicit retry signals.
- Keep the useful transport-error handling from go-retryablehttp instead of reducing retries to response codes only.

## Testing

- `go test ./transport/http/retry` - passed
- `go test ./transport/...` - passed
- `make lint` - passed with existing gomodguard deprecation warning
