### PR TITLE
feat(transport): harden timeout defaults and validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ matching skill for the task.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
-- Transport limiter keys are `"user-agent"`, `"ip"`, and `"user-id"`; `"token"` is intentionally not a limiter key. Server limiters run after token verification, so `"user-id"` is the verified principal (JWT/PASETO subject or SSH key name), and invalid or missing auth is rejected before the limiter.
+- Transport limiter keys are `"user-agent"`, `"ip"`, and `"user-id"`; `"token"` is intentionally not a limiter key. Server limiters run after metadata extraction and token verification, so `"user-id"` is the verified principal (JWT/PASETO subject or SSH key name), and missing, malformed, or invalid auth is rejected before the limiter by design. Do not flag that bypass; use an external edge/gateway/ingress/load-balancer/service-mesh limiter when those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
 - HTTP telemetry logger service/method derivation may include request URL path
   segments for non-canonical HTTP routes. This is intentional for client and

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ Note:
 - `interval` is parsed as a Go duration string. Invalid values can fail fast.
 - The built-in limiter is an in-memory, per-process safeguard. Use it as a last resort and prefer an external edge, gateway, ingress, load balancer, or service-mesh limiter for production abuse protection.
 - The `user-id` key uses the verified principal stored in metadata. For JWT/PASETO tokens this is the subject claim; for SSH tokens this is the verified key name.
-- Server-side HTTP and gRPC limiters run after token verification, so missing or invalid authorization is rejected before it reaches the limiter.
+- Server-side HTTP and gRPC limiters run after metadata extraction and token verification, so missing, malformed, or invalid authorization is rejected before it reaches the limiter. This is intentional; enforce quotas for those attempts with an external edge, gateway, ingress, load balancer, or service-mesh limiter.
 
 ---
 

--- a/bytes/size.go
+++ b/bytes/size.go
@@ -12,6 +12,11 @@ const KB Size = Size(units.KB)
 // MB is the decimal megabyte size constant: 1,000,000 bytes.
 const MB Size = Size(units.MB)
 
+// DefaultSize is the shared default size used by config surfaces that need a conservative byte limit.
+//
+// Its value is 4 megabytes.
+const DefaultSize Size = 4 * MB
+
 // GB is the decimal gigabyte size constant: 1,000,000,000 bytes.
 const GB Size = Size(units.GB)
 

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -12,6 +12,10 @@ func TestMustParseSize(t *testing.T) {
 	require.Panics(t, func() { bytes.MustParseSize("test") })
 }
 
+func TestDefaultSize(t *testing.T) {
+	require.Equal(t, 4*bytes.MB, bytes.DefaultSize)
+}
+
 func TestSizeTextRoundTrip(t *testing.T) {
 	size := bytes.MustParseSize("4MB")
 

--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -2,9 +2,6 @@ package config
 
 import "github.com/alexfalkowski/go-service/v2/bytes"
 
-// DefaultMaxSize is the default cache value limit applied when MaxSize is omitted or zero.
-const DefaultMaxSize bytes.Size = 4 * bytes.MB
-
 // Config configures the cache subsystem.
 type Config struct {
 	// Options contains implementation-specific configuration for the selected Kind.
@@ -27,7 +24,7 @@ type Config struct {
 	//
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//
-	// A zero value applies DefaultMaxSize. Negative values are invalid.
+	// A zero value applies bytes.DefaultSize. Negative values are invalid.
 	MaxSize bytes.Size `yaml:"max_size,omitempty" json:"max_size,omitempty" toml:"max_size,omitempty" validate:"gte=0"`
 }
 
@@ -38,10 +35,10 @@ func (c *Config) IsEnabled() bool {
 
 // GetMaxSize returns the configured cache value limit.
 //
-// A nil receiver or a zero value falls back to DefaultMaxSize.
+// A nil receiver or a zero value falls back to bytes.DefaultSize.
 func (c *Config) GetMaxSize() bytes.Size {
 	if c == nil || c.MaxSize == 0 {
-		return DefaultMaxSize
+		return bytes.DefaultSize
 	}
 
 	return c.MaxSize

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -11,12 +11,12 @@ import (
 func TestGetMaxSize(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		var cfg *config.Config
-		require.Equal(t, config.DefaultMaxSize, cfg.GetMaxSize())
+		require.Equal(t, bytes.DefaultSize, cfg.GetMaxSize())
 	})
 
 	t.Run("zero", func(t *testing.T) {
 		cfg := &config.Config{}
-		require.Equal(t, config.DefaultMaxSize, cfg.GetMaxSize())
+		require.Equal(t, bytes.DefaultSize, cfg.GetMaxSize())
 	})
 
 	t.Run("explicit", func(t *testing.T) {

--- a/config/client/config.go
+++ b/config/client/config.go
@@ -34,7 +34,9 @@ type Config struct {
 	// Timeout is the client request timeout duration.
 	//
 	// In config files it is encoded as a Go duration string (for example "30s", "5m").
-	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	//
+	// Negative values are invalid.
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether client configuration is present.

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -10,12 +10,18 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
 	require.False(t, (*client.Config)(nil).IsEnabled())
 	require.True(t, (&client.Config{}).IsEnabled())
+}
+
+func TestConfigRejectsNegativeTimeout(t *testing.T) {
+	cfg := &client.Config{Timeout: -time.Second}
+	require.Error(t, test.Validator.Struct(cfg))
 }
 
 func TestNewConfig(t *testing.T) {

--- a/config/options/options.go
+++ b/config/options/options.go
@@ -1,6 +1,7 @@
 package options
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
@@ -30,6 +31,20 @@ func (m Map) Duration(key string, fallback time.Duration) time.Duration {
 		return time.MustParseDuration(val)
 	}
 	return fallback
+}
+
+// NonNegativeDuration returns a duration option for key and panics if the resolved value is negative.
+//
+// It behaves like Duration for parsing and fallback resolution, then enforces
+// that startup configuration cannot disable timeout-like protections with a
+// negative duration.
+func (m Map) NonNegativeDuration(key string, fallback time.Duration) time.Duration {
+	duration := m.Duration(key, fallback)
+	if duration < 0 {
+		runtime.Must(fmt.Errorf("options: %s must be non-negative: %s", key, duration))
+	}
+
+	return duration
 }
 
 // Uint32 returns an unsigned integer option for key if present; otherwise it returns fallback.

--- a/config/options/options_test.go
+++ b/config/options/options_test.go
@@ -16,6 +16,15 @@ func TestDuration(t *testing.T) {
 	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("bob", 5*time.Second))
 }
 
+func TestNonNegativeDuration(t *testing.T) {
+	opts := options.Map{"timeout": "10s"}
+
+	require.Equal(t, 10*time.Second, opts.NonNegativeDuration("timeout", time.Second))
+	require.Equal(t, time.Second, opts.NonNegativeDuration("missing", time.Second))
+	require.Panics(t, func() { options.Map{"timeout": "-1s"}.NonNegativeDuration("timeout", time.Second) })
+	require.Panics(t, func() { options.Map{"timeout": "invalid"}.NonNegativeDuration("timeout", time.Second) })
+}
+
 func TestUint32(t *testing.T) {
 	opts := options.Map{"count": "12"}
 

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -11,12 +11,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
 
-// DefaultMaxReceiveSize is the default inbound payload limit applied when MaxReceiveSize is omitted or zero.
-const DefaultMaxReceiveSize bytes.Size = 4 * bytes.MB
-
-// DefaultTimeout is the default server timeout applied when Timeout is omitted or zero.
-const DefaultTimeout time.Duration = 30 * time.Second
-
 // Config configures server-side behavior shared across transports.
 type Config struct {
 	// Limiter configures server-side request limiting.
@@ -38,14 +32,14 @@ type Config struct {
 	//
 	// In config files it is encoded as a Go duration string (for example "30s", "5m").
 	//
-	// A zero value applies DefaultTimeout.
-	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	// A zero value applies time.DefaultTimeout. Negative values are invalid.
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gte=0"`
 
 	// MaxReceiveSize limits inbound request payload size.
 	//
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//
-	// A zero value applies DefaultMaxReceiveSize. Negative values are invalid.
+	// A zero value applies bytes.DefaultSize. Negative values are invalid.
 	MaxReceiveSize bytes.Size `yaml:"max_receive_size,omitempty" json:"max_receive_size,omitempty" toml:"max_receive_size,omitempty" validate:"gte=0"`
 }
 
@@ -56,10 +50,10 @@ func (c *Config) IsEnabled() bool {
 
 // GetMaxReceiveSize returns the configured inbound payload limit.
 //
-// A nil receiver or a zero value falls back to DefaultMaxReceiveSize.
+// A nil receiver or a zero value falls back to bytes.DefaultSize.
 func (c *Config) GetMaxReceiveSize() bytes.Size {
 	if c == nil || c.MaxReceiveSize == 0 {
-		return DefaultMaxReceiveSize
+		return bytes.DefaultSize
 	}
 
 	return c.MaxReceiveSize
@@ -67,10 +61,10 @@ func (c *Config) GetMaxReceiveSize() bytes.Size {
 
 // GetTimeout returns the configured server timeout.
 //
-// A nil receiver or a zero value falls back to DefaultTimeout.
+// A nil receiver or a non-positive value falls back to time.DefaultTimeout.
 func (c *Config) GetTimeout() time.Duration {
-	if c == nil || c.Timeout == 0 {
-		return DefaultTimeout
+	if c == nil || c.Timeout <= 0 {
+		return time.DefaultTimeout
 	}
 
 	return c.Timeout

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -21,8 +21,8 @@ func TestGetMaxReceiveSize(t *testing.T) {
 		name string
 		want bytes.Size
 	}{
-		{name: "nil", want: server.DefaultMaxReceiveSize},
-		{name: "zero", cfg: &server.Config{}, want: server.DefaultMaxReceiveSize},
+		{name: "nil", want: bytes.DefaultSize},
+		{name: "zero", cfg: &server.Config{}, want: bytes.DefaultSize},
 		{name: "explicit", cfg: &server.Config{MaxReceiveSize: 64}, want: 64},
 	}
 
@@ -39,8 +39,9 @@ func TestGetTimeout(t *testing.T) {
 		name string
 		want time.Duration
 	}{
-		{name: "nil", want: server.DefaultTimeout},
-		{name: "zero", cfg: &server.Config{}, want: server.DefaultTimeout},
+		{name: "nil", want: time.DefaultTimeout},
+		{name: "zero", cfg: &server.Config{}, want: time.DefaultTimeout},
+		{name: "negative", cfg: &server.Config{Timeout: -time.Second}, want: time.DefaultTimeout},
 		{name: "explicit", cfg: &server.Config{Timeout: 5 * time.Second}, want: 5 * time.Second},
 	}
 
@@ -53,6 +54,11 @@ func TestGetTimeout(t *testing.T) {
 
 func TestConfigRejectsNegativeMaxReceiveSize(t *testing.T) {
 	cfg := &server.Config{MaxReceiveSize: -1}
+	require.Error(t, test.Validator.Struct(cfg))
+}
+
+func TestConfigRejectsNegativeTimeout(t *testing.T) {
+	cfg := &server.Config{Timeout: -time.Second}
 	require.Error(t, test.Validator.Struct(cfg))
 }
 

--- a/database/sql/config/config.go
+++ b/database/sql/config/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
 	//
 	// In config files it is encoded as a Go duration string (for example "30s", "5m", "1h").
-	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime,omitempty" json:"conn_max_lifetime,omitempty" toml:"conn_max_lifetime,omitempty"`
+	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime,omitempty" json:"conn_max_lifetime,omitempty" toml:"conn_max_lifetime,omitempty" validate:"gte=0"`
 
 	// MaxOpenConns is the maximum number of open connections to the database.
 	MaxOpenConns int `yaml:"max_open_conns,omitempty" json:"max_open_conns,omitempty" toml:"max_open_conns,omitempty"`

--- a/database/sql/config/config_test.go
+++ b/database/sql/config/config_test.go
@@ -1,0 +1,15 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/database/sql/config"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigRejectsNegativeConnMaxLifetime(t *testing.T) {
+	cfg := &config.Config{ConnMaxLifetime: -time.Second}
+	require.Error(t, test.Validator.Struct(cfg))
+}

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -349,17 +349,17 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption) *Server {
 	os := make([]ServerOption, 0, 8+len(opts))
 	os = append(os, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-		MinTime:             options.Duration("keepalive_enforcement_policy_ping_min_time", timeout).Duration(),
+		MinTime:             options.NonNegativeDuration("keepalive_enforcement_policy_ping_min_time", timeout).Duration(),
 		PermitWithoutStream: true,
 	}))
 	os = append(os, grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionIdle:     options.Duration("keepalive_max_connection_idle", timeout).Duration(),
-		MaxConnectionAge:      options.Duration("keepalive_max_connection_age", timeout).Duration(),
-		MaxConnectionAgeGrace: options.Duration("keepalive_max_connection_age_grace", timeout).Duration(),
-		Time:                  options.Duration("keepalive_ping_time", timeout).Duration(),
+		MaxConnectionIdle:     options.NonNegativeDuration("keepalive_max_connection_idle", timeout).Duration(),
+		MaxConnectionAge:      options.NonNegativeDuration("keepalive_max_connection_age", timeout).Duration(),
+		MaxConnectionAgeGrace: options.NonNegativeDuration("keepalive_max_connection_age_grace", timeout).Duration(),
+		Time:                  options.NonNegativeDuration("keepalive_ping_time", timeout).Duration(),
 		Timeout:               timeout.Duration(),
 	}))
-	os = append(os, grpc.ConnectionTimeout(options.Duration("connection_timeout", timeout).Duration()))
+	os = append(os, grpc.ConnectionTimeout(options.NonNegativeDuration("connection_timeout", timeout).Duration()))
 	if _, ok := options["max_concurrent_streams"]; ok {
 		os = append(os, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 0)))
 	}

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -30,6 +30,25 @@ func TestNewServerWithAdvancedOptions(t *testing.T) {
 	})
 }
 
+func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
+	keys := []string{
+		"keepalive_enforcement_policy_ping_min_time",
+		"keepalive_max_connection_idle",
+		"keepalive_max_connection_age",
+		"keepalive_max_connection_age_grace",
+		"keepalive_ping_time",
+		"connection_timeout",
+	}
+
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			require.Panics(t, func() {
+				grpc.NewServer(options.Map{key: "-1s"}, time.Second)
+			})
+		})
+	}
+}
+
 func TestNewServerWithOverflowingAdvancedOptions(t *testing.T) {
 	require.Panics(t, func() {
 		grpc.NewServer(options.Map{"initial_window_size": "3GB"}, time.Second)

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -15,9 +15,6 @@ import (
 	"github.com/alexfalkowski/go-sync"
 )
 
-// DefaultMaxResponseSize is the default outbound response body limit.
-const DefaultMaxResponseSize bytes.Size = 4 * bytes.MB
-
 // ClientOption configures the HTTP client wrapper constructed by NewClient.
 //
 // Options are applied in the order provided to NewClient. If multiple options configure the same
@@ -56,7 +53,7 @@ func WithRoundTripper(rt http.RoundTripper) ClientOption {
 // The timeout value is assigned to http.Client.Timeout (total time limit for a request, including
 // connection time, redirects, and reading the response body).
 //
-// If not provided, NewClient defaults to 30 seconds.
+// If not provided, NewClient defaults to time.DefaultTimeout.
 func WithTimeout(timeout time.Duration) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.timeout = timeout
@@ -65,7 +62,7 @@ func WithTimeout(timeout time.Duration) ClientOption {
 
 // WithMaxResponseSize sets the maximum response body size buffered by Client.Do.
 //
-// If not provided, NewClient defaults to DefaultMaxResponseSize.
+// If not provided, NewClient defaults to bytes.DefaultSize.
 func WithMaxResponseSize(size bytes.Size) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.maxResponseSize = size
@@ -289,12 +286,12 @@ func options(opts ...ClientOption) *clientOpts {
 		o.apply(os)
 	}
 
-	if os.timeout == 0 {
-		os.timeout = 30 * time.Second
+	if os.timeout <= 0 {
+		os.timeout = time.DefaultTimeout
 	}
 
 	if os.maxResponseSize <= 0 {
-		os.maxResponseSize = DefaultMaxResponseSize
+		os.maxResponseSize = bytes.DefaultSize
 	}
 
 	if os.roundTripper == nil {

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -115,7 +115,7 @@ func TestDoUsesDefaultMaxResponseSize(t *testing.T) {
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.NoError(t, err)
-	require.Equal(t, 4*bytes.MB, client.DefaultMaxResponseSize)
+	require.Equal(t, 4*bytes.MB, bytes.DefaultSize)
 }
 
 func TestDoUsesMsgPack(t *testing.T) {

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -268,15 +268,15 @@ func StatusText(code int) string {
 //
 // Protocols are configured via Protocols().
 //
-// Note: options.Duration uses MustParseDuration under the hood; invalid option values will panic at
-// server construction time.
+// Note: options.NonNegativeDuration uses MustParseDuration under the hood; invalid or negative option
+// values will panic at server construction time.
 func NewServer(options options.Map, timeout time.Duration, handler Handler) *Server {
 	return &http.Server{
 		Handler:           handler,
-		ReadTimeout:       options.Duration("read_timeout", timeout).Duration(),
-		WriteTimeout:      options.Duration("write_timeout", timeout).Duration(),
-		IdleTimeout:       options.Duration("idle_timeout", timeout).Duration(),
-		ReadHeaderTimeout: options.Duration("read_header_timeout", timeout).Duration(),
+		ReadTimeout:       options.NonNegativeDuration("read_timeout", timeout).Duration(),
+		WriteTimeout:      options.NonNegativeDuration("write_timeout", timeout).Duration(),
+		IdleTimeout:       options.NonNegativeDuration("idle_timeout", timeout).Duration(),
+		ReadHeaderTimeout: options.NonNegativeDuration("read_header_timeout", timeout).Duration(),
 		MaxHeaderBytes:    mustIntSize(options, "max_header_bytes", bytes.Size(DefaultMaxHeaderBytes)),
 		Protocols:         Protocols(),
 	}

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -28,6 +30,18 @@ func TestMaxBytesHandler(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
+}
+
+func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	for _, key := range []string{"read_timeout", "write_timeout", "idle_timeout", "read_header_timeout"} {
+		t.Run(key, func(t *testing.T) {
+			require.Panics(t, func() {
+				http.NewServer(options.Map{key: "-1s"}, time.Second, handler)
+			})
+		})
+	}
 }
 
 func TestHandleWhenTelemetryDisabled(t *testing.T) {

--- a/time/duration.go
+++ b/time/duration.go
@@ -43,6 +43,11 @@ const Nanosecond Duration = Duration(time.Nanosecond)
 // Its value is one second.
 const Second Duration = Duration(time.Second)
 
+// DefaultTimeout is the shared default timeout used by client, server, and retry configuration.
+//
+// Its value is 30 seconds.
+const DefaultTimeout Duration = 30 * Second
+
 // Duration is the go-service duration type used across the repository.
 //
 // It is a named type over the standard library `time.Duration` so it can expose

--- a/time/duration_test.go
+++ b/time/duration_test.go
@@ -12,6 +12,10 @@ func TestMustParseDuration(t *testing.T) {
 	require.Panics(t, func() { time.MustParseDuration("test") })
 }
 
+func TestDefaultTimeout(t *testing.T) {
+	require.Equal(t, 30*time.Second, time.DefaultTimeout)
+}
+
 func TestDurationTextRoundTrip(t *testing.T) {
 	duration := 5*time.Second + 250*time.Millisecond
 

--- a/token/jwt/config.go
+++ b/token/jwt/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	// Expiration is the duration used to set and validate the `exp` claim.
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
-	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether JWT configuration is present.

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestConfigRejectsNegativeExpiration(t *testing.T) {
+	cfg := &jwt.Config{Expiration: -time.Second}
+	require.Error(t, test.Validator.Struct(cfg))
+}
+
 func TestValid(t *testing.T) {
 	ec := test.NewEd25519()
 	signer, _ := ed25519.NewSigner(test.PEM, ec)

--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	// Expiration is the duration used to set token expiration.
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
-	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether PASETO configuration is present.

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestConfigRejectsNegativeExpiration(t *testing.T) {
+	cfg := &paseto.Config{Expiration: -time.Second}
+	require.Error(t, test.Validator.Struct(cfg))
+}
+
 func TestValid(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	ec := test.NewEd25519()

--- a/token/ssh/config.go
+++ b/token/ssh/config.go
@@ -56,7 +56,7 @@ type Config struct {
 	// Expiration is the duration used to set token expiration.
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "1h".
-	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty"`
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether SSH token configuration is enabled.

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestConfigRejectsNegativeExpiration(t *testing.T) {
+	cfg := &ssh.Config{Expiration: -time.Second}
+	require.Error(t, test.Validator.Struct(cfg))
+}
+
 func TestValid(t *testing.T) {
 	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -81,7 +81,7 @@ func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 
 // WithClientTimeout sets the default per-RPC timeout applied by the timeout interceptor.
 //
-// If unset, a default timeout is applied (see `NewDialOptions` defaults).
+// If unset or negative, a default timeout is applied (see `NewDialOptions` defaults).
 //
 // Note: this timeout is enforced via an interceptor and is independent from any deadlines already set
 // on the incoming context; the interceptor will typically only apply a timeout when a deadline is not
@@ -362,8 +362,8 @@ func options(opts ...ClientOption) *clientOpts {
 	for _, o := range opts {
 		o.apply(os)
 	}
-	if os.timeout == 0 {
-		os.timeout = 30 * time.Second
+	if os.timeout <= 0 {
+		os.timeout = time.DefaultTimeout
 	}
 	if os.generator == nil {
 		os.generator = uuid.NewGenerator()

--- a/transport/grpc/limiter/doc.go
+++ b/transport/grpc/limiter/doc.go
@@ -8,9 +8,12 @@
 // external limiter at the edge, gateway, ingress, load balancer, or service-mesh
 // boundary for consistent enforcement before requests spend application CPU.
 //
-// Server-side gRPC limiter interceptors are installed after token verification
-// in the standard transport chain. Requests with missing or invalid
-// authorization are rejected before they reach this limiter.
+// Server-side gRPC limiter interceptors are installed after metadata extraction
+// and token verification in the standard transport chain. Requests with
+// missing, malformed, or invalid authorization are rejected before they reach
+// this limiter; that is intentional and should be handled by an external edge,
+// gateway, ingress, load balancer, or service-mesh limiter when those attempts
+// need quota enforcement.
 //
 // Start with `UnaryServerInterceptor` or `StreamServerInterceptor` for server-side limiting and
 // `UnaryClientInterceptor` or `StreamClientInterceptor` for client-side limiting.

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -58,7 +58,7 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 //
 // Behavior:
 //   - It checks whether the logical RPC is eligible for retry using policies.
-//   - It uses the typed per-attempt timeout and backoff durations from cfg.
+//   - It uses the typed per-attempt timeout from cfg.GetTimeout() and the backoff duration from cfg.
 //   - It retries up to `cfg.MaxAttempts()` total attempts (including the initial attempt).
 //   - It applies a per-attempt timeout (`retry.WithPerRetryTimeout`) so each attempt is bounded.
 //   - It uses a linear backoff strategy with a step duration derived from `cfg.Backoff`.
@@ -81,7 +81,7 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 		retry.WithCodes(codes.Unavailable, codes.DataLoss),
 		retry.WithMax(uint(cfg.MaxAttempts())),
 		retry.WithBackoff(retry.BackoffLinear(cfg.Backoff.Duration())),
-		retry.WithPerRetryTimeout(cfg.Timeout.Duration()),
+		retry.WithPerRetryTimeout(cfg.GetTimeout().Duration()),
 	)
 
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -80,7 +80,7 @@ func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 // This is the overall time limit for requests made by the constructed client (including connection time,
 // redirects, and reading the response body), as enforced by Go's `http.Client.Timeout` semantics.
 //
-// If unset, a default timeout is applied (see `options()` defaults).
+// If unset or negative, a default timeout is applied (see `options()` defaults).
 func WithClientTimeout(timeout time.Duration) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.timeout = timeout
@@ -290,8 +290,8 @@ func options(opts ...ClientOption) *clientOpts {
 		o.apply(os)
 	}
 
-	if os.timeout == 0 {
-		os.timeout = 30 * time.Second
+	if os.timeout <= 0 {
+		os.timeout = time.DefaultTimeout
 	}
 
 	if os.generator == nil {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/stretchr/testify/require"
 )
@@ -17,4 +18,10 @@ func TestClient(t *testing.T) {
 
 	_, err = http.NewClient(http.WithClientTLS(&tls.Config{}))
 	require.NoError(t, err)
+}
+
+func TestClientNegativeTimeoutUsesDefault(t *testing.T) {
+	client, err := http.NewClient(http.WithClientTimeout(-time.Second))
+	require.NoError(t, err)
+	require.Equal(t, time.DefaultTimeout.Duration(), client.Timeout)
 }

--- a/transport/http/limiter/doc.go
+++ b/transport/http/limiter/doc.go
@@ -8,9 +8,12 @@
 // external limiter at the edge, gateway, ingress, load balancer, or service-mesh
 // boundary for consistent enforcement before requests spend application CPU.
 //
-// Server-side HTTP limiter middleware is installed after token verification in
-// the standard transport chain. Requests with missing or invalid authorization
-// are rejected before they reach this limiter.
+// Server-side HTTP limiter middleware is installed after metadata extraction
+// and token verification in the standard transport chain. Requests with
+// missing, malformed, or invalid authorization are rejected before they reach
+// this limiter; that is intentional and should be handled by an external edge,
+// gateway, ingress, load balancer, or service-mesh limiter when those attempts
+// need quota enforcement.
 //
 // Start with `NewHandler` for server-side limiting and `NewRoundTripper` for client-side limiting.
 package limiter

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -74,7 +74,7 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 //
 // The constructed RoundTripper wraps hrt and, for each request:
 //   - checks whether the request is eligible for retry using policies, and
-//   - applies a per-attempt timeout derived from `cfg.Timeout`, and
+//   - applies a per-attempt timeout derived from `cfg.GetTimeout()`, and
 //   - retries responses and status errors with retryable HTTP status codes, and
 //   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`, and
 //   - waits a constant backoff derived from `cfg.Backoff` between attempts.
@@ -97,7 +97,7 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 		RoundTripper: hrt,
 		backoff:      cfg.Backoff,
 		policy:       composePolicy(policies),
-		timeout:      cfg.Timeout,
+		timeout:      cfg.GetTimeout(),
 		maxRetries:   cfg.MaxRetries(),
 	}
 }
@@ -175,10 +175,6 @@ func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *
 }
 
 func (r *RoundTripper) withAttemptTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	if r.timeout <= 0 {
-		return ctx, func() {}
-	}
-
 	return context.WithTimeoutCause(ctx, r.timeout, ErrAttemptTimeout)
 }
 

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -352,8 +352,12 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	require.Equal(t, []int{1, 1}, rt.AuthCounts)
 }
 
-func TestRoundTripperDoesNotSetAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
-	transport := &test.CauseRoundTripper{}
+func TestRoundTripperUsesDefaultAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
+	var deadlineSet bool
+	transport := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		_, deadlineSet = req.Context().Deadline()
+		return test.ResponseWithStatus(http.StatusOK), nil
+	})
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
 		Timeout:  0,
@@ -365,8 +369,7 @@ func TestRoundTripperDoesNotSetAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.NoError(t, transport.Err)
-	require.NoError(t, transport.Cause)
+	require.True(t, deadlineSet)
 }
 
 func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {

--- a/transport/limiter/config.go
+++ b/transport/limiter/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	// Interval is a typed duration that defines the refill window.
 	//
 	// In config files it is encoded as a Go duration string, for example "1s" or "1m".
-	Interval time.Duration `yaml:"interval,omitempty" json:"interval,omitempty" toml:"interval,omitempty"`
+	Interval time.Duration `yaml:"interval,omitempty" json:"interval,omitempty" toml:"interval,omitempty" validate:"gte=0"`
 
 	// Tokens is the maximum number of tokens available per interval, per derived key.
 	//

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -3,12 +3,18 @@ package limiter_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
+
+func TestConfigRejectsNegativeInterval(t *testing.T) {
+	cfg := &limiter.Config{Interval: -time.Second}
+	require.Error(t, test.Validator.Struct(cfg))
+}
 
 func TestValidLimiter(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)

--- a/transport/retry/config.go
+++ b/transport/retry/config.go
@@ -19,7 +19,8 @@ type Config struct {
 	// independently (for example by deriving a per-attempt context deadline).
 	//
 	// Value encoding: Go duration string (for example "250ms", "5s").
-	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	// A zero value applies time.DefaultTimeout. Negative values are invalid.
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gte=0"`
 
 	// Backoff is the delay between attempts after a failed attempt.
 	//
@@ -28,7 +29,7 @@ type Config struct {
 	// implementation.
 	//
 	// Value encoding: Go duration string (for example "100ms", "1s").
-	Backoff time.Duration `yaml:"backoff,omitempty" json:"backoff,omitempty" toml:"backoff,omitempty"`
+	Backoff time.Duration `yaml:"backoff,omitempty" json:"backoff,omitempty" toml:"backoff,omitempty" validate:"gte=0"`
 
 	// Attempts is the maximum number of attempts, including the initial attempt.
 	//
@@ -49,6 +50,17 @@ func (c *Config) MaxAttempts() uint64 {
 	}
 
 	return c.Attempts
+}
+
+// GetTimeout returns the configured per-attempt retry timeout.
+//
+// A nil receiver or a non-positive value falls back to time.DefaultTimeout.
+func (c *Config) GetTimeout() time.Duration {
+	if c == nil || c.Timeout <= 0 {
+		return time.DefaultTimeout
+	}
+
+	return c.Timeout
 }
 
 // MaxRetries returns the maximum number of retries after the initial attempt.

--- a/transport/retry/config_test.go
+++ b/transport/retry/config_test.go
@@ -3,9 +3,46 @@ package retry_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/retry"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConfigRejectsNegativeDurations(t *testing.T) {
+	tests := []struct {
+		cfg  *retry.Config
+		name string
+	}{
+		{name: "timeout", cfg: &retry.Config{Timeout: -time.Second}},
+		{name: "backoff", cfg: &retry.Config{Backoff: -time.Second}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, test.Validator.Struct(tt.cfg))
+		})
+	}
+}
+
+func TestConfigGetTimeout(t *testing.T) {
+	tests := []struct {
+		cfg  *retry.Config
+		name string
+		want time.Duration
+	}{
+		{name: "nil", want: time.DefaultTimeout},
+		{name: "zero", cfg: &retry.Config{}, want: time.DefaultTimeout},
+		{name: "negative", cfg: &retry.Config{Timeout: -time.Second}, want: time.DefaultTimeout},
+		{name: "explicit", cfg: &retry.Config{Timeout: time.Second}, want: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.cfg.GetTimeout())
+		})
+	}
+}
 
 func TestConfigMaxAttempts(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What

- Add a shared `time.DefaultTimeout` and use it for server, client, and retry timeout defaults.
- Add non-negative duration option handling for HTTP and gRPC server timeout/keepalive options.
- Reject negative duration config for client timeout, server timeout, retry timeout/backoff, limiter interval, token expirations, and SQL connection max lifetime.
- Make retry `timeout: 0s` use the default per-attempt timeout through `retry.Config.GetTimeout()`.
- Document that missing, malformed, or invalid auth is rejected before the server limiter by design.

## Why

- Prevent negative timeout values from disabling timeout protections or weakening startup configuration.
- Keep timeout defaulting consistent across HTTP, gRPC, server, client, and retry paths.
- Make the accepted limiter/auth ordering explicit so future reviews do not report it as a bypass.

## Testing

- `go test ./transport/...` - passed
- `go test ./config/... ./token/... ./database/sql/... ./net/http ./net/http/client ./net/grpc ./time` - passed
- `git diff --check` - passed
