### PR TITLE
feat(transport): harden security defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,11 @@ matching skill for the task.
   `Config.MaxReceiveSize` before verification. Do not flag this as an
   unbounded-read issue unless the code path bypasses the transport server chain
   without an equivalent request-size cap.
+- HTTP webhook verification intentionally does not maintain replay state.
+  Receivers must deduplicate or process idempotently using `Webhook-Id` or the
+  event id, preferably with durable shared storage when duplicate valid
+  deliveries would be unsafe. Do not flag missing transport-level replay
+  storage unless the code starts promising replay protection.
 - HTTP webhook signing intentionally ignores the Standard Webhooks `Sign` error
   because the current vendored implementation always returns nil. Do not flag
   this unless the dependency behavior changes.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ hooks:
 
 `secret` is a source string.
 
+Inbound verification checks Standard Webhooks signatures and timestamps, but
+does not store or reject previously seen webhook ids. Receivers that perform
+non-idempotent work should deduplicate or process idempotently using
+`Webhook-Id` or the event id, backed by durable shared storage when running more
+than one receiver instance.
+
 ---
 
 ## ID generation

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -5,11 +5,15 @@ import (
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	tlsconfig "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
+
+// ErrMissingKeyPair is returned when server TLS is configured without a complete certificate/key pair.
+var ErrMissingKeyPair = errors.New("server: missing tls key pair")
 
 // Config configures server-side behavior shared across transports.
 type Config struct {
@@ -84,14 +88,16 @@ func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
 		return config, nil
 	}
 
-	if cfg.HasKeyMaterial() {
-		pair, err := tlsconfig.NewKeyPair(fs, cfg)
-		if err != nil {
-			return config, err
-		}
-
-		config.Certificates = []tls.Certificate{pair}
+	if !cfg.HasKeyPair() {
+		return config, ErrMissingKeyPair
 	}
+
+	pair, err := tlsconfig.NewKeyPair(fs, cfg)
+	if err != nil {
+		return config, err
+	}
+
+	config.Certificates = []tls.Certificate{pair}
 
 	if cfg.HasCA() {
 		pool, err := tlsconfig.NewCertPool(fs, cfg)

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -125,10 +125,10 @@ func TestNewConfigWithKeyPairOnly(t *testing.T) {
 
 func TestNewConfigWithCAOnly(t *testing.T) {
 	tlsConfig, err := server.NewConfig(test.FS, &config.Config{CA: test.FilePath("certs/rootCA.pem")})
-	require.NoError(t, err)
+	require.ErrorIs(t, err, server.ErrMissingKeyPair)
 	require.Empty(t, tlsConfig.Certificates)
-	require.NotNil(t, tlsConfig.ClientCAs)
-	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+	require.Nil(t, tlsConfig.ClientCAs)
+	require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
 }
 
 func TestNewConfigInvalidKeyPair(t *testing.T) {

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -110,9 +110,9 @@ func WithClientKeepalive(ping, timeout time.Duration) ClientOption {
 // typically includes a maximum attempt count, per-retry timeout, and a backoff strategy.
 // Optional policies decide whether a logical unary RPC is eligible for retry.
 //
-// Backward compatibility: when no policy is provided, all unary RPCs are eligible for retry when they hit a
-// retryable gRPC status. New callers that only want side-effect-safe retries should pass
-// `transport/grpc/retry.IdempotentMethods` or another explicit policy.
+// When no policy is provided, only side-effect-safe unary RPCs are eligible for retry: AIP-style read methods,
+// or calls carrying a request-id idempotency contract. Callers that need different behavior can pass an
+// explicit policy.
 //
 // If cfg is nil, retries are not enabled.
 func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -4,9 +4,9 @@
 // client-side interceptors) and centralizes retry-related defaults used by the
 // transport stack.
 //
-// Backward compatibility: if no policy is passed to UnaryClientInterceptor, all unary RPCs are eligible for
-// retry when they hit a retryable gRPC status. New callers that only want side-effect-safe retries should pass
-// IdempotentMethods, StandardReadMethods, or another explicit policy.
+// Default policy: if no policy is passed to UnaryClientInterceptor, only side-effect-safe unary RPCs are
+// eligible for retry. This includes AIP-style read methods and requests carrying a request-id idempotency
+// contract. Callers that need broader retry behavior can pass an explicit policy.
 //
 // Start with `Config` and `UnaryClientInterceptor`.
 package retry

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -24,11 +24,6 @@ type Config = config.Config
 // configured gRPC status codes after the policy allows the logical RPC.
 type Policy func(ctx context.Context, fullMethod string, req any) bool
 
-// AllowAll allows retries for every unary RPC.
-func AllowAll(context.Context, string, any) bool {
-	return true
-}
-
 // StandardReadMethods allows retries for AIP-style read methods named Get* or List*.
 func StandardReadMethods(_ context.Context, fullMethod string, _ any) bool {
 	_, method, _ := strings.SplitServiceMethod(fullMethod)
@@ -65,12 +60,12 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 //
 // Failure classification:
 // Retries are only attempted for selected gRPC status codes. This implementation currently retries on
-// `codes.Unavailable` and `codes.DataLoss` (see `retry.WithCodes` in the implementation).
+// `codes.Unavailable` (see `retry.WithCodes` in the implementation).
 //
 // Policy behavior:
-// When no policy is provided, all unary RPCs are eligible for retry when they hit a retryable gRPC status.
-// This preserves historical behavior. New callers that only want side-effect-safe retries should pass
-// IdempotentMethods, StandardReadMethods, or another explicit policy.
+// When no policy is provided, only side-effect-safe unary RPCs are eligible for retry: AIP-style read methods,
+// or calls carrying a request-id idempotency contract. Callers that need different behavior can pass an
+// explicit policy.
 //
 // Notes:
 // This interceptor does not automatically retry on every error; application-level errors that map to other
@@ -78,7 +73,7 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInterceptor {
 	policy := composePolicy(policies)
 	interceptor := retry.UnaryClientInterceptor(
-		retry.WithCodes(codes.Unavailable, codes.DataLoss),
+		retry.WithCodes(codes.Unavailable),
 		retry.WithMax(uint(cfg.MaxAttempts())),
 		retry.WithBackoff(retry.BackoffLinear(cfg.Backoff.Duration())),
 		retry.WithPerRetryTimeout(cfg.GetTimeout().Duration()),
@@ -102,7 +97,7 @@ func composePolicy(policies []Policy) Policy {
 	}
 
 	if len(filtered) == 0 {
-		return AllowAll
+		return IdempotentMethods
 	}
 
 	return func(ctx context.Context, fullMethod string, req any) bool {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -31,7 +31,7 @@ func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorRetriesWhenAttemptsIsTwo(t *testing.T) {
+func TestUnaryClientInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 2,
 		Timeout:  time.Second,
@@ -39,7 +39,7 @@ func TestUnaryClientInterceptorRetriesWhenAttemptsIsTwo(t *testing.T) {
 	})
 
 	calls := 0
-	err := interceptor(t.Context(), "/test.Service/SayHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 		calls++
 		if calls == 1 {
 			return status.Error(codes.Unavailable, "unavailable")
@@ -50,6 +50,40 @@ func TestUnaryClientInterceptorRetriesWhenAttemptsIsTwo(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
+}
+
+func TestUnaryClientInterceptorDoesNotRetryUnsafeMethodByDefault(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	})
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestUnaryClientInterceptorDoesNotRetryDataLossByDefault(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	})
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.DataLoss, "data loss")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
 }
 
 func TestUnaryClientInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) {

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/config/server"
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -46,4 +47,20 @@ func TestInvalidServer(t *testing.T) {
 
 	_, err := grpc.NewServer(params)
 	require.Error(t, err)
+}
+
+func TestServerRejectsCAOnlyTLS(t *testing.T) {
+	cfg := &grpc.Config{
+		Config: &server.Config{
+			Timeout: 5 * time.Second,
+			TLS:     &tls.Config{CA: test.FilePath("certs/rootCA.pem")},
+		},
+	}
+	params := grpc.ServerParams{
+		Shutdowner: test.NewShutdowner(),
+		Config:     cfg,
+	}
+
+	_, err := grpc.NewServer(params)
+	require.ErrorIs(t, err, server.ErrMissingKeyPair)
 }

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -106,9 +106,9 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 // according to cfg (attempt count, backoff, and which status codes are considered retryable).
 // Optional policies decide whether a logical request is eligible for retry.
 //
-// Backward compatibility: when no policy is provided, all requests are eligible for retry when they hit a
-// retryable transport error or status. New callers that only want side-effect-safe retries should pass
-// `transport/http/retry.IdempotentRequests` or another explicit policy.
+// When no policy is provided, only side-effect-safe requests are eligible for retry: safe HTTP methods, or
+// requests carrying a request-id idempotency contract. Callers that need different behavior can pass an
+// explicit policy.
 //
 // If cfg is nil, retries are not enabled.
 func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {

--- a/transport/http/events/hooks/doc.go
+++ b/transport/http/events/hooks/doc.go
@@ -6,4 +6,9 @@
 // Disabled behavior:
 // When webhook support is disabled, the returned handler behaves as a pass-through and simply delegates to
 // the wrapped handler.
+//
+// Replay protection:
+// This adapter uses `transport/http/hooks` verification, which validates the signature and timestamp but does
+// not keep replay state. CloudEvents handlers that perform non-idempotent work must deduplicate or process
+// idempotently using the Webhook-Id or CloudEvent id.
 package hooks

--- a/transport/http/events/hooks/hooks.go
+++ b/transport/http/events/hooks/hooks.go
@@ -16,6 +16,9 @@ type Webhook = hooks.Webhook
 // The returned handler wraps handler and applies the webhook verification middleware first. If signature
 // verification fails, the request is rejected and handler is not invoked.
 //
+// Replay protection is intentionally left to the wrapped handler; use the Webhook-Id or CloudEvent id to
+// deduplicate or process idempotently when duplicate valid deliveries would be unsafe.
+//
 // If hook is nil, the returned handler behaves as a pass-through wrapper.
 func NewHandler(hook *Webhook, handler http.Handler) *Handler {
 	return &Handler{handler: hooks.NewHandler(hook), Handler: handler}
@@ -33,6 +36,10 @@ type Handler struct {
 //
 // If verification fails, the underlying middleware writes an HTTP error response and does not call the wrapped
 // handler.
+//
+// Replay protection:
+// The underlying middleware verifies the signature and timestamp but does not persist seen webhook ids. The
+// wrapped handler is responsible for idempotency or deduplication.
 //
 // Disabled behavior:
 // If the inner webhook handler is nil, ServeHTTP delegates directly to the wrapped handler.

--- a/transport/http/hooks/doc.go
+++ b/transport/http/hooks/doc.go
@@ -18,5 +18,12 @@
 // handlers run. Outbound requests are created by callers and are expected to be
 // bounded at the request construction boundary.
 //
+// Replay protection:
+// Verification covers the Standard Webhooks signature and timestamp checks, but
+// this package does not keep replay state or reject a previously seen
+// Webhook-Id. Receivers that perform non-idempotent work must deduplicate or
+// process idempotently using the Webhook-Id or event identifier, preferably with
+// durable storage shared by all receiver instances.
+//
 // Start with `NewWebhook` to adapt a Standard Webhooks instance into transport middleware helpers.
 package hooks

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -93,6 +93,10 @@ func (h *Webhook) Sign(req *http.Request) error {
 // webhook verification run. Callers that bypass the transport server are responsible for applying the same
 // request-level cap before invoking Verify.
 //
+// Replay protection:
+// Verify does not persist or reject previously seen Webhook-Id values. Receivers that perform non-idempotent
+// work must deduplicate or process idempotently using the Webhook-Id or event identifier.
+//
 // Disabled behavior:
 // If the receiver or underlying Standard Webhooks hook is nil, Verify is a no-op and returns nil.
 func (h *Webhook) Verify(req *http.Request) error {
@@ -144,6 +148,10 @@ func NewHandler(hook *Webhook) *Handler {
 // With the standard HTTP transport server, this handler runs after the request-body limiter, so verification
 // never sees a body larger than Config.MaxReceiveSize. Direct use outside that server chain must preserve the
 // same request-size invariant.
+//
+// Replay protection:
+// Signature verification does not maintain replay state. The wrapped handler is responsible for idempotency
+// or deduplication when duplicate valid deliveries would be unsafe.
 //
 // Disabled behavior:
 // If the handler or its hook is nil, ServeHTTP behaves as a pass-through and immediately calls next.

--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -11,7 +11,7 @@
 // intermediate retryable responses before scheduling the next attempt and returns the final retryable response if
 // all attempts fail. When retries are triggered by transport errors, the original error is preserved.
 //
-// Backward compatibility: if no policy is passed to NewRoundTripper, all requests are eligible for retry when
-// they hit a retryable transport error or status. New callers that only want side-effect-safe retries should pass
-// IdempotentRequests, SafeMethods, or another explicit policy.
+// Default policy: if no policy is passed to NewRoundTripper, only side-effect-safe requests are eligible for
+// retry. This includes safe HTTP methods and requests carrying a request-id idempotency contract. Callers that
+// need broader retry behavior can pass an explicit policy.
 package retry

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -29,11 +29,6 @@ type Config = config.Config
 // retryable responses/errors after the policy allows the logical request.
 type Policy func(req *http.Request) bool
 
-// AllowAll allows retries for every request.
-func AllowAll(*http.Request) bool {
-	return true
-}
-
 // SafeMethods allows retries for HTTP methods that should not have request side effects.
 func SafeMethods(req *http.Request) bool {
 	switch req.Method {
@@ -85,9 +80,9 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 // before wrapping the constant backoff in `WithMaxRetries`.
 //
 // Policy behavior:
-// When no policy is provided, all requests are eligible for retry when they hit a retryable transport error
-// or status. This preserves historical behavior. New callers that only want side-effect-safe retries should
-// pass IdempotentRequests, SafeMethods, or another explicit policy.
+// When no policy is provided, only side-effect-safe requests are eligible for retry: safe HTTP methods, or
+// requests carrying a request-id idempotency contract. Callers that need different behavior can pass an
+// explicit policy.
 //
 // Exhaustion behavior:
 //   - If retries are exhausted after retryable HTTP responses, the final retryable response is returned.
@@ -112,8 +107,8 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 //
 // Important:
 // Many HTTP requests are not safe to retry unless they are idempotent or the server supports safe retries.
-// This transport does not attempt to determine idempotency; it only applies the configured retry policy.
-// If no policy is configured, all requests are eligible for retry for backward compatibility.
+// This transport defaults to IdempotentRequests and only applies broader retry behavior when callers provide
+// an explicit policy.
 type RoundTripper struct {
 	http.RoundTripper
 	policy     Policy
@@ -292,7 +287,7 @@ func composePolicy(policies []Policy) Policy {
 	}
 
 	if len(filtered) == 0 {
-		return AllowAll
+		return IdempotentRequests
 	}
 
 	return func(req *http.Request) bool {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -119,6 +119,22 @@ func TestRoundTripperDoesNotRetryWhenPolicyDeniesRequest(t *testing.T) {
 	require.Equal(t, 1, rt.Calls)
 }
 
+func TestRoundTripperDoesNotRetryUnsafeRequestByDefault(t *testing.T) {
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+	require.Equal(t, 1, rt.Calls)
+}
+
 func TestRoundTripperRetriesWhenPolicyAllowsRequestID(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
@@ -215,7 +231,8 @@ func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
 		Backoff:  time.Millisecond,
 	}, rt)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", strings.NewReader("hello"))
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("hello"))
 	require.NoError(t, err)
 
 	res, roundTripErr := retrying.RoundTrip(req)
@@ -232,7 +249,8 @@ func TestRoundTripperReplaysRequestBodyAfterTransportError(t *testing.T) {
 		Backoff:  time.Millisecond,
 	}, rt)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", strings.NewReader("hello"))
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("hello"))
 	require.NoError(t, err)
 
 	res, roundTripErr := retrying.RoundTrip(req)
@@ -250,7 +268,8 @@ func TestRoundTripperUsesOriginalBodyOnFirstAttempt(t *testing.T) {
 		Backoff:  time.Millisecond,
 	}, rt)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", body)
 	require.NoError(t, err)
 	req.Body = body
 	req.GetBody = func() (io.ReadCloser, error) {
@@ -273,7 +292,8 @@ func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
 		Backoff:  time.Millisecond,
 	}, rt)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", &test.NonReplayableReader{Value: "hello"})
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", &test.NonReplayableReader{Value: "hello"})
 	require.NoError(t, err)
 	require.Nil(t, req.GetBody)
 

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/context"
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -30,6 +31,24 @@ func TestInvalidServer(t *testing.T) {
 
 	_, err := http.NewServer(params)
 	require.Error(t, err)
+}
+
+func TestServerRejectsCAOnlyTLS(t *testing.T) {
+	http.Register(test.FS)
+
+	cfg := &http.Config{
+		Config: &server.Config{
+			Timeout: 5 * time.Second,
+			TLS:     &tls.Config{CA: test.FilePath("certs/rootCA.pem")},
+		},
+	}
+	params := http.ServerParams{
+		Shutdowner: test.NewShutdowner(),
+		Config:     cfg,
+	}
+
+	_, err := http.NewServer(params)
+	require.ErrorIs(t, err, server.ErrMissingKeyPair)
 }
 
 func TestServerMaxReceiveSize(t *testing.T) {


### PR DESCRIPTION
## What

- Reject server TLS configurations that provide CA material without a complete certificate/key pair, with HTTP and gRPC coverage.
- Default HTTP and gRPC retries to idempotent operations and stop retrying gRPC DataLoss by default.
- Document that webhook signature verification does not maintain replay state and receivers must deduplicate or process idempotently.

## Why

- Server TLS should fail fast instead of starting with a configuration that cannot complete handshakes.
- Retry defaults should not replay unsafe write operations unless callers opt into an explicit idempotency policy.
- Webhook replay protection cannot be provided generically at the transport layer, so the receiver contract needs to be visible.

## Testing

- `go test ./transport/... ./config/server ./config/client ./config/options` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
