### PR TITLE
feat(mvc): advertise asset lengths and clarify error rendering

### DIFF
--- a/net/http/mvc/controller.go
+++ b/net/http/mvc/controller.go
@@ -15,6 +15,9 @@ import "github.com/alexfalkowski/go-service/v2/context"
 // Error behavior in server wiring:
 // When a controller returns a non-nil err, the handler produced by Route writes a status code derived from the
 // error (via net/http/status.Code) and renders the returned view using the error value as the template model.
+// That error is client-visible when the template renders it directly or through the `mvcModelError` metadata value;
+// controllers should therefore return errors that are safe for their views to expose, or map internal failures to a
+// separate safe presentation model.
 // Implementations should therefore ensure view is non-nil even in error cases, or accept that rendering may panic.
 type Controller[Model any] func(ctx context.Context) (*View, *Model, error)
 

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/fs"
 	"path"
+	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -65,6 +66,8 @@ func Patch[Model any](pattern string, controller Controller[Model]) bool {
 //
 // If controller returns an error, the handler renders the returned view using the error value as the template
 // model and writes the corresponding status code (see net/http/status.Code) only after rendering succeeds.
+// Since the error model and `mvcModelError` metadata are available to templates, controller errors should already
+// be safe for client-visible rendering.
 // If rendering itself fails, the handler writes the render error status instead.
 func Route[Model any](pattern string, controller Controller[Model]) bool {
 	if !IsDefined() {
@@ -152,6 +155,7 @@ func serveFile(res http.ResponseWriter, name string) {
 	}
 
 	setStaticContentType(res, name)
+	setStaticContentLength(res, info.Size())
 	res.WriteHeader(http.StatusOK)
 	_, _ = io.Copy(res, f)
 }
@@ -167,6 +171,12 @@ func setStaticContentType(res http.ResponseWriter, name string) {
 	mediaType := media.TypeByExtension(path.Ext(name))
 	if !strings.IsEmpty(mediaType) {
 		res.Header().Set(content.TypeKey, media.WithUTF8(mediaType))
+	}
+}
+
+func setStaticContentLength(res http.ResponseWriter, size int64) {
+	if size >= 0 {
+		res.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	}
 }
 

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -465,7 +465,7 @@ func TestNotFoundDoesNotReplaceMethodNotAllowed(t *testing.T) {
 	require.NotContains(t, res.Body.String(), "custom")
 }
 
-func TestStaticFileStreamsBody(t *testing.T) {
+func TestStaticFileSetsContentLength(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
 		Mux:         mux,
@@ -483,6 +483,7 @@ func TestStaticFileStreamsBody(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "6", res.Header().Get("Content-Length"))
 	require.Equal(t, "hello", res.Body.String())
 }
 
@@ -526,7 +527,7 @@ func (errFileInfo) Name() string {
 }
 
 func (errFileInfo) Size() int64 {
-	return 5
+	return 6
 }
 
 func (errFileInfo) Mode() fs.FileMode {


### PR DESCRIPTION
## What

- Set `Content-Length` for static file responses from the registered filesystem.
- Document that controller errors are client-visible when templates render the error model or `mvcModelError` metadata.
- Update the static file test to cover advertised response lengths.

## Why

- Let clients detect truncated static file responses instead of accepting short bodies as complete.
- Make the existing error-rendering contract explicit so controllers map internal failures to safe presentation errors when needed.

## Testing

- `go test ./net/http/mvc` - passed
- `go test ./net/http/...` - passed
- `go test ./net/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
