### PR TITLE
feat(telemetry): harden exporter metadata handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,14 @@ matching skill for the task.
   - For each package and subpackage under `<package>`, launch multiple agents.
   - Each agent should perform a thorough and accurate `$code-review` and
     `$security-audit`.
-  - After all agents finish, aggregate findings into `FINDINGS.md`.
-  - As findings are fixed, remove them from `FINDINGS.md`.
+  - After all agents finish, aggregate all confirmed findings into
+    `FINDINGS.md` before making fixes.
+  - Present `FINDINGS.md` and a proposed fix plan to the user.
+  - Do not fix findings in the same pass unless the user explicitly asks to
+    proceed after reviewing `FINDINGS.md`, or already requested automatic fixes.
+  - Keep `FINDINGS.md` as the working review ledger while fixes are in
+    progress.
+  - As each finding is fixed and validated, remove it from `FINDINGS.md`.
   - Once all findings are resolved, delete `FINDINGS.md`.
 
 ## Layout And Wiring

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -6,26 +6,27 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/peer"
 )
 
 func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
-	ctx := meta.WithAttributes(t.Context(),
-		meta.WithUserAgent(meta.String("current-agent")),
-		meta.WithRequestID(meta.String("current-id")),
+	ctx := grpcmeta.WithAttributes(t.Context(),
+		grpcmeta.WithUserAgent(grpcmeta.String("current-agent")),
+		grpcmeta.WithRequestID(grpcmeta.String("current-id")),
 	)
-	ctx = meta.NewOutgoingContext(ctx, meta.Pairs(
+	ctx = grpcmeta.NewOutgoingContext(ctx, grpcmeta.Pairs(
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := meta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		md, ok := meta.FromOutgoingContext(ctx)
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
@@ -36,17 +37,17 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 }
 
 func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
-	ctx := meta.WithAttributes(t.Context(),
-		meta.WithUserAgent(meta.String("current-agent")),
-		meta.WithRequestID(meta.String("current-id")),
+	ctx := grpcmeta.WithAttributes(t.Context(),
+		grpcmeta.WithUserAgent(grpcmeta.String("current-agent")),
+		grpcmeta.WithRequestID(grpcmeta.String("current-id")),
 	)
-	ctx = meta.NewOutgoingContext(ctx, meta.Pairs(
+	ctx = grpcmeta.NewOutgoingContext(ctx, grpcmeta.Pairs(
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := meta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
-		md, ok := meta.FromOutgoingContext(ctx)
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
@@ -62,12 +63,12 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
-	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
+	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
-		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
-		require.True(t, meta.IPAddr(ctx).IsEmpty())
+		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
+		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
 
 		return "ok", nil
 	})
@@ -76,13 +77,13 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
-	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
+	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
-		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
-		require.True(t, meta.IPAddr(ctx).IsEmpty())
+		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
+		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
 
 		return "ok", nil
 	})
@@ -91,13 +92,30 @@ func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
-	interceptor := meta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
+	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
-		require.Equal(t, meta.String("peer"), meta.Attribute(ctx, meta.IPAddrKindKey))
-		require.Equal(t, meta.String("127.0.0.1"), meta.IPAddr(ctx))
+		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
+		require.Equal(t, grpcmeta.String("127.0.0.1"), grpcmeta.IPAddr(ctx))
+
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+}
+
+func TestUnaryServerInterceptorStoresGeolocationAsIgnored(t *testing.T) {
+	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("geolocation", "geo:47,11"))
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
+		geolocation := meta.Geolocation(ctx)
+
+		require.Equal(t, "geo:47,11", geolocation.Value())
+		require.Empty(t, geolocation.String())
+		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.GeolocationKey)
 
 		return "ok", nil
 	})
@@ -106,8 +124,8 @@ func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 }
 
 func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
-	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(t.Context(), meta.Map{})
+	interceptor := grpcmeta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	stream := &test.MetaServerStream{Ctx: ctx}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(any, grpc.ServerStream) error {
@@ -119,15 +137,15 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 }
 
 func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
-	interceptor := meta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
-	ctx := meta.NewIncomingContext(t.Context(), meta.Pairs(
+	interceptor := grpcmeta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs(
 		"authorization", "invalid",
 		"user-agent", "watch-agent",
 	))
 	stream := &test.MetaServerStream{Ctx: ctx}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/grpc.health.v1.Health/Watch"}, func(_ any, stream grpc.ServerStream) error {
-		require.Equal(t, meta.String("watch-agent"), meta.UserAgent(stream.Context()))
+		require.Equal(t, grpcmeta.String("watch-agent"), grpcmeta.UserAgent(stream.Context()))
 
 		return nil
 	})
@@ -135,36 +153,36 @@ func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
 }
 
 func TestExtractIncomingReturnsMutableCopy(t *testing.T) {
-	ctx := meta.NewIncomingContext(t.Context(), meta.Pairs("request-id", "original"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("request-id", "original"))
 
-	md := meta.ExtractIncoming(ctx)
+	md := grpcmeta.ExtractIncoming(ctx)
 	md.Set("request-id", "changed")
 
-	original, ok := meta.FromIncomingContext(ctx)
+	original, ok := grpcmeta.FromIncomingContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, []string{"original"}, original.Get("request-id"))
 }
 
 func TestExtractIncomingReturnsEmptyMapWithoutMetadata(t *testing.T) {
-	md := meta.ExtractIncoming(t.Context())
+	md := grpcmeta.ExtractIncoming(t.Context())
 
 	require.NotNil(t, md)
 	require.Empty(t, md)
 }
 
 func TestExtractOutgoingReturnsMutableCopy(t *testing.T) {
-	ctx := meta.NewOutgoingContext(t.Context(), meta.Pairs("request-id", "original"))
+	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs("request-id", "original"))
 
-	md := meta.ExtractOutgoing(ctx)
+	md := grpcmeta.ExtractOutgoing(ctx)
 	md.Set("request-id", "changed")
 
-	original, ok := meta.FromOutgoingContext(ctx)
+	original, ok := grpcmeta.FromOutgoingContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, []string{"original"}, original.Get("request-id"))
 }
 
 func TestExtractOutgoingReturnsEmptyMapWithoutMetadata(t *testing.T) {
-	md := meta.ExtractOutgoing(t.Context())
+	md := grpcmeta.ExtractOutgoing(t.Context())
 
 	require.NotNil(t, md)
 	require.Empty(t, md)

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -29,7 +29,7 @@ import (
 //   - derives IP address information from trusted forwarding headers or, if
 //     absent, from the gRPC peer address
 //   - parses the "authorization" header into the request attribute model
-//   - stores "geolocation" when present
+//   - stores "geolocation" as ignored when present
 //   - sets response header metadata including "service-version" and
 //     "request-id"
 //
@@ -195,7 +195,7 @@ func serverAuthorization(ctx context.Context) (meta.Value, error) {
 
 func serverGeolocation(ctx context.Context) meta.Value {
 	if id := serverValue(ctx, "geolocation"); !strings.IsEmpty(id) {
-		return meta.String(id)
+		return meta.Ignored(id)
 	}
 	return meta.Blank()
 }

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	httpmeta "github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,23 +18,23 @@ func TestWithContent(t *testing.T) {
 	res := httptest.NewRecorder()
 	enc := test.NewEncoder(nil)
 
-	ctx := meta.WithContent(t.Context(), req, res, enc)
+	ctx := httpmeta.WithContent(t.Context(), req, res, enc)
 
-	require.Same(t, req, meta.Request(ctx))
-	require.Same(t, res, meta.Response(ctx))
-	require.Same(t, enc, meta.Encoder(ctx))
+	require.Same(t, req, httpmeta.Request(ctx))
+	require.Same(t, res, httpmeta.Response(ctx))
+	require.Same(t, enc, httpmeta.Encoder(ctx))
 }
 
 func TestWithContentAllowsPartialContent(t *testing.T) {
 	res := httptest.NewRecorder()
 
-	ctx := meta.WithContent(t.Context(), nil, res, nil)
+	ctx := httpmeta.WithContent(t.Context(), nil, res, nil)
 
-	require.Same(t, res, meta.Response(ctx))
+	require.Same(t, res, httpmeta.Response(ctx))
 }
 
 func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
-	roundTripper := meta.NewRoundTripper(
+	roundTripper := httpmeta.NewRoundTripper(
 		env.UserAgent("agent"),
 		test.StaticIDGenerator("request-id"),
 		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -56,7 +57,7 @@ func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 }
 
 func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
-	roundTripper := meta.NewRoundTripper(
+	roundTripper := httpmeta.NewRoundTripper(
 		env.UserAgent("agent"),
 		test.StaticIDGenerator("request-id"),
 		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -77,7 +78,7 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 }
 
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
-	handler := meta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -87,5 +88,21 @@ func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 
 		require.Equal(t, []string{"1", "v2"}, res.Header().Values("Service-Version"))
 		require.Equal(t, []string{"request-id"}, res.Header().Values("Request-Id"))
+	})
+}
+
+func TestHandlerStoresGeolocationAsIgnored(t *testing.T) {
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Geolocation", "geo:47,11")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		geolocation := meta.Geolocation(req.Context())
+
+		require.Equal(t, "geo:47,11", geolocation.Value())
+		require.Empty(t, geolocation.String())
+		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.GeolocationKey)
 	})
 }

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -24,8 +24,8 @@ func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, gen
 
 // Handler extracts request metadata and stores it in the request context.
 //
-// Extracted metadata includes user agent, request id, client IP address (and its source kind), geolocation,
-// and Authorization token value (when present and parseable).
+// Extracted metadata includes user agent, request id, client IP address (and its source kind), ignored geolocation,
+// and ignored Authorization token value (when present and parseable).
 type Handler struct {
 	generator      id.Generator
 	name           env.Name
@@ -47,7 +47,7 @@ type Handler struct {
 //   - user agent (from context, request header, or default userAgent parameter)
 //   - request id (from context, request header, or generated via generator)
 //   - client IP address and IP address kind (derived from forwarded headers or RemoteAddr)
-//   - geolocation (from "Geolocation" header)
+//   - geolocation (from "Geolocation" header, stored as ignored)
 //   - authorization value (derived from the "Authorization" header, when present)
 //
 // Error handling:
@@ -148,5 +148,5 @@ func serverAuthorization(req *http.Request) (meta.Value, error) {
 }
 
 func serverGeolocation(req *http.Request) meta.Value {
-	return meta.String(req.Header.Get("Geolocation"))
+	return meta.Ignored(req.Header.Get("Geolocation"))
 }

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -29,6 +29,14 @@
 // A nil Config typically means “telemetry disabled” at the top level, while subpackages may also support
 // their own enable/disable semantics (for example nil config or empty kind).
 //
+// # OTLP endpoint security
+//
+// Logger, metrics, and tracer OTLP exporters may send Config.Headers as outbound
+// request headers. When headers are configured, non-loopback "http://" endpoints
+// are rejected to avoid sending credential-bearing headers over cleartext
+// transport. Use "https://" for external collectors. Local development
+// collectors on "localhost" or loopback IP addresses may use "http://".
+//
 // # Global propagation (Register)
 //
 // Register configures the global OpenTelemetry TextMapPropagator to a composite propagator containing:

--- a/telemetry/internal/otlp/endpoint.go
+++ b/telemetry/internal/otlp/endpoint.go
@@ -1,0 +1,39 @@
+package otlp
+
+import (
+	"net/netip"
+	"net/url"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+// ErrInsecureEndpoint is returned when secret headers would be sent over a non-local HTTP endpoint.
+var ErrInsecureEndpoint = errors.New("otlp: insecure endpoint")
+
+// ValidateEndpoint rejects accidental cleartext OTLP endpoints when exporter headers are configured.
+func ValidateEndpoint(rawURL string, headers map[string]string) error {
+	if strings.IsEmpty(rawURL) || len(headers) == 0 {
+		return nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+
+	if u.Scheme != "http" || isLoopback(u.Hostname()) {
+		return nil
+	}
+
+	return ErrInsecureEndpoint
+}
+
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsLoopback()
+}

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -1,0 +1,28 @@
+package otlp_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEndpoint(t *testing.T) {
+	headers := map[string]string{"Authorization": "Bearer token"}
+
+	require.NoError(t, otlp.ValidateEndpoint("", headers))
+	require.NoError(t, otlp.ValidateEndpoint("https://collector.example.com/v1/traces", headers))
+	require.NoError(t, otlp.ValidateEndpoint("http://localhost:4318/v1/traces", headers))
+	require.NoError(t, otlp.ValidateEndpoint("http://127.0.0.1:4318/v1/traces", headers))
+	require.NoError(t, otlp.ValidateEndpoint("http://collector.example.com/v1/traces", nil))
+
+	err := otlp.ValidateEndpoint("http://collector.example.com/v1/traces", headers)
+	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestValidateEndpointInvalidURL(t *testing.T) {
+	err := otlp.ValidateEndpoint("http://%", map[string]string{"Authorization": "Bearer token"})
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}

--- a/telemetry/logger/doc.go
+++ b/telemetry/logger/doc.go
@@ -48,6 +48,11 @@
 // telemetry/header.Map.Secrets or telemetry/header.Map.MustSecrets by the consumer
 // that projects configuration before constructing exporters.
 //
+// When Config.Headers is non-empty, non-loopback "http://" OTLP endpoints are
+// rejected to avoid sending credential-bearing headers over cleartext transport.
+// Use "https://" for external collectors. Local development collectors on
+// "localhost" or loopback IP addresses may use "http://".
+//
 // # Notes
 //
 // This package is primarily wiring and thin adaptation. For exact exporter semantics

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -140,10 +140,6 @@ type LoggerParams struct {
 //
 // NewLogger returns [ErrNotFound] when Config.Kind is unknown and
 // [ErrInvalidLevel] when Config.Level is unsupported.
-//
-// NewLogger may panic if the selected logger kind performs mandatory startup
-// wiring that fails. In particular, the "otlp" logger panics if its exporter
-// cannot be created.
 func NewLogger(params LoggerParams) (*Logger, error) {
 	if !params.Config.IsEnabled() {
 		return nil, nil
@@ -263,7 +259,7 @@ func (l *Logger) GetLogger() *slog.Logger {
 func newLogger(params LoggerParams) (*slog.Logger, error) {
 	switch params.Config.Kind {
 	case "otlp":
-		return newOtlpLogger(params), nil
+		return newOtlpLogger(params)
 	case "json":
 		return newJSONLogger(params), nil
 	case "text":

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -1,10 +1,16 @@
 package logger_test
 
 import (
+	"log/slog"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/header"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
@@ -23,6 +29,45 @@ func TestLogger(t *testing.T) {
 		log.Warn("hello")
 		log.Error("hello")
 	})
+}
+
+func TestLoggerAllowsUserLevelAttr(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	log, err := test.NewLogger(lc, test.NewJSONLoggerConfig())
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		log.Log(t.Context(), logger.NewText("test"), logger.String(slog.LevelKey, "user-level"))
+	})
+}
+
+func TestMetaTruncatesLongValues(t *testing.T) {
+	value := strings.Repeat("a", 2048)
+	ctx := meta.WithAttributes(
+		t.Context(),
+		meta.WithRequestID(meta.String(value)),
+	)
+
+	attrs := logger.Meta(ctx)
+
+	require.Len(t, attrs, 1)
+	require.Equal(t, meta.RequestIDKey, attrs[0].Key)
+	require.Len(t, attrs[0].Value.String(), 1024)
+}
+
+func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
+	value := strings.Repeat("a", 1023) + "é" + "z"
+	ctx := meta.WithAttributes(
+		t.Context(),
+		meta.WithRequestID(meta.String(value)),
+	)
+
+	attrs := logger.Meta(ctx)
+	truncated := attrs[0].Value.String()
+
+	require.Len(t, attrs, 1)
+	require.True(t, utf8.ValidString(truncated))
+	require.Equal(t, strings.Repeat("a", 1023), truncated)
 }
 
 func TestInvalidLogger(t *testing.T) {
@@ -65,4 +110,26 @@ func TestInvalidLevel(t *testing.T) {
 
 	_, err := logger.NewLogger(params)
 	require.ErrorIs(t, err, logger.ErrInvalidLevel)
+}
+
+func TestInvalidOTLPEndpoint(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := &logger.Config{
+		Kind: "otlp",
+		URL:  "http://collector.example.com/v1/logs",
+		Headers: header.Map{
+			"Authorization": "Bearer token",
+		},
+	}
+	params := logger.LoggerParams{
+		Lifecycle:   lc,
+		Config:      cfg,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}
+
+	_, err := logger.NewLogger(params)
+	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }

--- a/telemetry/logger/meta.go
+++ b/telemetry/logger/meta.go
@@ -2,10 +2,13 @@ package logger
 
 import (
 	"log/slog"
+	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/meta"
 )
+
+const maxMetaValueLength = 1024
 
 // Meta extracts context metadata and returns it as slog attributes.
 //
@@ -19,8 +22,23 @@ func Meta(ctx context.Context) []slog.Attr {
 	fields := make([]slog.Attr, len(strings))
 	index := 0
 	for k, v := range strings {
-		fields[index] = slog.String(k, v)
+		fields[index] = slog.String(k, truncateMetaValue(v))
 		index++
 	}
-	return fields
+	return fields[:index]
+}
+
+func truncateMetaValue(value string) string {
+	if len(value) <= maxMetaValueLength {
+		return value
+	}
+
+	for index := range value {
+		if index > maxMetaValueLength {
+			_, size := utf8.DecodeLastRuneInString(value[:index])
+			return value[:index-size]
+		}
+	}
+
+	return value[:maxMetaValueLength]
 }

--- a/telemetry/logger/otlp.go
+++ b/telemetry/logger/otlp.go
@@ -5,18 +5,30 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
-	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
-	otlp "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-func newOtlpLogger(params LoggerParams) *slog.Logger {
-	exporter, err := otlp.New(context.Background(), otlp.WithEndpointURL(params.Config.URL), otlp.WithHeaders(params.Config.Headers))
-	runtime.Must(err)
+func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
+	if err := otlp.ValidateEndpoint(params.Config.URL, params.Config.Headers); err != nil {
+		return nil, err
+	}
+
+	opts := []otlploghttp.Option{otlploghttp.WithHeaders(params.Config.Headers)}
+	if !strings.IsEmpty(params.Config.URL) {
+		opts = append(opts, otlploghttp.WithEndpointURL(params.Config.URL))
+	}
+
+	exporter, err := otlploghttp.New(context.Background(), opts...)
+	if err != nil {
+		return nil, err
+	}
 
 	attrs := resource.NewWithAttributes(
 		attributes.SchemaURL,
@@ -39,5 +51,5 @@ func newOtlpLogger(params LoggerParams) *slog.Logger {
 		},
 	})
 
-	return otelslog.NewLogger(params.Name.String(), otelslog.WithLoggerProvider(provider))
+	return otelslog.NewLogger(params.Name.String(), otelslog.WithLoggerProvider(provider)), nil
 }

--- a/telemetry/logger/slog.go
+++ b/telemetry/logger/slog.go
@@ -11,8 +11,9 @@ func handlerOptions(cfg *Config) *slog.HandlerOptions {
 		Level: level(cfg),
 		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
 			if attr.Key == slog.LevelKey {
-				level := attr.Value.Any().(slog.Level)
-				attr.Value = slog.StringValue(strings.ToLower(level.String()))
+				if level, ok := attr.Value.Any().(slog.Level); ok {
+					attr.Value = slog.StringValue(strings.ToLower(level.String()))
+				}
 			}
 
 			return attr

--- a/telemetry/metrics/doc.go
+++ b/telemetry/metrics/doc.go
@@ -37,6 +37,13 @@
 //
 // If Config.Kind is unknown, NewReader returns ErrNotFound.
 //
+// # OTLP endpoint security
+//
+// When Config.Headers is non-empty, non-loopback "http://" OTLP endpoints are
+// rejected to avoid sending credential-bearing headers over cleartext transport.
+// Use "https://" for external collectors. Local development collectors on
+// "localhost" or loopback IP addresses may use "http://".
+//
 // # Global provider installation
 //
 // When enabled, NewMeterProvider installs the constructed provider as the process-wide

--- a/telemetry/metrics/reader.go
+++ b/telemetry/metrics/reader.go
@@ -5,7 +5,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
-	otlp "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
 )
@@ -47,7 +49,16 @@ func NewReader(lc di.Lifecycle, name env.Name, cfg *Config) (metric.Reader, erro
 func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
 	switch cfg.Kind {
 	case "otlp":
-		exporter, err := otlp.New(context.Background(), otlp.WithEndpointURL(cfg.URL), otlp.WithHeaders(cfg.Headers))
+		if err := otlp.ValidateEndpoint(cfg.URL, cfg.Headers); err != nil {
+			return nil, prefix(err)
+		}
+
+		opts := []otlpmetrichttp.Option{otlpmetrichttp.WithHeaders(cfg.Headers)}
+		if !strings.IsEmpty(cfg.URL) {
+			opts = append(opts, otlpmetrichttp.WithEndpointURL(cfg.URL))
+		}
+
+		exporter, err := otlpmetrichttp.New(context.Background(), opts...)
 		if err != nil {
 			return nil, prefix(err)
 		}

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/header"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
@@ -15,4 +17,18 @@ func TestInvalidReader(t *testing.T) {
 
 	_, err := metrics.NewReader(lc, test.Name, cfg)
 	require.Error(t, err)
+}
+
+func TestInvalidOTLPEndpoint(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := &metrics.Config{
+		Kind: "otlp",
+		URL:  "http://collector.example.com/v1/metrics",
+		Headers: header.Map{
+			"Authorization": "Bearer token",
+		},
+	}
+
+	_, err := metrics.NewReader(lc, test.Name, cfg)
+	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -45,4 +45,9 @@
 // literal value) and are resolved by telemetry/header.Map.Secrets or
 // telemetry/header.Map.MustSecrets by the consumer that projects configuration before
 // constructing exporters.
+//
+// When Config.Headers is non-empty, non-loopback "http://" OTLP endpoints are
+// rejected to avoid sending credential-bearing headers over cleartext transport.
+// Use "https://" for external collectors. Local development collectors on
+// "localhost" or loopback IP addresses may use "http://".
 package tracer

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -4,11 +4,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-sync"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	otlp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -70,7 +72,16 @@ func Register(params TracerParams) error {
 
 	switch params.Config.Kind {
 	case "otlp":
-		client := otlp.NewClient(otlp.WithEndpointURL(params.Config.URL), otlp.WithHeaders(params.Config.Headers))
+		if err := otlp.ValidateEndpoint(params.Config.URL, params.Config.Headers); err != nil {
+			return prefix(err)
+		}
+
+		opts := []otlptracehttp.Option{otlptracehttp.WithHeaders(params.Config.Headers)}
+		if !strings.IsEmpty(params.Config.URL) {
+			opts = append(opts, otlptracehttp.WithEndpointURL(params.Config.URL))
+		}
+
+		client := otlptracehttp.NewClient(opts...)
 		exporter := otlptrace.NewUnstarted(client)
 		attrs := resource.NewWithAttributes(
 			attributes.SchemaURL,

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/header"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -55,4 +57,19 @@ func TestRegisterInvalidKind(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, tracer.ErrNotFound)
+}
+
+func TestRegisterInvalidOTLPEndpoint(t *testing.T) {
+	err := tracer.Register(tracer.TracerParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config: &tracer.Config{
+			Kind: "otlp",
+			URL:  "http://collector.example.com/v1/traces",
+			Headers: header.Map{
+				"Authorization": "Bearer token",
+			},
+		},
+	})
+
+	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }


### PR DESCRIPTION
## What

- Reject OTLP exporter headers on non-loopback cleartext HTTP endpoints while preserving upstream default/env endpoint behavior when URLs are omitted.
- Return OTLP logger exporter creation errors instead of panicking, and guard user-provided `level` log attributes from type assertion panics.
- Store inbound geolocation metadata as ignored, cap exported logger metadata values, and document the OTLP endpoint security rule.
- Clarify the deep-dive review workflow so findings are recorded in `FINDINGS.md` before fixes.

## Why

- Prevent credential-bearing OTLP headers and request metadata from being leaked or amplified through observability paths.
- Keep local collector workflows working while nudging external collector configuration toward HTTPS.
- Make future secure review workflows keep an explicit findings ledger before remediation.

## Testing

- `go test ./...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
