### PR TITLE
feat(net): harden status and response handling

### DIFF
--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -347,6 +347,8 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 // Any additional opts are appended after the keepalive options and may further
 // customize server behavior (for example interceptors, credentials, or stats handlers).
 func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption) *Server {
+	timeout = options.NonNegativeDuration("timeout", timeout)
+
 	os := make([]ServerOption, 0, 8+len(opts))
 	os = append(os, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 		MinTime:             options.NonNegativeDuration("keepalive_enforcement_policy_ping_min_time", timeout).Duration(),

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -49,6 +49,21 @@ func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
 	}
 }
 
+func TestNewServerRejectsNegativeTimeoutFallback(t *testing.T) {
+	opts := options.Map{
+		"keepalive_enforcement_policy_ping_min_time": "1s",
+		"keepalive_max_connection_idle":              "1s",
+		"keepalive_max_connection_age":               "1s",
+		"keepalive_max_connection_age_grace":         "1s",
+		"keepalive_ping_time":                        "1s",
+		"connection_timeout":                         "1s",
+	}
+
+	require.Panics(t, func() {
+		grpc.NewServer(opts, -time.Second)
+	})
+}
+
 func TestNewServerWithOverflowingAdvancedOptions(t *testing.T) {
 	require.Panics(t, func() {
 		grpc.NewServer(options.Map{"initial_window_size": "3GB"}, time.Second)

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -40,7 +40,18 @@
 //
 // Use SafeError when the internal cause should remain available through
 // unwrapping but the client should receive a lowercase "grpc: " prefixed
-// status message.
+// status message. Use SafeErrorf when adding formatted internal context around
+// that cause:
+//
+//	return status.SafeErrorf(codes.Internal, err, "load tenant %s", tenantID)
+//
+// Return SafeError and SafeErrorf directly from gRPC handlers. Do not wrap the
+// returned error with fmt.Errorf("%w") before returning it to gRPC: upstream
+// status.FromError preserves wrapping context in the client-visible status
+// message for wrapped status errors. Put internal context in the cause passed
+// to SafeError or in the SafeErrorf format instead:
+//
+//	return status.SafeError(codes.Internal, fmt.Errorf("load tenant: %w", err))
 //
 // # Inspecting errors
 //
@@ -66,15 +77,15 @@
 // # Client-visible messages
 //
 // gRPC status messages are sent to clients. Error and Errorf treat their
-// messages as client-visible. SafeError sends a lowercase "grpc: " prefixed
-// status message while preserving an internal cause through Unwrap for
-// inspection with errors.Is and errors.As.
+// messages as client-visible. SafeError and SafeErrorf send a lowercase
+// "grpc: " prefixed status message while preserving an internal cause through
+// Unwrap for inspection with errors.Is and errors.As.
 //
 // # Non-goals
 //
 // This package intentionally exposes only the small subset of the upstream
 // status API that go-service uses broadly: Code, FromError, Error, Errorf,
-// SafeError, and the Status type alias. Higher-level code that needs additional
-// constructors or richer structured-detail helpers should use the upstream
-// status package directly.
+// SafeError, SafeErrorf, and the Status type alias. Higher-level code that
+// needs additional constructors or richer structured-detail helpers should use
+// the upstream status package directly.
 package status

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -76,12 +76,39 @@ func Errorf(c codes.Code, format string, a ...any) error {
 //
 // The wrapped error remains available through Unwrap for internal inspection, while gRPC sends the safe message instead
 // of err.Error(). If c is codes.OK, SafeError returns nil to preserve upstream gRPC status invariants.
+//
+// Return the SafeError result directly from gRPC handlers. If the result is later wrapped with fmt.Errorf("%w"),
+// upstream status.FromError may include that outer wrapping text in the client-visible status message. Put internal
+// context in err before passing it to SafeError instead.
 func SafeError(c codes.Code, err error) error {
 	if c == codes.OK {
 		return nil
 	}
 
 	return &statusError{code: c, msg: defaultSafeMessage(c), err: err}
+}
+
+// SafeErrorf formats internal context around err and wraps it with a safe gRPC-prefixed status message.
+//
+// The formatted context and err remain available through Unwrap for internal inspection, while gRPC sends the
+// safe message instead of the formatted cause. If c is codes.OK, SafeErrorf returns nil to preserve upstream
+// gRPC status invariants.
+//
+// SafeErrorf is the preferred helper when adding internal context to a safe status error. It keeps that
+// context inside the cause passed to SafeError, avoiding the client-visible wrapping behavior described by
+// SafeError.
+func SafeErrorf(c codes.Code, err error, format string, a ...any) error {
+	if c == codes.OK {
+		return nil
+	}
+	if err == nil {
+		return SafeError(c, fmt.Errorf(format, a...))
+	}
+	if strings.IsEmpty(format) {
+		return SafeError(c, err)
+	}
+
+	return SafeError(c, fmt.Errorf(format+": %w", append(a, err)...))
 }
 
 type statusError struct {

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -60,6 +60,57 @@ func TestSafeErrorOK(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSafeErrorf(t *testing.T) {
+	cause := errors.New("secret database failure")
+	err := status.SafeErrorf(codes.Internal, cause, "load tenant %s", "tenant-1")
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, s.Code())
+	require.Equal(t, "grpc: internal", s.Message())
+	require.NotContains(t, s.Message(), "tenant-1")
+	require.NotContains(t, s.Message(), "secret database failure")
+	require.ErrorIs(t, err, cause)
+
+	unwrapper, ok := err.(interface{ Unwrap() error })
+	require.True(t, ok)
+	require.Contains(t, unwrapper.Unwrap().Error(), "load tenant tenant-1")
+}
+
+func TestSafeErrorfWithoutCause(t *testing.T) {
+	err := status.SafeErrorf(codes.Internal, nil, "load tenant %s", "tenant-1")
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, s.Code())
+	require.Equal(t, "grpc: internal", s.Message())
+
+	unwrapper, ok := err.(interface{ Unwrap() error })
+	require.True(t, ok)
+	require.EqualError(t, unwrapper.Unwrap(), "load tenant tenant-1")
+}
+
+func TestSafeErrorfWithoutFormat(t *testing.T) {
+	cause := errors.New("secret database failure")
+	err := status.SafeErrorf(codes.Internal, cause, "")
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, s.Code())
+	require.Equal(t, "grpc: internal", s.Message())
+	require.ErrorIs(t, err, cause)
+
+	unwrapper, ok := err.(interface{ Unwrap() error })
+	require.True(t, ok)
+	require.Same(t, cause, unwrapper.Unwrap())
+}
+
+func TestSafeErrorfOK(t *testing.T) {
+	err := status.SafeErrorf(codes.OK, errors.New("ignored"), "ignored")
+
+	require.NoError(t, err)
+}
+
 func TestSafeErrorWrapped(t *testing.T) {
 	cause := errors.New("secret database failure")
 	err := fmt.Errorf("wrapped: %w", status.SafeError(codes.Internal, cause))

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -80,7 +80,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 
 		mediaType := cont.NewFromRequest(req)
 		ctx = meta.WithContent(ctx, req, res, mediaType.Encoder)
-		res.Header().Add(TypeKey, media.WithUTF8(mediaType.Type))
+		res.Header().Set(TypeKey, media.WithUTF8(mediaType.Type))
 
 		data, err := handler(ctx)
 		if err != nil {

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -83,6 +83,23 @@ func TestNewHandlerTreatsInternalErrorAcceptAsText(t *testing.T) {
 	require.Equal(t, "Hello Bob", res.Body.String())
 }
 
+func TestNewHandlerReplacesExistingContentType(t *testing.T) {
+	handler := content.NewHandler(test.Content, func(_ context.Context) (*bytes.Buffer, error) {
+		return bytes.NewBufferString("Hello Bob"), nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.Text)
+	res := httptest.NewRecorder()
+	res.Header().Set(content.TypeKey, media.HTML)
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, []string{media.WithUTF8(media.Text)}, res.Header().Values(content.TypeKey))
+	require.Equal(t, "Hello Bob", res.Body.String())
+}
+
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	enc := encoding.NewMap(encoding.MapParams{})
 	enc.Register("json", test.PartialEncoder{})


### PR DESCRIPTION
## What

- Add `SafeErrorf` for gRPC status errors so callers can attach internal context without making wrapper text client-visible.
- Normalize the lower-level gRPC server timeout fallback with `options.NonNegativeDuration` before keepalive settings use it.
- Replace successful content handler `Content-Type` writes with `Set` so stale values are removed.

## Why

- gRPC safe errors should keep diagnostic context available internally while preserving safe client-visible status messages.
- Direct `net/grpc.NewServer` callers should not be able to pass a negative keepalive ping timeout fallback.
- Successful HTTP content responses should emit one authoritative negotiated `Content-Type` value.

## Testing

- `go test ./net/...` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
