### PR TITLE
feat(mvc): reject directory static assets

### DIFF
--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -141,6 +141,16 @@ func serveFile(res http.ResponseWriter, name string) {
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		res.WriteHeader(staticStatusCode(err))
+		return
+	}
+	if info.IsDir() {
+		res.WriteHeader(http.StatusNotFound)
+		return
+	}
+
 	setStaticContentType(res, name)
 	res.WriteHeader(http.StatusOK)
 	_, _ = io.Copy(res, f)

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -62,6 +62,27 @@ func TestStaticPathValueSetsContentType(t *testing.T) {
 	require.Equal(t, "image/svg+xml", res.Header().Get(content.TypeKey))
 }
 
+func TestStaticPathValueRejectsDirectory(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/assets": &fstest.MapFile{Mode: fs.ModeDir},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticPathValue("/{file...}", "file", "static"))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/assets", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+}
+
 func TestStaticFileSetsContentType(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
@@ -82,6 +103,27 @@ func TestStaticFileSetsContentType(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, "image/svg+xml", res.Header().Get(content.TypeKey))
+}
+
+func TestStaticFileRejectsDirectory(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/assets": &fstest.MapFile{Mode: fs.ModeDir},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticFile("/assets", "static/assets"))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/assets", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
 }
 
 func TestViewRenderReturnsContextError(t *testing.T) {


### PR DESCRIPTION
## What

- Reject static asset requests that resolve to directories before writing response headers.
- Return `404 Not Found` for directory entries served through `StaticFile` or `StaticPathValue`.
- Add regression coverage for both static-file registration paths.

## Why

- Static serving should only return `200 OK` for files, not directory entries.
- Rejecting directories avoids misleading cache/client behavior and removes a status-code signal that a directory exists as a served asset.

## Testing

- `go test ./net/http/mvc` - passed
- `go test ./net/... ./transport/...` - passed
- `make lint` - passed
