### PR TITLE
feat(header): reject empty bearer credentials

### DIFF
--- a/net/header/header.go
+++ b/net/header/header.go
@@ -61,6 +61,7 @@ type ForwardedIP struct {
 //
 // Error behavior:
 //   - If the header cannot be split into two parts on the first ASCII space, it returns ErrInvalidAuthorization.
+//   - If the parsed value is empty, it returns ErrInvalidAuthorization.
 //   - If the parsed scheme is not Bearer, it returns ErrNotSupportedAuthorization.
 //
 // On error, the returned value is an empty string.
@@ -72,6 +73,11 @@ func ParseBearer(header string) (string, error) {
 
 	if strings.ToLower(key) != strings.ToLower(BearerAuthorization) {
 		return strings.Empty, ErrNotSupportedAuthorization
+	}
+
+	value = strings.TrimSpace(value)
+	if strings.IsEmpty(value) {
+		return strings.Empty, ErrInvalidAuthorization
 	}
 
 	return value, nil

--- a/net/header/header_test.go
+++ b/net/header/header_test.go
@@ -34,6 +34,23 @@ func TestMissingParseBearer(t *testing.T) {
 	require.ErrorIs(t, err, header.ErrInvalidAuthorization)
 }
 
+func TestParseBearerRejectsEmptyToken(t *testing.T) {
+	tests := []struct {
+		header string
+		name   string
+	}{
+		{name: "empty", header: "Bearer "},
+		{name: "whitespace", header: "Bearer \t"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := header.ParseBearer(tt.header)
+			require.ErrorIs(t, err, header.ErrInvalidAuthorization)
+		})
+	}
+}
+
 func TestNotSupportedParseBearer(t *testing.T) {
 	_, err := header.ParseBearer("Bob token")
 	require.ErrorIs(t, err, header.ErrNotSupportedAuthorization)


### PR DESCRIPTION
## What

- Reject empty or whitespace-only Bearer authorization values in `net/header.ParseBearer`.
- Document the new invalid-authorization behavior.
- Add regression coverage for empty and whitespace-only bearer tokens.

## Why

- Prevent malformed `Authorization: Bearer ` headers from being treated as parsed credentials and flowing downstream as empty auth values.

## Testing

- `go test ./net/header ./net/http/meta ./net/grpc/meta` - passed
- `make lint` - passed with existing gomodguard deprecation warning
