### PR TITLE
feat(compress): reject invalid zstd decode limits

### DIFF
--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -1,6 +1,7 @@
 package compress_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
@@ -100,4 +101,25 @@ func TestZstdDecompressPreservesDecoderSizeError(t *testing.T) {
 	_, err = cmp.Decompress(encoded, zstd.MinWindowSize)
 	require.ErrorIs(t, err, errors.ErrTooLarge)
 	require.ErrorIs(t, err, zstd.ErrDecoderSizeExceeded)
+}
+
+func TestZstdDecompressRejectsInvalidLimits(t *testing.T) {
+	cmp := zstd.NewCompressor()
+	data := strings.Bytes("hello")
+	encoded, err := cmp.Compress(data, bytes.KB)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name string
+		size bytes.Size
+	}{
+		{name: "negative", size: -1},
+		{name: "max int64", size: math.MaxInt64},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			decoded, err := cmp.Decompress(encoded, tt.size)
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+			require.Nil(t, decoded)
+		})
+	}
 }

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -2,6 +2,7 @@ package zstd
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	compress "github.com/alexfalkowski/go-service/v2/compress/errors"
@@ -52,6 +53,10 @@ func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 // An error is returned if data is not valid zstd-encoded content or the decompressed data exceeds size.
 func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 	limit := size.Bytes()
+	if limit < 0 || limit == math.MaxInt64 {
+		return nil, compress.ErrTooLarge
+	}
+
 	maxMemory := uint64(max(limit, int64(MinWindowSize)))
 	d, err := zstd.NewReader(
 		bytes.NewReader(data),


### PR DESCRIPTION
## What

- Reject negative and non-incrementable zstd decode limits before constructing the sentinel LimitReader.
- Add regression coverage for negative and math.MaxInt64 zstd decompression limits.

## Why

- Prevent invalid size limits from turning into an immediate EOF path that can return empty decoded data with no error.
- Preserve the existing compress.ErrTooLarge contract for invalid or over-limit payloads.

## Testing

- go test ./compress - passed
- go test -race ./compress/... - passed
- go test ./compress -coverpkg=./compress/... -coverprofile=/private/tmp/compress.cov - passed
- govulncheck ./compress/... - passed
- make specs - passed
- make lint - passed
- make sec - passed
