### PR TITLE
feat(http): log http client transport errors

### DIFF
--- a/transport/http/telemetry/logger/logger.go
+++ b/transport/http/telemetry/logger/logger.go
@@ -88,6 +88,7 @@ type RoundTripper struct {
 //   - service/method: derived from the request (see `http.ParseServiceMethod`)
 //   - duration: wall-clock elapsed time
 //   - code: HTTP response status code (when available)
+//   - error: transport error (when present)
 //
 // Log level is derived from the status code:
 //   - 4xx → warn
@@ -115,7 +116,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		attrs = append(attrs, logger.Int(meta.CodeKey, resp.StatusCode))
 	}
 
-	message := logger.NewText(message(strings.Join(strings.Space, method, service)))
+	message := logger.NewMessage(message(strings.Join(strings.Space, method, service)), err)
 
 	r.logger.LogAttrs(ctx, respToLevel(resp), message, attrs...)
 	return resp, err

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -1,0 +1,38 @@
+package logger_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	httplogger "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripperLogsTransportError(t *testing.T) {
+	var logs bytes.Buffer
+	transportErr := errors.New("dial failed")
+	base := errorRoundTripper{err: transportErr}
+	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+	rt := httplogger.NewRoundTripper(&logger.Logger{Logger: slogLogger}, base)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/users", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.ErrorIs(t, err, transportErr)
+	require.Nil(t, res)
+	require.Contains(t, logs.String(), `"level":"ERROR"`)
+	require.Contains(t, logs.String(), `"error":"dial failed"`)
+}
+
+type errorRoundTripper struct {
+	err error
+}
+
+func (r errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, r.err
+}


### PR DESCRIPTION
- attach HTTP client transport errors to telemetry log messages
- document the emitted error attribute for HTTP client logging
- add a regression test for nil-response transport failures

Validation:
- go test ./transport/http/telemetry/logger ./telemetry/logger
- go test -race ./transport/http/telemetry/logger ./telemetry/logger
- go test ./telemetry/... ./net/http/telemetry ./net/grpc/telemetry ./transport/http/telemetry/... ./transport/grpc/telemetry/... ./database/sql/telemetry ./cache/telemetry
- go test -race ./telemetry/... ./net/http/telemetry ./net/grpc/telemetry ./transport/http/telemetry/... ./transport/grpc/telemetry/... ./database/sql/telemetry ./cache/telemetry
- make lint
- git diff --check
