### PR TITLE
fix(http): separate request body ownership

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -204,18 +204,21 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 //
 //nolint:cyclop
 func (c *Client) Do(ctx context.Context, method, url string, opts Options) error {
-	buffer := c.pool.Get()
-	defer c.pool.Put(buffer)
-
 	mediaType := c.content.NewFromMedia(opts.ContentType)
 
+	body := io.Reader(http.NoBody)
 	if opts.HasRequest() {
-		if err := mediaType.Encoder.Encode(buffer, opts.Request); err != nil {
+		var requestBody bytes.Buffer
+		if err := mediaType.Encoder.Encode(&requestBody, opts.Request); err != nil {
 			return errors.Prefix("http: encode", err)
 		}
+
+		// Do not use a pooled buffer for the request body: net/http may keep
+		// reading it from a transport goroutine after Do returns.
+		body = bytes.NewReader(requestBody.Bytes())
 	}
 
-	request, err := http.NewRequestWithContext(ctx, method, url, buffer)
+	request, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return errors.Prefix("http: new request", err)
 	}
@@ -229,9 +232,10 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 
 	defer response.Body.Close()
 
-	buffer.Reset()
+	responseBody := c.pool.Get()
+	defer c.pool.Put(responseBody)
 
-	if err := c.readResponse(buffer, response.Body); err != nil {
+	if err := c.readResponse(responseBody, response.Body); err != nil {
 		return err
 	}
 
@@ -246,7 +250,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 			code = http.StatusInternalServerError
 		}
 
-		return status.Error(code, strings.TrimSpace(buffer.String()))
+		return status.Error(code, strings.TrimSpace(responseBody.String()))
 	}
 
 	if isErrorStatus(response.StatusCode) {
@@ -254,7 +258,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	}
 
 	if opts.HasResponse() {
-		if err := media.Encoder.Decode(buffer, opts.Response); err != nil {
+		if err := media.Encoder.Decode(responseBody, opts.Response); err != nil {
 			return errors.Prefix("http: decode", err)
 		}
 	}

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,4 +116,33 @@ func TestDoUsesDefaultMaxResponseSize(t *testing.T) {
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.NoError(t, err)
 	require.Equal(t, 4*bytes.MB, client.DefaultMaxResponseSize)
+}
+
+func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
+	var body io.ReadCloser
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		body = req.Body
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{content.TypeKey: []string{media.Text}},
+			Body:       io.NopCloser(strings.NewReader("response")),
+		}, nil
+	})))
+
+	err := c.Post(t.Context(), "http://example.com", client.Options{
+		ContentType: media.JSON,
+		Request:     &test.Request{Name: "Bob"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, body)
+
+	data, _, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"Name":"Bob"}`, string(data))
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
## What

- Stop using a pooled buffer as the outbound request body in the content-aware client.
- Keep pooled buffering for response bodies only, with the response buffer named for that role.
- Add a regression test that verifies the request body remains readable after the response path reuses pooled response storage.

## Why

- The Go HTTP transport can continue reading a request body from a transport goroutine after `Do` returns, so returning or reusing a pooled request buffer can race with the transport.
- Keeping request-body ownership separate prevents the observed race while preserving response buffering and size-limit behavior.

## Testing

- `go test ./net/http/client` - passed
- `go test -race ./net/http/client` - passed
- `go test -race ./transport/http` - passed
- `go test ./net/http/...` - passed
- `go test ./net/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
