### PR TITLE
feat(cache): replace external driver backend

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -71,15 +71,15 @@ type Cache struct {
 //
 // For persistent backends such as Redis this can be a destructive operation for the selected database.
 // It is intentionally not called during lifecycle shutdown.
-func (c *Cache) Flush(_ context.Context) error {
-	return c.driver.Flush()
+func (c *Cache) Flush(ctx context.Context) error {
+	return c.driver.Flush(ctx)
 }
 
 // Remove deletes a cached key.
 //
 // If the key does not exist, driver behavior is implementation-specific.
-func (c *Cache) Remove(_ context.Context, key string) error {
-	return c.driver.Delete(key)
+func (c *Cache) Remove(ctx context.Context, key string) error {
+	return c.driver.Delete(ctx, key)
 }
 
 // Get loads a cached value for key into value.
@@ -88,8 +88,8 @@ func (c *Cache) Remove(_ context.Context, key string) error {
 // leaves value unchanged.
 //
 // The value parameter should be a pointer to the destination value (for example *MyStruct).
-func (c *Cache) Get(_ context.Context, key string, value any) error {
-	val, err := c.driver.Fetch(key)
+func (c *Cache) Get(ctx context.Context, key string, value any) error {
+	val, err := c.driver.Fetch(ctx, key)
 	if err != nil {
 		if driver.IsMissingError(err) || driver.IsExpiredError(err) {
 			return nil
@@ -107,16 +107,14 @@ func (c *Cache) Get(_ context.Context, key string, value any) error {
 // A TTL <= 0 is passed through to the driver; semantics are driver-specific (for example, it may mean
 // "no expiration" or "immediate expiration").
 //
-// TTL resolution is also driver-specific. The built-in in-memory `sync` driver provided by the vendored
-// cachego dependency uses whole-second expiry tracking, so sub-second TTLs should not be relied on with
-// that backend.
-func (c *Cache) Persist(_ context.Context, key string, value any, ttl time.Duration) error {
+// TTL resolution is driver-specific.
+func (c *Cache) Persist(ctx context.Context, key string, value any, ttl time.Duration) error {
 	enc, err := c.encode(value)
 	if err != nil {
 		return err
 	}
 
-	return c.driver.Save(key, enc, ttl.Duration())
+	return c.driver.Save(ctx, key, enc, ttl)
 }
 
 func (c *Cache) encode(value any) (string, error) {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
@@ -217,7 +218,7 @@ func TestMissingCache(t *testing.T) {
 
 	kind := cache.NewCache(params)
 	t.Cleanup(func() {
-		require.NoError(t, kind.Flush(t.Context()))
+		require.NoError(t, kind.Flush(context.Background()))
 	})
 	value := "existing"
 

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -19,7 +19,7 @@
 //
 // # TTL resolution
 //
-// TTL handling depends on the selected driver. In particular, the built-in in-memory `sync` driver comes
-// from an upstream dependency and currently tracks expiry at whole-second resolution. Sub-second TTLs may
-// therefore be rounded in driver-specific ways and should not be relied on with that backend.
+// TTL handling depends on the selected driver. The built-in in-memory `sync`
+// driver stores values in process memory and expires entries lazily when they
+// are read.
 package cache

--- a/cache/driver/doc.go
+++ b/cache/driver/doc.go
@@ -15,19 +15,18 @@
 //
 // The built-in Redis backend resolves its URL from a go-service "source
 // string", constructs a go-redis client, and instruments that client via
-// `cache/telemetry` before exposing it through the cachego Redis adapter.
+// `cache/telemetry` before exposing it through a context-aware driver.
 // Redis configuration is strict by design: `Config.Options["url"]` must exist
 // and be a string. The standard config fixtures provide that shape; callers that
 // build config manually should validate it before calling `NewDriver`.
 //
-// The built-in `sync` driver comes from the upstream cachego dependency and currently has whole-second TTL
-// resolution. Callers should not rely on sub-second expiration with that backend.
+// The built-in `sync` driver uses an in-process go-sync Map and lazily expires
+// entries when they are read.
 //
 // If the configured kind is unknown, `NewDriver` returns `ErrNotFound`.
 //
 // # Errors
 //
-// This package re-exports `cachego.ErrCacheExpired` as `ErrExpired` and provides
-// `IsExpiredError` / `IsMissingError` helpers to classify backend-specific miss conditions in a
-// backend-agnostic way.
+// This package provides `ErrExpired`, `ErrMissing`, and helper functions to
+// classify backend-specific miss conditions in a backend-agnostic way.
 package driver

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -11,18 +11,20 @@ import (
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
-	"github.com/faabiosr/cachego"
-	"github.com/faabiosr/cachego/redis"
-	"github.com/faabiosr/cachego/sync"
+	"github.com/alexfalkowski/go-service/v2/time"
 	client "github.com/redis/go-redis/v9"
 	notifications "github.com/redis/go-redis/v9/maintnotifications"
 )
 
-// ErrExpired is an alias for cachego.ErrCacheExpired.
+// ErrExpired is returned when a cache entry exists but is expired.
 //
-// Drivers may return this error (or wrap it) to indicate that a cache entry exists but is expired.
-// Use IsExpiredError to classify this condition.
-const ErrExpired = cachego.ErrCacheExpired
+// Drivers may wrap this error; use IsExpiredError to classify this condition.
+var ErrExpired = errors.New("cache: expired")
+
+// ErrMissing is returned when a cache entry does not exist.
+//
+// Drivers may wrap this error; use IsMissingError to classify this condition.
+var ErrMissing = errors.New("cache: missing")
 
 // ErrNotFound is returned when the configured cache driver kind is unknown.
 var ErrNotFound = errors.New("cache: driver not found")
@@ -62,10 +64,9 @@ type DriverParams struct {
 //
 // Supported kinds include:
 //   - "redis": Redis backend using github.com/redis/go-redis
-//   - "sync": in-memory backend using github.com/faabiosr/cachego/sync
+//   - "sync": in-memory backend using github.com/alexfalkowski/go-sync Map
 //
-// The built-in `sync` backend currently inherits whole-second TTL resolution from the upstream cachego
-// dependency, so callers should not rely on sub-second expiration with that backend.
+// The built-in `sync` backend stores values in process memory and expires entries lazily on access.
 //
 // If cfg.Kind is unknown, NewDriver returns ErrNotFound.
 func NewDriver(params DriverParams) (Driver, error) {
@@ -104,12 +105,29 @@ func NewDriver(params DriverParams) (Driver, error) {
 			},
 		})
 
-		return redis.New(redisClient), nil
+		return &redisDriver{client: redisClient}, nil
 	case "sync":
-		return sync.New(), nil
+		return &syncDriver{}, nil
 	default:
 		return nil, ErrNotFound
 	}
+}
+
+// Driver is the minimal cache backend interface used by the cache facade.
+//
+// Implementations must honor the provided context for blocking operations.
+type Driver interface {
+	// Delete removes the cached key.
+	Delete(ctx context.Context, key string) error
+
+	// Fetch retrieves the cached value for key.
+	Fetch(ctx context.Context, key string) (string, error)
+
+	// Flush removes all cached keys managed by the driver.
+	Flush(ctx context.Context) error
+
+	// Save stores value under key for the provided lifetime.
+	Save(ctx context.Context, key, value string, lifetime time.Duration) error
 }
 
 // IsExpiredError reports whether err represents an expired cache entry.
@@ -123,19 +141,11 @@ func IsExpiredError(err error) bool {
 // IsMissingError reports whether err represents a missing cache entry.
 //
 // This helper normalizes the miss semantics of the backends currently supported by this package,
-// including Redis nil replies and the in-memory sync driver's plain "key not found" error.
+// including Redis nil replies.
 func IsMissingError(err error) bool {
 	if errors.Is(err, client.Nil) {
 		return true
 	}
 
-	return err != nil && err.Error() == "key not found"
+	return errors.Is(err, ErrMissing)
 }
-
-// Driver is an alias for cachego.Cache.
-//
-// It is the minimal interface used by the cache facade (`cache.Cache`) for persistence operations:
-// fetch/save/delete/flush.
-//
-// The alias preserves the upstream cachego interface shape exactly.
-type Driver = cachego.Cache

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	redis "github.com/redis/go-redis/v9"
@@ -18,7 +19,7 @@ func TestIsMissingError(t *testing.T) {
 	d, err := driver.NewDriver(driver.DriverParams{Config: cfg})
 	require.NoError(t, err)
 
-	_, err = d.Fetch("missing")
+	_, err = d.Fetch(t.Context(), "missing")
 	require.True(t, driver.IsMissingError(err))
 	require.True(t, driver.IsMissingError(redis.Nil))
 	require.True(t, driver.IsMissingError(errors.Prefix("wrapped", redis.Nil)))
@@ -45,6 +46,19 @@ func TestRedisClientClosesOnStop(t *testing.T) {
 	lc.RequireStart()
 	lc.RequireStop()
 
-	_, err = d.Fetch("missing")
+	_, err = d.Fetch(t.Context(), "missing")
 	require.ErrorIs(t, err, redis.ErrClosed)
+}
+
+func TestSyncDriverHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync"}})
+	require.NoError(t, err)
+	require.ErrorIs(t, d.Save(ctx, "key", "value", 0), context.Canceled)
+	_, err = d.Fetch(ctx, "key")
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, d.Delete(ctx, "key"), context.Canceled)
+	require.ErrorIs(t, d.Flush(ctx), context.Canceled)
 }

--- a/cache/driver/logger.go
+++ b/cache/driver/logger.go
@@ -1,8 +1,7 @@
 package driver
 
 import (
-	"context"
-
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/cache/driver/redis.go
+++ b/cache/driver/redis.go
@@ -1,0 +1,33 @@
+package driver
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/time"
+	client "github.com/redis/go-redis/v9"
+)
+
+type redisDriver struct {
+	client *client.Client
+}
+
+func (d *redisDriver) Delete(ctx context.Context, key string) error {
+	return d.client.Del(ctx, key).Err()
+}
+
+func (d *redisDriver) Fetch(ctx context.Context, key string) (string, error) {
+	value, err := d.client.Get(ctx, key).Result()
+	if errors.Is(err, client.Nil) {
+		return "", ErrMissing
+	}
+
+	return value, err
+}
+
+func (d *redisDriver) Flush(ctx context.Context) error {
+	return d.client.FlushDB(ctx).Err()
+}
+
+func (d *redisDriver) Save(ctx context.Context, key, value string, lifetime time.Duration) error {
+	return d.client.Set(ctx, key, value, lifetime.Duration()).Err()
+}

--- a/cache/driver/sync.go
+++ b/cache/driver/sync.go
@@ -1,0 +1,76 @@
+package driver
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/time"
+	sync "github.com/alexfalkowski/go-sync"
+)
+
+type syncDriver struct {
+	items sync.Map[string, syncEntry]
+}
+
+type syncEntry struct {
+	expiresAt time.Time
+	value     string
+}
+
+func (d *syncDriver) Delete(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	d.items.Delete(key)
+
+	return nil
+}
+
+func (d *syncDriver) Fetch(ctx context.Context, key string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	value, ok := d.items.Load(key)
+	if !ok {
+		return "", ErrMissing
+	}
+
+	if !value.expiresAt.IsZero() && time.Now().After(value.expiresAt) {
+		d.items.Delete(key)
+
+		return "", ErrExpired
+	}
+
+	return value.value, nil
+}
+
+func (d *syncDriver) Flush(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	d.items.Clear()
+
+	return nil
+}
+
+func (d *syncDriver) Save(ctx context.Context, key, value string, lifetime time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	d.items.Store(key, syncEntry{
+		expiresAt: expiresAt(lifetime),
+		value:     value,
+	})
+
+	return nil
+}
+
+func expiresAt(lifetime time.Duration) time.Time {
+	if lifetime <= 0 {
+		return time.Time{}
+	}
+
+	return time.Now().Add(lifetime.Duration())
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/cristalhq/acmd v0.12.0
 	github.com/docker/go-units v0.5.0
-	github.com/faabiosr/cachego v0.26.0
 	github.com/felixge/fgprof v0.9.5
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-playground/validator/v10 v10.30.2
@@ -109,6 +108,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lib/pq v1.12.3 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/faabiosr/cachego v0.26.0 h1:EDDv2y9T0XJ4Cx3tUhbKSUayGWxCGkkZUivNLceHRWY=
-github.com/faabiosr/cachego v0.26.0/go.mod h1:p54WXVzeB1CctH1ix/rjqv1EotNzD0Xoxk2IsR1PQX8=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/fgprof v0.9.5 h1:8+vR6yu2vvSKn08urWyEuxx75NWPEvybbkBirEpsbVY=

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -2,12 +2,13 @@ package test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/alexfalkowski/go-service/v2/cache"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,66 +17,46 @@ type Cache struct {
 	Value string
 }
 
-// Contains reports whether the cache contains the given key.
-func (c *Cache) Contains(_ string) bool {
-	return true
-}
-
 // Delete removes the given key from the cache.
-func (c *Cache) Delete(_ string) error {
+func (c *Cache) Delete(context.Context, string) error {
 	return nil
 }
 
 // Fetch returns the cached value.
-func (c *Cache) Fetch(_ string) (string, error) {
+func (c *Cache) Fetch(context.Context, string) (string, error) {
 	return c.Value, nil
 }
 
-// FetchMulti returns cached values for the given keys.
-func (c *Cache) FetchMulti(_ []string) map[string]string {
-	return map[string]string{}
-}
-
 // Flush clears the cache.
-func (c *Cache) Flush() error {
+func (c *Cache) Flush(context.Context) error {
 	return nil
 }
 
 // Save stores the value in the cache for the given TTL.
-func (c *Cache) Save(_, _ string, _ time.Duration) error {
+func (c *Cache) Save(context.Context, string, string, time.Duration) error {
 	return nil
 }
 
 // ErrCache is a cache.Cache test double that fails lookup and mutation operations with ErrFailed.
 type ErrCache struct{}
 
-// Contains reports whether the cache contains the given key.
-func (*ErrCache) Contains(_ string) bool {
-	return true
-}
-
 // Delete removes the given key from the cache.
-func (*ErrCache) Delete(_ string) error {
+func (*ErrCache) Delete(context.Context, string) error {
 	return ErrFailed
 }
 
 // Fetch returns ErrFailed.
-func (*ErrCache) Fetch(_ string) (string, error) {
+func (*ErrCache) Fetch(context.Context, string) (string, error) {
 	return strings.Empty, ErrFailed
 }
 
-// FetchMulti returns cached values for the given keys.
-func (*ErrCache) FetchMulti(_ []string) map[string]string {
-	return map[string]string{}
-}
-
 // Flush clears the cache.
-func (*ErrCache) Flush() error {
+func (*ErrCache) Flush(context.Context) error {
 	return nil
 }
 
 // Save stores the value in the cache for the given TTL.
-func (*ErrCache) Save(_, _ string, _ time.Duration) error {
+func (*ErrCache) Save(context.Context, string, string, time.Duration) error {
 	return ErrFailed
 }
 


### PR DESCRIPTION
## What

- Replaces the cachego-backed cache driver with repo-owned Redis and in-memory driver implementations.
- Propagates caller contexts through cache driver operations and maps cache misses through driver-owned errors.
- Changes Redis flush behavior to clear only the selected database and updates cache driver docs and tests.
- Removes github.com/faabiosr/cachego from the module graph while keeping go-sqlite3 explicit as an indirect dependency.

## Why

- Avoids the previous Redis adapter behavior that used background contexts and global Redis flushing.
- Keeps cache behavior under this repository control while preserving the existing public cache facade.
- Uses the repo time package and go-sync typed map wrapper for consistency with local package conventions.

## Testing

- `go test ./cache/...` - passed
- `go test -race ./cache/driver` - passed
- `govulncheck ./cache/...` - passed
- `go test ./...` - passed
- `make lint` - passed (with an existing gomodguard deprecation warning)
