### PR TITLE
feat(http): isolate per-request retry budgets

### DIFF
--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -91,11 +91,9 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 //   - If retries are exhausted after retryable HTTP responses, the final retryable response is returned.
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
-	backoff := retry.WithMaxRetries(cfg.MaxRetries(), retry.NewConstant(cfg.Backoff.Duration()))
-
 	return &RoundTripper{
 		RoundTripper: hrt,
-		backoff:      backoff,
+		backoff:      cfg.Backoff,
 		policy:       composePolicy(policies),
 		timeout:      cfg.Timeout,
 		maxRetries:   cfg.MaxRetries(),
@@ -116,8 +114,8 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 // If no policy is configured, all requests are eligible for retry for backward compatibility.
 type RoundTripper struct {
 	http.RoundTripper
-	backoff    retry.Backoff
 	policy     Policy
+	backoff    time.Duration
 	timeout    time.Duration
 	maxRetries uint64
 }
@@ -152,7 +150,8 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return r.attempt(ctx, req, attempt)
 	}
 
-	res, err := retry.DoValue(req.Context(), r.backoff, operation)
+	backoff := retry.WithMaxRetries(r.maxRetries, retry.NewConstant(r.backoff.Duration()))
+	res, err := retry.DoValue(req.Context(), backoff, operation)
 	return res, err
 }
 

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -64,6 +64,29 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, rt.calls)
 }
 
+func TestRoundTripperUsesIndependentRetryBudgetPerRequest(t *testing.T) {
+	rt := &roundTripper{codes: []int{
+		http.StatusTooManyRequests, http.StatusOK,
+		http.StatusTooManyRequests, http.StatusOK,
+	}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	res, err = retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 4, rt.calls)
+}
+
 func TestRoundTripperDoesNotRetryUnhandledStatusCode(t *testing.T) {
 	rt := &roundTripper{codes: []int{http.StatusInternalServerError, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{


### PR DESCRIPTION
## What

- Store the retry backoff duration on the HTTP retry transport and create a fresh max-retry backoff for each RoundTrip call.
- Add regression coverage for reusing one retrying RoundTripper across sequential retryable requests.

## Why

- The previous stateful backoff was shared by all requests, so one request could exhaust retry budget for later requests.

## Testing

- `go test ./transport/http/retry ./transport/http` - passed
- `go test -race ./transport/http/retry` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
