### PR TITLE
test(cache): clarify failing fake cleanup behavior

### DIFF
--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -37,7 +37,9 @@ func (c *Cache) Save(context.Context, string, string, time.Duration) error {
 	return nil
 }
 
-// ErrCache is a cache.Cache test double that fails lookup and mutation operations with ErrFailed.
+// ErrCache is a cache.Cache test double that fails fetch, delete, and save operations with ErrFailed.
+//
+// Flush succeeds so tests can use ErrCache in started worlds without turning cleanup into the failure under test.
 type ErrCache struct{}
 
 // Delete removes the given key from the cache.


### PR DESCRIPTION
## What

- Clarifies the ErrCache test double documentation to say fetch, delete, and save fail with ErrFailed.
- Documents that Flush intentionally succeeds so started-world cleanup does not become the failure under test.

## Why

- Aligns the internal test helper comment with its actual behavior after the cache driver interface changes.
- Preserves cleanup behavior for tests that use ErrCache to exercise operation failure paths.

## Testing

- `go test ./internal/test ./cache/...` - passed
- `make lint` - passed (with an existing gomodguard deprecation warning)
