### PR TITLE
docs(id): explain generator tradeoffs

### DIFF
--- a/id/doc.go
+++ b/id/doc.go
@@ -10,6 +10,11 @@
 // `id/ksuid`, `id/ulid`, `id/nanoid`, and `id/xid`). The `id.Module` wiring constructs these
 // generators and registers them into a `*Map`.
 //
+// Generator kinds are selected for different operational properties. The "uuid" generator is the
+// default and is optimized for the request metadata hot path. The "xid" generator is intentionally
+// available for compact, roughly sortable identifiers, but callers should not treat XIDs as opaque
+// or unpredictable values.
+//
 // # Configuration and enablement
 //
 // ID generation configuration is optional. A nil `*id.Config` selects the default "uuid" generator.

--- a/id/uuid/uuid.go
+++ b/id/uuid/uuid.go
@@ -8,6 +8,8 @@ import (
 func init() {
 	// UUIDv7 generation is on the request metadata hot path. The google/uuid
 	// random pool cuts it from 2 allocs/op to 1 alloc/op in BenchmarkGenerators.
+	// This intentionally accepts the library's process-wide heap-backed pool
+	// tradeoff because these IDs are operational identifiers, not secrets.
 	uuid.EnableRandPool()
 }
 

--- a/id/xid/xid.go
+++ b/id/xid/xid.go
@@ -6,11 +6,16 @@ import "github.com/rs/xid"
 //
 // The returned generator produces XID identifiers (globally unique identifiers that are compact and
 // roughly sortable) via github.com/rs/xid.
+//
+// XIDs intentionally expose ordering characteristics and are not designed to be opaque or
+// unpredictable. Use this generator for compact sortable IDs, not for secrets or bearer values.
 func NewGenerator() *Generator {
 	return &Generator{}
 }
 
 // Generator generates XID identifiers.
+//
+// XID values are compact and roughly sortable, but they are not opaque security tokens.
 type Generator struct{}
 
 // Generate returns a newly generated XID string.


### PR DESCRIPTION
## What

- Document that the default UUID generator intentionally uses the upstream random pool for request metadata hot-path performance.
- Clarify that XID is intentionally available for compact sortable identifiers, but should not be treated as opaque, unpredictable, secret, or bearer-token material.

## Why

- Record the accepted design tradeoffs from the `id` review so future reviews do not flag them as accidental security issues.

## Testing

- `git diff --check` - passed
- `go test ./id/...` - passed
- `make lint` - passed
