### PR TITLE
feat(transport): key server limits by verified principals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ matching skill for the task.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
+- Transport limiter keys are `"user-agent"`, `"ip"`, and `"user-id"`; `"token"` is intentionally not a limiter key. Server limiters run after token verification, so `"user-id"` is the verified principal (JWT/PASETO subject or SSH key name), and invalid or missing auth is rejected before the limiter.
+- The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
 - HTTP telemetry logger service/method derivation may include request URL path
   segments for non-canonical HTTP routes. This is intentional for client and
   server debugging because HTTP clients can call arbitrary paths and route

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ Supported key kinds (built-in):
 
 - `user-agent`
 - `ip`
-- `token`
+- `user-id`
 
 Example:
 
@@ -659,6 +659,9 @@ transport:
 Note:
 
 - `interval` is parsed as a Go duration string. Invalid values can fail fast.
+- The built-in limiter is an in-memory, per-process safeguard. Use it as a last resort and prefer an external edge, gateway, ingress, load balancer, or service-mesh limiter for production abuse protection.
+- The `user-id` key uses the verified principal stored in metadata. For JWT/PASETO tokens this is the subject claim; for SSH tokens this is the verified key name.
+- Server-side HTTP and gRPC limiters run after token verification, so missing or invalid authorization is rejected before it reaches the limiter.
 
 ---
 

--- a/transport/grpc/limiter/doc.go
+++ b/transport/grpc/limiter/doc.go
@@ -3,6 +3,15 @@
 // This package integrates rate limiting into gRPC servers (server-side interceptors) and gRPC clients
 // (client-side interceptors).
 //
+// Security note: treat the built-in limiter as a last-resort local protection
+// layer, not as the primary production abuse-control mechanism. Prefer an
+// external limiter at the edge, gateway, ingress, load balancer, or service-mesh
+// boundary for consistent enforcement before requests spend application CPU.
+//
+// Server-side gRPC limiter interceptors are installed after token verification
+// in the standard transport chain. Requests with missing or invalid
+// authorization are rejected before they reach this limiter.
+//
 // Start with `UnaryServerInterceptor` or `StreamServerInterceptor` for server-side limiting and
 // `UnaryClientInterceptor` or `StreamClientInterceptor` for client-side limiting.
 package limiter

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -69,10 +69,10 @@ func TestClientLimiterStream(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
-func TestClientLimiterUsesGeneratedTokenUnary(t *testing.T) {
+func TestServerLimiterUsesVerifiedUserIDUnary(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
-		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-id", "1s", 0)),
 		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldGRPC(),
 	)
@@ -87,13 +87,14 @@ func TestClientLimiterUsesGeneratedTokenUnary(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.SayHello(t.Context(), req)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
-func TestClientLimiterUsesGeneratedTokenStream(t *testing.T) {
+func TestServerLimiterUsesVerifiedUserIDStream(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
-		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-id", "1s", 0)),
 		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldGRPC(),
 	)
@@ -104,7 +105,9 @@ func TestClientLimiterUsesGeneratedTokenStream(t *testing.T) {
 	client := v1.NewGreeterServiceClient(conn)
 
 	require.NoError(t, sayStreamHello(t, client))
-	require.NoError(t, sayStreamHello(t, client))
+	err := sayStreamHello(t, client)
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
 func TestLimiterUnlimitedUnary(t *testing.T) {

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -78,9 +78,9 @@ type ServerParams struct {
 // The constructed server includes:
 //   - OpenTelemetry stats handling when tracing or metrics are enabled.
 //   - A unary interceptor chain that performs metadata extraction/injection, and optionally logging,
-//     rate limiting, and token verification, followed by any user-provided interceptors.
+//     token verification, and rate limiting, followed by any user-provided interceptors.
 //   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging
-//     rate limiting, and token verification, followed by any user-provided interceptors.
+//     token verification, and rate limiting, followed by any user-provided interceptors.
 //
 // TLS:
 // If TLS is enabled in config, server credentials are built from `params.Config.TLS`. Certificate/key
@@ -163,15 +163,12 @@ func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInte
 		uis = append(uis, logger.UnaryServerInterceptor(params.Logger))
 	}
 
-	// security: rate limiting runs before token verification so missing tokens
-	// and syntactically valid tokens that fail verification still consume quota
-	// instead of bypassing auth-cost protection.
-	if params.Limiter != nil {
-		uis = append(uis, limiter.UnaryServerInterceptor(params.Limiter))
-	}
-
 	if params.Verifier != nil {
 		uis = append(uis, token.UnaryServerInterceptor(params.UserID, params.Verifier))
+	}
+
+	if params.Limiter != nil {
+		uis = append(uis, limiter.UnaryServerInterceptor(params.Limiter))
 	}
 
 	uis = append(uis, interceptors...)
@@ -186,15 +183,12 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 		sis = append(sis, logger.StreamServerInterceptor(params.Logger))
 	}
 
-	// security: rate limiting runs before token verification so missing tokens
-	// and syntactically valid tokens that fail verification still consume quota
-	// instead of bypassing auth-cost protection.
-	if params.Limiter != nil {
-		sis = append(sis, limiter.StreamServerInterceptor(params.Limiter))
-	}
-
 	if params.Verifier != nil {
 		sis = append(sis, token.StreamServerInterceptor(params.UserID, params.Verifier))
+	}
+
+	if params.Limiter != nil {
+		sis = append(sis, limiter.StreamServerInterceptor(params.Limiter))
 	}
 
 	sis = append(sis, interceptors...)

--- a/transport/http/limiter/doc.go
+++ b/transport/http/limiter/doc.go
@@ -3,5 +3,14 @@
 // This package integrates rate limiting into HTTP servers (handler middleware) and HTTP clients
 // (RoundTripper middleware).
 //
+// Security note: treat the built-in limiter as a last-resort local protection
+// layer, not as the primary production abuse-control mechanism. Prefer an
+// external limiter at the edge, gateway, ingress, load balancer, or service-mesh
+// boundary for consistent enforcement before requests spend application CPU.
+//
+// Server-side HTTP limiter middleware is installed after token verification in
+// the standard transport chain. Requests with missing or invalid authorization
+// are rejected before they reach this limiter.
+//
 // Start with `NewHandler` for server-side limiting and `NewRoundTripper` for client-side limiting.
 package limiter

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -96,10 +96,10 @@ func TestClientLimiter(t *testing.T) {
 	}
 }
 
-func TestClientLimiterUsesGeneratedToken(t *testing.T) {
+func TestServerLimiterUsesVerifiedUserID(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
-		test.WithWorldClientLimiter(test.NewLimiterConfig("token", "1s", 0)),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-id", "1s", 0)),
 		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldHTTP(),
 		test.WithWorldHello(),
@@ -114,8 +114,8 @@ func TestClientLimiterUsesGeneratedToken(t *testing.T) {
 
 	res, body, err = world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "hello!", body)
+	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+	require.Equal(t, http.StatusText(http.StatusTooManyRequests), body)
 }
 
 func TestServerClosedLimiter(t *testing.T) {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -89,8 +89,8 @@ type ServerParams struct {
 // The server is built using Negroni and composes middleware in this order (first listed runs first):
 //   - metadata extraction/injection and response headers (`net/http/meta`)
 //   - optional logging (`transport/http/telemetry/logger`) when `params.Logger` is non-nil
-//   - optional rate limiting (`transport/http/limiter`) when `params.Limiter` is non-nil
 //   - optional token verification (`transport/http/token`) when `params.Verifier` is non-nil
+//   - optional rate limiting (`transport/http/limiter`) when `params.Limiter` is non-nil
 //   - inbound request body size limiting (`transport/http/body`)
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - gzip compression wrapping the mux not-found handler (`gzhttp.GzipHandler(http.NewNotFoundHandler(...))`)
@@ -122,15 +122,12 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(logger.NewHandler(params.Name, params.Logger))
 	}
 
-	// security: rate limiting runs before token verification so missing tokens
-	// and syntactically valid tokens that fail verification still consume quota
-	// instead of bypassing auth-cost protection.
-	if params.Limiter != nil {
-		neg.Use(limiter.NewHandler(params.Name, params.Limiter))
-	}
-
 	if params.Verifier != nil {
 		neg.Use(token.NewHandler(params.Name, params.UserID, params.Verifier))
+	}
+
+	if params.Limiter != nil {
+		neg.Use(limiter.NewHandler(params.Name, params.Limiter))
 	}
 
 	neg.Use(body.NewHandler(params.Config.GetMaxReceiveSize().Bytes()))

--- a/transport/limiter/config.go
+++ b/transport/limiter/config.go
@@ -7,7 +7,7 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // The limiter is typically constructed by `NewLimiter`, which interprets these fields as:
 //
 //   - Kind: selects how request keys are derived from context metadata (see NewKeyMap for default kinds).
-//     Examples: "user-agent", "ip", "token".
+//     Examples: "user-agent", "ip", "user-id".
 //
 //   - Interval: a typed duration encoded as a Go duration string (e.g. "1s", "1m")
 //     defining the refill/measurement window used by the underlying token bucket store.

--- a/transport/limiter/doc.go
+++ b/transport/limiter/doc.go
@@ -12,7 +12,7 @@
 //
 //   - "user-agent": meta.UserAgent
 //   - "ip": meta.IPAddr
-//   - "token": meta.Authorization
+//   - "user-id": meta.UserID
 //
 // The configured kind is typically provided via `Config.Kind`. If the kind is not present in the KeyMap,
 // limiter construction fails with ErrMissingKey.
@@ -25,15 +25,24 @@
 //
 // Use the "ip" key when the service is only reachable through trusted edge
 // infrastructure that strips or overwrites client-supplied forwarding headers.
-// If direct origin access is possible, prefer a different key such as "token" or
-// add application-specific trusted proxy validation before relying on IP-based
-// limits.
+// If direct origin access is possible, prefer a verified identity key such as
+// "user-id" or add application-specific trusted proxy validation before relying
+// on IP-based limits.
+//
+// The "user-id" key uses the verified principal stored in metadata. For
+// JWT/PASETO tokens this is the subject claim; for SSH tokens this is the
+// verified key name returned by the token verifier.
 //
 // # In-memory behavior and lifecycle
 //
 // The limiter uses an in-memory store. Limits are enforced per process and are not shared across replicas.
-// This makes it suitable for single-instance deployments, development environments, or as a local
-// protection mechanism, but not as a global distributed rate limit.
+// This makes it suitable for single-instance deployments, development environments, or as a last-resort
+// local safeguard, but not as a global distributed rate limit.
+//
+// For primary production abuse protection, prefer an external rate limiter at
+// the edge, gateway, ingress, load balancer, or service-mesh boundary. Those
+// layers can enforce limits consistently across replicas and before requests
+// spend application CPU.
 //
 // When constructed via `NewLimiter`, the underlying store is closed on application shutdown via an Fx/Dig
 // lifecycle hook.

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -16,7 +16,7 @@ import (
 // KeyFunc derives the metadata value used to key rate limits for ctx.
 //
 // The returned meta.Value is expected to yield a stable string via Value() that can be used as a
-// per-request/per-actor limiter key (for example a user-agent, an IP address, or an authorization token).
+// per-request/per-actor limiter key (for example a user-agent, an IP address, or a verified principal).
 type KeyFunc func(context.Context) meta.Value
 
 // KeyMap maps a configured kind string to the KeyFunc used to derive the limiter key.
@@ -29,7 +29,7 @@ type KeyMap map[string]KeyFunc
 // Supported default kinds are:
 //   - "user-agent": rate limit per User-Agent header (meta.UserAgent)
 //   - "ip": rate limit per client IP address (meta.IPAddr)
-//   - "token": rate limit per authorization token/header (meta.Authorization)
+//   - "user-id": rate limit per verified user/principal identifier (meta.UserID)
 //
 // These defaults are intended for controlled service-to-service traffic where user agents,
 // forwarded IP headers, and authorization metadata are supplied by trusted clients or platform
@@ -40,7 +40,7 @@ func NewKeyMap() KeyMap {
 	return KeyMap{
 		"user-agent": meta.UserAgent,
 		"ip":         meta.IPAddr,
-		"token":      meta.Authorization,
+		"user-id":    meta.UserID,
 	}
 }
 
@@ -72,9 +72,11 @@ func NewLimiter(lc di.Lifecycle, keys KeyMap, cfg *Config) (*Limiter, error) {
 	}
 
 	config := &memorystore.Config{
-		Tokens:        cfg.Tokens,
-		Interval:      cfg.Interval.Duration(),
-		SweepMinTTL:   time.Hour.Duration(),
+		Tokens:   cfg.Tokens,
+		Interval: cfg.Interval.Duration(),
+		// Keep buckets at least as long as the configured limiter window so long
+		// intervals are not purged and reset before the window completes.
+		SweepMinTTL:   max(time.Hour.Duration(), cfg.Interval.Duration()),
 		SweepInterval: time.Hour.Duration(),
 	}
 	store, _ := memorystore.New(config)

--- a/transport/limiter/module.go
+++ b/transport/limiter/module.go
@@ -5,7 +5,7 @@ import "github.com/alexfalkowski/go-service/v2/di"
 // Module wires limiter key derivation helpers into Fx/Dig.
 //
 // It provides a constructor for the default `KeyMap` via `NewKeyMap`. The returned map contains the
-// built-in key kinds supported by this package (e.g. "user-agent", "ip", and "token").
+// built-in key kinds supported by this package (e.g. "user-agent", "ip", and "user-id").
 //
 // # Extending key kinds
 //


### PR DESCRIPTION
## What

- Move HTTP and gRPC server limiter execution after token verification.
- Replace the built-in `token` limiter key with `user-id`, backed by the verified principal in metadata.
- Keep limiter buckets alive for at least the configured interval.
- Update limiter docs, README, AGENTS guidance, and server-side HTTP/gRPC tests.

## Why

- Avoid keying limits by raw authorization tokens.
- Make `user-id` limits use the verified subject for JWT/PASETO and the verified key name for SSH.
- Document that invalid or missing auth is rejected before the app limiter, and that the in-memory limiter is a last-resort local safeguard.

## Testing

- `go test ./transport/...` - passed
- `git diff --check` - passed
- `rg -n --glob '!bin/**' --glob '!vendor/**' -- 'NewLimiterConfig\\("token"|kind: token|"token":\\s*meta\\.Authorization|`token`.*limiter|limiter key.*token|token.*limiter key' .` - passed
