### PR TITLE
feat(http): harden server construction and response buffering

### DIFF
--- a/net/grpc/server/server.go
+++ b/net/grpc/server/server.go
@@ -51,20 +51,16 @@ func NewService(name string, grpc *grpc.Server, cfg *config.Config, logger *logg
 // via net.ListenNetworkAddress and then bound using net.Listen. Raw listen
 // addresses such as ":9090" default to the "tcp" network.
 //
-// On listen error, the returned *Server is still non-nil (and contains the
-// underlying *grpc.Server) to preserve existing behavior, but it will not have a
-// listener configured.
+// On listen error, NewServer returns nil and the listener error.
 func NewServer(server *grpc.Server, cfg *config.Config) (*Server, error) {
-	srv := &Server{server: server}
 	n, a := net.ListenNetworkAddress(cfg.Address)
 
 	l, err := net.Listen(context.Background(), n, a)
 	if err != nil {
-		return srv, err
+		return nil, err
 	}
 
-	srv.listener = l
-	return srv, nil
+	return &Server{server: server, listener: l}, nil
 }
 
 // Server wraps a *grpc.Server together with the net.Listener it serves on.

--- a/net/grpc/server/server_test.go
+++ b/net/grpc/server/server_test.go
@@ -29,3 +29,9 @@ func TestNewServerWithRawAddress(t *testing.T) {
 	require.NoError(t, srv.Shutdown(context.Background()))
 	require.NoError(t, <-errCh)
 }
+
+func TestNewServerWithInvalidNetwork(t *testing.T) {
+	srv, err := server.NewServer(grpc.NewServer(test.ConfigOptions, time.Second), &config.Config{Address: "invalid://:0"})
+	require.Error(t, err)
+	require.Nil(t, srv)
+}

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -30,6 +30,11 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 //
 // Successful responses are encoded into a pooled in-memory buffer before being written to the live
 // response writer, so encode failures do not leak partial success bodies.
+//
+// Size limits:
+// NewRequestHandler does not enforce request body size caps itself. In supported wiring, inbound request bodies
+// are capped by the transport HTTP server before content handlers run. Direct users should wrap the handler with
+// an equivalent request-size limit.
 func NewRequestHandler[Req any, Res any](cont *Content, handler RequestHandler[Req, Res]) http.HandlerFunc {
 	return newHandler(cont, func(ctx context.Context) (*Res, error) {
 		req := ptr.Zero[Req]()

--- a/net/http/mvc/writer.go
+++ b/net/http/mvc/writer.go
@@ -30,6 +30,10 @@ func (w *bufferedWriter) Write(p []byte) (int, error) {
 }
 
 func (w *bufferedWriter) WriteHeader(code int) {
+	if w.code != 0 {
+		return
+	}
+
 	w.code = code
 }
 

--- a/net/http/server/server.go
+++ b/net/http/server/server.go
@@ -44,7 +44,7 @@ func NewService(name string, http *http.Server, cfg *config.Config, logger *logg
 //
 // Listener lifecycle:
 // NewServer creates and stores the listener immediately. The listener is used by Serve/ServeTLS. If listener
-// creation fails, the returned Server is still non-nil (with nil listener) alongside the error.
+// creation fails, NewServer returns nil and the listener error.
 //
 // TLS behavior:
 // If cfg.TLS is non-nil, Serve will set the underlying http.Server.TLSConfig and call ServeTLS with empty
@@ -55,16 +55,14 @@ func NewService(name string, http *http.Server, cfg *config.Config, logger *logg
 // cfg.Address may use either the go-service "<network>://<address>" convention or a raw listen address such as
 // ":8080". Raw addresses default to the "tcp" network.
 func NewServer(server *http.Server, cfg *config.Config) (*Server, error) {
-	srv := &Server{server: server, tls: cfg.TLS}
 	n, a := net.ListenNetworkAddress(cfg.Address)
 
 	l, err := net.Listen(context.Background(), n, a)
 	if err != nil {
-		return srv, err
+		return nil, err
 	}
 
-	srv.listener = l
-	return srv, nil
+	return &Server{server: server, tls: cfg.TLS, listener: l}, nil
 }
 
 // Server adapts a *http.Server to the net/server.Server interface used by go-service.

--- a/net/http/server/server_test.go
+++ b/net/http/server/server_test.go
@@ -37,3 +37,9 @@ func TestNewServerWithRawAddress(t *testing.T) {
 	require.NoError(t, srv.Shutdown(context.Background()))
 	require.NoError(t, <-errCh)
 }
+
+func TestNewServerWithInvalidNetwork(t *testing.T) {
+	srv, err := server.NewServer(&http.Server{Handler: http.NewServeMux()}, &config.Config{Address: "invalid://:0"})
+	require.Error(t, err)
+	require.Nil(t, srv)
+}


### PR DESCRIPTION
## What

- Changed HTTP and gRPC server adapter constructors to return nil when listener creation fails.
- Added invalid-network tests for both server adapters.
- Made the MVC buffered writer preserve the first status code written.
- Documented that content request handlers rely on supported transport wiring, or an equivalent direct wrapper, for request body size caps.

## Why

- Keeps constructed server adapters in a valid state with a listener attached.
- Aligns MVC buffered response behavior with net/http ResponseWriter semantics.
- Makes the request-size trust boundary explicit for direct content handler users.

## Testing

- `go test ./net/http/server ./net/grpc/server ./net/http/content ./net/http/mvc ./net/http` - passed
- `git diff --check` - passed
- `go test ./net/...` - passed
- `make lint` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
