### PR TITLE
docs(token): clarify unknown kind failure behavior

### DIFF
--- a/token/doc.go
+++ b/token/doc.go
@@ -22,12 +22,12 @@
 //
 // The Token facade is intentionally conservative when Config.Kind is unknown:
 //
-//   - Generate returns (nil, nil).
-//   - Verify returns (strings.Empty, nil).
+//   - Generate returns (nil, token/errors.ErrInvalidConfig).
+//   - Verify returns (strings.Empty, token/errors.ErrInvalidConfig).
 //
-// This makes “unknown token kind” behave like “feature disabled” in some wiring
-// scenarios, but it also means callers should treat a nil/empty successful result
-// as a signal to check configuration.
+// This makes “unknown token kind” fail closed instead of behaving like “feature
+// disabled” in wiring scenarios. Callers should treat ErrInvalidConfig as a
+// startup or deployment configuration issue.
 //
 // # Configuration and enablement
 //


### PR DESCRIPTION
## What

- Updated package GoDoc to state unknown kinds return token/errors.ErrInvalidConfig from Generate and Verify.

## Why

- Keeps public docs aligned with fail-closed facade behavior and existing tests.

## Testing

- go test ./token/... - passed
- make lint - passed
- make sec - passed
