### PR TITLE
docs(transport): clarify request id retry semantics

### DIFF
--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -38,8 +38,10 @@ func StandardReadMethods(_ context.Context, fullMethod string, _ any) bool {
 
 // HasRequestID allows retries when request metadata contains a request id.
 //
-// A request id only makes write retries safe when the server treats it as an idempotency key and deduplicates
-// repeated attempts for the same logical operation.
+// In go-service, Request-Id identifies the logical request, not an individual wire attempt. The client metadata
+// middleware installs it outside the retry middleware, so all retry attempts for one logical request share the same
+// value. Services that retry writes should treat Request-Id as the idempotency key and deduplicate repeated attempts
+// by it.
 func HasRequestID(ctx context.Context, _ string, _ any) bool {
 	return !meta.RequestID(ctx).IsEmpty()
 }

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -46,8 +46,10 @@ func SafeMethods(req *http.Request) bool {
 
 // HasRequestID allows retries when request metadata contains a request id.
 //
-// A request id only makes write retries safe when the server treats it as an idempotency key and deduplicates
-// repeated attempts for the same logical operation.
+// In go-service, Request-Id identifies the logical request, not an individual wire attempt. The client metadata
+// middleware installs it outside the retry middleware, so all retry attempts for one logical request share the same
+// value. Services that retry writes should treat Request-Id as the idempotency key and deduplicate repeated attempts
+// by it.
 func HasRequestID(req *http.Request) bool {
 	return !meta.RequestID(req.Context()).IsEmpty()
 }


### PR DESCRIPTION
## What

- Clarify that `Request-Id` identifies the logical request across HTTP and gRPC retry attempts.
- Document that services retrying writes should treat `Request-Id` as the idempotency key and deduplicate repeated attempts by it.

## Why

- Make the retry policy contract explicit where `HasRequestID` enables write retries.
- Prevent future review confusion between per-attempt identifiers and logical request identifiers.

## Testing

- `go test ./transport/http/retry ./transport/grpc/retry` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
