### PR TITLE
feat(transport): add retry idempotency policies

### DIFF
--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
-	ctx := meta.WithAttributes(context.Background(),
+	ctx := meta.WithAttributes(t.Context(),
 		meta.WithUserAgent(meta.String("current-agent")),
 		meta.WithRequestID(meta.String("current-id")),
 	)
@@ -35,7 +35,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 }
 
 func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
-	ctx := meta.WithAttributes(context.Background(),
+	ctx := meta.WithAttributes(t.Context(),
 		meta.WithUserAgent(meta.String("current-agent")),
 		meta.WithRequestID(meta.String("current-id")),
 	)
@@ -62,7 +62,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
+	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
@@ -76,7 +76,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 
 func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
+	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
@@ -91,7 +91,7 @@ func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 
 func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
+	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
@@ -106,7 +106,7 @@ func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 
 func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(context.Background(), meta.Map{})
+	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 	stream := &serverStream{ctx: ctx}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(any, grpc.ServerStream) error {
@@ -119,7 +119,7 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 
 func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
 	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(context.Background(), meta.Pairs(
+	ctx := meta.NewIncomingContext(t.Context(), meta.Pairs(
 		"authorization", "invalid",
 		"user-agent", "watch-agent",
 	))
@@ -134,7 +134,7 @@ func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
 }
 
 func TestExtractIncomingReturnsMutableCopy(t *testing.T) {
-	ctx := meta.NewIncomingContext(context.Background(), meta.Pairs("request-id", "original"))
+	ctx := meta.NewIncomingContext(t.Context(), meta.Pairs("request-id", "original"))
 
 	md := meta.ExtractIncoming(ctx)
 	md.Set("request-id", "changed")
@@ -144,8 +144,15 @@ func TestExtractIncomingReturnsMutableCopy(t *testing.T) {
 	require.Equal(t, []string{"original"}, original.Get("request-id"))
 }
 
+func TestExtractIncomingReturnsEmptyMapWithoutMetadata(t *testing.T) {
+	md := meta.ExtractIncoming(t.Context())
+
+	require.NotNil(t, md)
+	require.Empty(t, md)
+}
+
 func TestExtractOutgoingReturnsMutableCopy(t *testing.T) {
-	ctx := meta.NewOutgoingContext(context.Background(), meta.Pairs("request-id", "original"))
+	ctx := meta.NewOutgoingContext(t.Context(), meta.Pairs("request-id", "original"))
 
 	md := meta.ExtractOutgoing(ctx)
 	md.Set("request-id", "changed")
@@ -153,6 +160,13 @@ func TestExtractOutgoingReturnsMutableCopy(t *testing.T) {
 	original, ok := meta.FromOutgoingContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, []string{"original"}, original.Get("request-id"))
+}
+
+func TestExtractOutgoingReturnsEmptyMapWithoutMetadata(t *testing.T) {
+	md := meta.ExtractOutgoing(t.Context())
+
+	require.NotNil(t, md)
+	require.Empty(t, md)
 }
 
 type staticGenerator string

--- a/net/grpc/strings/strings.go
+++ b/net/grpc/strings/strings.go
@@ -20,6 +20,11 @@ func Contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
 
+// HasPrefix is an alias for strings.HasPrefix.
+func HasPrefix(s, prefix string) bool {
+	return strings.HasPrefix(s, prefix)
+}
+
 // Concat is an alias for strings.Concat.
 func Concat(ss ...string) string {
 	return strings.Concat(ss...)

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -26,6 +26,12 @@ const MethodDelete = http.MethodDelete
 // MethodGet is an alias of http.MethodGet.
 const MethodGet = http.MethodGet
 
+// MethodHead is an alias of http.MethodHead.
+const MethodHead = http.MethodHead
+
+// MethodOptions is an alias of http.MethodOptions.
+const MethodOptions = http.MethodOptions
+
 // MethodPatch is an alias of http.MethodPatch.
 const MethodPatch = http.MethodPatch
 

--- a/net/net.go
+++ b/net/net.go
@@ -111,7 +111,8 @@ func JoinHostPort(host, port string) string {
 
 // DefaultAddress returns a go-service server address in the form "tcp://:<port>".
 //
-// This is commonly used as a default bind address when only a port is configured.
+// This binds all interfaces by default so containerized workloads remain reachable through
+// their pod/container IPs by Kubernetes Services, probes, ingress controllers, and sidecars.
 func DefaultAddress(port string) string {
 	return NetworkAddress("tcp", ":"+port)
 }

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -36,6 +36,7 @@ type clientOpts struct {
 	security          *tls.Config
 	logger            *logger.Logger
 	retry             *retry.Config
+	retryPolicies     []retry.Policy
 	limiter           *limiter.Client
 	userAgent         env.UserAgent
 	id                env.UserID
@@ -107,11 +108,13 @@ func WithClientKeepalive(ping, timeout time.Duration) ClientOption {
 //
 // Retries are applied via a unary client interceptor. The retry policy is derived from cfg and
 // typically includes a maximum attempt count, per-retry timeout, and a backoff strategy.
+// Optional policies decide whether a logical unary RPC is eligible for retry.
 //
 // If cfg is nil, retries are not enabled.
-func WithClientRetry(cfg *retry.Config) ClientOption {
+func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.retry = cfg
+		o.retryPolicies = policies
 	})
 }
 
@@ -146,20 +149,22 @@ func WithClientDialOption(opts ...grpc.DialOption) ClientOption {
 	})
 }
 
-// WithClientUnaryInterceptors prepends custom unary client interceptors.
+// WithClientUnaryInterceptors adds custom unary client interceptors after metadata propagation.
 //
-// Interceptors provided here are executed before the standard interceptors added by this package
-// (timeout, retry, breaker, logging, token injection, metadata propagation, etc.).
+// Metadata propagation runs first so custom interceptors see the resolved user-agent and request-id.
+// Interceptors provided here then run before the remaining standard interceptors added by this package
+// (timeout, retry, breaker, logging, token injection, etc.).
 func WithClientUnaryInterceptors(unary ...grpc.UnaryClientInterceptor) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.unary = unary
 	})
 }
 
-// WithClientStreamInterceptors prepends custom stream client interceptors.
+// WithClientStreamInterceptors adds custom stream client interceptors after metadata propagation.
 //
-// Interceptors provided here are executed before the standard interceptors added by this package
-// (logging, token injection, metadata propagation, etc.).
+// Metadata propagation runs first so custom interceptors see the resolved user-agent and request-id.
+// Interceptors provided here then run before the remaining standard interceptors added by this package
+// (logging, token injection, limiter, etc.).
 func WithClientStreamInterceptors(stream ...grpc.StreamClientInterceptor) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.stream = stream
@@ -219,6 +224,8 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //   - if TLS is enabled, TLS config is constructed using the package-registered filesystem (see `Register`)
 //     to resolve TLS source strings.
 //   - otherwise, insecure transport credentials are used.
+//     This default is intended for local and in-cluster/container traffic where transport security is provided
+//     at the platform boundary; use WithClientTLS for calls outside that trusted boundary.
 func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
 	os := options(opts...)
 
@@ -287,23 +294,24 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 // UnaryClientInterceptors builds the unary client interceptor chain derived from opts.
 //
 // Order matters. Interceptors are appended in the following sequence:
+//   - metadata propagation interceptor (user-agent and request-id)
 //   - any custom interceptors provided via `WithClientUnaryInterceptors`
 //   - a timeout interceptor
 //   - optional retry interceptor (when configured)
 //   - optional circuit breaker interceptor (when enabled via `WithClientBreaker`)
 //   - optional logging interceptor (when configured)
 //   - optional token injection interceptor (when configured)
-//   - metadata propagation interceptor (user-agent and request-id)
 //   - optional limiter interceptor (when configured)
 func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor {
 	os := options(opts...)
 	unary := []grpc.UnaryClientInterceptor{}
 
+	unary = append(unary, meta.UnaryClientInterceptor(os.userAgent, os.generator))
 	unary = append(unary, os.unary...)
 	unary = append(unary, grpc.TimeoutUnaryClientInterceptor(os.timeout))
 
 	if os.retry != nil {
-		unary = append(unary, retry.UnaryClientInterceptor(os.retry))
+		unary = append(unary, retry.UnaryClientInterceptor(os.retry, os.retryPolicies...))
 	}
 
 	if os.breaker {
@@ -318,7 +326,6 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 		unary = append(unary, token.UnaryClientInterceptor(os.id, os.gen))
 	}
 
-	unary = append(unary, meta.UnaryClientInterceptor(os.userAgent, os.generator))
 	if os.limiter != nil {
 		unary = append(unary, limiter.UnaryClientInterceptor(os.limiter))
 	}
@@ -328,6 +335,7 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 
 func streamDialOption(opts *clientOpts) grpc.DialOption {
 	stream := []grpc.StreamClientInterceptor{}
+	stream = append(stream, meta.StreamClientInterceptor(opts.userAgent, opts.generator))
 	stream = append(stream, opts.stream...)
 
 	if opts.logger != nil {
@@ -338,7 +346,6 @@ func streamDialOption(opts *clientOpts) grpc.DialOption {
 		stream = append(stream, token.StreamClientInterceptor(opts.id, opts.gen))
 	}
 
-	stream = append(stream, meta.StreamClientInterceptor(opts.userAgent, opts.generator))
 	if opts.limiter != nil {
 		stream = append(stream, limiter.StreamClientInterceptor(opts.limiter))
 	}

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -1,8 +1,11 @@
 package retry
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 )
@@ -15,12 +18,44 @@ import (
 //   - `Backoff`: backoff duration used by the chosen backoff strategy.
 type Config = config.Config
 
+// Policy decides whether a unary RPC is eligible for retry.
+//
+// Policies describe operation safety, not transient failure classification. The retry interceptor still only retries
+// configured gRPC status codes after the policy allows the logical RPC.
+type Policy func(ctx context.Context, fullMethod string, req any) bool
+
+// AllowAll allows retries for every unary RPC.
+func AllowAll(context.Context, string, any) bool {
+	return true
+}
+
+// StandardReadMethods allows retries for AIP-style read methods named Get* or List*.
+func StandardReadMethods(_ context.Context, fullMethod string, _ any) bool {
+	_, method, _ := strings.SplitServiceMethod(fullMethod)
+
+	return strings.HasPrefix(method, "Get") || strings.HasPrefix(method, "List")
+}
+
+// HasRequestID allows retries when request metadata contains a request id.
+//
+// A request id only makes write retries safe when the server treats it as an idempotency key and deduplicates
+// repeated attempts for the same logical operation.
+func HasRequestID(ctx context.Context, _ string, _ any) bool {
+	return !meta.RequestID(ctx).IsEmpty()
+}
+
+// IdempotentMethods allows AIP-style read methods, or requests with a request-id idempotency contract.
+func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
+	return StandardReadMethods(ctx, fullMethod, req) || HasRequestID(ctx, fullMethod, req)
+}
+
 // UnaryClientInterceptor returns a gRPC unary client interceptor that retries failed calls.
 //
 // The interceptor is built using `go-grpc-middleware`'s retry interceptor and is intended to be used on the
 // client side.
 //
 // Behavior:
+//   - It checks whether the logical RPC is eligible for retry using policies.
 //   - It uses the typed per-attempt timeout and backoff durations from cfg.
 //   - It retries up to `cfg.MaxAttempts()` total attempts (including the initial attempt).
 //   - It applies a per-attempt timeout (`retry.WithPerRetryTimeout`) so each attempt is bounded.
@@ -33,11 +68,43 @@ type Config = config.Config
 // Notes:
 // This interceptor does not automatically retry on every error; application-level errors that map to other
 // status codes will not be retried by default.
-func UnaryClientInterceptor(cfg *Config) grpc.UnaryClientInterceptor {
-	return retry.UnaryClientInterceptor(
+func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInterceptor {
+	policy := composePolicy(policies)
+	interceptor := retry.UnaryClientInterceptor(
 		retry.WithCodes(codes.Unavailable, codes.DataLoss),
 		retry.WithMax(uint(cfg.MaxAttempts())),
 		retry.WithBackoff(retry.BackoffLinear(cfg.Backoff.Duration())),
 		retry.WithPerRetryTimeout(cfg.Timeout.Duration()),
 	)
+
+	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if !policy(ctx, fullMethod, req) {
+			return invoker(ctx, fullMethod, req, resp, conn, opts...)
+		}
+
+		return interceptor(ctx, fullMethod, req, resp, conn, invoker, opts...)
+	}
+}
+
+func composePolicy(policies []Policy) Policy {
+	filtered := make([]Policy, 0, len(policies))
+	for _, policy := range policies {
+		if policy != nil {
+			filtered = append(filtered, policy)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return AllowAll
+	}
+
+	return func(ctx context.Context, fullMethod string, req any) bool {
+		for _, policy := range filtered {
+			if !policy(ctx, fullMethod, req) {
+				return false
+			}
+		}
+
+		return true
+	}
 }

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
@@ -39,6 +40,66 @@ func TestUnaryClientInterceptorRetriesWhenAttemptsIsTwo(t *testing.T) {
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/SayHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		if calls == 1 {
+			return status.Error(codes.Unavailable, "unavailable")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestUnaryClientInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, retry.StandardReadMethods)
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestUnaryClientInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, retry.StandardReadMethods)
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		if calls == 1 {
+			return status.Error(codes.Unavailable, "unavailable")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestUnaryClientInterceptorRetriesWhenPolicyAllowsRequestID(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, retry.IdempotentMethods)
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	calls := 0
+	err := interceptor(ctx, "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 		calls++
 		if calls == 1 {
 			return status.Error(codes.Unavailable, "unavailable")

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -34,6 +34,7 @@ type clientOpts struct {
 	roundTripper   http.RoundTripper
 	limiter        *limiter.Client
 	retry          *retry.Config
+	retryPolicies  []retry.Policy
 	tls            *tls.Config
 	logger         *logger.Logger
 	userAgent      env.UserAgent
@@ -103,11 +104,13 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 //
 // When configured, the composed RoundTripper will apply per-attempt timeouts and retry failed requests
 // according to cfg (attempt count, backoff, and which status codes are considered retryable).
+// Optional policies decide whether a logical request is eligible for retry.
 //
 // If cfg is nil, retries are not enabled.
-func WithClientRetry(cfg *retry.Config) ClientOption {
+func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.retry = cfg
+		o.retryPolicies = policies
 	})
 }
 
@@ -224,7 +227,7 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 	}
 
 	if os.retry != nil {
-		hrt = retry.NewRoundTripper(os.retry, hrt)
+		hrt = retry.NewRoundTripper(os.retry, hrt, os.retryPolicies...)
 	}
 
 	if os.breaker {

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -22,6 +23,40 @@ import (
 //   - `Backoff`: constant delay between retries.
 type Config = config.Config
 
+// Policy decides whether req is eligible for retry.
+//
+// Policies describe operation safety, not transient failure classification. The retry transport still only retries
+// retryable responses/errors after the policy allows the logical request.
+type Policy func(req *http.Request) bool
+
+// AllowAll allows retries for every request.
+func AllowAll(*http.Request) bool {
+	return true
+}
+
+// SafeMethods allows retries for HTTP methods that should not have request side effects.
+func SafeMethods(req *http.Request) bool {
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+// HasRequestID allows retries when request metadata contains a request id.
+//
+// A request id only makes write retries safe when the server treats it as an idempotency key and deduplicates
+// repeated attempts for the same logical operation.
+func HasRequestID(req *http.Request) bool {
+	return !meta.RequestID(req.Context()).IsEmpty()
+}
+
+// IdempotentRequests allows safe methods, or requests with a request-id idempotency contract.
+func IdempotentRequests(req *http.Request) bool {
+	return SafeMethods(req) || HasRequestID(req)
+}
+
 // ErrInvalidStatusCode indicates an HTTP response status code that is considered invalid in the context
 // of a retry decision.
 //
@@ -36,6 +71,7 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 // NewRoundTripper constructs a RoundTripper that applies per-attempt timeouts and retries.
 //
 // The constructed RoundTripper wraps hrt and, for each request:
+//   - checks whether the request is eligible for retry using policies, and
 //   - applies a per-attempt timeout derived from `cfg.Timeout`, and
 //   - retries responses and status errors with retryable HTTP status codes, and
 //   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`, and
@@ -49,10 +85,10 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 // Exhaustion behavior:
 //   - If retries are exhausted after retryable HTTP responses, the first retryable response is returned.
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
-func NewRoundTripper(cfg *Config, hrt http.RoundTripper) *RoundTripper {
+func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
 	backoff := retry.WithMaxRetries(cfg.MaxRetries(), retry.NewConstant(cfg.Backoff.Duration()))
 
-	return &RoundTripper{RoundTripper: hrt, timeout: cfg.Timeout, backoff: backoff}
+	return &RoundTripper{RoundTripper: hrt, timeout: cfg.Timeout, backoff: backoff, policy: composePolicy(policies)}
 }
 
 // RoundTripper wraps an underlying `http.RoundTripper` and retries requests according to its configuration.
@@ -69,6 +105,7 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper) *RoundTripper {
 type RoundTripper struct {
 	http.RoundTripper
 	backoff retry.Backoff
+	policy  Policy
 	timeout time.Duration
 }
 
@@ -92,6 +129,10 @@ type RoundTripper struct {
 // this implementation relies on `req.GetBody`; when it is nil for a request with a body, the first attempt
 // is still executed but any retryable result is treated as non-retryable to avoid reusing a consumed body.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.policy != nil && !r.policy(req) {
+		return r.RoundTripper.RoundTrip(req)
+	}
+
 	attempt := &roundTripAttempt{}
 
 	operation := func(ctx context.Context) (*http.Response, error) {
@@ -257,5 +298,28 @@ func statusError(retryErr, err error) error {
 func closeResponse(res *http.Response) {
 	if res != nil && res.Body != nil {
 		_ = res.Body.Close()
+	}
+}
+
+func composePolicy(policies []Policy) Policy {
+	filtered := make([]Policy, 0, len(policies))
+	for _, policy := range policies {
+		if policy != nil {
+			filtered = append(filtered, policy)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return AllowAll
+	}
+
+	return func(req *http.Request) bool {
+		for _, policy := range filtered {
+			if !policy(req) {
+				return false
+			}
+		}
+
+		return true
 	}
 }

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -77,6 +78,39 @@ func TestRoundTripperDoesNotRetryUnhandledStatusCode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	require.Equal(t, 1, rt.calls)
+}
+
+func TestRoundTripperDoesNotRetryWhenPolicyDeniesRequest(t *testing.T) {
+	rt := &roundTripper{codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt, retry.SafeMethods)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+	require.Equal(t, 1, rt.calls)
+}
+
+func TestRoundTripperRetriesWhenPolicyAllowsRequestID(t *testing.T) {
+	rt := &roundTripper{codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt, retry.IdempotentRequests)
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 2, rt.calls)
 }
 
 func TestRoundTripperReturnsLastRetryableResponseWhenExhausted(t *testing.T) {

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -31,9 +31,11 @@ type KeyMap map[string]KeyFunc
 //   - "ip": rate limit per client IP address (meta.IPAddr)
 //   - "token": rate limit per authorization token/header (meta.Authorization)
 //
-// These are simple defaults and may not be appropriate for all deployments. For example,
-// User-Agent can be spoofed, and IP-based keys behave differently behind NATs/proxies unless
-// meta.IPAddr is populated correctly by upstream middleware.
+// These defaults are intended for controlled service-to-service traffic where user agents,
+// forwarded IP headers, and authorization metadata are supplied by trusted clients or platform
+// infrastructure. They are not sufficient as public-edge anti-abuse controls when clients can
+// freely spoof headers; use trusted ingress, gateway, service-mesh, or post-auth identity limits
+// for those boundaries.
 func NewKeyMap() KeyMap {
 	return KeyMap{
 		"user-agent": meta.UserAgent,


### PR DESCRIPTION
## What

- Add HTTP and gRPC retry policy hooks and idempotency-oriented default helpers.
- Run gRPC client metadata before retries so request metadata is stable for policy checks.
- Document container/in-cluster defaults and limiter key trust boundaries.
- Re-export missing HTTP method and gRPC string helper aliases used by retry policies.

## Why

- Let callers opt into safer retry behavior for read/idempotent operations without breaking existing retry configuration.
- Make request-id metadata the shared retry/idempotency signal across HTTP and gRPC.
- Clarify deployment assumptions for Kubernetes/container networking and trusted service-to-service limiter keys.

## Testing

- `git diff --check` - passed
- `go test ./transport/http/retry ./transport/grpc/retry` - passed
- `go test ./net/... ./transport/...` - passed
- `make lint` - passed (gomodguard deprecation warning only)
