### PR TITLE
feat(token): harden credential validation paths

### DIFF
--- a/token/access/doc.go
+++ b/token/access/doc.go
@@ -19,6 +19,10 @@
 //   - The model is resolved with os.FS.ReadSource and parsed by Casbin.
 //   - The policy is resolved with os.FS.ReadSource and loaded using Casbin's string adapter.
 //
+// Security note: Casbin's string adapter ignores malformed policy-line errors.
+// Policy content is treated as trusted deployment configuration here, and startup
+// still fails for empty policy content or invalid model construction.
+//
 // Model and Policy support go-service source strings such as "env:" and "file:",
 // plus literal content.
 //

--- a/token/errors/doc.go
+++ b/token/errors/doc.go
@@ -30,6 +30,7 @@
 //     invalid encoding, etc.).
 //   - ErrInvalidIssuer: issuer ("iss") claim mismatch.
 //   - ErrInvalidAudience: audience ("aud") claim mismatch.
+//   - ErrInvalidSubject: missing or invalid subject ("sub") claim.
 //   - ErrInvalidAlgorithm: algorithm mismatch (token signed/encrypted with an unexpected
 //     algorithm).
 //   - ErrInvalidKeyID: missing or unexpected key identifier (for example JWT "kid").

--- a/token/errors/errors.go
+++ b/token/errors/errors.go
@@ -27,6 +27,12 @@ var (
 	// mismatch. Implementations should wrap this error to preserve additional context.
 	ErrInvalidAudience = errors.New("token: invalid audience")
 
+	// ErrInvalidSubject is a sentinel error indicating the subject claim is invalid.
+	//
+	// For claim-based token formats, this commonly corresponds to a missing or empty
+	// "sub" claim after the token has otherwise been structurally and cryptographically validated.
+	ErrInvalidSubject = errors.New("token: invalid subject")
+
 	// ErrInvalidAlgorithm is a sentinel error indicating the token used an unexpected algorithm.
 	//
 	// Implementations may return or wrap this when a token is signed/encrypted with an

--- a/token/jwt/config.go
+++ b/token/jwt/config.go
@@ -24,11 +24,11 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // This is part of the verification contract and helps prevent accepting tokens minted for a
 // different key identity.
 //
-// # Expiration parsing and panics
+// # Validation
 //
-// Issuance uses Expiration directly. Invalid config-file values fail during decoding because
-// the field is encoded as a Go duration string. If your deployment requires additional
-// validation policy, apply it earlier during configuration loading.
+// Issuer and KeyID are required because generated tokens must be verifiable by
+// this package. Expiration must be greater than zero because zero-duration tokens
+// are immediately expired.
 //
 // # Enablement
 //
@@ -36,18 +36,18 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // NewToken returns nil.
 type Config struct {
 	// Issuer is written to and verified against the `iss` claim.
-	Issuer string `yaml:"iss,omitempty" json:"iss,omitempty" toml:"iss,omitempty"`
+	Issuer string `yaml:"iss,omitempty" json:"iss,omitempty" toml:"iss,omitempty" validate:"required"`
 
 	// KeyID is written to and verified against the JWT header `kid`.
 	//
 	// Note: this repository's JWT verification expects the `kid` header to be set and
 	// to match this value exactly.
-	KeyID string `yaml:"kid,omitempty" json:"kid,omitempty" toml:"kid,omitempty"`
+	KeyID string `yaml:"kid,omitempty" json:"kid,omitempty" toml:"kid,omitempty" validate:"required"`
 
 	// Expiration is the duration used to set and validate the `exp` claim.
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
-	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gte=0"`
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gt=0"`
 }
 
 // IsEnabled reports whether JWT configuration is present.

--- a/token/jwt/errors.go
+++ b/token/jwt/errors.go
@@ -1,0 +1,12 @@
+package jwt
+
+import webtoken "github.com/golang-jwt/jwt/v4"
+
+// ValidationError aliases the upstream JWT validation error type.
+type ValidationError = webtoken.ValidationError
+
+// ErrTokenMalformed aliases the upstream malformed JWT error.
+var ErrTokenMalformed = webtoken.ErrTokenMalformed
+
+// ErrTokenSignatureInvalid aliases the upstream invalid JWT signature error.
+var ErrTokenSignatureInvalid = webtoken.ErrTokenSignatureInvalid

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -27,8 +27,7 @@ func NewToken(cfg *Config, sig *ed25519.Signer, ver *ed25519.Verifier, gen id.Ge
 // Issued tokens use standard registered claims (jwt.RegisteredClaims) and include a
 // "kid" header to bind the token to a configured key identity.
 //
-// Note: This type assumes cfg, signer, verifier, and generator are non-nil. If you
-// construct a Token with missing dependencies, methods may panic.
+// Missing generation or verification dependencies are reported as token/errors.ErrInvalidConfig.
 type Token struct {
 	cfg       *Config
 	signer    *ed25519.Signer
@@ -53,6 +52,10 @@ type Token struct {
 //
 //   - kid: from cfg.KeyID
 func (t *Token) Generate(aud, sub string) (string, error) {
+	if t.signer == nil || len(t.signer.PrivateKey) == 0 || t.generator == nil {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
+
 	key := t.signer.PrivateKey
 	now := time.Now()
 	claims := &jwt.RegisteredClaims{
@@ -84,6 +87,10 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 // failures (issuer/audience mismatches and validate-time algorithm/kid mismatches).
 // Parse/validation errors produced by the upstream JWT library may be returned as-is.
 func (t *Token) Verify(token, aud string) (string, error) {
+	if t.verifier == nil || len(t.verifier.PublicKey) == 0 {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
+
 	claims := &jwt.RegisteredClaims{}
 
 	_, err := jwt.ParseWithClaims(token, claims, t.validate)
@@ -100,6 +107,10 @@ func (t *Token) Verify(token, aud string) (string, error) {
 	}
 
 	if err := claims.Valid(); err != nil {
+		return strings.Empty, err
+	}
+
+	if err := validateRequiredClaims(claims); err != nil {
 		return strings.Empty, err
 	}
 
@@ -121,4 +132,16 @@ func (j *Token) validate(token *jwt.Token) (any, error) {
 	}
 
 	return j.verifier.PublicKey, nil
+}
+
+func validateRequiredClaims(claims *jwt.RegisteredClaims) error {
+	if claims.ExpiresAt == nil || claims.IssuedAt == nil || claims.NotBefore == nil {
+		return errors.ErrInvalidTime
+	}
+
+	if strings.IsEmpty(claims.Subject) {
+		return errors.ErrInvalidSubject
+	}
+
+	return nil
 }

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/jwt"
@@ -13,9 +14,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigRejectsNegativeExpiration(t *testing.T) {
-	cfg := &jwt.Config{Expiration: -time.Second}
-	require.Error(t, test.Validator.Struct(cfg))
+func TestConfigRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		config *jwt.Config
+		name   string
+	}{
+		{
+			name: "missing issuer",
+			config: &jwt.Config{
+				KeyID:      "1234567890",
+				Expiration: time.Hour,
+			},
+		},
+		{
+			name: "missing key id",
+			config: &jwt.Config{
+				Issuer:     "iss",
+				Expiration: time.Hour,
+			},
+		},
+		{
+			name: "zero expiration",
+			config: &jwt.Config{
+				Issuer: "iss",
+				KeyID:  "1234567890",
+			},
+		},
+		{
+			name: "negative expiration",
+			config: &jwt.Config{
+				Issuer:     "iss",
+				KeyID:      "1234567890",
+				Expiration: -time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, test.Validator.Struct(tt.config))
+		})
+	}
+
+	cfg := &jwt.Config{Issuer: "iss", KeyID: "1234567890", Expiration: time.Hour}
+	require.NoError(t, test.Validator.Struct(cfg))
 }
 
 func TestValid(t *testing.T) {
@@ -100,6 +142,128 @@ func TestInvalidKeyID(t *testing.T) {
 
 	_, err = token.Verify(tkn, "hello")
 	require.ErrorIs(t, err, errors.ErrInvalidKeyID)
+}
+
+func TestInvalidMissingClaims(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	token := jwt.NewToken(cfg.JWT, signer, verifier, gen)
+
+	now := time.Now()
+	tests := []struct {
+		err    error
+		mutate func(*v4.RegisteredClaims)
+		name   string
+	}{
+		{
+			name:   "missing expiration",
+			err:    errors.ErrInvalidTime,
+			mutate: func(claims *v4.RegisteredClaims) { claims.ExpiresAt = nil },
+		},
+		{
+			name:   "missing issued at",
+			err:    errors.ErrInvalidTime,
+			mutate: func(claims *v4.RegisteredClaims) { claims.IssuedAt = nil },
+		},
+		{
+			name:   "missing not before",
+			err:    errors.ErrInvalidTime,
+			mutate: func(claims *v4.RegisteredClaims) { claims.NotBefore = nil },
+		},
+		{
+			name:   "missing subject",
+			err:    errors.ErrInvalidSubject,
+			mutate: func(claims *v4.RegisteredClaims) { claims.Subject = strings.Empty },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := validClaims(cfg.JWT, gen, now)
+			tt.mutate(claims)
+
+			jwtToken := v4.NewWithClaims(v4.SigningMethodEdDSA, claims)
+			jwtToken.Header["kid"] = cfg.JWT.KeyID
+
+			tkn, err := jwtToken.SignedString(signer.PrivateKey)
+			require.NoError(t, err)
+
+			sub, err := token.Verify(tkn, "hello")
+			require.Empty(t, sub)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestInvalidConfigDoesNotPanic(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+
+	t.Run("generate without signer", func(t *testing.T) {
+		token := jwt.NewToken(cfg.JWT, nil, verifier, gen)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("generate without private key", func(t *testing.T) {
+		token := jwt.NewToken(cfg.JWT, &ed25519.Signer{}, verifier, gen)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("generate without generator", func(t *testing.T) {
+		token := jwt.NewToken(cfg.JWT, signer, verifier, nil)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("verify without verifier", func(t *testing.T) {
+		valid := jwt.NewToken(cfg.JWT, signer, verifier, gen)
+		tkn, err := valid.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+
+		token := jwt.NewToken(cfg.JWT, signer, nil, gen)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("verify without public key", func(t *testing.T) {
+		valid := jwt.NewToken(cfg.JWT, signer, verifier, gen)
+		tkn, err := valid.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+
+		token := jwt.NewToken(cfg.JWT, signer, &ed25519.Verifier{}, gen)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+}
+
+func validClaims(cfg *jwt.Config, gen *uuid.Generator, now time.Time) *v4.RegisteredClaims {
+	return &v4.RegisteredClaims{
+		ExpiresAt: &v4.NumericDate{Time: now.Add(time.Hour.Duration())},
+		ID:        gen.Generate(),
+		IssuedAt:  &v4.NumericDate{Time: now},
+		Issuer:    cfg.Issuer,
+		NotBefore: &v4.NumericDate{Time: now},
+		Audience:  []string{"hello"},
+		Subject:   test.UserID.String(),
+	}
 }
 
 func TestInvalidAlgorithm(t *testing.T) {

--- a/token/paseto/errors.go
+++ b/token/paseto/errors.go
@@ -1,0 +1,9 @@
+package paseto
+
+import pasetolib "aidanwoods.dev/go-paseto"
+
+// RuleError aliases the upstream PASETO rule validation error type.
+type RuleError = pasetolib.RuleError
+
+// TokenError aliases the upstream PASETO token parsing error type.
+type TokenError = pasetolib.TokenError

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/token/errors"
 )
 
 // NewToken constructs a Token that issues and validates PASETO v4 public (asymmetric) tokens.
@@ -26,8 +27,7 @@ func NewToken(cfg *Config, sig *ed25519.Signer, ver *ed25519.Verifier, gen id.Ge
 //
 // Issued tokens set common PASETO claims and identity fields (jti/iat/nbf/exp/iss/aud/sub).
 //
-// Note: This type assumes cfg, signer, verifier, and generator are non-nil. If you
-// construct a Token with missing dependencies, methods may panic.
+// Missing generation or verification dependencies are reported as token/errors.ErrInvalidConfig.
 type Token struct {
 	cfg       *Config
 	signer    *ed25519.Signer
@@ -48,6 +48,10 @@ type Token struct {
 //   - aud: set to the provided aud
 //   - sub: set to the provided sub
 func (t *Token) Generate(aud, sub string) (string, error) {
+	if t.signer == nil || len(t.signer.PrivateKey) == 0 || t.generator == nil {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
+
 	now := time.Now()
 	token := paseto.NewToken()
 	token.SetJti(t.generator.Generate())
@@ -80,6 +84,10 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 // On failure, this method returns errors from the upstream PASETO library or from key
 // construction. It does not currently map failures onto shared sentinel errors.
 func (t *Token) Verify(token, aud string) (string, error) {
+	if t.verifier == nil || len(t.verifier.PublicKey) == 0 {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
+
 	parser := paseto.NewParser()
 	parser.AddRule(paseto.IssuedBy(t.cfg.Issuer))
 	parser.AddRule(paseto.NotExpired())

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/paseto"
 	"github.com/stretchr/testify/require"
 )
@@ -80,4 +81,60 @@ func TestInvalid(t *testing.T) {
 
 	token = paseto.NewToken(nil, signer, verifier, gen)
 	require.Nil(t, token)
+}
+
+func TestInvalidConfigDoesNotPanic(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+
+	t.Run("generate without signer", func(t *testing.T) {
+		token := paseto.NewToken(cfg.Paseto, nil, verifier, gen)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("generate without private key", func(t *testing.T) {
+		token := paseto.NewToken(cfg.Paseto, &ed25519.Signer{}, verifier, gen)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("generate without generator", func(t *testing.T) {
+		token := paseto.NewToken(cfg.Paseto, signer, verifier, nil)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("verify without verifier", func(t *testing.T) {
+		valid := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+		tkn, err := valid.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+
+		token := paseto.NewToken(cfg.Paseto, signer, nil, gen)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("verify without public key", func(t *testing.T) {
+		valid := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+		tkn, err := valid.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+
+		token := paseto.NewToken(cfg.Paseto, signer, &ed25519.Verifier{}, gen)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
 }

--- a/token/ssh/claims.go
+++ b/token/ssh/claims.go
@@ -46,7 +46,7 @@ func validateClaims(c *claims, aud string, now int64) error {
 	if c.Version != tokenVersion {
 		return crypto.ErrInvalidMatch
 	}
-	if c.IssuedAt > now || c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt {
+	if c.IssuedAt <= 0 || c.IssuedAt > now || c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt {
 		return token.ErrInvalidTime
 	}
 

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
+	cryptossh "github.com/alexfalkowski/go-service/v2/crypto/ssh"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -67,6 +69,31 @@ func TestInvalidExpired(t *testing.T) {
 	require.NotEmpty(t, tkn)
 
 	time.Sleep(time.Millisecond)
+
+	sub, err := token.Verify(tkn, "/service.Method")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidTime)
+}
+
+func TestInvalidMissingIssuedAt(t *testing.T) {
+	cfg := test.NewToken("ssh").SSH
+	signer, err := cryptossh.NewSigner(test.FS, cfg.Key.Config)
+	require.NoError(t, err)
+
+	claims := map[string]any{
+		"ver": "v1",
+		"kid": cfg.Key.Name,
+		"aud": "/service.Method",
+		"exp": time.Now().Add(time.Hour.Duration()).UnixNano(),
+	}
+	encoded, err := json.Marshal(claims)
+	require.NoError(t, err)
+
+	signature, err := signer.Sign(encoded)
+	require.NoError(t, err)
+
+	token := ssh.NewToken(cfg, test.FS)
+	tkn := strings.Join(".", base64.Encode(encoded), base64.Encode(signature))
 
 	sub, err := token.Verify(tkn, "/service.Method")
 	require.Empty(t, sub)

--- a/token/token.go
+++ b/token/token.go
@@ -4,10 +4,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
-	"github.com/alexfalkowski/go-service/v2/token/errors"
+	tokenerrors "github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/jwt"
 	"github.com/alexfalkowski/go-service/v2/token/paseto"
 	"github.com/alexfalkowski/go-service/v2/token/ssh"
@@ -70,24 +71,24 @@ func (t *Token) Generate(aud, sub string) ([]byte, error) {
 	switch t.cfg.Kind {
 	case "jwt":
 		if t.jwt == nil {
-			return nil, errors.ErrInvalidConfig
+			return nil, tokenerrors.ErrInvalidConfig
 		}
 		token, err := t.jwt.Generate(aud, sub)
 		return strings.Bytes(token), err
 	case "paseto":
 		if t.paseto == nil {
-			return nil, errors.ErrInvalidConfig
+			return nil, tokenerrors.ErrInvalidConfig
 		}
 		token, err := t.paseto.Generate(aud, sub)
 		return strings.Bytes(token), err
 	case "ssh":
 		if t.ssh == nil {
-			return nil, errors.ErrInvalidConfig
+			return nil, tokenerrors.ErrInvalidConfig
 		}
 		token, err := t.ssh.Generate(aud, sub)
 		return strings.Bytes(token), err
 	default:
-		return nil, errors.ErrInvalidConfig
+		return nil, tokenerrors.ErrInvalidConfig
 	}
 }
 
@@ -106,20 +107,68 @@ func (t *Token) Verify(token []byte, aud string) (string, error) {
 	switch t.cfg.Kind {
 	case "jwt":
 		if t.jwt == nil {
-			return strings.Empty, errors.ErrInvalidConfig
+			return strings.Empty, tokenerrors.ErrInvalidConfig
 		}
-		return t.jwt.Verify(bytes.String(token), aud)
+		sub, err := t.jwt.Verify(bytes.String(token), aud)
+		return sub, invalidMatch(err)
 	case "paseto":
 		if t.paseto == nil {
-			return strings.Empty, errors.ErrInvalidConfig
+			return strings.Empty, tokenerrors.ErrInvalidConfig
 		}
-		return t.paseto.Verify(bytes.String(token), aud)
+		sub, err := t.paseto.Verify(bytes.String(token), aud)
+		return sub, invalidMatch(err)
 	case "ssh":
 		if t.ssh == nil {
-			return strings.Empty, errors.ErrInvalidConfig
+			return strings.Empty, tokenerrors.ErrInvalidConfig
 		}
-		return t.ssh.Verify(bytes.String(token), aud)
+		sub, err := t.ssh.Verify(bytes.String(token), aud)
+		return sub, invalidMatch(err)
 	default:
-		return strings.Empty, errors.ErrInvalidConfig
+		return strings.Empty, tokenerrors.ErrInvalidConfig
 	}
+}
+
+func invalidMatch(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if isTokenSentinel(err) {
+		return err
+	}
+
+	if isInvalidMatch(err) {
+		return errors.Join(tokenerrors.ErrInvalidMatch, err)
+	}
+
+	if isPasetoRuleError(err) || isJWTValidationError(err) {
+		return err
+	}
+
+	return errors.Join(tokenerrors.ErrInvalidMatch, err)
+}
+
+func isTokenSentinel(err error) bool {
+	return errors.Is(err, tokenerrors.ErrInvalidConfig) ||
+		errors.Is(err, tokenerrors.ErrInvalidIssuer) ||
+		errors.Is(err, tokenerrors.ErrInvalidAudience) ||
+		errors.Is(err, tokenerrors.ErrInvalidSubject) ||
+		errors.Is(err, tokenerrors.ErrInvalidAlgorithm) ||
+		errors.Is(err, tokenerrors.ErrInvalidKeyID) ||
+		errors.Is(err, tokenerrors.ErrInvalidTime)
+}
+
+func isInvalidMatch(err error) bool {
+	return errors.Is(err, jwt.ErrTokenMalformed) ||
+		errors.Is(err, jwt.ErrTokenSignatureInvalid) ||
+		errors.Is(err, paseto.TokenError{})
+}
+
+func isPasetoRuleError(err error) bool {
+	return errors.Is(err, paseto.RuleError{})
+}
+
+func isJWTValidationError(err error) bool {
+	var validation *jwt.ValidationError
+	return errors.As(err, &validation)
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -44,6 +44,11 @@ func TestVerify(t *testing.T) {
 			sub, err := tkn.Verify(token, "hello")
 			require.NoError(t, err)
 			require.Equal(t, test.UserID.String(), sub)
+
+			sub, err = tkn.Verify(token, "other")
+			require.Equal(t, strings.Empty, sub)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, errors.ErrInvalidMatch)
 		})
 	}
 
@@ -97,4 +102,48 @@ func TestInvalidKindConfig(t *testing.T) {
 			require.ErrorIs(t, err, errors.ErrInvalidConfig)
 		})
 	}
+}
+
+func TestInvalidDependenciesDoNotPanic(t *testing.T) {
+	for _, kind := range []string{"jwt", "paseto"} {
+		t.Run(kind, func(t *testing.T) {
+			cfg := test.NewToken(kind)
+			tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
+
+			gen, err := tkn.Generate("hello", test.UserID.String())
+			require.Nil(t, gen)
+			require.ErrorIs(t, err, errors.ErrInvalidConfig)
+
+			sub, err := tkn.Verify([]byte("test"), "hello")
+			require.Equal(t, strings.Empty, sub)
+			require.ErrorIs(t, err, errors.ErrInvalidConfig)
+		})
+	}
+}
+
+func TestInvalidMatchClassification(t *testing.T) {
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+
+	for _, kind := range []string{"jwt", "paseto"} {
+		t.Run(kind, func(t *testing.T) {
+			cfg := test.NewToken(kind)
+			tkn := token.NewToken(test.Name, cfg, test.FS, signer, verifier, gen)
+
+			sub, err := tkn.Verify([]byte("test"), "hello")
+			require.Equal(t, strings.Empty, sub)
+			require.ErrorIs(t, err, errors.ErrInvalidMatch)
+		})
+	}
+
+	t.Run("ssh", func(t *testing.T) {
+		cfg := test.NewToken("ssh")
+		tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
+
+		sub, err := tkn.Verify([]byte("test"), "hello")
+		require.Equal(t, strings.Empty, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidMatch)
+	})
 }


### PR DESCRIPTION
## What

- Require JWT issuer/key ID and positive expiration during config validation.
- Reject signed JWTs that are missing required time or subject claims.
- Return invalid config errors instead of panicking when JWT/PASETO dependencies are absent.
- Normalize facade invalid-match classification for malformed credentials while preserving semantic validation errors.
- Harden SSH signed-claim validation for missing issued-at timestamps.
- Document the accepted Casbin string-adapter policy-loading behavior.

## Why

- Close the token secure-review findings around non-expiring JWTs, unusable JWT config, nil dependency panics, and inconsistent malformed credential classification.

## Testing

- `go test ./token/...` - passed
- `make lint` - passed
- `go test -race ./token/...` - passed
- `govulncheck -test ./token/...` - passed
