### PR TITLE
feat(http): preserve failure status accounting

### DIFF
--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -115,6 +115,20 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 
 	s := r.opts.settings
 	s.Name = key
+	isSuccessful := s.IsSuccessful
+	s.IsSuccessful = func(err error) bool {
+		if err == nil {
+			return true
+		}
+		if _, ok := errors.AsType[responseError](err); ok {
+			return false
+		}
+		if isSuccessful != nil {
+			return isSuccessful(err)
+		}
+
+		return false
+	}
 
 	cb := breaker.NewCircuitBreaker(s)
 	actual, _ := r.breakers.LoadOrStore(key, cb)

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -31,10 +31,69 @@ func TestRoundTripperOpensOnTransportError(t *testing.T) {
 	require.ErrorIs(t, err, breaker.ErrOpenState)
 }
 
+func TestRoundTripperOpensOnFailureStatus(t *testing.T) {
+	rt := breaker.NewRoundTripper(
+		statusRoundTripper{status: http.StatusInternalServerError},
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+		breaker.WithFailureStatuses(http.StatusInternalServerError),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+}
+
+func TestRoundTripperCountsFailureStatusWithCustomIsSuccessful(t *testing.T) {
+	rt := breaker.NewRoundTripper(
+		statusRoundTripper{status: http.StatusInternalServerError},
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+			IsSuccessful: func(error) bool {
+				return true
+			},
+		}),
+		breaker.WithFailureStatuses(http.StatusInternalServerError),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+}
+
 type errorRoundTripper struct {
 	err error
 }
 
 func (r errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, r.err
+}
+
+type statusRoundTripper struct {
+	status int
+}
+
+func (r statusRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: r.status,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}, nil
 }


### PR DESCRIPTION
## What

- Wrap HTTP breaker success classification so configured failure-status responses always count as breaker failures.
- Preserve caller-provided `Settings.IsSuccessful` behavior for ordinary transport errors.
- Add regression coverage for failure-status tripping, including custom success predicates.

## Why

- Custom breaker settings could previously mark the synthetic response failure as successful, preventing configured 429/5xx failures from opening the breaker.

## Testing

- `go test ./transport/http/breaker ./transport/http` - passed
- `go test -race ./transport/http/breaker` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
