### PR TITLE
docs(encoding): document decoder input bounds

### DIFF
--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -19,6 +19,10 @@ import "github.com/alexfalkowski/go-service/v2/io"
 // value so the decoder can mutate it (e.g. *MyStruct). Implementations may return an error if v is not
 // a supported type (for example encoding/errors.ErrInvalidType).
 //
+// Some implementations buffer the remaining contents of r before decoding. When r contains untrusted
+// input, callers must bound it before calling Decode. Standard go-service HTTP and cache wiring applies
+// those limits before values reach encoders.
+//
 // Implementations should return any underlying I/O errors and any parse/unmarshal errors produced by
 // their respective codecs.
 type Encoder interface {


### PR DESCRIPTION
## What

- Clarify the `encoding.Encoder` decode contract for implementations that buffer readers.

## Why

- Direct callers need to bound untrusted input before decoding, while standard go-service HTTP and cache wiring already applies those limits.

## Testing

- `go test ./encoding/...` - passed
- `make lint` - passed
