### PR TITLE
feat(crypto): clarify key generator contracts

### DIFF
--- a/crypto/aes/generator.go
+++ b/crypto/aes/generator.go
@@ -14,10 +14,10 @@ type Generator struct {
 	generator *rand.Generator
 }
 
-// Generate returns a base64-encoded text key suitable for AES-256.
+// Generate returns a 32-character alphanumeric key suitable for AES-256.
 //
-// The generated key represents 32 random bytes (256 bits) encoded as base64 text.
-// Callers that need the raw key bytes should decode the returned string.
+// The generated key is safe to store in text configuration and can be used
+// directly as 32-byte AES key material.
 func (g *Generator) Generate() (string, error) {
 	return g.generator.GenerateText(32)
 }

--- a/crypto/rsa/generator.go
+++ b/crypto/rsa/generator.go
@@ -13,7 +13,9 @@ import (
 
 // NewGenerator constructs a Generator that produces RSA key pairs.
 //
-// The provided generator is used as the cryptographically-secure randomness source for key generation.
+// The generator parameter is retained for API consistency with other crypto
+// generators. With Go 1.26 and later, crypto/rsa.GenerateKey uses the standard
+// library's secure random source and ignores the supplied reader by default.
 func NewGenerator(generator *rand.Generator) *Generator {
 	return &Generator{generator: generator}
 }
@@ -26,6 +28,8 @@ type Generator struct {
 // Generate returns an RSA public/private key pair encoded as PEM strings.
 //
 // The generated key size is 4096 bits.
+// With Go 1.26 and later, crypto/rsa.GenerateKey uses the standard library's
+// secure random source and ignores this Generator's injected reader by default.
 //
 // The returned PEM blocks are compatible with the expectations of `crypto/rsa.Config`:
 //

--- a/crypto/tls/config/pool.go
+++ b/crypto/tls/config/pool.go
@@ -8,6 +8,10 @@ import (
 
 // NewCertPool resolves and parses cfg's configured CA bundle.
 func NewCertPool(fs *os.FS, cfg *Config) (*x509.CertPool, error) {
+	if !cfg.HasCA() {
+		return nil, ErrInvalidCA
+	}
+
 	ca, err := cfg.GetCA(fs)
 	if err != nil {
 		return nil, err

--- a/crypto/tls/config/pool_test.go
+++ b/crypto/tls/config/pool_test.go
@@ -30,9 +30,22 @@ func TestNewCertPool(t *testing.T) {
 }
 
 func TestNewCertPoolInvalid(t *testing.T) {
-	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: "invalid ca"})
-	require.Error(t, err)
-	require.True(t, errors.Is(err, tls.ErrInvalidCA))
+	tests := []struct {
+		config *tls.Config
+		name   string
+	}{
+		{name: "nil config"},
+		{name: "empty config", config: &tls.Config{}},
+		{name: "invalid ca", config: &tls.Config{CA: "invalid ca"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tls.NewCertPool(test.FS, tt.config)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tls.ErrInvalidCA))
+		})
+	}
 }
 
 func TestNewCertPoolSourceError(t *testing.T) {


### PR DESCRIPTION
## What

- Correct AES generator GoDoc to describe the actual 32-character alphanumeric key output.
- Document Go 1.26 RSA key generation reader behavior.
- Return `ErrInvalidCA` for nil or empty TLS CA config and cover invalid CA pool inputs.

## Why

- Keeps public crypto docs aligned with runtime behavior.
- Prevents direct TLS CA pool callers from hitting a nil-config panic.

## Testing

- `go test ./crypto/aes ./crypto/rsa ./crypto/tls/config` - passed
- `go test ./crypto/...` - passed
- `git diff --check` - passed
- `gmake lint` - passed
