### PR TITLE
test(testing): consolidate shared fixtures

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -23,7 +22,7 @@ import (
 func TestValidCache(t *testing.T) {
 	for _, tt := range cacheRoundTripCases() {
 		t.Run(tt.name, func(t *testing.T) {
-			testValidCacheCase(t, tt.config, tt.persist(), tt.get())
+			test.RequireCacheRoundTrip(t, tt.config, tt.persist(), tt.get())
 		})
 	}
 }
@@ -156,7 +155,7 @@ func TestErroneousSave(t *testing.T) {
 	t.Run("read from only falls back to configured encoder", func(t *testing.T) {
 		config := test.NewCacheConfig("sync", "none", "json", "redis")
 		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config))
-		require.NoError(t, world.Persist(t.Context(), "test", &readFromOnly{Name: "hello?"}, time.Minute))
+		require.NoError(t, world.Persist(t.Context(), "test", &test.ReadFromOnly{Name: "hello?"}, time.Minute))
 
 		var get test.Request
 		require.NoError(t, world.Get(t.Context(), "test", &get))
@@ -193,7 +192,7 @@ func TestWriteToOnlyUsesConfiguredEncoderOnGet(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config))
 	require.NoError(t, world.Persist(t.Context(), "test", &test.Request{Name: "hello?"}, time.Minute))
 
-	get := &writeToOnly{}
+	get := &test.WriteToOnly{}
 	require.NoError(t, world.Get(t.Context(), "test", get))
 	require.Equal(t, "hello?", get.Name)
 }
@@ -271,53 +270,9 @@ func cacheRoundTripCases() []cacheRoundTripCase {
 	return tests
 }
 
-func testValidCacheCase(t *testing.T, cfg *config.Config, persist, get any) {
-	t.Helper()
-
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg))
-
-	require.NoError(t, world.Persist(t.Context(), "test", persist, time.Minute))
-	require.NoError(t, world.Get(t.Context(), "test", get))
-	assertValidCacheValue(t, get)
-	require.NoError(t, world.Remove(t.Context(), "test"))
-}
-
-func assertValidCacheValue(t *testing.T, get any) {
-	t.Helper()
-
-	switch kind := get.(type) {
-	case *string:
-		require.Equal(t, "hello?", *kind)
-	case *bytes.Buffer:
-		require.Equal(t, strings.Bytes("hello?"), kind.Bytes())
-	case *v1.SayHelloRequest:
-		require.Equal(t, "hello?", kind.GetName())
-	case *test.Request:
-		require.Equal(t, "hello?", kind.Name)
-	default:
-		require.Fail(t, "invalid kind")
-	}
-}
-
 type cacheRoundTripCase struct {
 	persist func() any
 	get     func() any
 	config  *config.Config
 	name    string
-}
-
-type readFromOnly struct {
-	Name string `json:"name"`
-}
-
-func (*readFromOnly) ReadFrom(io.Reader) (int64, error) {
-	return 0, nil
-}
-
-type writeToOnly struct {
-	Name string `json:"name"`
-}
-
-func (*writeToOnly) WriteTo(io.Writer) (int64, error) {
-	return 0, nil
 }

--- a/cache/driver/benchmark_test.go
+++ b/cache/driver/benchmark_test.go
@@ -5,12 +5,8 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
-	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
-	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 var driverSink driver.Driver
@@ -18,9 +14,9 @@ var driverSink driver.Driver
 func BenchmarkRedisTelemetry(b *testing.B) {
 	bench := func(name string, setup func(testing.TB)) {
 		b.Run(name, func(b *testing.B) {
-			resetTelemetry(b)
+			test.ResetTelemetry(b)
 			setup(b)
-			defer resetTelemetry(b)
+			defer test.ResetTelemetry(b)
 
 			cfg := &config.Config{
 				Kind: "redis",
@@ -29,7 +25,7 @@ func BenchmarkRedisTelemetry(b *testing.B) {
 				},
 			}
 
-			lc := noopLifecycle{}
+			lc := test.NoopLifecycle{}
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -47,52 +43,7 @@ func BenchmarkRedisTelemetry(b *testing.B) {
 	}
 
 	bench("disabled", func(testing.TB) {})
-	bench("metrics", enableMetrics)
-	bench("tracer", enableTracer)
-	bench("enabled", enableTelemetry)
-}
-
-type noopLifecycle struct{}
-
-func (noopLifecycle) Append(di.Hook) {}
-
-func resetTelemetry(tb testing.TB) {
-	tb.Helper()
-
-	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
-	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
-}
-
-func enableMetrics(tb testing.TB) {
-	tb.Helper()
-
-	metrics.NewMeterProvider(metrics.MeterProviderParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &metrics.Config{},
-		Reader:      metrics.NewManualReader(),
-		ID:          test.ID,
-		Name:        test.Name,
-		Version:     test.Version,
-		Environment: test.Environment,
-	})
-}
-
-func enableTracer(tb testing.TB) {
-	tb.Helper()
-
-	require.NoError(tb, tracer.Register(tracer.TracerParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{Kind: "otlp"},
-		ID:          test.ID,
-		Name:        test.Name,
-		Version:     test.Version,
-		Environment: test.Environment,
-	}))
-}
-
-func enableTelemetry(tb testing.TB) {
-	tb.Helper()
-
-	enableMetrics(tb)
-	enableTracer(tb)
+	bench("metrics", test.EnableMetrics)
+	bench("tracer", test.EnableTracer)
+	bench("enabled", test.EnableTelemetry)
 }

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -1,14 +1,12 @@
 package cli_test
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/cli"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -226,7 +224,7 @@ func TestApplicationServerHonorsContextCancellation(t *testing.T) {
 	stopped := make(chan error, 1)
 	app := cli.NewApplication(
 		func(c cli.Commander) {
-			c.AddServer("server", "Start the server.", lifecycleOption(started, stopped))
+			c.AddServer("server", "Start the server.", test.LifecycleOption(started, stopped))
 		},
 	)
 
@@ -268,7 +266,7 @@ func TestApplicationServerShutdownExitCodeIsReturned(t *testing.T) {
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
-			c.AddServer("server", "Start the server.", shutdownExitCodeOption(3))
+			c.AddServer("server", "Start the server.", test.ShutdownExitCodeOption(3))
 		},
 	)
 
@@ -282,7 +280,7 @@ func TestApplicationServerServeFailureReturnsServeFailureExitCode(t *testing.T) 
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
-			c.AddServer("server", "Start the server.", serverFailureOption())
+			c.AddServer("server", "Start the server.", test.ServerFailureOption())
 		},
 	)
 
@@ -313,73 +311,4 @@ func TestApplicationInvalidClient(t *testing.T) {
 			require.Contains(t, err.Error(), "unknown port")
 		})
 	}
-}
-
-func lifecycleOption(started chan<- struct{}, stopped chan<- error) di.Option {
-	return di.Module(
-		di.Constructor(slog.Default),
-		di.Register(func(lc di.Lifecycle) {
-			lc.Append(di.Hook{
-				OnStart: func(context.Context) error {
-					// Signal readiness after Start has had a chance to return so cancellation
-					// exercises the post-start shutdown path instead of racing startup.
-					go func() {
-						time.Sleep(10 * time.Millisecond)
-						close(started)
-					}()
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					stopped <- ctx.Err()
-					return nil
-				},
-			})
-		}),
-	)
-}
-
-func shutdownExitCodeOption(code int) di.Option {
-	return di.Module(
-		di.NoLogger,
-		di.Constructor(slog.Default),
-		di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
-			lc.Append(di.Hook{
-				OnStart: func(context.Context) error {
-					go func() {
-						time.Sleep(10 * time.Millisecond)
-						_ = sh.Shutdown(di.ExitCode(code))
-					}()
-					return nil
-				},
-			})
-		}),
-	)
-}
-
-func serverFailureOption() di.Option {
-	return di.Module(
-		di.NoLogger,
-		di.Constructor(slog.Default),
-		di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
-			server.Register(lc, []*server.Service{
-				server.NewService("test", failingServer{}, nil, sh),
-			})
-		}),
-	)
-}
-
-type failingServer struct{}
-
-func (failingServer) Serve() error {
-	time.Sleep(10 * time.Millisecond)
-
-	return test.ErrFailed
-}
-
-func (failingServer) Shutdown(context.Context) error {
-	return nil
-}
-
-func (failingServer) String() string {
-	return "test"
 }

--- a/crypto/rand/rand_test.go
+++ b/crypto/rand/rand_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +21,7 @@ func TestValidRand(t *testing.T) {
 }
 
 func TestGenerateBytesUsesRawBytes(t *testing.T) {
-	gen := rand.NewGenerator(staticReader{data: []byte{0x00, 0x01, 0x7f, 0x80, 0xff}})
+	gen := rand.NewGenerator(test.StaticReader{Data: []byte{0x00, 0x01, 0x7f, 0x80, 0xff}})
 
 	data, err := gen.GenerateBytes(5)
 	require.NoError(t, err)
@@ -38,17 +37,4 @@ func TestInvalidRand(t *testing.T) {
 	gen = rand.NewGenerator(&test.ErrReaderCloser{})
 	_, err = gen.GenerateText(5)
 	require.Error(t, err)
-}
-
-type staticReader struct {
-	data []byte
-}
-
-func (s staticReader) Read(p []byte) (int, error) {
-	n := copy(p, s.data)
-	if n < len(p) {
-		return n, io.EOF
-	}
-
-	return n, nil
 }

--- a/database/sql/driver/benchmark_test.go
+++ b/database/sql/driver/benchmark_test.go
@@ -4,16 +4,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/database/sql/driver"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/io"
-	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
-	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 var driverID sync.Uint64
@@ -21,12 +16,12 @@ var driverID sync.Uint64
 func BenchmarkSQLTelemetry(b *testing.B) {
 	bench := func(name string, setup func(testing.TB)) {
 		b.Run(name, func(b *testing.B) {
-			resetTelemetry(b)
+			test.ResetTelemetry(b)
 			setup(b)
-			defer resetTelemetry(b)
+			defer test.ResetTelemetry(b)
 
 			driverName := "benchmark-sql-" + name + "-" + strconv.FormatUint(driverID.Add(1), 10)
-			require.NoError(b, driver.Register(driverName, benchmarkDriver{}))
+			require.NoError(b, driver.Register(driverName, test.BenchmarkSQLDriver{}))
 
 			db, err := sql.Open(driverName, "benchmark")
 			require.NoError(b, err)
@@ -45,86 +40,7 @@ func BenchmarkSQLTelemetry(b *testing.B) {
 	}
 
 	bench("disabled", func(testing.TB) {})
-	bench("metrics", enableMetrics)
-	bench("tracer", enableTracer)
-	bench("enabled", enableTelemetry)
-}
-
-type benchmarkDriver struct{}
-
-func (benchmarkDriver) Open(string) (driver.Conn, error) {
-	return benchmarkConn{}, nil
-}
-
-type benchmarkConn struct{}
-
-func (benchmarkConn) Prepare(string) (driver.Stmt, error) {
-	return nil, driver.ErrSkip
-}
-
-func (benchmarkConn) Close() error {
-	return nil
-}
-
-func (benchmarkConn) Begin() (driver.Tx, error) {
-	return nil, driver.ErrSkip
-}
-
-func (benchmarkConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
-	return benchmarkRows{}, nil
-}
-
-type benchmarkRows struct{}
-
-func (benchmarkRows) Columns() []string {
-	return []string{"value"}
-}
-
-func (benchmarkRows) Close() error {
-	return nil
-}
-
-func (benchmarkRows) Next([]driver.Value) error {
-	return io.EOF
-}
-
-func resetTelemetry(tb testing.TB) {
-	tb.Helper()
-
-	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
-	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
-}
-
-func enableMetrics(tb testing.TB) {
-	tb.Helper()
-
-	metrics.NewMeterProvider(metrics.MeterProviderParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &metrics.Config{},
-		Reader:      metrics.NewManualReader(),
-		ID:          test.ID,
-		Name:        test.Name,
-		Version:     test.Version,
-		Environment: test.Environment,
-	})
-}
-
-func enableTracer(tb testing.TB) {
-	tb.Helper()
-
-	require.NoError(tb, tracer.Register(tracer.TracerParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{Kind: "otlp"},
-		ID:          test.ID,
-		Name:        test.Name,
-		Version:     test.Version,
-		Environment: test.Environment,
-	}))
-}
-
-func enableTelemetry(tb testing.TB) {
-	tb.Helper()
-
-	enableMetrics(tb)
-	enableTracer(tb)
+	bench("metrics", test.EnableMetrics)
+	bench("tracer", test.EnableTracer)
+	bench("enabled", test.EnableTelemetry)
 }

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -48,12 +48,12 @@ func TestInvalidBinaryDecode(t *testing.T) {
 
 func TestInvalidBinaryDecodeDoesNotRead(t *testing.T) {
 	encoder := proto.NewBinary()
-	reader := &trackingReader{err: io.EOF}
+	reader := &test.TrackingReader{Err: io.EOF}
 
 	var msg string
 	err := encoder.Decode(reader, &msg)
 	require.ErrorIs(t, err, errors.ErrInvalidType)
-	require.Zero(t, reader.reads)
+	require.Zero(t, reader.Reads)
 }
 
 func TestValidTextEncoder(t *testing.T) {
@@ -93,12 +93,12 @@ func TestInvalidTextDecode(t *testing.T) {
 
 func TestInvalidTextDecodeDoesNotRead(t *testing.T) {
 	encoder := proto.NewText()
-	reader := &trackingReader{err: io.EOF}
+	reader := &test.TrackingReader{Err: io.EOF}
 
 	var msg string
 	err := encoder.Decode(reader, &msg)
 	require.ErrorIs(t, err, errors.ErrInvalidType)
-	require.Zero(t, reader.reads)
+	require.Zero(t, reader.Reads)
 }
 
 func TestValidJSONEncoder(t *testing.T) {
@@ -138,12 +138,12 @@ func TestInvalidJSONDecode(t *testing.T) {
 
 func TestInvalidJSONDecodeDoesNotRead(t *testing.T) {
 	encoder := proto.NewJSON()
-	reader := &trackingReader{err: io.EOF}
+	reader := &test.TrackingReader{Err: io.EOF}
 
 	var msg string
 	err := encoder.Decode(reader, &msg)
 	require.ErrorIs(t, err, errors.ErrInvalidType)
-	require.Zero(t, reader.reads)
+	require.Zero(t, reader.Reads)
 }
 
 func TestErrBinaryDecode(t *testing.T) {
@@ -162,14 +162,4 @@ func TestErrJSONDecode(t *testing.T) {
 	encoder := proto.NewJSON()
 	var msg health.Response
 	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &msg))
-}
-
-type trackingReader struct {
-	err   error
-	reads int
-}
-
-func (r *trackingReader) Read(_ []byte) (int, error) {
-	r.reads++
-	return 0, r.err
 }

--- a/errors/safe_test.go
+++ b/errors/safe_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,40 +17,12 @@ func TestSafeMessage(t *testing.T) {
 	}{
 		{name: "nil", want: "fallback"},
 		{name: "plain", err: errors.New("internal"), want: "fallback"},
-		{name: "wrapped", err: fmt.Errorf("wrapped: %w", safeError{msg: "safe"}), want: "safe"},
-		{name: "empty", err: emptySafeError{err: safeError{msg: "safe"}}, want: "safe"},
-		{name: "joined", err: errors.Join(errors.New("internal"), safeError{msg: "safe"}), want: "safe"},
+		{name: "wrapped", err: fmt.Errorf("wrapped: %w", test.SafeMessageError{Message: "safe"}), want: "safe"},
+		{name: "empty", err: test.EmptySafeMessageError{Err: test.SafeMessageError{Message: "safe"}}, want: "safe"},
+		{name: "joined", err: errors.Join(errors.New("internal"), test.SafeMessageError{Message: "safe"}), want: "safe"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, errors.SafeMessage(tc.err, "fallback"))
 		})
 	}
-}
-
-type safeError struct {
-	msg string
-}
-
-func (s safeError) Error() string {
-	return "internal"
-}
-
-func (s safeError) SafeMessage() string {
-	return s.msg
-}
-
-type emptySafeError struct {
-	err error
-}
-
-func (e emptySafeError) Error() string {
-	return "internal"
-}
-
-func (e emptySafeError) SafeMessage() string {
-	return ""
-}
-
-func (e emptySafeError) Unwrap() error {
-	return e.err
 }

--- a/internal/test/benchmark.go
+++ b/internal/test/benchmark.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+// ResetTelemetry disables global telemetry state for benchmarks and tests.
+func ResetTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
+}
+
+// EnableMetrics installs the shared test meter provider.
+func EnableMetrics(tb testing.TB) {
+	tb.Helper()
+
+	metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          ID,
+		Name:        Name,
+		Version:     Version,
+		Environment: Environment,
+	})
+}
+
+// EnableTracer installs the shared test tracer provider.
+func EnableTracer(tb testing.TB) {
+	tb.Helper()
+
+	require.NoError(tb, tracer.Register(tracer.TracerParams{
+		Lifecycle:   fxtest.NewLifecycle(tb),
+		Config:      &tracer.Config{Kind: "otlp"},
+		ID:          ID,
+		Name:        Name,
+		Version:     Version,
+		Environment: Environment,
+	}))
+}
+
+// EnableTelemetry installs the shared test meter and tracer providers.
+func EnableTelemetry(tb testing.TB) {
+	tb.Helper()
+
+	EnableMetrics(tb)
+	EnableTracer(tb)
+}

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -3,10 +3,14 @@ package test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/cache"
+	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
+	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -60,6 +64,56 @@ func (*ErrCache) Flush(context.Context) error {
 // Save stores the value in the cache for the given TTL.
 func (*ErrCache) Save(context.Context, string, string, time.Duration) error {
 	return ErrFailed
+}
+
+// RequireCacheRoundTrip persists a value, reads it back, and asserts the shared hello payload.
+func RequireCacheRoundTrip(tb testing.TB, cfg *config.Config, persist, get any) {
+	tb.Helper()
+
+	world := NewStartedWorld(tb, WithWorldCacheConfig(cfg))
+
+	require.NoError(tb, world.Persist(tb.Context(), "test", persist, time.Minute))
+	require.NoError(tb, world.Get(tb.Context(), "test", get))
+	RequireCacheValue(tb, get)
+	require.NoError(tb, world.Remove(tb.Context(), "test"))
+}
+
+// RequireCacheValue asserts that get contains the shared hello payload.
+func RequireCacheValue(tb testing.TB, get any) {
+	tb.Helper()
+
+	switch kind := get.(type) {
+	case *string:
+		require.Equal(tb, "hello?", *kind)
+	case *bytes.Buffer:
+		require.Equal(tb, strings.Bytes("hello?"), kind.Bytes())
+	case *v1.SayHelloRequest:
+		require.Equal(tb, "hello?", kind.GetName())
+	case *Request:
+		require.Equal(tb, "hello?", kind.Name)
+	default:
+		require.Fail(tb, "invalid kind")
+	}
+}
+
+// ReadFromOnly is a cache payload that implements io.ReaderFrom but relies on normal encoding.
+type ReadFromOnly struct {
+	Name string `json:"name"`
+}
+
+// ReadFrom implements io.ReaderFrom without consuming input.
+func (*ReadFromOnly) ReadFrom(io.Reader) (int64, error) {
+	return 0, nil
+}
+
+// WriteToOnly is a cache payload that implements io.WriterTo but relies on normal decoding.
+type WriteToOnly struct {
+	Name string `json:"name"`
+}
+
+// WriteTo implements io.WriterTo without writing output.
+func (*WriteToOnly) WriteTo(io.Writer) (int64, error) {
+	return 0, nil
 }
 
 func redisCache(lc di.Lifecycle) (*cache.Cache, error) {

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"log/slog"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
+
+// LifecycleOption returns a DI option that reports lifecycle start and stop events.
+func LifecycleOption(started chan<- struct{}, stopped chan<- error) di.Option {
+	return di.Module(
+		di.Constructor(slog.Default),
+		di.Register(func(lc di.Lifecycle) {
+			lc.Append(di.Hook{
+				OnStart: func(context.Context) error {
+					// Signal readiness after Start has had a chance to return so cancellation
+					// exercises the post-start shutdown path instead of racing startup.
+					go func() {
+						time.Sleep(10 * time.Millisecond)
+						close(started)
+					}()
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					stopped <- ctx.Err()
+					return nil
+				},
+			})
+		}),
+	)
+}
+
+// ShutdownExitCodeOption returns a DI option that requests shutdown with code.
+func ShutdownExitCodeOption(code int) di.Option {
+	return di.Module(
+		di.NoLogger,
+		di.Constructor(slog.Default),
+		di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
+			lc.Append(di.Hook{
+				OnStart: func(context.Context) error {
+					go func() {
+						time.Sleep(10 * time.Millisecond)
+						_ = sh.Shutdown(di.ExitCode(code))
+					}()
+					return nil
+				},
+			})
+		}),
+	)
+}
+
+// ServerFailureOption returns a DI option that registers a server whose Serve method fails.
+func ServerFailureOption() di.Option {
+	return di.Module(
+		di.NoLogger,
+		di.Constructor(slog.Default),
+		di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
+			server.Register(lc, []*server.Service{
+				server.NewService("test", DelayedFailingServer{}, nil, sh),
+			})
+		}),
+	)
+}
+
+// DelayedFailingServer is a server.Server test double whose Serve method fails after a short delay.
+type DelayedFailingServer struct{}
+
+// Serve returns ErrFailed after a short delay.
+func (DelayedFailingServer) Serve() error {
+	time.Sleep(10 * time.Millisecond)
+
+	return ErrFailed
+}
+
+// Shutdown implements server.Server and always succeeds.
+func (DelayedFailingServer) Shutdown(context.Context) error {
+	return nil
+}
+
+// String returns a stable identifier for logs and assertions.
+func (DelayedFailingServer) String() string {
+	return "test"
+}

--- a/internal/test/db.go
+++ b/internal/test/db.go
@@ -2,10 +2,61 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/database/sql/driver"
 	"github.com/alexfalkowski/go-service/v2/database/sql/pg"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
 )
+
+// BenchmarkSQLDriver is a database/sql driver test double that returns empty result sets.
+type BenchmarkSQLDriver struct{}
+
+// Open implements driver.Driver.
+func (BenchmarkSQLDriver) Open(string) (driver.Conn, error) {
+	return BenchmarkSQLConn{}, nil
+}
+
+// BenchmarkSQLConn is a database/sql connection test double.
+type BenchmarkSQLConn struct{}
+
+// Prepare implements driver.Conn and returns driver.ErrSkip.
+func (BenchmarkSQLConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+// Close implements driver.Conn and always succeeds.
+func (BenchmarkSQLConn) Close() error {
+	return nil
+}
+
+// Begin implements driver.Conn and returns driver.ErrSkip.
+func (BenchmarkSQLConn) Begin() (driver.Tx, error) {
+	return nil, driver.ErrSkip
+}
+
+// QueryContext implements driver.QueryerContext and returns empty rows.
+func (BenchmarkSQLConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return BenchmarkSQLRows{}, nil
+}
+
+// BenchmarkSQLRows is an empty rows test double.
+type BenchmarkSQLRows struct{}
+
+// Columns returns the value column.
+func (BenchmarkSQLRows) Columns() []string {
+	return []string{"value"}
+}
+
+// Close implements driver.Rows and always succeeds.
+func (BenchmarkSQLRows) Close() error {
+	return nil
+}
+
+// Next implements driver.Rows and returns io.EOF.
+func (BenchmarkSQLRows) Next([]driver.Value) error {
+	return io.EOF
+}
 
 func (w *World) registerDatabase() {
 	pg.Register()

--- a/internal/test/di.go
+++ b/internal/test/di.go
@@ -32,6 +32,12 @@ import (
 	webhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
 )
 
+// NoopLifecycle is a di.Lifecycle test double that ignores appended hooks.
+type NoopLifecycle struct{}
+
+// Append implements di.Lifecycle.
+func (NoopLifecycle) Append(di.Hook) {}
+
 // Options returns the DI options used by tests that exercise the full server module wiring.
 //
 // The option set decorates config, registers health checks and observers, and

--- a/internal/test/encoding.go
+++ b/internal/test/encoding.go
@@ -49,3 +49,17 @@ func (e *enc) Encode(_ io.Writer, _ any) error {
 func (e *enc) Decode(_ io.Reader, _ any) error {
 	return e.err
 }
+
+// PartialEncoder writes a partial payload and then fails encoding.
+type PartialEncoder struct{}
+
+// Encode writes a partial payload and returns ErrFailed.
+func (PartialEncoder) Encode(w io.Writer, _ any) error {
+	_, _ = io.WriteString(w, "partial")
+	return ErrFailed
+}
+
+// Decode implements encoding.Encoder and always succeeds.
+func (PartialEncoder) Decode(io.Reader, any) error {
+	return nil
+}

--- a/internal/test/error.go
+++ b/internal/test/error.go
@@ -21,6 +21,84 @@ var (
 	_ status.Coder = ErrInternal
 )
 
+// SafeMessageError is an error test double that exposes a safe message.
+type SafeMessageError struct {
+	Message string
+}
+
+// Error implements the error interface.
+func (e SafeMessageError) Error() string {
+	return "internal"
+}
+
+// SafeMessage returns the configured safe message.
+func (e SafeMessageError) SafeMessage() string {
+	return e.Message
+}
+
+// EmptySafeMessageError is an error test double that unwraps another error but has no safe message.
+type EmptySafeMessageError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e EmptySafeMessageError) Error() string {
+	return "internal"
+}
+
+// SafeMessage returns an empty safe message.
+func (e EmptySafeMessageError) SafeMessage() string {
+	return ""
+}
+
+// Unwrap returns the wrapped error.
+func (e EmptySafeMessageError) Unwrap() error {
+	return e.Err
+}
+
+// NilError is an error test double used for typed nil checks.
+type NilError struct{}
+
+// Error implements the error interface.
+func (e *NilError) Error() string {
+	return "nil"
+}
+
+// MessageError is an error test double that returns Message.
+type MessageError struct {
+	Message string
+}
+
+// Error implements the error interface.
+func (e *MessageError) Error() string {
+	return e.Message
+}
+
+// Stringer is an fmt.Stringer test double that returns Value.
+type Stringer struct {
+	Value string
+}
+
+// String implements fmt.Stringer.
+func (s *Stringer) String() string {
+	return s.Value
+}
+
+// CoderError is an error test double that exposes an HTTP status code.
+type CoderError struct {
+	StatusCode int
+}
+
+// Error implements the error interface.
+func (e *CoderError) Error() string {
+	return "custom"
+}
+
+// Code returns the configured status code.
+func (e *CoderError) Code() int {
+	return e.StatusCode
+}
+
 type internalError struct{}
 
 // Error implements the error interface.

--- a/internal/test/grpc.go
+++ b/internal/test/grpc.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+)
+
+// MetaServerStream is a grpc.ServerStream test double that records response headers.
+type MetaServerStream struct {
+	grpc.ServerStream
+	Header meta.Map
+	Ctx    context.Context
+}
+
+// Context returns Ctx.
+func (s *MetaServerStream) Context() context.Context {
+	return s.Ctx
+}
+
+// SetHeader records md after appending a service-version value.
+func (s *MetaServerStream) SetHeader(md meta.Map) error {
+	md.Append("service-version", "v2")
+	s.Header = md
+
+	return nil
+}
+
+// NewWatchStream returns a WatchStream with a buffered response channel.
+func NewWatchStream(ctx context.Context) *WatchStream {
+	return &WatchStream{Ctx: ctx, Responses: make(chan *health.Response, 4)}
+}
+
+// WatchStream is a grpc.ServerStream test double for health watch tests.
+type WatchStream struct {
+	grpc.ServerStream
+	Ctx       context.Context
+	Responses chan *health.Response
+}
+
+// Context returns Ctx.
+func (w *WatchStream) Context() context.Context {
+	return w.Ctx
+}
+
+// Send records resp or returns the context error if canceled.
+func (w *WatchStream) Send(resp *health.Response) error {
+	select {
+	case <-w.Ctx.Done():
+		return w.Ctx.Err()
+	case w.Responses <- resp:
+		return nil
+	}
+}
+
+// SetHeader implements grpc.ServerStream.
+func (*WatchStream) SetHeader(meta.Map) error {
+	return nil
+}
+
+// SendHeader implements grpc.ServerStream.
+func (*WatchStream) SendHeader(meta.Map) error {
+	return nil
+}
+
+// SetTrailer implements grpc.ServerStream.
+func (*WatchStream) SetTrailer(meta.Map) {}
+
+// SendMsg implements grpc.ServerStream.
+func (*WatchStream) SendMsg(any) error {
+	return nil
+}
+
+// RecvMsg implements grpc.ServerStream.
+func (*WatchStream) RecvMsg(any) error {
+	return nil
+}

--- a/internal/test/http.go
+++ b/internal/test/http.go
@@ -1,8 +1,15 @@
 package test
 
 import (
+	"fmt"
+	"io/fs"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 )
 
 // MessageMediaType describes an HTTP content type and its corresponding encoder kind.
@@ -43,4 +50,326 @@ func (w *ErrResponseWriter) Write([]byte) (int, error) {
 // WriteHeader stores code in the Code field.
 func (w *ErrResponseWriter) WriteHeader(code int) {
 	w.Code = code
+}
+
+// RoundTripperFunc adapts a function to http.RoundTripper.
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip calls f(req).
+func (f RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// ErrorRoundTripper is an http.RoundTripper test double that always returns Err.
+type ErrorRoundTripper struct {
+	Err   error
+	Calls int
+}
+
+// RoundTrip records the call and returns Err.
+func (r *ErrorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.Calls++
+	return nil, r.Err
+}
+
+// StatusRoundTripper is an http.RoundTripper test double that returns Status.
+type StatusRoundTripper struct {
+	Status int
+	Calls  int
+}
+
+// RoundTrip records the call and returns a response with Status.
+func (r *StatusRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.Calls++
+	return ResponseWithStatus(r.Status), nil
+}
+
+// StatusSequenceRoundTripper returns one response status for each call.
+type StatusSequenceRoundTripper struct {
+	Codes []int
+	Calls int
+}
+
+// RoundTrip records the call and returns the next status response.
+func (r *StatusSequenceRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	code := r.Codes[r.Calls]
+	r.Calls++
+
+	return ResponseWithStatus(code), nil
+}
+
+// BodySequenceRoundTripper returns service unavailable responses with configured bodies.
+type BodySequenceRoundTripper struct {
+	Responses []string
+	Calls     int
+}
+
+// RoundTrip records the call and returns the next response body.
+func (r *BodySequenceRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	body := r.Responses[r.Calls]
+	r.Calls++
+
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     StatusLine(http.StatusServiceUnavailable),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// RequestBodyRecorderRoundTripper records request bodies and returns Status.
+type RequestBodyRecorderRoundTripper struct {
+	Bodies []string
+	Status int
+}
+
+// RoundTrip records the request body and returns the configured status response.
+func (r *RequestBodyRecorderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Bodies = append(r.Bodies, string(body))
+
+	return ResponseWithStatus(defaultStatus(r.Status, http.StatusServiceUnavailable)), nil
+}
+
+// TransportErrorThenSuccessRoundTripper fails once, then returns Status.
+type TransportErrorThenSuccessRoundTripper struct {
+	Err    error
+	Bodies []string
+	Status int
+	Calls  int
+}
+
+// RoundTrip records the request body, returns Err on the first call, then succeeds.
+func (r *TransportErrorThenSuccessRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Calls++
+	r.Bodies = append(r.Bodies, string(body))
+	if r.Calls == 1 {
+		return nil, defaultError(r.Err, io.ErrUnexpectedEOF)
+	}
+
+	return ResponseWithStatus(defaultStatus(r.Status, http.StatusOK)), nil
+}
+
+// OriginalBodyRoundTripper records whether the first request used Original.
+type OriginalBodyRoundTripper struct {
+	Original          io.ReadCloser
+	Bodies            []string
+	Calls             int
+	FirstUsedOriginal bool
+}
+
+// RoundTrip records the request body and closes it.
+func (r *OriginalBodyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.Calls == 0 {
+		r.FirstUsedOriginal = req.Body == r.Original
+	}
+
+	body, _, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	r.Calls++
+	r.Bodies = append(r.Bodies, string(body))
+
+	return ResponseWithStatus(http.StatusServiceUnavailable), nil
+}
+
+// AuthRoundTripper records Authorization headers and returns configured status codes.
+type AuthRoundTripper struct {
+	AuthValues []string
+	AuthCounts []int
+	Codes      []int
+	Calls      int
+}
+
+// RoundTrip records the Authorization headers and returns the next status response.
+func (r *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.AuthValues = append(r.AuthValues, req.Header.Get("Authorization"))
+	r.AuthCounts = append(r.AuthCounts, len(req.Header.Values("Authorization")))
+	code := r.Codes[r.Calls]
+	r.Calls++
+
+	return ResponseWithStatus(code), nil
+}
+
+// CauseRoundTripper records the request context error and cause.
+type CauseRoundTripper struct {
+	Cause error
+	Err   error
+	Wait  bool
+}
+
+// RoundTrip optionally waits for cancellation, then records context state.
+func (r *CauseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.Wait {
+		<-req.Context().Done()
+	}
+
+	r.Cause = context.Cause(req.Context())
+	r.Err = req.Context().Err()
+
+	return ResponseWithStatus(http.StatusOK), nil
+}
+
+// NonReplayableReader is an io.Reader whose contents can only be read once.
+type NonReplayableReader struct {
+	Value string
+	read  bool
+}
+
+// Read copies Value on the first read and EOF afterwards.
+func (r *NonReplayableReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+
+	r.read = true
+	copy(p, r.Value)
+	return len(r.Value), io.EOF
+}
+
+// TrackedBody is an io.ReadCloser that records Close calls.
+type TrackedBody struct {
+	*strings.Reader
+	Closed bool
+}
+
+// Close records that the body was closed.
+func (b *TrackedBody) Close() error {
+	b.Closed = true
+	return nil
+}
+
+// UnknownLengthReader hides the concrete reader length from HTTP request construction.
+type UnknownLengthReader struct {
+	*strings.Reader
+}
+
+// HeaderDeletingRoundTripper deletes Header before calling RoundTripper.
+type HeaderDeletingRoundTripper struct {
+	RoundTripper http.RoundTripper
+	Header       string
+}
+
+// RoundTrip deletes Header from req and calls the wrapped RoundTripper.
+func (r *HeaderDeletingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Del(r.Header)
+
+	return r.RoundTripper.RoundTrip(req)
+}
+
+// ErrFileSystem is an fs.FS test double whose file read returns a partial payload and ErrFailed.
+type ErrFileSystem struct{}
+
+// Open returns a failing file for asset.txt and fs.ErrNotExist for other names.
+func (ErrFileSystem) Open(name string) (fs.File, error) {
+	if name != "asset.txt" {
+		return nil, fs.ErrNotExist
+	}
+
+	return &ErrFile{}, nil
+}
+
+// ErrFile is an fs.File test double that returns a partial payload and ErrFailed.
+type ErrFile struct {
+	read bool
+}
+
+// Stat returns ErrFileInfo.
+func (f *ErrFile) Stat() (fs.FileInfo, error) {
+	return ErrFileInfo{}, nil
+}
+
+// Read copies a partial payload and returns ErrFailed on the first read.
+func (f *ErrFile) Read(p []byte) (int, error) {
+	if f.read {
+		return 0, io.EOF
+	}
+
+	f.read = true
+	copy(p, "hello")
+
+	return len("hello"), ErrFailed
+}
+
+// Close implements fs.File and always succeeds.
+func (f *ErrFile) Close() error {
+	return nil
+}
+
+// ErrFileInfo is an fs.FileInfo test double for ErrFile.
+type ErrFileInfo struct{}
+
+// Name returns asset.txt.
+func (ErrFileInfo) Name() string {
+	return "asset.txt"
+}
+
+// Size returns a size larger than the readable payload.
+func (ErrFileInfo) Size() int64 {
+	return 6
+}
+
+// Mode returns no file mode bits.
+func (ErrFileInfo) Mode() fs.FileMode {
+	return 0
+}
+
+// ModTime returns the zero time.
+func (ErrFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+// IsDir reports false.
+func (ErrFileInfo) IsDir() bool {
+	return false
+}
+
+// Sys returns nil.
+func (ErrFileInfo) Sys() any {
+	return nil
+}
+
+// ResponseWithStatus returns a response for code with an empty body.
+func ResponseWithStatus(code int) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Status:     StatusLine(code),
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}
+}
+
+// StatusLine formats an HTTP status line fragment for code.
+func StatusLine(code int) string {
+	return fmt.Sprintf("%d %s", code, http.StatusText(code))
+}
+
+func defaultStatus(status, fallback int) int {
+	if status == 0 {
+		return fallback
+	}
+
+	return status
+}
+
+func defaultError(err, fallback error) error {
+	if err == nil {
+		return fallback
+	}
+
+	return err
 }

--- a/internal/test/id.go
+++ b/internal/test/id.go
@@ -18,3 +18,24 @@ var Generators = id.NewMap(id.MapParams{
 	UUID:   uuid.NewGenerator(),
 	XID:    xid.NewGenerator(),
 })
+
+// IDSequenceGenerator is an id.Generator test double that returns configured IDs in order.
+type IDSequenceGenerator struct {
+	IDs []string
+}
+
+// Generate returns the next configured ID.
+func (g *IDSequenceGenerator) Generate() string {
+	id := g.IDs[0]
+	g.IDs = g.IDs[1:]
+
+	return id
+}
+
+// StaticIDGenerator is an id.Generator test double that always returns the same ID.
+type StaticIDGenerator string
+
+// Generate returns the configured ID.
+func (g StaticIDGenerator) Generate() string {
+	return string(g)
+}

--- a/internal/test/reader.go
+++ b/internal/test/reader.go
@@ -1,5 +1,7 @@
 package test
 
+import "github.com/alexfalkowski/go-service/v2/io"
+
 // ErrReaderCloser is an io.ReadCloser test double whose methods fail with ErrFailed.
 type ErrReaderCloser struct{}
 
@@ -11,4 +13,31 @@ func (r *ErrReaderCloser) Read(_ []byte) (int, error) {
 // Close returns ErrFailed.
 func (r *ErrReaderCloser) Close() error {
 	return ErrFailed
+}
+
+// StaticReader is an io.Reader test double that reads from Data.
+type StaticReader struct {
+	Data []byte
+}
+
+// Read copies Data into p and returns EOF if p was not filled.
+func (r StaticReader) Read(p []byte) (int, error) {
+	n := copy(p, r.Data)
+	if n < len(p) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+// TrackingReader is an io.Reader test double that records read attempts.
+type TrackingReader struct {
+	Err   error
+	Reads int
+}
+
+// Read increments Reads and returns Err.
+func (r *TrackingReader) Read(_ []byte) (int, error) {
+	r.Reads++
+	return 0, r.Err
 }

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -154,3 +154,35 @@ func (s *NoopServer) Shutdown(_ context.Context) error {
 func (s *NoopServer) String() string {
 	return "test"
 }
+
+// NewObservableServer returns an ObservableServer with an initialized Done channel.
+func NewObservableServer(err, shutdownErr error) *ObservableServer {
+	return &ObservableServer{Err: err, ShutdownErr: shutdownErr, Done: make(chan struct{})}
+}
+
+// ObservableServer is a server.Server test double that records serve and shutdown activity.
+type ObservableServer struct {
+	Err         error
+	ShutdownErr error
+	Done        chan struct{}
+	Shutdowns   int
+}
+
+// Serve closes Done and returns Err.
+func (s *ObservableServer) Serve() error {
+	close(s.Done)
+
+	return s.Err
+}
+
+// Shutdown increments Shutdowns and returns ShutdownErr.
+func (s *ObservableServer) Shutdown(_ context.Context) error {
+	s.Shutdowns++
+
+	return s.ShutdownErr
+}
+
+// String returns a stable identifier for logs and assertions.
+func (*ObservableServer) String() string {
+	return "test"
+}

--- a/internal/test/token.go
+++ b/internal/test/token.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"strconv"
+
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
@@ -37,5 +39,25 @@ func (v *Verifier) Verify(token []byte, aud string) (string, error) {
 		return strings.Empty, ErrInvalid
 	}
 
+	return UserID.String(), nil
+}
+
+// SequenceGenerator is a token.Generator test double that returns token-N values.
+type SequenceGenerator struct {
+	next int
+}
+
+// Generate implements token.Generator and returns the next token value.
+func (g *SequenceGenerator) Generate(_, _ string) ([]byte, error) {
+	g.next++
+
+	return []byte("token-" + strconv.Itoa(g.next)), nil
+}
+
+// AcceptingVerifier is a token.Verifier test double that accepts any token.
+type AcceptingVerifier struct{}
+
+// Verify implements token.Verifier and returns the shared test user ID.
+func (AcceptingVerifier) Verify([]byte, string) (string, error) {
 	return UserID.String(), nil
 }

--- a/meta/value_test.go
+++ b/meta/value_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +14,7 @@ func TestErrorWithNil(t *testing.T) {
 }
 
 func TestErrorWithTypedNil(t *testing.T) {
-	var err error = (*panicError)(nil)
+	var err error = (*test.MessageError)(nil)
 
 	require.Equal(t, meta.Blank(), meta.Error(err))
 }
@@ -23,19 +24,19 @@ func TestToStringWithNil(t *testing.T) {
 }
 
 func TestToStringWithTypedNil(t *testing.T) {
-	var stringer fmt.Stringer = (*panicStringer)(nil)
+	var stringer fmt.Stringer = (*test.Stringer)(nil)
 
 	require.Equal(t, meta.Blank(), meta.ToString(stringer))
 }
 
 func TestToRedactedWithTypedNil(t *testing.T) {
-	var stringer fmt.Stringer = (*panicStringer)(nil)
+	var stringer fmt.Stringer = (*test.Stringer)(nil)
 
 	require.Equal(t, meta.Blank(), meta.ToRedacted(stringer))
 }
 
 func TestToIgnoredWithTypedNil(t *testing.T) {
-	var stringer fmt.Stringer = (*panicStringer)(nil)
+	var stringer fmt.Stringer = (*test.Stringer)(nil)
 
 	require.Equal(t, meta.Blank(), meta.ToIgnored(stringer))
 }
@@ -43,20 +44,4 @@ func TestToIgnoredWithTypedNil(t *testing.T) {
 func TestRedactedWithMultiByteValue(t *testing.T) {
 	require.Equal(t, "*", meta.Redacted("é").String())
 	require.Equal(t, "**", meta.Redacted("éa").String())
-}
-
-type panicError struct {
-	message string
-}
-
-func (e *panicError) Error() string {
-	return e.message
-}
-
-type panicStringer struct {
-	value string
-}
-
-func (s *panicStringer) String() string {
-	return s.value
 }

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
@@ -21,7 +22,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := meta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), staticGenerator("generated-id"))
+	interceptor := meta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		md, ok := meta.FromOutgoingContext(ctx)
@@ -43,7 +44,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := meta.StreamClientInterceptor(env.UserAgent("fallback-agent"), staticGenerator("generated-id"))
+	interceptor := meta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		md, ok := meta.FromOutgoingContext(ctx)
 		require.True(t, ok)
@@ -61,7 +62,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
-	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
@@ -75,7 +76,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
-	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{})
 
@@ -90,7 +91,7 @@ func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
-	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
 
@@ -105,25 +106,25 @@ func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 }
 
 func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
-	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
-	stream := &serverStream{ctx: ctx}
+	stream := &test.MetaServerStream{Ctx: ctx}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(any, grpc.ServerStream) error {
 		return nil
 	})
 	require.NoError(t, err)
-	require.Equal(t, []string{"1", "v2"}, stream.header.Get("service-version"))
-	require.Equal(t, []string{"generated-id"}, stream.header.Get("request-id"))
+	require.Equal(t, []string{"1", "v2"}, stream.Header.Get("service-version"))
+	require.Equal(t, []string{"generated-id"}, stream.Header.Get("request-id"))
 }
 
 func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
-	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), staticGenerator("generated-id"))
+	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := meta.NewIncomingContext(t.Context(), meta.Pairs(
 		"authorization", "invalid",
 		"user-agent", "watch-agent",
 	))
-	stream := &serverStream{ctx: ctx}
+	stream := &test.MetaServerStream{Ctx: ctx}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/grpc.health.v1.Health/Watch"}, func(_ any, stream grpc.ServerStream) error {
 		require.Equal(t, meta.String("watch-agent"), meta.UserAgent(stream.Context()))
@@ -167,27 +168,4 @@ func TestExtractOutgoingReturnsEmptyMapWithoutMetadata(t *testing.T) {
 
 	require.NotNil(t, md)
 	require.Empty(t, md)
-}
-
-type staticGenerator string
-
-func (g staticGenerator) Generate() string {
-	return string(g)
-}
-
-type serverStream struct {
-	grpc.ServerStream
-	header meta.Map
-	ctx    context.Context
-}
-
-func (s *serverStream) SetHeader(md meta.Map) error {
-	md.Append("service-version", "v2")
-	s.header = md
-
-	return nil
-}
-
-func (s *serverStream) Context() context.Context {
-	return s.ctx
 }

--- a/net/http/benchmark_test.go
+++ b/net/http/benchmark_test.go
@@ -6,11 +6,8 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
-	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 func BenchmarkClientTelemetry(b *testing.B) {
@@ -19,9 +16,9 @@ func BenchmarkClientTelemetry(b *testing.B) {
 
 	bench := func(name string, setup func(testing.TB)) {
 		b.Run(name, func(b *testing.B) {
-			resetTelemetry(b)
+			test.ResetTelemetry(b)
 			setup(b)
-			defer resetTelemetry(b)
+			defer test.ResetTelemetry(b)
 
 			b.ReportAllocs()
 
@@ -43,40 +40,6 @@ func BenchmarkClientTelemetry(b *testing.B) {
 	}
 
 	bench("disabled", func(testing.TB) {})
-	bench("metrics", enableMetrics)
-	bench("tracer", enableTracer)
-}
-
-func resetTelemetry(tb testing.TB) {
-	tb.Helper()
-
-	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
-	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
-}
-
-func enableMetrics(tb testing.TB) {
-	tb.Helper()
-
-	metrics.NewMeterProvider(metrics.MeterProviderParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &metrics.Config{},
-		Reader:      metrics.NewManualReader(),
-		ID:          test.ID,
-		Name:        test.Name,
-		Version:     test.Version,
-		Environment: test.Environment,
-	})
-}
-
-func enableTracer(tb testing.TB) {
-	tb.Helper()
-
-	require.NoError(tb, tracer.Register(tracer.TracerParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{Kind: "otlp"},
-		ID:          test.ID,
-		Name:        test.Name,
-		Version:     test.Version,
-		Environment: test.Environment,
-	}))
+	bench("metrics", test.EnableMetrics)
+	bench("tracer", test.EnableTracer)
 }

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -142,7 +142,7 @@ func TestDoUsesMsgPack(t *testing.T) {
 
 func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	var body io.ReadCloser
-	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		body = req.Body
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -161,10 +161,4 @@ func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	data, _, err := io.ReadAll(body)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"Name":"Bob"}`, string(data))
-}
-
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
 }

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -86,7 +85,7 @@ func TestNewHandlerTreatsInternalErrorAcceptAsText(t *testing.T) {
 
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	enc := encoding.NewMap(encoding.MapParams{})
-	enc.Register("json", partialEncoder{})
+	enc.Register("json", test.PartialEncoder{})
 	cont := content.NewContent(enc, test.Pool)
 
 	handler := content.NewHandler(cont, func(_ context.Context) (*test.Response, error) {
@@ -113,15 +112,4 @@ func TestNotFoundHandlerWritesStatusError(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, res.Code)
 	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
 	require.Equal(t, "http: not found", strings.TrimSpace(res.Body.String()))
-}
-
-type partialEncoder struct{}
-
-func (partialEncoder) Encode(w io.Writer, _ any) error {
-	_, _ = io.WriteString(w, "partial")
-	return test.ErrFailed
-}
-
-func (partialEncoder) Decode(io.Reader, any) error {
-	return nil
 }

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/env"
-	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/stretchr/testify/require"
@@ -15,7 +15,7 @@ func TestWithContent(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
-	enc := &encoder{}
+	enc := test.NewEncoder(nil)
 
 	ctx := meta.WithContent(t.Context(), req, res, enc)
 
@@ -35,8 +35,8 @@ func TestWithContentAllowsPartialContent(t *testing.T) {
 func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 	roundTripper := meta.NewRoundTripper(
 		env.UserAgent("agent"),
-		staticGenerator("request-id"),
-		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		test.StaticIDGenerator("request-id"),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			req.Header.Add("User-Agent", "next-agent")
 
 			require.Equal(t, []string{"agent", "next-agent"}, req.Header.Values("User-Agent"))
@@ -58,8 +58,8 @@ func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	roundTripper := meta.NewRoundTripper(
 		env.UserAgent("agent"),
-		staticGenerator("request-id"),
-		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		test.StaticIDGenerator("request-id"),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "agent", req.Header.Get("User-Agent"))
 			require.Equal(t, "request-id", req.Header.Get("Request-Id"))
 
@@ -77,7 +77,7 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 }
 
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
-	handler := meta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), staticGenerator("request-id"))
+	handler := meta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -88,26 +88,4 @@ func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 		require.Equal(t, []string{"1", "v2"}, res.Header().Values("Service-Version"))
 		require.Equal(t, []string{"request-id"}, res.Header().Values("Request-Id"))
 	})
-}
-
-type encoder struct{}
-
-func (e *encoder) Decode(_ io.Reader, _ any) error {
-	return nil
-}
-
-func (e *encoder) Encode(_ io.Writer, _ any) error {
-	return nil
-}
-
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-type staticGenerator string
-
-func (g staticGenerator) Generate() string {
-	return string(g)
 }

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -9,14 +9,12 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -470,7 +468,7 @@ func TestStaticFileSetsContentLength(t *testing.T) {
 	mvc.Register(mvc.RegisterParams{
 		Mux:         mux,
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
-		FileSystem:  errFileSystem{},
+		FileSystem:  test.ErrFileSystem{},
 		Pool:        test.Pool,
 		Layout:      test.Layout,
 	})
@@ -485,65 +483,6 @@ func TestStaticFileSetsContentLength(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, "6", res.Header().Get("Content-Length"))
 	require.Equal(t, "hello", res.Body.String())
-}
-
-type errFileSystem struct{}
-
-func (errFileSystem) Open(name string) (fs.File, error) {
-	if name != "asset.txt" {
-		return nil, fs.ErrNotExist
-	}
-
-	return &errFile{}, nil
-}
-
-type errFile struct {
-	read bool
-}
-
-func (f *errFile) Stat() (fs.FileInfo, error) {
-	return errFileInfo{}, nil
-}
-
-func (f *errFile) Read(p []byte) (int, error) {
-	if f.read {
-		return 0, io.EOF
-	}
-
-	f.read = true
-	copy(p, "hello")
-
-	return len("hello"), test.ErrFailed
-}
-
-func (f *errFile) Close() error {
-	return nil
-}
-
-type errFileInfo struct{}
-
-func (errFileInfo) Name() string {
-	return "asset.txt"
-}
-
-func (errFileInfo) Size() int64 {
-	return 6
-}
-
-func (errFileInfo) Mode() fs.FileMode {
-	return 0
-}
-
-func (errFileInfo) ModTime() time.Time {
-	return time.Time{}
-}
-
-func (errFileInfo) IsDir() bool {
-	return false
-}
-
-func (errFileInfo) Sys() any {
-	return nil
 }
 
 type requestModel struct {

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -15,17 +15,17 @@ import (
 )
 
 func TestIsErrorRecognizesWrappedCoder(t *testing.T) {
-	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
+	err := fmt.Errorf("wrapped: %w", &test.CoderError{StatusCode: http.StatusConflict})
 	require.True(t, httpstatus.IsError(err))
 }
 
 func TestCodeRecognizesWrappedCoder(t *testing.T) {
-	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
+	err := fmt.Errorf("wrapped: %w", &test.CoderError{StatusCode: http.StatusConflict})
 	require.Equal(t, http.StatusConflict, httpstatus.Code(err))
 }
 
 func TestFromErrorKeepsWrappedCoder(t *testing.T) {
-	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
+	err := fmt.Errorf("wrapped: %w", &test.CoderError{StatusCode: http.StatusConflict})
 	require.Same(t, err, httpstatus.FromError(http.StatusBadRequest, err))
 }
 
@@ -78,7 +78,7 @@ func TestSafeErrorAllowsNilCause(t *testing.T) {
 }
 
 func TestSafeErrorKeepsWrappedCoder(t *testing.T) {
-	err := fmt.Errorf("wrapped: %w", &customCoderError{code: http.StatusConflict})
+	err := fmt.Errorf("wrapped: %w", &test.CoderError{StatusCode: http.StatusConflict})
 
 	require.Same(t, err, httpstatus.SafeError(http.StatusBadRequest, err))
 }
@@ -93,7 +93,7 @@ func TestSafeErrorUsesRequestEntityTooLargeForMaxBytesError(t *testing.T) {
 func TestWriteErrorUsesDefaultSafeMessageForUnknownStatusCode(t *testing.T) {
 	res := httptest.NewRecorder()
 
-	err := httpstatus.WriteError(res, &customCoderError{code: 999})
+	err := httpstatus.WriteError(res, &test.CoderError{StatusCode: 999})
 
 	require.NoError(t, err)
 	require.Equal(t, 999, res.Code)
@@ -174,16 +174,4 @@ func TestWriteTextReturnsWriteFailure(t *testing.T) {
 
 	require.ErrorIs(t, err, test.ErrFailed)
 	require.Equal(t, http.StatusOK, res.Code)
-}
-
-type customCoderError struct {
-	code int
-}
-
-func (c *customCoderError) Error() string {
-	return "custom"
-}
-
-func (c *customCoderError) Code() int {
-	return c.code
 }

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestRegisterStopErrors(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
-	first := newTestServer(nil, test.ErrFailed)
+	first := test.NewObservableServer(nil, test.ErrFailed)
 	secondErr := errors.New("other failed")
-	second := newTestServer(nil, secondErr)
+	second := test.NewObservableServer(nil, secondErr)
 	sh := test.NewShutdowner()
 
 	server.Register(lc, []*server.Service{
@@ -30,6 +30,6 @@ func TestRegisterStopErrors(t *testing.T) {
 	require.ErrorIs(t, err, secondErr)
 	require.ErrorContains(t, err, "first: failed")
 	require.ErrorContains(t, err, "second: other failed")
-	require.Equal(t, 1, first.shutdowns)
-	require.Equal(t, 1, second.shutdowns)
+	require.Equal(t, 1, first.Shutdowns)
+	require.Equal(t, 1, second.Shutdowns)
 }

--- a/net/server/service_test.go
+++ b/net/server/service_test.go
@@ -4,52 +4,24 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
 
-type testServer struct {
-	err         error
-	shutdownErr error
-	done        chan struct{}
-	shutdowns   int
-}
-
-func newTestServer(err, shutdownErr error) *testServer {
-	return &testServer{err: err, shutdownErr: shutdownErr, done: make(chan struct{})}
-}
-
-func (s *testServer) Serve() error {
-	close(s.done)
-
-	return s.err
-}
-
-func (s *testServer) Shutdown(_ context.Context) error {
-	s.shutdowns++
-
-	return s.shutdownErr
-}
-
-func (*testServer) String() string {
-	return "test"
-}
-
 func TestInvalidServer(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	l, err := test.NewLogger(lc, test.NewJSONLoggerConfig())
 	require.NoError(t, err)
 	sh := test.NewShutdowner()
-	srv := newTestServer(test.ErrFailed, nil)
+	srv := test.NewObservableServer(test.ErrFailed, nil)
 	svc := server.NewService("test", srv, l, sh)
 
 	svc.Start()
 
 	select {
-	case <-srv.done:
+	case <-srv.Done:
 	case <-time.After(2 * time.Second):
 		require.FailNow(t, "timeout waiting for server to serve")
 	}
@@ -65,13 +37,13 @@ func TestInvalidServer(t *testing.T) {
 
 func TestValidServer(t *testing.T) {
 	sh := test.NewShutdowner()
-	srv := newTestServer(nil, nil)
+	srv := test.NewObservableServer(nil, nil)
 	svc := server.NewService("test", srv, nil, sh)
 
 	svc.Start()
 
 	select {
-	case <-srv.done:
+	case <-srv.Done:
 	case <-time.After(2 * time.Second):
 		require.FailNow(t, "timeout waiting for server to serve")
 	}
@@ -83,7 +55,7 @@ func TestValidServer(t *testing.T) {
 
 func TestInvalidStop(t *testing.T) {
 	sh := test.NewShutdowner()
-	srv := newTestServer(nil, test.ErrFailed)
+	srv := test.NewObservableServer(nil, test.ErrFailed)
 	svc := server.NewService("test", srv, nil, sh)
 
 	err := svc.Stop(t.Context())

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -3,6 +3,7 @@ package reflect_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/reflect"
 	"github.com/stretchr/testify/require"
 )
@@ -12,7 +13,7 @@ func TestIsNil(t *testing.T) {
 }
 
 func TestIsNilWithTypedNil(t *testing.T) {
-	var err error = (*nilError)(nil)
+	var err error = (*test.NilError)(nil)
 
 	require.True(t, reflect.IsNil(err))
 }
@@ -23,10 +24,4 @@ func TestIsNilWithValue(t *testing.T) {
 
 func TestIsNilWithNonNillableKind(t *testing.T) {
 	require.False(t, reflect.IsNil(42))
-}
-
-type nilError struct{}
-
-func (e *nilError) Error() string {
-	return "nil"
 }

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
-	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
-	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
@@ -59,8 +57,8 @@ func BenchmarkGRPC(b *testing.B) {
 
 	b.Run("none", func(b *testing.B) {
 		b.ReportAllocs()
-		disableTelemetry(b)
-		defer disableTelemetry(b)
+		test.ResetTelemetry(b)
+		defer test.ResetTelemetry(b)
 
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
@@ -192,11 +190,4 @@ func BenchmarkGRPC(b *testing.B) {
 		require.NoError(b, conn.Close())
 		lc.RequireStop()
 	})
-}
-
-func disableTelemetry(b *testing.B) {
-	b.Helper()
-
-	require.NoError(b, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(b)}))
-	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(b)})
 }

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -274,20 +274,20 @@ func TestWatchStatusChanges(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	stream := newWatchStream(ctx)
+	stream := test.NewWatchStream(ctx)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- watcher.Watch(&health.Request{Service: test.Name.String()}, stream)
 	}()
 
-	resp := requireWatchResponse(t, stream.responses)
+	resp := requireWatchResponse(t, stream.Responses)
 	require.Equal(t, health.Serving, resp.GetStatus())
 
 	unhealthy.Store(true)
 
 	require.Eventually(t, func() bool {
 		select {
-		case resp = <-stream.responses:
+		case resp = <-stream.Responses:
 			return resp.GetStatus() == health.NotServing
 		default:
 			return false
@@ -381,45 +381,4 @@ func requireWatchResponse(t *testing.T, responses <-chan *health.Response) *heal
 		require.FailNow(t, "timed out waiting for watch response")
 		return nil
 	}
-}
-
-func newWatchStream(ctx context.Context) *watchStream {
-	return &watchStream{ctx: ctx, responses: make(chan *health.Response, 4)}
-}
-
-type watchStream struct {
-	grpc.ServerStream
-	ctx       context.Context
-	responses chan *health.Response
-}
-
-func (w *watchStream) Context() context.Context {
-	return w.ctx
-}
-
-func (w *watchStream) Send(resp *health.Response) error {
-	select {
-	case <-w.ctx.Done():
-		return w.ctx.Err()
-	case w.responses <- resp:
-		return nil
-	}
-}
-
-func (*watchStream) SetHeader(meta.Map) error {
-	return nil
-}
-
-func (*watchStream) SendHeader(meta.Map) error {
-	return nil
-}
-
-func (*watchStream) SetTrailer(meta.Map) {}
-
-func (*watchStream) SendMsg(any) error {
-	return nil
-}
-
-func (*watchStream) RecvMsg(any) error {
-	return nil
 }

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -73,7 +73,7 @@ func TestClientLimiterUsesGeneratedTokenUnary(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
-		test.WithWorldToken(&sequenceGenerator{}, acceptingVerifier{}),
+		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldGRPC(),
 	)
 
@@ -94,7 +94,7 @@ func TestClientLimiterUsesGeneratedTokenStream(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
-		test.WithWorldToken(&sequenceGenerator{}, acceptingVerifier{}),
+		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldGRPC(),
 	)
 
@@ -195,20 +195,4 @@ func sayStreamHello(t *testing.T, client v1.GreeterServiceClient) error {
 
 	_, err = stream.Recv()
 	return err
-}
-
-type sequenceGenerator struct {
-	next int
-}
-
-func (g *sequenceGenerator) Generate(_, _ string) ([]byte, error) {
-	g.next++
-
-	return []byte("token-" + strconv.Itoa(g.next)), nil
-}
-
-type acceptingVerifier struct{}
-
-func (acceptingVerifier) Verify([]byte, string) (string, error) {
-	return test.UserID.String(), nil
 }

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 func TestRoundTripperOpensOnTransportError(t *testing.T) {
 	transportErr := errors.New("transport unavailable")
 	rt := breaker.NewRoundTripper(
-		errorRoundTripper{err: transportErr},
+		&test.ErrorRoundTripper{Err: transportErr},
 		breaker.WithSettings(breaker.Settings{
 			ReadyToTrip: func(counts breaker.Counts) bool {
 				return counts.ConsecutiveFailures >= 1
@@ -33,7 +34,7 @@ func TestRoundTripperOpensOnTransportError(t *testing.T) {
 
 func TestRoundTripperOpensOnFailureStatus(t *testing.T) {
 	rt := breaker.NewRoundTripper(
-		statusRoundTripper{status: http.StatusInternalServerError},
+		&test.StatusRoundTripper{Status: http.StatusInternalServerError},
 		breaker.WithSettings(breaker.Settings{
 			ReadyToTrip: func(counts breaker.Counts) bool {
 				return counts.ConsecutiveFailures >= 1
@@ -55,7 +56,7 @@ func TestRoundTripperOpensOnFailureStatus(t *testing.T) {
 
 func TestRoundTripperCountsFailureStatusWithCustomIsSuccessful(t *testing.T) {
 	rt := breaker.NewRoundTripper(
-		statusRoundTripper{status: http.StatusInternalServerError},
+		&test.StatusRoundTripper{Status: http.StatusInternalServerError},
 		breaker.WithSettings(breaker.Settings{
 			ReadyToTrip: func(counts breaker.Counts) bool {
 				return counts.ConsecutiveFailures >= 1
@@ -76,24 +77,4 @@ func TestRoundTripperCountsFailureStatusWithCustomIsSuccessful(t *testing.T) {
 	res, err = rt.RoundTrip(req)
 	require.Nil(t, res)
 	require.ErrorIs(t, err, breaker.ErrOpenState)
-}
-
-type errorRoundTripper struct {
-	err error
-}
-
-func (r errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	return nil, r.err
-}
-
-type statusRoundTripper struct {
-	status int
-}
-
-func (r statusRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: r.status,
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
 }

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -53,7 +53,14 @@ func TestSendReceiveWithoutRoundTripper(t *testing.T) {
 }
 
 func TestSendNotReceive(t *testing.T) {
-	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRoundTripper(&delRoundTripper{rt: http.DefaultTransport}), test.WithWorldHTTP())
+	world := test.NewStartedWorld(t,
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldRoundTripper(&test.HeaderDeletingRoundTripper{
+			RoundTripper: http.DefaultTransport,
+			Header:       webhooks.HeaderWebhookID,
+		}),
+		test.WithWorldHTTP(),
+	)
 
 	world.RegisterEvents(t.Context())
 
@@ -92,14 +99,4 @@ func TestReceiveUsesServerMaxReceiveSizeBeforeWebhookVerification(t *testing.T) 
 
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 	require.Nil(t, world.Event)
-}
-
-type delRoundTripper struct {
-	rt http.RoundTripper
-}
-
-func (r *delRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Del(webhooks.HeaderWebhookID)
-
-	return r.rt.RoundTrip(req)
 }

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -29,7 +29,7 @@ func TestSignOverwritesHeaders(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)
 
-	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1", "id-2"}})
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1", "id-2"}})
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
 
 	require.NoError(t, hook.Sign(req))
@@ -44,7 +44,7 @@ func TestSignAndVerifyNilBody(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)
 
-	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
 	req := &http.Request{Header: make(http.Header)}
 
 	require.NoError(t, hook.Sign(req))
@@ -59,7 +59,7 @@ func TestSignHandlesNilRequestHeader(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)
 
-	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
 	req := &http.Request{Body: http.NoBody}
 
 	require.NoError(t, hook.Sign(req))
@@ -71,7 +71,7 @@ func TestSignHandlesNilRequestHeader(t *testing.T) {
 
 func TestRoundTripper(t *testing.T) {
 	hook := hooks.NewWebhook(nil, nil)
-	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	rt := hooks.NewRoundTripper(hook, test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
 	}))
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", &test.ErrReaderCloser{})
@@ -85,8 +85,8 @@ func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)
 
-	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
-	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
+	rt := hooks.NewRoundTripper(hook, test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookID))
 		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookSignature))
 		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookTimestamp))
@@ -107,8 +107,8 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)
 
-	hook := hooks.NewWebhook(webhook, &generator{ids: []string{"id-1"}})
-	rt := hooks.NewRoundTripper(hook, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
+	rt := hooks.NewRoundTripper(hook, test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookID))
 		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookSignature))
 		require.NotEmpty(t, req.Header.Get(webhooks.HeaderWebhookTimestamp))
@@ -136,21 +136,4 @@ func TestHandler(t *testing.T) {
 
 	require.True(t, called)
 	require.Equal(t, http.StatusOK, res.Code)
-}
-
-type roundTripperFunc func(req *http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-type generator struct {
-	ids []string
-}
-
-func (g *generator) Generate() string {
-	id := g.ids[0]
-	g.ids = g.ids[1:]
-
-	return id
 }

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -1,7 +1,6 @@
 package http_test
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -101,7 +100,7 @@ func TestClientLimiterUsesGeneratedToken(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
-		test.WithWorldToken(&sequenceGenerator{}, acceptingVerifier{}),
+		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldHTTP(),
 		test.WithWorldHello(),
 	)
@@ -153,20 +152,4 @@ func TestClientClosedLimiter(t *testing.T) {
 	_, _, err = world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
 	require.Error(t, err)
 	require.Equal(t, http.StatusInternalServerError, status.Code(err))
-}
-
-type sequenceGenerator struct {
-	next int
-}
-
-func (g *sequenceGenerator) Generate(_, _ string) ([]byte, error) {
-	g.next++
-
-	return []byte("token-" + strconv.Itoa(g.next)), nil
-}
-
-type acceptingVerifier struct{}
-
-func (acceptingVerifier) Verify([]byte, string) (string, error) {
-	return test.UserID.String(), nil
 }

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -1,12 +1,12 @@
 package retry_test
 
 import (
-	"fmt"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -31,7 +31,7 @@ func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rt := &roundTripper{codes: tt.codes}
+			rt := &test.StatusSequenceRoundTripper{Codes: tt.codes}
 			retrying := retry.NewRoundTripper(&retry.Config{
 				Attempts: 2,
 				Timeout:  time.Second,
@@ -43,13 +43,13 @@ func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 			res, err := retrying.RoundTrip(req)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, res.StatusCode)
-			require.Equal(t, tt.calls, rt.calls)
+			require.Equal(t, tt.calls, rt.Calls)
 		})
 	}
 }
 
 func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
-	rt := &roundTripper{codes: []int{http.StatusTooManyRequests, http.StatusOK}}
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
 		Timeout:  time.Second,
@@ -61,11 +61,11 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
-	require.Equal(t, 1, rt.calls)
+	require.Equal(t, 1, rt.Calls)
 }
 
 func TestRoundTripperUsesIndependentRetryBudgetPerRequest(t *testing.T) {
-	rt := &roundTripper{codes: []int{
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{
 		http.StatusTooManyRequests, http.StatusOK,
 		http.StatusTooManyRequests, http.StatusOK,
 	}}
@@ -84,11 +84,11 @@ func TestRoundTripperUsesIndependentRetryBudgetPerRequest(t *testing.T) {
 	res, err = retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, 4, rt.calls)
+	require.Equal(t, 4, rt.Calls)
 }
 
 func TestRoundTripperDoesNotRetryUnhandledStatusCode(t *testing.T) {
-	rt := &roundTripper{codes: []int{http.StatusInternalServerError, http.StatusOK}}
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusInternalServerError, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -100,11 +100,11 @@ func TestRoundTripperDoesNotRetryUnhandledStatusCode(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-	require.Equal(t, 1, rt.calls)
+	require.Equal(t, 1, rt.Calls)
 }
 
 func TestRoundTripperDoesNotRetryWhenPolicyDeniesRequest(t *testing.T) {
-	rt := &roundTripper{codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -116,11 +116,11 @@ func TestRoundTripperDoesNotRetryWhenPolicyDeniesRequest(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-	require.Equal(t, 1, rt.calls)
+	require.Equal(t, 1, rt.Calls)
 }
 
 func TestRoundTripperRetriesWhenPolicyAllowsRequestID(t *testing.T) {
-	rt := &roundTripper{codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -133,11 +133,11 @@ func TestRoundTripperRetriesWhenPolicyAllowsRequestID(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, 2, rt.calls)
+	require.Equal(t, 2, rt.Calls)
 }
 
 func TestRoundTripperReturnsLastRetryableResponseWhenExhausted(t *testing.T) {
-	rt := &roundTripper{codes: []int{http.StatusTooManyRequests, http.StatusTooManyRequests}}
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusTooManyRequests}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -149,11 +149,11 @@ func TestRoundTripperReturnsLastRetryableResponseWhenExhausted(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
-	require.Equal(t, 2, rt.calls)
+	require.Equal(t, 2, rt.Calls)
 }
 
 func TestRoundTripperReturnsFinalRetryableResponseWhenExhausted(t *testing.T) {
-	rt := &bodyRoundTripper{responses: []string{"first failure", "second failure"}}
+	rt := &test.BodySequenceRoundTripper{Responses: []string{"first failure", "second failure"}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -170,7 +170,7 @@ func TestRoundTripperReturnsFinalRetryableResponseWhenExhausted(t *testing.T) {
 	require.NoError(t, readErr)
 	require.Equal(t, "second failure", string(body))
 	require.NoError(t, res.Body.Close())
-	require.Equal(t, 2, rt.calls)
+	require.Equal(t, 2, rt.Calls)
 }
 
 func TestRoundTripperClosesRetryableResponseBeforeNextAttempt(t *testing.T) {
@@ -208,7 +208,7 @@ func TestRoundTripperClosesRetryableResponseBeforeNextAttempt(t *testing.T) {
 }
 
 func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
-	rt := &requestRoundTripper{}
+	rt := &test.RequestBodyRecorderRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -221,11 +221,11 @@ func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
+	require.Equal(t, []string{"hello", "hello"}, rt.Bodies)
 }
 
 func TestRoundTripperReplaysRequestBodyAfterTransportError(t *testing.T) {
-	rt := &transportErrorThenSuccessRoundTripper{}
+	rt := &test.TransportErrorThenSuccessRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -238,12 +238,12 @@ func TestRoundTripperReplaysRequestBodyAfterTransportError(t *testing.T) {
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
+	require.Equal(t, []string{"hello", "hello"}, rt.Bodies)
 }
 
 func TestRoundTripperUsesOriginalBodyOnFirstAttempt(t *testing.T) {
-	body := &trackedBody{Reader: strings.NewReader("hello")}
-	rt := &originalBodyRoundTripper{original: body}
+	body := &test.TrackedBody{Reader: strings.NewReader("hello")}
+	rt := &test.OriginalBodyRoundTripper{Original: body}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -260,31 +260,31 @@ func TestRoundTripperUsesOriginalBodyOnFirstAttempt(t *testing.T) {
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-	require.True(t, rt.firstUsedOriginal)
-	require.True(t, body.closed)
-	require.Equal(t, []string{"hello", "hello"}, rt.bodies)
+	require.True(t, rt.FirstUsedOriginal)
+	require.True(t, body.Closed)
+	require.Equal(t, []string{"hello", "hello"}, rt.Bodies)
 }
 
 func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
-	rt := &requestRoundTripper{}
+	rt := &test.RequestBodyRecorderRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", &nonReplayableReader{value: "hello"})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", &test.NonReplayableReader{Value: "hello"})
 	require.NoError(t, err)
 	require.Nil(t, req.GetBody)
 
 	res, roundTripErr := retrying.RoundTrip(req)
 	require.NoError(t, roundTripErr)
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-	require.Equal(t, []string{"hello"}, rt.bodies)
+	require.Equal(t, []string{"hello"}, rt.Bodies)
 }
 
 func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
-	rt := &errorRoundTripper{err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
+	rt := &test.ErrorRoundTripper{Err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -297,12 +297,12 @@ func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
 	require.Nil(t, res)
 	require.Error(t, err)
 	require.Equal(t, http.StatusTooManyRequests, status.Code(err))
-	require.Equal(t, 2, rt.calls)
+	require.Equal(t, 2, rt.Calls)
 }
 
 func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
 	wantErr := io.ErrUnexpectedEOF
-	rt := &errorRoundTripper{err: wantErr}
+	rt := &test.ErrorRoundTripper{Err: wantErr}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -314,11 +314,11 @@ func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.Nil(t, res)
 	require.ErrorIs(t, err, wantErr)
-	require.Equal(t, 2, rt.calls)
+	require.Equal(t, 2, rt.Calls)
 }
 
 func TestRoundTripperDoesNotRetryUnhandledTransportError(t *testing.T) {
-	rt := &errorRoundTripper{err: status.Errorf(http.StatusInternalServerError, "internal")}
+	rt := &test.ErrorRoundTripper{Err: status.Errorf(http.StatusInternalServerError, "internal")}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -331,12 +331,12 @@ func TestRoundTripperDoesNotRetryUnhandledTransportError(t *testing.T) {
 	require.Nil(t, res)
 	require.Error(t, err)
 	require.Equal(t, http.StatusInternalServerError, status.Code(err))
-	require.Equal(t, 1, rt.calls)
+	require.Equal(t, 1, rt.Calls)
 }
 
 func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testing.T) {
-	rt := &authRoundTripper{codes: []int{http.StatusTooManyRequests, http.StatusOK}}
-	generator := &tokenGenerator{}
+	rt := &test.AuthRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
+	generator := &test.SequenceGenerator{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -348,12 +348,12 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, rt.authValues)
-	require.Equal(t, []int{1, 1}, rt.authCounts)
+	require.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, rt.AuthValues)
+	require.Equal(t, []int{1, 1}, rt.AuthCounts)
 }
 
 func TestRoundTripperDoesNotSetAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
-	transport := &causeRoundTripper{}
+	transport := &test.CauseRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
 		Timeout:  0,
@@ -365,12 +365,12 @@ func TestRoundTripperDoesNotSetAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.NoError(t, transport.err)
-	require.NoError(t, transport.cause)
+	require.NoError(t, transport.Err)
+	require.NoError(t, transport.Cause)
 }
 
 func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {
-	transport := &causeRoundTripper{wait: true}
+	transport := &test.CauseRoundTripper{Wait: true}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
 		Timeout:  time.Nanosecond,
@@ -382,204 +382,7 @@ func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.ErrorIs(t, transport.err, context.DeadlineExceeded)
-	require.ErrorIs(t, transport.cause, retry.ErrAttemptTimeout)
-	require.ErrorIs(t, transport.cause, sync.ErrTimeout)
-}
-
-type roundTripper struct {
-	codes []int
-	calls int
-}
-
-func (r *roundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	code := r.codes[r.calls]
-	r.calls++
-
-	return &http.Response{
-		StatusCode: code,
-		Status:     fmt.Sprintf("%d %s", code, http.StatusText(code)),
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-type bodyRoundTripper struct {
-	responses []string
-	calls     int
-}
-
-func (r *bodyRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	body := r.responses[r.calls]
-	r.calls++
-
-	return &http.Response{
-		StatusCode: http.StatusServiceUnavailable,
-		Status:     fmt.Sprintf("%d %s", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)),
-		Body:       io.NopCloser(strings.NewReader(body)),
-		Header:     make(http.Header),
-	}, nil
-}
-
-type requestRoundTripper struct {
-	bodies []string
-}
-
-func (r *requestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	body, _, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	r.bodies = append(r.bodies, string(body))
-
-	return &http.Response{
-		StatusCode: http.StatusServiceUnavailable,
-		Status:     fmt.Sprintf("%d %s", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)),
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-type transportErrorThenSuccessRoundTripper struct {
-	bodies []string
-	calls  int
-}
-
-func (r *transportErrorThenSuccessRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	body, _, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	r.calls++
-	r.bodies = append(r.bodies, string(body))
-	if r.calls == 1 {
-		return nil, io.ErrUnexpectedEOF
-	}
-
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Status:     fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK)),
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-type originalBodyRoundTripper struct {
-	original          io.ReadCloser
-	bodies            []string
-	calls             int
-	firstUsedOriginal bool
-}
-
-func (r *originalBodyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if r.calls == 0 {
-		r.firstUsedOriginal = req.Body == r.original
-	}
-
-	body, _, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	if err := req.Body.Close(); err != nil {
-		return nil, err
-	}
-
-	r.calls++
-	r.bodies = append(r.bodies, string(body))
-
-	return &http.Response{
-		StatusCode: http.StatusServiceUnavailable,
-		Status:     fmt.Sprintf("%d %s", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)),
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-type errorRoundTripper struct {
-	err   error
-	calls int
-}
-
-func (r *errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	r.calls++
-	return nil, r.err
-}
-
-type authRoundTripper struct {
-	authValues []string
-	authCounts []int
-	codes      []int
-	calls      int
-}
-
-func (r *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.authValues = append(r.authValues, req.Header.Get("Authorization"))
-	r.authCounts = append(r.authCounts, len(req.Header.Values("Authorization")))
-	code := r.codes[r.calls]
-	r.calls++
-
-	return &http.Response{
-		StatusCode: code,
-		Status:     fmt.Sprintf("%d %s", code, http.StatusText(code)),
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-type causeRoundTripper struct {
-	cause error
-	err   error
-	wait  bool
-}
-
-func (r *causeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if r.wait {
-		<-req.Context().Done()
-	}
-
-	r.cause = context.Cause(req.Context())
-	r.err = req.Context().Err()
-
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Status:     http.StatusText(http.StatusOK),
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-	}, nil
-}
-
-type tokenGenerator struct {
-	calls int
-}
-
-func (g *tokenGenerator) Generate(_, _ string) ([]byte, error) {
-	g.calls++
-	return fmt.Appendf(nil, "token-%d", g.calls), nil
-}
-
-type nonReplayableReader struct {
-	value string
-	read  bool
-}
-
-func (r *nonReplayableReader) Read(p []byte) (int, error) {
-	if r.read {
-		return 0, io.EOF
-	}
-
-	r.read = true
-	copy(p, r.value)
-	return len(r.value), io.EOF
-}
-
-type trackedBody struct {
-	*strings.Reader
-	closed bool
-}
-
-func (b *trackedBody) Close() error {
-	b.closed = true
-	return nil
+	require.ErrorIs(t, transport.Err, context.DeadlineExceeded)
+	require.ErrorIs(t, transport.Cause, retry.ErrAttemptTimeout)
+	require.ErrorIs(t, transport.Cause, sync.ErrTimeout)
 }

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -73,13 +73,9 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 		t.Context(),
 		world.PathServerURL("http", "hello"),
 		header,
-		&unknownLengthReader{Reader: strings.NewReader(`{"name":"` + strings.Repeat("a", 256) + `"}`)},
+		&test.UnknownLengthReader{Reader: strings.NewReader(`{"name":"` + strings.Repeat("a", 256) + `"}`)},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 	require.Equal(t, "http: request entity too large", body)
-}
-
-type unknownLengthReader struct {
-	*strings.Reader
 }

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	httplogger "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ import (
 func TestRoundTripperLogsTransportError(t *testing.T) {
 	var logs bytes.Buffer
 	transportErr := errors.New("dial failed")
-	base := errorRoundTripper{err: transportErr}
+	base := &test.ErrorRoundTripper{Err: transportErr}
 	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
 	rt := httplogger.NewRoundTripper(&logger.Logger{Logger: slogLogger}, base)
 
@@ -27,12 +28,4 @@ func TestRoundTripperLogsTransportError(t *testing.T) {
 	require.Nil(t, res)
 	require.Contains(t, logs.String(), `"level":"ERROR"`)
 	require.Contains(t, logs.String(), `"error":"dial failed"`)
-}
-
-type errorRoundTripper struct {
-	err error
-}
-
-func (r errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
-	return nil, r.err
 }

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	"github.com/stretchr/testify/require"
@@ -12,8 +13,8 @@ import (
 func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
 	roundTripper := token.NewRoundTripper(
 		env.UserID("service-user"),
-		staticGenerator("fresh-token"),
-		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		test.NewGenerator("fresh-token", nil),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "Bearer fresh-token", req.Header.Get("Authorization"))
 
 			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
@@ -31,8 +32,8 @@ func TestRoundTripperDoesNotMutateRequest(t *testing.T) {
 func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	roundTripper := token.NewRoundTripper(
 		env.UserID("service-user"),
-		staticGenerator("fresh-token"),
-		roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		test.NewGenerator("fresh-token", nil),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "Bearer fresh-token", req.Header.Get("Authorization"))
 
 			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
@@ -46,16 +47,4 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
 	require.Nil(t, req.Header)
-}
-
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-type staticGenerator string
-
-func (g staticGenerator) Generate(_, _ string) ([]byte, error) {
-	return []byte(g), nil
 }


### PR DESCRIPTION
## What

- Move reusable benchmark telemetry setup, HTTP/gRPC doubles, token generators, lifecycle/server helpers, encoding readers, cache assertions, and error fakes into `internal/test`.
- Update cache, CLI, net, transport, encoding, meta, reflect, and database benchmark tests to use shared helpers.
- Keep package-local table data and narrowly scoped helper workflows in their current `_test.go` files.

## Why

- Reduce repeated named helpers across the suite while keeping common testing behavior in the repository test utility package.

## Testing

- `git diff --check` - passed
- `go test ./...` - passed
- `make specs` - passed
- `make lint` - passed
