### PR TITLE
feat(transport): harden retry and diagnostics defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor
 test/new_config.yml
 test/reports/coverage.html
 .source-key
+FINDINGS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,17 @@ matching skill for the task.
 - TLS fixtures: `mkcert -install` then `make create-certs`.
 - `encode-config` expects GNU `base64 -w 0`; on macOS/BSD use `base64 | tr -d '\n'`.
 
+## Review Workflows
+
+- When the user asks "Do a deep dive secure code review of <package>",
+  interpret it as:
+  - For each package and subpackage under `<package>`, launch multiple agents.
+  - Each agent should perform a thorough and accurate `$code-review` and
+    `$security-audit`.
+  - After all agents finish, aggregate findings into `FINDINGS.md`.
+  - As findings are fixed, remove them from `FINDINGS.md`.
+  - Once all findings are resolved, delete `FINDINGS.md`.
+
 ## Layout And Wiring
 
 - Feature packages usually use `config.go`, `module.go`, plus implementation files.
@@ -60,6 +71,20 @@ matching skill for the task.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
+- `Request-Id`/`request-id` is intentionally a logical request identifier, not
+  a per-wire-attempt identifier. Client metadata runs before retry middleware,
+  so all retry attempts for one logical HTTP/gRPC request share the same value.
+  Retry policies intentionally treat a present request id as the idempotency
+  key/contract for retryable writes; services that accept retried writes should
+  deduplicate by request id when duplicate processing would be unsafe. Do not
+  flag the default HTTP/gRPC retry policy merely because metadata injects
+  request ids before retry.
+- gRPC client constructor options use the package's last-wins functional option
+  convention. `WithClientDialOption`, `WithClientUnaryInterceptors`, and
+  `WithClientStreamInterceptors` expect all custom values for one client
+  construction to be passed in a single call; repeated calls intentionally
+  replace earlier values. Do not flag this as dropped configuration unless a
+  public API starts promising accumulation across repeated option helpers.
 - Transport limiter keys are `"user-agent"`, `"ip"`, and `"user-id"`; `"token"` is intentionally not a limiter key. Server limiters run after metadata extraction and token verification, so `"user-id"` is the verified principal (JWT/PASETO subject or SSH key name), and missing, malformed, or invalid auth is rejected before the limiter by design. Do not flag that bypass; use an external edge/gateway/ingress/load-balancer/service-mesh limiter when those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
 - HTTP telemetry logger service/method derivation may include request URL path
@@ -69,6 +94,22 @@ matching skill for the task.
   query/header/body leakage issue unless the logger starts recording
   `RawQuery`, `RequestURI`, headers, cookies, or bodies, or a specific route
   places secrets in path segments contrary to service policy.
+- gRPC telemetry logging intentionally records raw error values for operator
+  diagnostics. Client-facing safety is handled by gRPC status/error rendering;
+  logs are backend observability data and should be protected by deployment log
+  access controls. Do not flag raw gRPC error logging as a data leak unless a
+  concrete code path places secrets, credentials, request bodies, or other
+  prohibited sensitive values into those errors contrary to service policy.
+- gRPC client telemetry intentionally includes the raw `conn.Target()` in client
+  log messages to identify the configured downstream endpoint. Targets are
+  expected to be configuration-controlled service addresses and must not contain
+  credentials, tokens, request data, or other secrets. Do not flag raw target
+  logging unless a concrete configuration or call path allows sensitive data in
+  the target string.
+- Before flagging a nil-pointer panic on embedded pointer configuration types,
+  inspect the called method. Go permits calling pointer-receiver methods on nil
+  pointers, and methods such as `(*config/server.Config).IsEnabled` are
+  intentionally nil-safe.
 - gRPC server reflection is intentionally always registered by `net/grpc.NewServer`; restrict public exposure at the bind address, TLS/auth, ingress, firewall, or service-mesh boundary.
 - MVC controller errors render a client-safe `mvc.Error` model; `mvcModelError` metadata intentionally remains the raw error string for compatibility and must not be rendered unless diagnostic detail exposure is acceptable.
 - JWT verification requires both the expected algorithm and a `kid` header.

--- a/net/grpc/meta/doc.go
+++ b/net/grpc/meta/doc.go
@@ -21,6 +21,18 @@
 // Server interceptors also emit response header metadata such as
 // "service-version" and "request-id".
 //
+// # Request-Id semantics
+//
+// "request-id" identifies one logical gRPC request. Client metadata
+// interceptors create it before retry interceptors run, so all retry attempts
+// for the same logical request keep the same value. Server metadata
+// interceptors preserve an incoming "request-id" when present, otherwise they
+// generate one for the RPC before passing control to downstream handlers.
+//
+// Because "request-id" is stable across attempts, transports and services may
+// use it as the idempotency key for retryable write operations. It is not a
+// per-wire attempt id.
+//
 // # Forwarded IP trust boundary
 //
 // Server metadata extraction intentionally treats common forwarding metadata,

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -41,5 +41,17 @@
 // strips or overwrites client-supplied forwarding headers before traffic reaches
 // the service.
 //
+// # Request-Id semantics
+//
+// Request-Id identifies one logical HTTP request. Client metadata middleware
+// creates it before retry middleware runs, so all retry attempts for the same
+// logical request keep the same value. Server metadata middleware preserves an
+// incoming Request-Id when present, otherwise it generates one for the request
+// before passing control to downstream handlers.
+//
+// Because Request-Id is stable across attempts, transports and services may use
+// it as the idempotency key for retryable write operations. It is not a per-wire
+// attempt id.
+//
 // This package also provides HTTP metadata middleware via `NewHandler` and `NewRoundTripper`.
 package meta

--- a/transport/grpc/breaker/breaker_test.go
+++ b/transport/grpc/breaker/breaker_test.go
@@ -1,0 +1,92 @@
+package breaker_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	basebreaker "github.com/alexfalkowski/go-service/v2/transport/breaker"
+	"github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnaryClientInterceptorDoesNotOpenOnNonFailureCode(t *testing.T) {
+	interceptor := breaker.UnaryClientInterceptor(
+		breaker.WithSettings(settings()),
+		breaker.WithFailureCodes(codes.Unavailable),
+	)
+
+	calls := 0
+	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.InvalidArgument, "invalid")
+	}
+
+	err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Equal(t, 2, calls)
+}
+
+func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
+	tests := map[string]struct {
+		isSuccessful func(error) bool
+		code         codes.Code
+	}{
+		"failure code wins over custom success": {
+			isSuccessful: func(error) bool {
+				return true
+			},
+			code: codes.Unavailable,
+		},
+		"custom failure handles non-failure code": {
+			isSuccessful: func(error) bool {
+				return false
+			},
+			code: codes.InvalidArgument,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			interceptor := breaker.UnaryClientInterceptor(
+				breaker.WithSettings(settings(test.isSuccessful)),
+				breaker.WithFailureCodes(codes.Unavailable),
+			)
+
+			calls := 0
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				return status.Error(test.code, test.code.String())
+			}
+
+			err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+			require.Error(t, err)
+			require.Equal(t, test.code, status.Code(err))
+
+			err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+			require.Error(t, err)
+			require.Equal(t, codes.ResourceExhausted, status.Code(err))
+			require.Equal(t, 1, calls)
+		})
+	}
+}
+
+func settings(isSuccessful ...func(error) bool) breaker.Settings {
+	settings := breaker.Settings{
+		ReadyToTrip: func(counts basebreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+	}
+	if len(isSuccessful) > 0 {
+		settings.IsSuccessful = isSuccessful[0]
+	}
+
+	return settings
+}

--- a/transport/grpc/breaker/registry.go
+++ b/transport/grpc/breaker/registry.go
@@ -19,11 +19,18 @@ func (r *registry) get(fullMethod string) *breaker.CircuitBreaker {
 	s := r.opts.settings
 	s.Name = fullMethod
 
+	isSuccessful := s.IsSuccessful
 	failureCodes := r.opts.failureCodes
 	s.IsSuccessful = func(err error) bool {
-		if err != nil {
-			_, isFailure := failureCodes[status.Code(err)]
-			return !isFailure
+		if err == nil {
+			return true
+		}
+
+		if _, isFailure := failureCodes[status.Code(err)]; isFailure {
+			return false
+		}
+		if isSuccessful != nil {
+			return isSuccessful(err)
 		}
 
 		return true

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -143,10 +143,14 @@ func WithClientTLS(sec *tls.Config) ClientOption {
 	})
 }
 
-// WithClientDialOption appends raw gRPC dial options.
+// WithClientDialOption configures raw gRPC dial options.
 //
-// This is an escape hatch for passing options not modeled by this package. Options are appended after
-// the package's baseline options, so callers can override behavior when supported by gRPC.
+// This is an escape hatch for passing options not modeled by this package. NewDialOptions appends the
+// provided options after the package's baseline options, so callers can override behavior when supported
+// by gRPC.
+//
+// Pass all custom dial options for a client construction in one call. Repeating this option follows the
+// package's last-wins functional option convention and replaces earlier raw dial options.
 func WithClientDialOption(opts ...grpc.DialOption) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.opts = opts
@@ -158,6 +162,9 @@ func WithClientDialOption(opts ...grpc.DialOption) ClientOption {
 // Metadata propagation runs first so custom interceptors see the resolved user-agent and request-id.
 // Interceptors provided here then run before the remaining standard interceptors added by this package
 // (timeout, retry, breaker, logging, token injection, etc.).
+//
+// Pass all custom unary interceptors for a client construction in one call. Repeating this option follows
+// the package's last-wins functional option convention and replaces earlier custom unary interceptors.
 func WithClientUnaryInterceptors(unary ...grpc.UnaryClientInterceptor) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.unary = unary
@@ -169,6 +176,9 @@ func WithClientUnaryInterceptors(unary ...grpc.UnaryClientInterceptor) ClientOpt
 // Metadata propagation runs first so custom interceptors see the resolved user-agent and request-id.
 // Interceptors provided here then run before the remaining standard interceptors added by this package
 // (logging, token injection, limiter, etc.).
+//
+// Pass all custom stream interceptors for a client construction in one call. Repeating this option follows
+// the package's last-wins functional option convention and replaces earlier custom stream interceptors.
 func WithClientStreamInterceptors(stream ...grpc.StreamClientInterceptor) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.stream = stream

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -5,8 +5,9 @@
 // transport stack.
 //
 // Default policy: if no policy is passed to UnaryClientInterceptor, only side-effect-safe unary RPCs are
-// eligible for retry. This includes AIP-style read methods and requests carrying a request-id idempotency
-// contract. Callers that need broader retry behavior can pass an explicit policy.
+// eligible for retry. This includes AIP-style read methods and requests carrying a request-id. In go-service,
+// request-id identifies the logical request and is stable across retry attempts, so services that retry writes
+// should deduplicate by request-id. Callers that need different retry eligibility can pass an explicit policy.
 //
 // Start with `Config` and `UnaryClientInterceptor`.
 package retry

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -56,7 +56,7 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 //   - It uses the typed per-attempt timeout from cfg.GetTimeout() and the backoff duration from cfg.
 //   - It retries up to `cfg.MaxAttempts()` total attempts (including the initial attempt).
 //   - It applies a per-attempt timeout (`retry.WithPerRetryTimeout`) so each attempt is bounded.
-//   - It uses a linear backoff strategy with a step duration derived from `cfg.Backoff`.
+//   - It uses a linear backoff strategy with a step duration derived from `cfg.GetBackoff()`.
 //
 // Failure classification:
 // Retries are only attempted for selected gRPC status codes. This implementation currently retries on
@@ -75,7 +75,7 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 	interceptor := retry.UnaryClientInterceptor(
 		retry.WithCodes(codes.Unavailable),
 		retry.WithMax(uint(cfg.MaxAttempts())),
-		retry.WithBackoff(retry.BackoffLinear(cfg.Backoff.Duration())),
+		retry.WithBackoff(retry.BackoffLinear(cfg.GetBackoff().Duration())),
 		retry.WithPerRetryTimeout(cfg.GetTimeout().Duration()),
 	)
 

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -52,6 +52,26 @@ func TestUnaryClientInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) 
 	require.Equal(t, 2, calls)
 }
 
+func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+	})
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		if calls == 1 {
+			return status.Error(codes.Unavailable, "unavailable")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
 func TestUnaryClientInterceptorDoesNotRetryUnsafeMethodByDefault(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 2,

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -90,8 +90,9 @@ type ServerParams struct {
 // params.Config.GetMaxReceiveSize() is applied via grpc.MaxRecvMsgSize, which caps each inbound unary
 // request and each inbound stream message independently.
 //
-// If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
-// to the actual bound listener address after construction.
+// If the configured address uses an ephemeral port such as `localhost:0`, the actual bound listener address
+// is available from the returned server's service (`server.GetService().String()`) after construction.
+// params.Config.Address remains the configured value.
 func NewServer(params ServerParams) (*Server, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil

--- a/transport/grpc/telemetry/logger/logger.go
+++ b/transport/grpc/telemetry/logger/logger.go
@@ -32,6 +32,11 @@ type Logger = logger.Logger
 //
 // Log level is derived from the status code (see `CodeToLevel`). The log message includes the full
 // method name and, when present, error details.
+//
+// Operator diagnostics:
+// The raw error is intentionally attached to the log record for backend observability. Client-facing
+// responses remain controlled by the gRPC status/error path; logs are expected to be protected operator
+// telemetry.
 func UnaryServerInterceptor(log *Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if strings.IsOperationMethod(info.FullMethod) {
@@ -69,6 +74,11 @@ func UnaryServerInterceptor(log *Logger) grpc.UnaryServerInterceptor {
 //
 // Log level is derived from the status code (see `CodeToLevel`). The log message includes the full
 // method name and, when present, error details.
+//
+// Operator diagnostics:
+// The raw error is intentionally attached to the log record for backend observability. Client-facing
+// responses remain controlled by the gRPC status/error path; logs are expected to be protected operator
+// telemetry.
 func StreamServerInterceptor(log *Logger) grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if strings.IsOperationMethod(info.FullMethod) {
@@ -108,6 +118,15 @@ func StreamServerInterceptor(log *Logger) grpc.StreamServerInterceptor {
 // Log level is derived from the status code (see `CodeToLevel`).
 //
 // The log message prefixes the target address and full method (for example, `conn.Target()+fullMethod`).
+//
+// Operator diagnostics:
+// The raw error is intentionally attached to the log record for backend observability. Logs are expected
+// to be protected operator telemetry.
+//
+// Target logging:
+// The raw gRPC client target is intentionally included to identify the configured downstream endpoint in
+// operator logs. Client targets are expected to be configuration-controlled service addresses and must not
+// contain credentials, tokens, request data, or other secrets.
 func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if strings.IsOperationMethod(fullMethod) {
@@ -146,6 +165,15 @@ func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 // Log level is derived from the status code (see `CodeToLevel`).
 //
 // The log message prefixes the target address and full method (for example, `conn.Target()+fullMethod`).
+//
+// Operator diagnostics:
+// The raw error is intentionally attached to the log record for backend observability. Logs are expected
+// to be protected operator telemetry.
+//
+// Target logging:
+// The raw gRPC client target is intentionally included to identify the configured downstream endpoint in
+// operator logs. Client targets are expected to be configuration-controlled service addresses and must not
+// contain credentials, tokens, request data, or other secrets.
 func StreamClientInterceptor(log *Logger) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		if strings.IsOperationMethod(fullMethod) {

--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -12,6 +12,7 @@
 // all attempts fail. When retries are triggered by transport errors, the original error is preserved.
 //
 // Default policy: if no policy is passed to NewRoundTripper, only side-effect-safe requests are eligible for
-// retry. This includes safe HTTP methods and requests carrying a request-id idempotency contract. Callers that
-// need broader retry behavior can pass an explicit policy.
+// retry. This includes safe HTTP methods and requests carrying a Request-Id. In go-service, Request-Id
+// identifies the logical request and is stable across retry attempts, so services that retry writes should
+// deduplicate by Request-Id. Callers that need different retry eligibility can pass an explicit policy.
 package retry

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -72,7 +72,7 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 //   - applies a per-attempt timeout derived from `cfg.GetTimeout()`, and
 //   - retries responses and status errors with retryable HTTP status codes, and
 //   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`, and
-//   - waits a constant backoff derived from `cfg.Backoff` between attempts.
+//   - waits a constant backoff derived from `cfg.GetBackoff()` between attempts.
 //
 // Attempts/backoff:
 // `cfg.Attempts` is interpreted as the total attempt count (initial attempt + retries). Since
@@ -90,7 +90,7 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
 	return &RoundTripper{
 		RoundTripper: hrt,
-		backoff:      cfg.Backoff,
+		backoff:      cfg.GetBackoff(),
 		policy:       composePolicy(policies),
 		timeout:      cfg.GetTimeout(),
 		maxRetries:   cfg.MaxRetries(),

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -64,6 +64,38 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, rt.Calls)
 }
 
+func TestRoundTripperDoesNotPanicWithOmittedBackoff(t *testing.T) {
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 1,
+		Timeout:  time.Second,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	require.NotPanics(t, func() {
+		res, err := retrying.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+	})
+	require.Equal(t, 1, rt.Calls)
+}
+
+func TestRoundTripperRetriesWithDefaultBackoff(t *testing.T) {
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 2, rt.Calls)
+}
+
 func TestRoundTripperUsesIndependentRetryBudgetPerRequest(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{
 		http.StatusTooManyRequests, http.StatusOK,

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -108,8 +108,9 @@ type ServerParams struct {
 // params.Config.GetMaxReceiveSize() is enforced in this transport stack before downstream handlers read
 // from the request body.
 //
-// If the configured address uses an ephemeral port such as `localhost:0`, params.Config.Address is updated
-// to the actual bound listener address after construction.
+// If the configured address uses an ephemeral port such as `localhost:0`, the actual bound listener address
+// is available from the returned server's service (`server.GetService().String()`) after construction.
+// params.Config.Address remains the configured value.
 func NewServer(params ServerParams) (*Server, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -56,7 +56,7 @@ var ErrMissingKey = errors.New("limiter: missing key")
 //   - OnStop: closes the underlying store via (*Limiter).Close.
 //
 // Errors:
-//   - Returns ErrMissingKey when cfg.Kind is not present in keys.
+//   - Returns ErrMissingKey when cfg.Kind is not present in keys or maps to a nil KeyFunc.
 //
 // Notes:
 //   - cfg.Interval is used directly as a typed duration decoded from config.
@@ -67,7 +67,7 @@ func NewLimiter(lc di.Lifecycle, keys KeyMap, cfg *Config) (*Limiter, error) {
 	}
 
 	k, ok := keys[cfg.Kind]
-	if !ok {
+	if !ok || k == nil {
 		return nil, ErrMissingKey
 	}
 

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -34,7 +34,16 @@ func TestMissingLimiter(t *testing.T) {
 	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
 
 	_, err := limiter.NewLimiter(lc, m, config)
-	require.Error(t, err)
+	require.ErrorIs(t, err, limiter.ErrMissingKey)
+}
+
+func TestNilKeyFuncLimiter(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": nil}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
+
+	_, err := limiter.NewLimiter(lc, m, config)
+	require.ErrorIs(t, err, limiter.ErrMissingKey)
 }
 
 func TestDisabledLimiter(t *testing.T) {

--- a/transport/retry/config.go
+++ b/transport/retry/config.go
@@ -2,6 +2,9 @@ package retry
 
 import "github.com/alexfalkowski/go-service/v2/time"
 
+// DefaultBackoff is the shared retry backoff used when Config.Backoff is unset.
+const DefaultBackoff time.Duration = 100 * time.Millisecond
+
 // Config configures retry behavior for an operation.
 //
 // This package defines configuration only; concrete retry behavior is implemented
@@ -29,6 +32,7 @@ type Config struct {
 	// implementation.
 	//
 	// Value encoding: Go duration string (for example "100ms", "1s").
+	// A zero value applies DefaultBackoff. Negative values are invalid.
 	Backoff time.Duration `yaml:"backoff,omitempty" json:"backoff,omitempty" toml:"backoff,omitempty" validate:"gte=0"`
 
 	// Attempts is the maximum number of attempts, including the initial attempt.
@@ -61,6 +65,17 @@ func (c *Config) GetTimeout() time.Duration {
 	}
 
 	return c.Timeout
+}
+
+// GetBackoff returns the configured retry backoff.
+//
+// A nil receiver or a non-positive value falls back to DefaultBackoff.
+func (c *Config) GetBackoff() time.Duration {
+	if c == nil || c.Backoff <= 0 {
+		return DefaultBackoff
+	}
+
+	return c.Backoff
 }
 
 // MaxRetries returns the maximum number of retries after the initial attempt.

--- a/transport/retry/config_test.go
+++ b/transport/retry/config_test.go
@@ -44,6 +44,25 @@ func TestConfigGetTimeout(t *testing.T) {
 	}
 }
 
+func TestConfigGetBackoff(t *testing.T) {
+	tests := []struct {
+		cfg  *retry.Config
+		name string
+		want time.Duration
+	}{
+		{name: "nil", want: retry.DefaultBackoff},
+		{name: "zero", cfg: &retry.Config{}, want: retry.DefaultBackoff},
+		{name: "negative", cfg: &retry.Config{Backoff: -time.Second}, want: retry.DefaultBackoff},
+		{name: "explicit", cfg: &retry.Config{Backoff: time.Second}, want: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.cfg.GetBackoff())
+		})
+	}
+}
+
 func TestConfigMaxAttempts(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/transport/retry/doc.go
+++ b/transport/retry/doc.go
@@ -34,14 +34,14 @@
 //
 // # Defaults and disabling
 //
-// This package does not define defaults. Callers should consult the transport packages
-// to understand default values and how zero values are handled.
+// This package defines shared defaults for common knobs. Callers should consult the
+// transport packages to understand any transport-specific behavior.
 //
 // A common convention is:
 //   - Attempts == 0: retries disabled using the transport's zero-value behavior.
 //   - Attempts == 1: retries disabled.
-//   - Timeout == 0 or Backoff == 0: treated as "unspecified" and replaced with
-//     transport defaults.
+//   - Timeout == 0: treated as "unspecified" and replaced with time.DefaultTimeout.
+//   - Backoff == 0: treated as "unspecified" and replaced with DefaultBackoff.
 //
 // # Usage
 //


### PR DESCRIPTION
## What
- Add a shared retry backoff default and apply it to HTTP and gRPC retry paths.
- Preserve custom gRPC breaker success classification for non-failure codes and add coverage.
- Reject nil limiter key functions with ErrMissingKey.
- Clarify metadata, retry, server, logger, gRPC option, and audit workflow docs.

## Why
- Prevent zero-backoff retry behavior from surprising callers.
- Keep custom breaker settings honored while preserving failure-code precedence.
- Document intentional observability and request-id semantics so future audits focus on concrete risks.

## Testing
- `go test ./transport/grpc/breaker ./transport/...` - passed
- `govulncheck -test ./transport/...` - passed, no vulnerabilities found
- `make lint` - passed with existing gomodguard deprecation warning only
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
