### PR TITLE
feat(grpc): limit long-lived health watch streams

### DIFF
--- a/net/grpc/meta/meta.go
+++ b/net/grpc/meta/meta.go
@@ -59,6 +59,13 @@ func WithUserAgent(value meta.Value) Pair {
 	return meta.WithUserAgent(value)
 }
 
+// UserAgent returns the user agent attribute stored on ctx.
+//
+// If no value is present, it returns the zero-value meta.Value.
+func UserAgent(ctx context.Context) meta.Value {
+	return meta.UserAgent(ctx)
+}
+
 // WithUserID creates a user ID pair for WithAttributes.
 func WithUserID(value meta.Value) Pair {
 	return meta.WithUserID(value)

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -117,6 +117,22 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 	require.Equal(t, []string{"generated-id"}, stream.header.Get("request-id"))
 }
 
+func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
+	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	ctx := meta.NewIncomingContext(context.Background(), meta.Pairs(
+		"authorization", "invalid",
+		"user-agent", "watch-agent",
+	))
+	stream := &serverStream{ctx: ctx}
+
+	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/grpc.health.v1.Health/Watch"}, func(_ any, stream grpc.ServerStream) error {
+		require.Equal(t, meta.String("watch-agent"), meta.UserAgent(stream.Context()))
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestExtractIncomingReturnsMutableCopy(t *testing.T) {
 	ctx := meta.NewIncomingContext(context.Background(), meta.Pairs("request-id", "original"))
 

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -19,7 +19,7 @@ import (
 
 // UnaryServerInterceptor returns a gRPC unary server interceptor that extracts metadata into the context.
 //
-// Requests with ignorable methods bypass extraction.
+// Requests with ignorable unary methods bypass extraction.
 //
 // For non-ignored methods, the interceptor:
 //
@@ -70,19 +70,15 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 
 // StreamServerInterceptor returns a gRPC stream server interceptor that extracts metadata into the stream context.
 //
-// Requests with ignorable methods bypass extraction.
+// Stream methods always run metadata extraction. This keeps long-lived operation streams, such as health Watch,
+// visible to downstream stream interceptors that need request metadata for resource controls.
 //
-// For non-ignored methods, the interceptor performs the same metadata-to-context
-// projection as [UnaryServerInterceptor], but applies it to the wrapped stream
-// context and emits response headers through the stream API.
+// The interceptor performs the same metadata-to-context projection as [UnaryServerInterceptor], but applies it to
+// the wrapped stream context and emits response headers through the stream API.
 func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, generator id.Generator) grpc.StreamServerInterceptor {
 	serviceVersion := version.String()
 
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if strings.IsOperationMethod(info.FullMethod) {
-			return handler(srv, stream)
-		}
-
 		ctx := stream.Context()
 		ua := serverUserAgent(ctx, userAgent)
 
@@ -91,9 +87,17 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 		kind, ip := serverIPAddr(ctx)
 		geolocation := serverGeolocation(ctx)
 
-		auth, err := serverAuthorization(ctx)
-		if err != nil {
-			return status.SafeError(codes.InvalidArgument, err)
+		// Operation streams still need metadata for limiting, but they keep the same auth bypass as unary
+		// operation methods.
+		var auth meta.Value
+		if strings.IsOperationMethod(info.FullMethod) {
+			auth = meta.Blank()
+		} else {
+			a, err := serverAuthorization(ctx)
+			if err != nil {
+				return status.SafeError(codes.InvalidArgument, err)
+			}
+			auth = a
 		}
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),

--- a/net/grpc/strings/doc.go
+++ b/net/grpc/strings/doc.go
@@ -1,7 +1,8 @@
 // Package strings provides gRPC-specific string helpers for net-layer middleware.
 //
 // This package contains helpers for parsing gRPC full method names and matching standard transport
-// operation RPCs that can bypass auth, limiter, and logging middleware.
+// operation RPCs that selected middleware can treat specially, such as auth, logging, or unary-only limiter
+// bypasses.
 //
 // Start with `SplitServiceMethod` and `IsOperationMethod`.
 package strings

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -153,6 +153,37 @@ func TestWatch(t *testing.T) {
 	requireWatchStaysOpen(t, cancel, wc)
 }
 
+func TestWatchServerLimiter(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"),
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
+	)
+	requireGRPCReady(t, world)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+	req := &health.Request{Service: test.Name.String()}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	wc, err := client.Watch(ctx, req)
+	require.NoError(t, err)
+
+	resp, err := wc.Recv()
+	require.NoError(t, err)
+	require.Equal(t, health.Serving, resp.GetStatus())
+
+	rejected, err := client.Watch(t.Context(), req)
+	if err == nil {
+		_, err = rejected.Recv()
+	}
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
 func TestInvalidWatch(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -43,7 +43,9 @@ type Server struct {
 
 // UnaryServerInterceptor returns a gRPC unary server interceptor that enforces rate limiting.
 //
-// Operation RPC methods (health/metrics/etc.) bypass limiting (see `net/grpc/strings.IsOperationMethod`).
+// Operation unary RPC methods (health/metrics/etc.) bypass limiting (see `net/grpc/strings.IsOperationMethod`).
+// Stream RPCs do not bypass limiting because long-lived streams, such as health Watch, can hold server resources
+// until the client disconnects.
 //
 // On every request, the interceptor calls `limiter.Take(ctx)` to determine whether the request is allowed:
 //
@@ -76,7 +78,8 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 
 // StreamServerInterceptor returns a gRPC stream server interceptor that enforces rate limiting.
 //
-// Operation RPC methods (health/metrics/etc.) bypass limiting (see `net/grpc/strings.IsOperationMethod`).
+// Unlike unary RPCs, operation streams are limited. This keeps long-lived streams, such as health Watch, from
+// bypassing the resource controls that protect regular service streams.
 //
 // On every stream, the interceptor calls `limiter.Take(ctx)` to determine whether the stream is allowed:
 //
@@ -87,11 +90,7 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 //
 // Callers should only install this interceptor when limiter is non-nil.
 func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
-	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if strings.IsOperationMethod(info.FullMethod) {
-			return handler(srv, stream)
-		}
-
+	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ok, header, err := limiter.Take(stream.Context())
 		if err != nil {
 			return status.SafeError(codes.Internal, err)


### PR DESCRIPTION
## What

- Limit server-side gRPC stream RPCs, including health Watch, instead of letting operation streams bypass rate limiting.
- Keep stream metadata extraction enabled for operation streams so limiter keys can use user-agent, IP, or token metadata while preserving auth bypass for operation-stream authorization metadata.
- Add gRPC metadata and health Watch regression coverage and update docs for unary-only limiter bypass.

## Why

- Health Watch streams are long-lived and can hold server resources, so they need the same limiter controls as service streams.
- Unary operation checks stay cheap and unauthenticated, while stream behavior is documented explicitly.

## Testing

- `go test ./net/grpc/... ./transport/...` - passed
- `make lint` - passed
