### PR TITLE
feat(net): harden redirect and shutdown handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,14 @@ matching skill for the task.
   query/header/body leakage issue unless the logger starts recording
   `RawQuery`, `RequestURI`, headers, cookies, or bodies, or a specific route
   places secrets in path segments contrary to service policy.
+- OpenTelemetry HTTP client instrumentation is delegated to upstream
+  `otelhttp.NewTransport`, which currently records semantic-convention URL
+  attributes from the request URL and may include `RawQuery` in `url.full`.
+  Treat this as a documented third-party instrumentation behavior, not a local
+  `net/http` finding. Do not flag it unless this repository adds local URL
+  attribute construction, logging/export code that records queries directly, or
+  a supported upstream option that can sanitize this behavior without mutating
+  the outbound request.
 - gRPC telemetry logging intentionally records raw error values for operator
   diagnostics. Client-facing safety is handled by gRPC status/error rendering;
   logs are backend observability data and should be protected by deployment log

--- a/net/grpc/server/server.go
+++ b/net/grpc/server/server.go
@@ -87,6 +87,8 @@ func (s *Server) Serve() error {
 // deadline before graceful shutdown completes, Shutdown force-stops the server
 // and returns ctx.Err().
 func (s *Server) Shutdown(ctx context.Context) error {
+	defer s.listener.Close()
+
 	done := make(chan struct{})
 
 	go func() {

--- a/net/grpc/server/server_test.go
+++ b/net/grpc/server/server_test.go
@@ -30,6 +30,18 @@ func TestNewServerWithRawAddress(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
+func TestShutdownClosesUnservedListener(t *testing.T) {
+	srv, err := server.NewServer(grpc.NewServer(test.ConfigOptions, time.Second), &config.Config{Address: ":0"})
+	require.NoError(t, err)
+
+	addr := srv.String()
+	require.NoError(t, srv.Shutdown(context.Background()))
+
+	conn, err := test.Connect(t.Context(), addr)
+	require.Error(t, err)
+	require.Nil(t, conn)
+}
+
 func TestNewServerWithInvalidNetwork(t *testing.T) {
 	srv, err := server.NewServer(grpc.NewServer(test.ConfigOptions, time.Second), &config.Config{Address: "invalid://:0"})
 	require.Error(t, err)

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -23,11 +23,23 @@ type ClientOption interface {
 	apply(opts *clientOpts)
 }
 
+// Redirect configures how Client handles HTTP redirects.
+type Redirect int
+
+// RedirectFollow follows redirects using the standard library default policy.
+const RedirectFollow Redirect = iota
+
+// RedirectIgnore returns redirect responses without following them.
+const RedirectIgnore Redirect = 1
+
+// RedirectSameOrigin follows redirects only when scheme and host are unchanged.
+const RedirectSameOrigin Redirect = 2
+
 type clientOpts struct {
 	roundTripper    http.RoundTripper
 	timeout         time.Duration
 	maxResponseSize bytes.Size
-	ignoreRedirect  bool
+	redirect        Redirect
 }
 
 type clientOptionFunc func(*clientOpts)
@@ -69,13 +81,12 @@ func WithMaxResponseSize(size bytes.Size) ClientOption {
 	})
 }
 
-// WithIgnoreRedirect disables automatic redirect following.
+// WithRedirect sets the redirect policy used by the underlying http.Client.
 //
-// When set, the underlying http.Client.CheckRedirect is configured to return http.ErrUseLastResponse,
-// causing the underlying client to use the last response instead of following the redirect.
-func WithIgnoreRedirect() ClientOption {
+// If not provided, NewClient uses RedirectFollow, which preserves standard library redirect behavior.
+func WithRedirect(redirect Redirect) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
-		o.ignoreRedirect = true
+		o.redirect = redirect
 	})
 }
 
@@ -91,10 +102,11 @@ func NewClient(content *content.Content, pool *sync.BufferPool, opts ...ClientOp
 	os := options(opts...)
 	client := http.NewClient(os.roundTripper, os.timeout)
 
-	if os.ignoreRedirect {
-		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
+	switch os.redirect {
+	case RedirectIgnore:
+		client.CheckRedirect = http.IgnoreRedirect
+	case RedirectSameOrigin:
+		client.CheckRedirect = http.SameOriginRedirect
 	}
 
 	return &Client{client: client, content: content, pool: pool, maxResponseSize: os.maxResponseSize.Bytes()}

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -162,3 +162,124 @@ func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"Name":"Bob"}`, string(data))
 }
+
+func TestDoRedirectFollowAllowsCrossOriginCredentialRoundTrip(t *testing.T) {
+	var urls []string
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		urls = append(urls, req.URL.String())
+		if len(urls) == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTemporaryRedirect,
+				Header:     http.Header{"Location": []string{"https://other.example.com/target"}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		}
+
+		require.Equal(t, "Bearer secret", req.Header.Get("Authorization"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{content.TypeKey: []string{media.Text}},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    req,
+		}, nil
+	})
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(authRoundTripper{RoundTripper: rt}))
+
+	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://example.com/start", "https://other.example.com/target"}, urls)
+}
+
+func TestDoRedirectSameOriginRejectsCrossOriginCredentialRoundTrip(t *testing.T) {
+	var urls []string
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		urls = append(urls, req.URL.String())
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Header:     http.Header{"Location": []string{"https://other.example.com/target"}},
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	})
+	c := client.NewClient(
+		test.Content,
+		test.Pool,
+		client.WithRoundTripper(authRoundTripper{RoundTripper: rt}),
+		client.WithRedirect(client.RedirectSameOrigin),
+	)
+
+	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://example.com/start"}, urls)
+}
+
+func TestDoRedirectSameOriginAllowsSameOriginCredentialRoundTrip(t *testing.T) {
+	var urls []string
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		urls = append(urls, req.URL.String())
+		if len(urls) == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTemporaryRedirect,
+				Header:     http.Header{"Location": []string{"https://example.com/target"}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		}
+
+		require.Equal(t, "Bearer secret", req.Header.Get("Authorization"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{content.TypeKey: []string{media.Text}},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    req,
+		}, nil
+	})
+	c := client.NewClient(
+		test.Content,
+		test.Pool,
+		client.WithRoundTripper(authRoundTripper{RoundTripper: rt}),
+		client.WithRedirect(client.RedirectSameOrigin),
+	)
+
+	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://example.com/start", "https://example.com/target"}, urls)
+}
+
+func TestDoRedirectIgnoreRejectsRedirectRoundTrip(t *testing.T) {
+	var urls []string
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		urls = append(urls, req.URL.String())
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Header:     http.Header{"Location": []string{"https://example.com/target"}},
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	})
+	c := client.NewClient(
+		test.Content,
+		test.Pool,
+		client.WithRoundTripper(rt),
+		client.WithRedirect(client.RedirectIgnore),
+	)
+
+	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://example.com/start"}, urls)
+}
+
+type authRoundTripper struct {
+	http.RoundTripper
+}
+
+func (r authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set("Authorization", "Bearer secret")
+	return r.RoundTripper.RoundTrip(cloned)
+}

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -56,6 +56,26 @@ func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
 }
 
+func TestNewFromRequestNormalizesMediaTypeCase(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.TypeKey, "Application/YAML")
+
+	media := test.Content.NewFromRequest(req)
+
+	require.Equal(t, "yaml", media.Subtype)
+	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
+}
+
+func TestNewFromRequestNormalizesAcceptMediaTypeCase(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.AcceptKey, "Application/YAML, Application/TOML")
+
+	media := test.Content.NewFromRequest(req)
+
+	require.Equal(t, "yaml", media.Subtype)
+	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
+}
+
 func TestNewFromRequestFallsBackFromInternalErrorMedia(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 	req.Header.Set(content.AcceptKey, media.Error)

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -197,6 +197,11 @@ func NewClient(rt http.RoundTripper, timeout time.Duration) *http.Client {
 	}
 }
 
+// IgnoreRedirect returns redirect responses without following them.
+func IgnoreRedirect(_ *Request, _ []*Request) error {
+	return ErrUseLastResponse
+}
+
 // SameOriginRedirect allows redirects only when the next request stays on the same scheme and host.
 //
 // It is intended for clients that add credentials or signatures in RoundTripper middleware, where Go's

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -73,6 +73,11 @@ func TestSameOriginRedirect(t *testing.T) {
 	}
 }
 
+func TestIgnoreRedirect(t *testing.T) {
+	err := http.IgnoreRedirect(nil, nil)
+	require.ErrorIs(t, err, http.ErrUseLastResponse)
+}
+
 func TestHandleWhenTelemetryDisabled(t *testing.T) {
 	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -80,7 +80,7 @@ func TypeByExtension(ext string) string {
 // Parameters are ignored because content negotiation only uses the base media type.
 func Parse(value string) (string, string, error) {
 	mediaType, _, _ := strings.Cut(value, ";")
-	mediaType = strings.TrimSpace(mediaType)
+	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
 
 	_, subtype, ok := strings.Cut(mediaType, "/")
 	if !ok || strings.IsEmpty(subtype) {

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -15,6 +15,14 @@ func TestParseInvalidMediaType(t *testing.T) {
 	require.True(t, errors.Is(err, media.ErrInvalidType))
 }
 
+func TestParseNormalizesMediaTypeCase(t *testing.T) {
+	value, subtype, err := media.Parse("Application/YAML; profile=test")
+
+	require.NoError(t, err)
+	require.Equal(t, media.YAML, value)
+	require.Equal(t, "yaml", subtype)
+}
+
 func TestTypeByExtension(t *testing.T) {
 	require.Equal(t, "image/svg+xml", media.TypeByExtension(".svg"))
 }

--- a/net/http/rest/client.go
+++ b/net/http/rest/client.go
@@ -62,7 +62,7 @@ func NewClient(opts ...ClientOption) *Client {
 	client := client.NewClient(cont, pool,
 		client.WithRoundTripper(os.roundTripper),
 		client.WithTimeout(os.timeout),
-		client.WithIgnoreRedirect(),
+		client.WithRedirect(client.RedirectIgnore),
 	)
 
 	return &Client{client}

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -81,7 +81,7 @@ func NewClient(url string, opts ...ClientOption) *Client {
 	client := client.NewClient(cont, pool,
 		client.WithRoundTripper(os.roundTripper),
 		client.WithTimeout(os.timeout),
-		client.WithIgnoreRedirect(),
+		client.WithRedirect(client.RedirectIgnore),
 	)
 
 	return &Client{client: client, url: url, contentType: os.contentType}

--- a/net/http/server/server.go
+++ b/net/http/server/server.go
@@ -89,6 +89,8 @@ func (s *Server) Serve() error {
 //
 // The provided context controls shutdown deadlines/cancellation.
 func (s *Server) Shutdown(ctx context.Context) error {
+	defer s.listener.Close()
+
 	return s.server.Shutdown(ctx)
 }
 

--- a/net/http/server/server_test.go
+++ b/net/http/server/server_test.go
@@ -38,6 +38,18 @@ func TestNewServerWithRawAddress(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
+func TestShutdownClosesUnservedListener(t *testing.T) {
+	srv, err := server.NewServer(&http.Server{Handler: http.NewServeMux()}, &config.Config{Address: ":0"})
+	require.NoError(t, err)
+
+	addr := srv.String()
+	require.NoError(t, srv.Shutdown(context.Background()))
+
+	conn, err := test.Connect(t.Context(), addr)
+	require.Error(t, err)
+	require.Nil(t, conn)
+}
+
 func TestNewServerWithInvalidNetwork(t *testing.T) {
 	srv, err := server.NewServer(&http.Server{Handler: http.NewServeMux()}, &config.Config{Address: "invalid://:0"})
 	require.Error(t, err)


### PR DESCRIPTION
## What

- Replace the boolean redirect option with a typed redirect policy, including follow, ignore, and same-origin behavior.
- Update REST and RPC clients to use explicit ignored redirects, and add shared ignore/same-origin redirect helpers.
- Close owned HTTP and gRPC listeners during shutdown, normalize media type casing, and document the upstream OpenTelemetry URL attribute behavior.

## Why

- Prevent credential-adding transports from following cross-origin redirects unless callers explicitly allow that behavior.
- Release listeners even when a server is constructed but never served.
- Accept valid mixed-case media types and keep documented third-party telemetry behavior from resurfacing as a local finding.

## Testing

- `go test ./net/http/client` - passed
- `go test ./net/http/...` - passed
- `go test ./net/http/server ./net/grpc/server` - passed
- `go test ./net/...` - passed
- `make lint` - passed
- `make specs` - passed
- `govulncheck -test ./net/...` - passed
