### PR TITLE
feat(grpc): document retry defaults and neutralize rpc logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,14 @@ matching skill for the task.
   `Config.MaxReceiveSize` before verification. Do not flag this as an
   unbounded-read issue unless the code path bypasses the transport server chain
   without an equivalent request-size cap.
+- HTTP webhook signing intentionally ignores the Standard Webhooks `Sign` error
+  because the current vendored implementation always returns nil. Do not flag
+  this unless the dependency behavior changes.
+- HTTP CloudEvents receiver registration intentionally ignores the current
+  CloudEvents constructor errors because supported wiring passes no protocol
+  options and uses the typed `ReceiverFunc`, which matches the SDK receive
+  handler shape. Do not flag this unless dependency behavior or call arguments
+  change.
 
 ## Testing, Style, And Docs
 

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -110,6 +110,10 @@ func WithClientKeepalive(ping, timeout time.Duration) ClientOption {
 // typically includes a maximum attempt count, per-retry timeout, and a backoff strategy.
 // Optional policies decide whether a logical unary RPC is eligible for retry.
 //
+// Backward compatibility: when no policy is provided, all unary RPCs are eligible for retry when they hit a
+// retryable gRPC status. New callers that only want side-effect-safe retries should pass
+// `transport/grpc/retry.IdempotentMethods` or another explicit policy.
+//
 // If cfg is nil, retries are not enabled.
 func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -4,5 +4,9 @@
 // client-side interceptors) and centralizes retry-related defaults used by the
 // transport stack.
 //
+// Backward compatibility: if no policy is passed to UnaryClientInterceptor, all unary RPCs are eligible for
+// retry when they hit a retryable gRPC status. New callers that only want side-effect-safe retries should pass
+// IdempotentMethods, StandardReadMethods, or another explicit policy.
+//
 // Start with `Config` and `UnaryClientInterceptor`.
 package retry

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -65,6 +65,11 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 // Retries are only attempted for selected gRPC status codes. This implementation currently retries on
 // `codes.Unavailable` and `codes.DataLoss` (see `retry.WithCodes` in the implementation).
 //
+// Policy behavior:
+// When no policy is provided, all unary RPCs are eligible for retry when they hit a retryable gRPC status.
+// This preserves historical behavior. New callers that only want side-effect-safe retries should pass
+// IdempotentMethods, StandardReadMethods, or another explicit policy.
+//
 // Notes:
 // This interceptor does not automatically retry on every error; application-level errors that map to other
 // status codes will not be retried by default.

--- a/transport/grpc/telemetry/logger/logger.go
+++ b/transport/grpc/telemetry/logger/logger.go
@@ -191,5 +191,5 @@ func CodeToLevel(code codes.Code) logger.Level {
 }
 
 func message(msg string) string {
-	return "grpc: get " + msg
+	return "grpc: " + msg
 }

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -106,6 +106,10 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 // according to cfg (attempt count, backoff, and which status codes are considered retryable).
 // Optional policies decide whether a logical request is eligible for retry.
 //
+// Backward compatibility: when no policy is provided, all requests are eligible for retry when they hit a
+// retryable transport error or status. New callers that only want side-effect-safe retries should pass
+// `transport/http/retry.IdempotentRequests` or another explicit policy.
+//
 // If cfg is nil, retries are not enabled.
 func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {

--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -10,4 +10,8 @@
 // In particular, when retries are triggered by HTTP responses (for example 429/503), the wrapper keeps the first
 // retryable response and returns that response if all retries fail. When retries are triggered by transport errors,
 // the original error is preserved.
+//
+// Backward compatibility: if no policy is passed to NewRoundTripper, all requests are eligible for retry when
+// they hit a retryable transport error or status. New callers that only want side-effect-safe retries should pass
+// IdempotentRequests, SafeMethods, or another explicit policy.
 package retry

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -82,6 +82,11 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 // `sethvargo/go-retry` expects a retry count, NewRoundTripper converts it via `cfg.MaxRetries()`
 // before wrapping the constant backoff in `WithMaxRetries`.
 //
+// Policy behavior:
+// When no policy is provided, all requests are eligible for retry when they hit a retryable transport error
+// or status. This preserves historical behavior. New callers that only want side-effect-safe retries should
+// pass IdempotentRequests, SafeMethods, or another explicit policy.
+//
 // Exhaustion behavior:
 //   - If retries are exhausted after retryable HTTP responses, the first retryable response is returned.
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
@@ -102,6 +107,7 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 // Important:
 // Many HTTP requests are not safe to retry unless they are idempotent or the server supports safe retries.
 // This transport does not attempt to determine idempotency; it only applies the configured retry policy.
+// If no policy is configured, all requests are eligible for retry for backward compatibility.
 type RoundTripper struct {
 	http.RoundTripper
 	backoff retry.Backoff


### PR DESCRIPTION
## What

- Documented HTTP and gRPC retry policy default behavior, including backward-compatible retry eligibility when no policy is provided.
- Added AGENTS notes for intentionally ignored Standard Webhooks and CloudEvents constructor errors under supported wiring.
- Removed the misleading `get` verb from gRPC telemetry log messages.

## Why

- Makes retry safety expectations explicit while preserving backward compatibility.
- Prevents future audit churn on intentional dependency behaviors.
- Keeps gRPC logs protocol-neutral.

## Testing

- `go test ./transport/http/retry ./transport/grpc/retry ./transport/grpc/telemetry/logger ./transport/http ./transport/grpc` - passed
- `git diff --check` - passed
- `make lint` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
