### PR TITLE
feat(http): protect mvc error rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ matching skill for the task.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
+- gRPC server reflection is intentionally always registered by `net/grpc.NewServer`; restrict public exposure at the bind address, TLS/auth, ingress, firewall, or service-mesh boundary.
+- MVC controller errors render a client-safe `mvc.Error` model; `mvcModelError` metadata intentionally remains the raw error string for compatibility and must not be rendered unless diagnostic detail exposure is acceptable.
 - JWT verification requires both the expected algorithm and a `kid` header.
 - `telemetry/header.Map.MustSecrets` can panic if secret resolution fails during config projection.
 - Health registration helpers require `*net/http.ServeMux`.

--- a/README.md
+++ b/README.md
@@ -737,6 +737,12 @@ The HTTP transport wraps the mux with `net/http.NewNotFoundHandler` so generated
 - MVC missing routes can use `net/http/mvc.NotFoundHandler` to render the registered MVC not-found view when the request accepts HTML (`Accept: text/html`) or is an HTMX request (`Hx-Request: true`).
 - Routes that match and write their own status are not replaced by this mux-level not-found handler.
 
+### HTTP MVC errors
+
+When an MVC controller returns an error, `net/http/mvc.Route` renders the returned view with a client-safe `mvc.Error` model. The model contains the HTTP status `Code` and safe client-visible `Message`.
+
+The raw error string remains available to templates as `mvcModelError` metadata for compatibility. Rendering that metadata can expose diagnostic details, so prefer `.Model.Message` for client-visible error pages.
+
 ### Transport configuration (servers)
 
 Transport config root is `transport.Config`:
@@ -762,6 +768,7 @@ Notes:
 - If address is omitted, defaults are `tcp://:8080` (HTTP) and `tcp://:9090` (gRPC).
 - `max_receive_size` limits inbound payload size. A zero value uses the default `4MB`.
 - For HTTP, `max_receive_size` applies per request body. For gRPC, it applies per inbound unary request and per inbound stream message.
+- MVC does not enforce its own body-size caps; supported HTTP server wiring applies `max_receive_size` before MVC handlers run, and go-service HTTP clients apply their configured response-size cap when reading responses.
 
 Receive-limit example:
 
@@ -823,6 +830,12 @@ Important note:
 - If you are using `go-service-template` or composing the standard bundles such as `module.Server`, `module.Client`, or `transport.Module`, the required transport registration is handled for you by DI.
 - You only need to call transport-level `Register(...)` functions yourself when you intentionally wire transports manually or compose lower-level packages outside the standard module graph.
 - If you are wiring server lifecycle manually, use `net/server.Register(...)`.
+
+### Forwarded IPs and reflection
+
+HTTP and gRPC metadata extraction intentionally trusts common forwarded IP headers/metadata such as `X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`, and `True-Client-IP`. Services that rely on extracted IPs for logging, policy, or rate limiting should only receive traffic through trusted edge infrastructure that strips or overwrites client-supplied forwarding headers.
+
+gRPC server reflection is intentionally always registered by `net/grpc.NewServer` so internal tooling can discover services. Services that should not expose reflection publicly should restrict access with bind addresses, TLS/client authentication, ingress policy, firewall rules, or service-mesh authorization.
 
 ### Transport Dependencies
 

--- a/internal/test/mvc.go
+++ b/internal/test/mvc.go
@@ -8,40 +8,38 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 )
 
-type (
-	// Todo is the view model for a single todo item in the embedded MVC fixtures.
-	//nolint:godox
-	Todo struct {
-		Title string
-		Done  bool
-	}
+// Todo is the view model for a single todo item in the embedded MVC fixtures.
+//
+//nolint:godox
+type Todo struct {
+	Title string
+	Done  bool
+}
 
-	// Page is the top-level view model rendered by the embedded MVC fixtures.
-	Page struct {
-		Title string
-		Todos []Todo
-	}
-)
+// Page is the top-level view model rendered by the embedded MVC fixtures.
+type Page struct {
+	Title string
+	Todos []Todo
+}
 
-var (
-	// FileSystem embeds the MVC templates and static assets used by tests.
-	//go:embed views/*.tmpl
-	//go:embed static/*.txt
-	FileSystem embed.FS
+// FileSystem embeds the MVC templates and static assets used by tests.
+//
+//go:embed views/*.tmpl
+//go:embed static/*.txt
+var FileSystem embed.FS
 
-	// Layout is the shared MVC layout used when rendering the embedded templates.
-	Layout = mvc.NewLayout("views/full.tmpl", "views/partial.tmpl")
+// Layout is the shared MVC layout used when rendering the embedded templates.
+var Layout = mvc.NewLayout("views/full.tmpl", "views/partial.tmpl")
 
-	// Model is the sample page rendered by MVC tests.
-	Model = Page{
-		Title: "My task list",
-		Todos: []Todo{
-			{Title: "Task 1", Done: false},
-			{Title: "Task 2", Done: true},
-			{Title: "Task 3", Done: true},
-		},
-	}
-)
+// Model is the sample page rendered by MVC tests.
+var Model = Page{
+	Title: "My task list",
+	Todos: []Todo{
+		{Title: "Task 1", Done: false},
+		{Title: "Task 2", Done: true},
+		{Title: "Task 3", Done: true},
+	},
+}
 
 func registerMVC(mux *http.ServeMux, logger *slog.Logger) {
 	mvc.Register(mvc.RegisterParams{

--- a/internal/test/views/error.tmpl
+++ b/internal/test/views/error.tmpl
@@ -1,5 +1,5 @@
 {{ define "content" }}
 
-<h1>{{ .Model.Error | quote }}</h1>
+<h1>{{ .Model.Message | quote }}</h1>
 
 {{ end }}

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -40,6 +40,14 @@
 //
 // NewServer always enables server reflection via reflection.Register.
 //
+// # Server reflection exposure
+//
+// gRPC server reflection is intentionally always registered by NewServer so internal tooling such as grpcurl can
+// discover services. This package does not provide a runtime switch to disable reflection or decide which callers
+// may use it. Services that should not expose reflection publicly should enforce that at the deployment boundary,
+// for example with bind addresses, TLS/client authentication, ingress policy, firewall rules, or service-mesh
+// authorization.
+//
 // # Telemetry and higher-level wiring
 //
 // This package is not responsible for full transport wiring (listeners, dial

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -340,7 +340,9 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 //   - max_send_msg_size
 //
 // This function always registers server reflection via reflection.Register so
-// tools such as grpcurl can discover services when reflection is permitted.
+// tools such as grpcurl can discover services. Deployments that should not expose
+// reflection publicly should restrict access with bind addresses, TLS/client
+// authentication, ingress policy, firewall rules, or service-mesh authorization.
 //
 // Any additional opts are appended after the keepalive options and may further
 // customize server behavior (for example interceptors, credentials, or stats handlers).
@@ -381,7 +383,8 @@ func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption)
 
 	server := grpc.NewServer(os...)
 	// security: reflection is intentionally always enabled for go-service
-	// servers so internal tooling can discover registered services.
+	// servers so internal tooling can discover registered services. Restrict
+	// public exposure at the network/auth boundary when needed.
 	reflection.Register(server)
 
 	return server

--- a/net/header/doc.go
+++ b/net/header/doc.go
@@ -3,5 +3,9 @@
 // This package currently focuses on Bearer Authorization header parsing and shared forwarding header names so
 // HTTP and gRPC integrations can use the same metadata semantics.
 //
+// Forwarded IP headers are accepted as trusted inputs by transport metadata extraction. Services that rely on
+// extracted IPs for access logs, policy, or rate limiting should only receive traffic through trusted edge
+// infrastructure that strips or overwrites client-supplied forwarding headers.
+//
 // Start with `ParseBearer` and `ForwardedIPs`.
 package header

--- a/net/header/header.go
+++ b/net/header/header.go
@@ -17,6 +17,9 @@ const BearerAuthorization = "Bearer"
 var (
 	// ForwardedIPs lists the forwarding headers used to derive a client IP address.
 	//
+	// Metadata extraction accepts these as trusted inputs, so callers should only rely on derived IPs behind
+	// trusted edge infrastructure that strips or overwrites client-supplied forwarding headers.
+	//
 	// The order reflects the preferred source when multiple headers are present.
 	ForwardedIPs = [...]ForwardedIP{
 		{HTTP: "X-Real-Ip", GRPC: "x-real-ip"},

--- a/net/http/mvc/controller.go
+++ b/net/http/mvc/controller.go
@@ -14,10 +14,9 @@ import "github.com/alexfalkowski/go-service/v2/context"
 //
 // Error behavior in server wiring:
 // When a controller returns a non-nil err, the handler produced by Route writes a status code derived from the
-// error (via net/http/status.Code) and renders the returned view using the error value as the template model.
-// That error is client-visible when the template renders it directly or through the `mvcModelError` metadata value;
-// controllers should therefore return errors that are safe for their views to expose, or map internal failures to a
-// separate safe presentation model.
+// error (via net/http/status.Code) and renders the returned view using a client-safe Error model.
+// The `mvcModelError` metadata value contains the raw error string for compatibility; templates that render it
+// can expose diagnostic details.
 // Implementations should therefore ensure view is non-nil even in error cases, or accept that rendering may panic.
 type Controller[Model any] func(ctx context.Context) (*View, *Model, error)
 

--- a/net/http/mvc/model.go
+++ b/net/http/mvc/model.go
@@ -1,0 +1,10 @@
+package mvc
+
+// Error is the client-safe model passed to MVC error views.
+type Error struct {
+	// Message is the safe, client-visible error message.
+	Message string
+
+	// Code is the HTTP status code associated with the error.
+	Code int
+}

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -64,10 +64,9 @@ func Patch[Model any](pattern string, controller Controller[Model]) bool {
 // The handler sets the response Content-Type to HTML and stores the request and response writer in the
 // request context (via net/http/meta) before invoking the controller.
 //
-// If controller returns an error, the handler renders the returned view using the error value as the template
-// model and writes the corresponding status code (see net/http/status.Code) only after rendering succeeds.
-// Since the error model and `mvcModelError` metadata are available to templates, controller errors should already
-// be safe for client-visible rendering.
+// If controller returns an error, the handler renders the returned view using a safe Error model and writes the
+// corresponding status code (see net/http/status.Code) only after rendering succeeds. The raw error remains
+// available as `mvcModelError` metadata for compatibility; templates that render it can expose diagnostic details.
 // If rendering itself fails, the handler writes the render error status instead.
 func Route[Model any](pattern string, controller Controller[Model]) bool {
 	if !IsDefined() {
@@ -82,8 +81,12 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 
 		view, model, err := controller(ctx)
 		if err != nil {
+			code := status.Code(err)
+			message := errors.SafeMessage(err, status.DefaultMessage(code))
+			model := &Error{Code: code, Message: message}
+
 			ctx = meta.WithAttributes(ctx, meta.NewPair("mvcModelError", meta.Error(err)))
-			writeView(ctx, res, view, err, status.Code(err))
+			writeView(ctx, res, view, model, model.Code)
 			return
 		}
 

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -163,7 +163,7 @@ func TestViewRenderReturnsWriteError(t *testing.T) {
 	require.ErrorIs(t, err, test.ErrFailed)
 }
 
-func TestRouteErrorIncludesMetaInTemplate(t *testing.T) {
+func TestRouteErrorIncludesSafeModelAndRawMetaInTemplate(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
 		Mux:         mux,
@@ -171,7 +171,7 @@ func TestRouteErrorIncludesMetaInTemplate(t *testing.T) {
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
 			"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
-			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ index .Meta "mvcModelError" }}{{ end }}`)},
+			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Message }} {{ index .Meta "mvcModelError" }}{{ end }}`)},
 		},
 		Pool:   test.Pool,
 		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
@@ -188,7 +188,7 @@ func TestRouteErrorIncludesMetaInTemplate(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Contains(t, res.Body.String(), fs.ErrInvalid.Error())
+	require.Contains(t, res.Body.String(), "400 http: bad request invalid argument")
 }
 
 func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
@@ -288,16 +288,16 @@ func TestNotFoundHandlesNotFound(t *testing.T) {
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
 			"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
-			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Err }}{{ end }}`)},
+			"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Message }}{{ end }}`)},
 		},
 		Pool:   test.Pool,
 		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
 	})
 
-	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *errorModel) {
-		return mvc.NewFullView("views/error.tmpl"), &errorModel{
-			Code: http.StatusNotFound,
-			Err:  status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound)),
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+		return mvc.NewFullView("views/error.tmpl"), &mvc.Error{
+			Code:    http.StatusNotFound,
+			Message: http.StatusText(http.StatusNotFound),
 		}
 	}))
 
@@ -381,16 +381,16 @@ func TestFallback(t *testing.T) {
 				FileSystem: fstest.MapFS{
 					"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
 					"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
-					"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Err }}{{ end }}`)},
+					"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Message }}{{ end }}`)},
 				},
 				Pool:   test.Pool,
 				Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
 			})
 
-			require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *errorModel) {
-				return mvc.NewPartialView("views/error.tmpl"), &errorModel{
-					Code: http.StatusNotFound,
-					Err:  status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound)),
+			require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+				return mvc.NewPartialView("views/error.tmpl"), &mvc.Error{
+					Code:    http.StatusNotFound,
+					Message: http.StatusText(http.StatusNotFound),
 				}
 			}))
 
@@ -449,8 +449,8 @@ func TestNotFoundDoesNotReplaceMethodNotAllowed(t *testing.T) {
 		Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
 	})
 
-	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *errorModel) {
-		return mvc.NewFullView("views/error.tmpl"), &errorModel{Code: http.StatusNotFound}
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+		return mvc.NewFullView("views/error.tmpl"), &mvc.Error{Code: http.StatusNotFound}
 	}))
 	require.True(t, mvc.Get("/hello", func(_ context.Context) (*mvc.View, *test.Page, error) {
 		return mvc.NewFullView("views/hello.tmpl"), &test.Model, nil
@@ -544,11 +544,6 @@ func (errFileInfo) IsDir() bool {
 
 func (errFileInfo) Sys() any {
 	return nil
-}
-
-type errorModel struct {
-	Err  error
-	Code int
 }
 
 type requestModel struct {

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -117,6 +117,11 @@ type View struct {
 // Render renders into an internal buffer before writing to the response so template execution failures do not
 // commit a partial response. If ctx is already canceled, Render returns the context error without executing the
 // template. Otherwise, Render returns any template execution error or final response write error.
+//
+// Size limits:
+// MVC does not enforce body size caps itself. In supported wiring, inbound request bodies are capped by the
+// transport HTTP server before MVC handlers run, and outbound response bodies are capped by go-service HTTP
+// clients when responses are read.
 func (v *View) Render(ctx context.Context, model any) error {
 	buffer := pool.Get()
 	defer pool.Put(buffer)

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -39,7 +39,7 @@ func WriteError(res http.ResponseWriter, err error) error {
 	code := Code(err)
 	res.WriteHeader(code)
 
-	_, writeErr := fmt.Fprintln(res, errors.SafeMessage(err, defaultSafeMessage(code)))
+	_, writeErr := fmt.Fprintln(res, errors.SafeMessage(err, DefaultMessage(code)))
 	return writeErr
 }
 

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -23,7 +23,7 @@ func Error(code int, msg string) error {
 // instead of err.Error(). If err already carries a status code, it is returned unchanged.
 func SafeError(code int, err error) error {
 	code = normalizeCode(code, err)
-	msg := defaultSafeMessage(code)
+	msg := DefaultMessage(code)
 
 	if err == nil {
 		return &statusError{code: code, error: msg, msg: msg}
@@ -93,6 +93,17 @@ func Errorf(code int, format string, a ...any) error {
 func IsError(err error) bool {
 	_, ok := coderFromError(err)
 	return ok
+}
+
+// DefaultMessage returns the default safe message for code.
+//
+// Unknown codes fall back to StatusInternalServerError.
+func DefaultMessage(code int) string {
+	if msg := http.StatusText(code); msg != "" {
+		return "http: " + strings.ToLower(msg)
+	}
+
+	return "http: " + strings.ToLower(http.StatusText(http.StatusInternalServerError))
 }
 
 // Code extracts the HTTP status code from err.
@@ -170,12 +181,4 @@ func (s *statusError) SafeMessage() string {
 // Unwrap returns the wrapped cause, if any.
 func (s *statusError) Unwrap() error {
 	return s.err
-}
-
-func defaultSafeMessage(code int) string {
-	if msg := http.StatusText(code); msg != "" {
-		return "http: " + strings.ToLower(msg)
-	}
-
-	return "http: " + strings.ToLower(http.StatusText(http.StatusInternalServerError))
 }

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -65,6 +65,11 @@ func TestWriteErrorUsesSafeMessage(t *testing.T) {
 	require.Equal(t, "http: unauthorized", strings.TrimSpace(res.Body.String()))
 }
 
+func TestDefaultMessage(t *testing.T) {
+	require.Equal(t, "http: bad request", httpstatus.DefaultMessage(http.StatusBadRequest))
+	require.Equal(t, "http: internal server error", httpstatus.DefaultMessage(999))
+}
+
 func TestSafeErrorAllowsNilCause(t *testing.T) {
 	err := httpstatus.SafeError(http.StatusUnauthorized, nil)
 

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -95,8 +95,8 @@ func TestRouteError(t *testing.T) {
 func TestNotFound(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
-	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *notFoundModel) {
-		return mvc.NewFullView("views/error.tmpl"), &notFoundModel{Error: http.StatusText(http.StatusNotFound)}
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+		return mvc.NewFullView("views/error.tmpl"), &mvc.Error{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
 	}))
 
 	header := http.Header{}
@@ -118,8 +118,8 @@ func TestNotFound(t *testing.T) {
 func TestNotFoundUsesContentFallbackWithoutHTMLAccept(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
-	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *notFoundModel) {
-		return mvc.NewFullView("views/error.tmpl"), &notFoundModel{Error: http.StatusText(http.StatusNotFound)}
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+		return mvc.NewFullView("views/error.tmpl"), &mvc.Error{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
 	}))
 
 	header := http.Header{}
@@ -137,8 +137,8 @@ func TestNotFoundUsesContentFallbackWithoutHTMLAccept(t *testing.T) {
 func TestNotFoundHandlesHTMXRequest(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
-	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *notFoundModel) {
-		return mvc.NewPartialView("views/error.tmpl"), &notFoundModel{Error: http.StatusText(http.StatusNotFound)}
+	require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+		return mvc.NewPartialView("views/error.tmpl"), &mvc.Error{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
 	}))
 
 	header := http.Header{}
@@ -250,8 +250,4 @@ func TestMissingViews(t *testing.T) {
 	}))
 	require.False(t, mvc.StaticFile("/robots.txt", "static/robots.txt"))
 	require.False(t, mvc.StaticPathValue("/{file}", "file", "static"))
-}
-
-type notFoundModel struct {
-	Error string
 }


### PR DESCRIPTION
## What

- Add a safe MVC error model for controller failures while preserving the raw `mvcModelError` metadata value for compatibility.
- Share default safe HTTP status text through `status.DefaultMessage` and reuse it from MVC and status error writing.
- Document trust boundaries for forwarded IP headers, always-on gRPC reflection, and MVC body-size limits.

## Why

- MVC error templates should have a client-safe model by default, while existing templates that intentionally read `mvcModelError` should still work with a clear warning about diagnostic detail exposure.
- Forwarded IP extraction and gRPC reflection are intentional defaults, so their deployment boundary expectations need to be visible at the public package surfaces.

## Testing

- `go test ./net/... ./transport/http ./transport/grpc ./transport/limiter` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed
