### PR TITLE
feat(http): normalize error media status codes

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -241,10 +241,15 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	// The server handlers return text/error to indicate an error.
 	media := c.content.NewFromMedia(contentType)
 	if media.IsError() {
-		return status.Error(response.StatusCode, strings.TrimSpace(buffer.String()))
+		code := response.StatusCode
+		if !isErrorStatus(code) {
+			code = http.StatusInternalServerError
+		}
+
+		return status.Error(code, strings.TrimSpace(buffer.String()))
 	}
 
-	if response.StatusCode >= 400 && response.StatusCode <= 599 {
+	if isErrorStatus(response.StatusCode) {
 		return status.Error(response.StatusCode, strings.ToLower(http.StatusText(response.StatusCode)))
 	}
 
@@ -255,6 +260,10 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	}
 
 	return nil
+}
+
+func isErrorStatus(code int) bool {
+	return code >= 400 && code <= 599
 }
 
 func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -59,6 +59,50 @@ func TestDoRejectsErrorResponseOverMaxResponseSize(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
 }
 
+func TestDoPreservesErrorMediaStatusCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.Error)
+		res.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(res, "bad request")
+	}))
+	defer server.Close()
+
+	c := client.NewClient(test.Content, test.Pool)
+
+	err := c.Get(t.Context(), server.URL, client.Options{})
+	require.Error(t, err)
+	require.EqualError(t, err, "bad request")
+	require.Equal(t, http.StatusBadRequest, status.Code(err))
+}
+
+func TestDoNormalizesErrorMediaSuccessStatusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{name: "ok", code: http.StatusOK},
+		{name: "redirect", code: 302},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+				res.Header().Set(content.TypeKey, media.Error)
+				res.WriteHeader(tt.code)
+				_, _ = io.WriteString(res, "upstream error")
+			}))
+			defer server.Close()
+
+			c := client.NewClient(test.Content, test.Pool)
+
+			err := c.Get(t.Context(), server.URL, client.Options{Response: &struct{}{}})
+			require.Error(t, err)
+			require.EqualError(t, err, "upstream error")
+			require.Equal(t, http.StatusInternalServerError, status.Code(err))
+		})
+	}
+}
+
 func TestDoUsesDefaultMaxResponseSize(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		res.Header().Set(content.TypeKey, media.Text)


### PR DESCRIPTION
## What

- Normalize `text/error` responses with non-error HTTP status codes to `500 Internal Server Error` in the content-aware HTTP client.
- Preserve the original status code for `text/error` responses that already use a 4xx or 5xx status.
- Added regression coverage for both preserved error statuses and malformed success/redirect statuses with error media.

## Why

- Prevent callers from receiving a non-nil error whose `status.Code(err)` is a success or redirect status.

## Testing

- `go test ./net/http/client ./net/http/status ./net/http/content` - passed
- `make lint` - passed with existing gomodguard deprecation warning
