### PR TITLE
feat(net): handle parameterized messagepack and snapshot services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,11 @@ matching skill for the task.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
+- `net/header.ForwardedIPs` is intentionally an exported mutable list, similar
+  to standard-library package variables such as `os.Args`. Do not flag this
+  solely because importing packages could mutate it; only report concrete bugs
+  with evidence of accidental mutation, concurrent mutation, or an API promise
+  of immutability.
 - `Request-Id`/`request-id` is intentionally a logical request identifier, not
   a per-wire-attempt identifier. Client metadata runs before retry middleware,
   so all retry attempts for one logical HTTP/gRPC request share the same value.
@@ -112,6 +117,11 @@ matching skill for the task.
   intentionally nil-safe.
 - gRPC server reflection is intentionally always registered by `net/grpc.NewServer`; restrict public exposure at the bind address, TLS/auth, ingress, firewall, or service-mesh boundary.
 - MVC controller errors render a client-safe `mvc.Error` model; `mvcModelError` metadata intentionally remains the raw error string for compatibility and must not be rendered unless diagnostic detail exposure is acceptable.
+- MVC not-found handling intentionally uses a simple `Accept` header check for
+  `text/html` and does not fully evaluate quality weights such as
+  `text/html;q=0`. Do not flag this unless there is concrete evidence of a
+  real client, route, or deployment contract that depends on strict weighted
+  `Accept` negotiation for MVC 404 responses.
 - JWT verification requires both the expected algorithm and a `kid` header.
 - `telemetry/header.Map.MustSecrets` can panic if secret resolution fails during config projection.
 - Health registration helpers require `*net/http.ServeMux`.

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -123,7 +123,7 @@ func TestDoUsesMsgPack(t *testing.T) {
 		var request test.Request
 		require.Equal(t, media.MessagePack, req.Header.Get(content.TypeKey))
 		require.NoError(t, test.Encoder.Get("msgpack").Decode(req.Body, &request))
-		res.Header().Set(content.TypeKey, media.MessagePack)
+		res.Header().Set(content.TypeKey, media.MessagePack+"; profile=test")
 		require.NoError(t, test.Encoder.Get("msgpack").Encode(res, &test.Response{Greeting: "Hello " + request.Name}))
 	}))
 	defer server.Close()

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -91,11 +91,26 @@ func TestNewFromContentTypeFallsBackFromInternalErrorMedia(t *testing.T) {
 }
 
 func TestNewFromMediaWithParameters(t *testing.T) {
-	media := test.Content.NewFromMedia("application/json; profile=test")
+	tests := []struct {
+		name      string
+		mediaType string
+		expected  string
+		subtype   string
+		kind      string
+	}{
+		{name: "json", mediaType: "application/json; profile=test", expected: media.JSON, subtype: "json", kind: "json"},
+		{name: "msgpack", mediaType: "application/vnd.msgpack; profile=test", expected: media.MessagePack, subtype: "msgpack", kind: "msgpack"},
+	}
 
-	require.Equal(t, "application/json", media.Type)
-	require.Equal(t, "json", media.Subtype)
-	require.Same(t, test.Encoder.Get("json"), media.Encoder)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			media := test.Content.NewFromMedia(tt.mediaType)
+
+			require.Equal(t, tt.expected, media.Type)
+			require.Equal(t, tt.subtype, media.Subtype)
+			require.Same(t, test.Encoder.Get(tt.kind), media.Encoder)
+		})
+	}
 }
 
 func TestNewFromMediaPreservesInternalErrorMedia(t *testing.T) {

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -39,7 +39,7 @@ func TestNewRequestHandlerUsesMsgPack(t *testing.T) {
 	body := bytes.NewBuffer(nil)
 	require.NoError(t, test.Encoder.Get("msgpack").Encode(body, &test.Request{Name: "Bob"}))
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", body)
-	req.Header.Set(content.TypeKey, media.MessagePack)
+	req.Header.Set(content.TypeKey, media.MessagePack+"; profile=test")
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)

--- a/net/http/content/media.go
+++ b/net/http/content/media.go
@@ -5,9 +5,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 )
 
-const jsonKind = "json"
-
-const errorSubtype = "error"
+const (
+	jsonKind                 = "json"
+	errorSubtype             = "error"
+	messagePackSubtype       = "msgpack"
+	vendorMessagePackSubtype = "vnd.msgpack"
+)
 
 // NewMedia builds a Media from a media type string and encoder map.
 //
@@ -61,7 +64,7 @@ func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {
 	case media.TOML:
 		return Media{Type: media.TOML, Subtype: "toml", Encoder: enc.Get("toml")}, true
 	case media.MessagePack:
-		return newMedia(media.MessagePack, "msgpack", enc), true
+		return newMedia(media.MessagePack, messagePackSubtype, enc), true
 	case media.Protobuf:
 		return Media{Type: media.Protobuf, Subtype: "protobuf", Encoder: enc.Get("protobuf")}, true
 	case media.ProtobufJSON:
@@ -74,6 +77,7 @@ func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {
 }
 
 func newMedia(value, subtype string, enc *encoding.Map) Media {
+	subtype = normalizeSubtype(subtype)
 	if subtype == errorSubtype {
 		return Media{Type: value, Subtype: subtype}
 	}
@@ -88,4 +92,11 @@ func newMedia(value, subtype string, enc *encoding.Map) Media {
 
 func jsonMedia(enc *encoding.Map) Media {
 	return Media{Type: media.JSON, Subtype: jsonKind, Encoder: enc.Get(jsonKind)}
+}
+
+func normalizeSubtype(subtype string) string {
+	if subtype == vendorMessagePackSubtype {
+		return messagePackSubtype
+	}
+	return subtype
 }

--- a/net/server/register.go
+++ b/net/server/register.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/slices"
 )
 
 // Register wires server services into the application lifecycle.
@@ -15,6 +16,8 @@ import (
 //
 // Callers should ensure the slice does not contain nil entries.
 func Register(lc di.Lifecycle, services []*Service) {
+	services = slices.Clone(services)
+
 	lc.Append(di.Hook{
 		OnStart: func(context.Context) error {
 			for _, s := range services {

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -32,4 +33,28 @@ func TestRegisterStopErrors(t *testing.T) {
 	require.ErrorContains(t, err, "second: other failed")
 	require.Equal(t, 1, first.Shutdowns)
 	require.Equal(t, 1, second.Shutdowns)
+}
+
+func TestRegisterSnapshotsServices(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	original := test.NewObservableServer(nil, nil)
+	replacement := test.NewObservableServer(nil, nil)
+	sh := test.NewShutdowner()
+	services := []*server.Service{
+		server.NewService("original", original, nil, sh),
+	}
+
+	server.Register(lc, services)
+	services[0] = server.NewService("replacement", replacement, nil, sh)
+
+	require.NoError(t, lc.Start(t.Context()))
+	select {
+	case <-original.Done:
+	case <-time.After(time.Second):
+		require.Fail(t, "registered service was not started")
+	}
+
+	require.NoError(t, lc.Stop(t.Context()))
+	require.Equal(t, 1, original.Shutdowns)
+	require.Equal(t, 0, replacement.Shutdowns)
 }


### PR DESCRIPTION
## What

- Normalize the parsed `application/vnd.msgpack` subtype so parameterized MessagePack content types use the registered MessagePack encoder.
- Add request and response coverage for parameterized MessagePack media types.
- Snapshot registered server services before lifecycle hooks run.
- Document review guidance for intentionally simple MVC not-found negotiation and exported forwarding header state.

## Why

- Parameterized MessagePack content types should not fall back to JSON decoding.
- Lifecycle registration should preserve the services that were registered even if the caller mutates its slice later.
- The review notes prevent resurfacing low-confidence findings without concrete evidence.

## Testing

- `go test ./net/http/content ./net/http/client` - passed
- `go test ./net/server` - passed
- `go test ./net/...` - passed
- `make lint` - passed
- `make specs` - passed
