### PR TITLE
feat(encoding): harden request body decoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,10 @@ matching skill for the task.
   options and uses the typed `ReceiverFunc`, which matches the SDK receive
   handler shape. Do not flag this unless dependency behavior or call arguments
   change.
+- JSON decoding intentionally keeps the standard library's duplicate object key
+  behavior, where later values replace earlier values. Do not flag this as a
+  finding unless a public API starts promising duplicate-key rejection or this
+  repository adds a strict JSON decoder mode.
 
 ## Testing, Style, And Docs
 

--- a/encoding/errors/errors.go
+++ b/encoding/errors/errors.go
@@ -1,6 +1,11 @@
 package errors
 
-import "github.com/alexfalkowski/go-service/v2/errors"
+import (
+	"fmt"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+)
 
 // ErrInvalidType indicates that an Encoder cannot operate on the provided value type.
 //
@@ -8,3 +13,18 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // (for example io.WriterTo/io.ReaderFrom for the bytes passthrough encoder, or proto.Message for protobuf
 // encoders).
 var ErrInvalidType = errors.New("encoding: invalid type")
+
+// ErrTrailingData indicates that a decoder found another value after the first decoded payload.
+var ErrTrailingData = errors.New("encoding: trailing data")
+
+// TrailingData returns nil for EOF and ErrTrailingData for any extra decoded value or parse error.
+func TrailingData(err error) error {
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return ErrTrailingData
+	}
+
+	return fmt.Errorf("%w: %w", ErrTrailingData, err)
+}

--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -36,5 +36,8 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 		return err
 	}
 
-	return hjson.Unmarshal(data, v)
+	options := hjson.DefaultDecoderOptions()
+	options.DisallowDuplicateKeys = true
+
+	return hjson.UnmarshalWithOptions(data, v, options)
 }

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +27,14 @@ func TestDecode(t *testing.T) {
 
 	require.NoError(t, encoder.Decode(bytes.NewBufferString("{\n  // hjson comment\n  test: test\n}\n"), msg))
 	require.Equal(t, "test", msg.Test)
+}
+
+func TestDecodeRejectsDuplicateKeys(t *testing.T) {
+	encoder := hjson.NewEncoder()
+	msg := &message{}
+
+	err := encoder.Decode(bytes.NewBufferString("{\n  test: first\n  test: second\n}\n"), msg)
+
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "duplicate")
 }

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -3,6 +3,7 @@ package json
 import (
 	"encoding/json"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -58,9 +59,18 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value, such as
 // `*MyStruct` or `*map[string]any`. Decode is equivalent to calling
-// `json.NewDecoder(r).Decode(v)`.
+// `json.NewDecoder(r).Decode(v)`, then requiring the stream to contain no
+// additional JSON values.
+//
+// Duplicate JSON object keys keep the standard library's last-wins behavior.
 func (e *Encoder) Decode(r io.Reader, v any) error {
-	return json.NewDecoder(r).Decode(v)
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+
+	var extra any
+	return errors.TrailingData(decoder.Decode(&extra))
 }
 
 // Marshal encodes v as JSON using the standard library implementation.

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,22 @@ func TestDecode(t *testing.T) {
 
 	require.NoError(t, encoder.Decode(bytes.NewBufferString("{\"test\":\"test\"}"), &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
+}
+
+func TestDecodeRejectsTrailingData(t *testing.T) {
+	for _, input := range []string{
+		`{"test":"test"} garbage`,
+		`{"test":"test"}{"test":"other"}`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			encoder := json.NewEncoder()
+			var msg map[string]string
+
+			err := encoder.Decode(bytes.NewBufferString(input), &msg)
+
+			require.ErrorIs(t, err, errors.ErrTrailingData)
+		})
+	}
 }
 
 func TestMarshal(t *testing.T) {

--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	yaml "go.yaml.in/yaml/v3"
 )
@@ -28,7 +29,13 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads YAML from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
-// This is a thin wrapper around `yaml.NewDecoder(r).Decode(v)`.
+// Decode reads one YAML document and rejects additional documents in the same stream.
 func (e *Encoder) Decode(r io.Reader, v any) error {
-	return yaml.NewDecoder(r).Decode(v)
+	decoder := yaml.NewDecoder(r)
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+
+	var extra any
+	return errors.TrailingData(decoder.Decode(&extra))
 }

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -27,4 +28,13 @@ func TestDecode(t *testing.T) {
 
 	require.NoError(t, encoder.Decode(bytes.NewBufferString("test: test"), &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
+}
+
+func TestDecodeRejectsTrailingDocument(t *testing.T) {
+	encoder := yaml.NewEncoder()
+	var msg map[string]string
+
+	err := encoder.Decode(bytes.NewBufferString("test: test\n---\ntest: other"), &msg)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
 }

--- a/internal/test/http.go
+++ b/internal/test/http.go
@@ -27,8 +27,6 @@ func MessageMediaTypes() []MessageMediaType {
 		{Name: "yaml", ContentType: media.YAML, Kind: "yaml"},
 		{Name: "yml", ContentType: "application/yml", Kind: "yml"},
 		{Name: "toml", ContentType: media.TOML, Kind: "toml"},
-		{Name: "gob", ContentType: "application/gob", Kind: "gob"},
-		{Name: "msgpack", ContentType: media.MessagePack, Kind: "msgpack"},
 	}
 }
 

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -62,6 +62,19 @@ func (c *Content) NewFromContentType(req *http.Request) Media {
 	return c.newRequestMedia(req.Header.Get(TypeKey))
 }
 
+// NewFromRequestBody parses the request Content-Type header and returns a matching Media for body decoding.
+//
+// It rejects media types that are available for internal use but intentionally unsupported for public
+// request-body decoding.
+func (c *Content) NewFromRequestBody(req *http.Request) (Media, error) {
+	media := c.NewFromContentType(req)
+	if !media.IsRequestBodySupported() {
+		return media, ErrUnsupportedRequestMedia
+	}
+
+	return media, nil
+}
+
 // NewFromMedia parses mediaType and returns a matching Media.
 //
 // If parsing fails, it falls back to JSON.

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -110,6 +110,20 @@ func TestNewFromContentTypeFallsBackFromInternalErrorMedia(t *testing.T) {
 	require.Same(t, test.Encoder.Get("plain"), media.Encoder)
 }
 
+func TestNewFromRequestBodyRejectsUnsafeBinaryMedia(t *testing.T) {
+	for _, mediaType := range []string{"application/gob", media.MessagePack + "; profile=test"} {
+		t.Run(mediaType, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+			req.Header.Set(content.TypeKey, mediaType)
+
+			media, err := test.Content.NewFromRequestBody(req)
+
+			require.ErrorIs(t, err, content.ErrUnsupportedRequestMedia)
+			require.False(t, media.IsRequestBodySupported())
+		})
+	}
+}
+
 func TestNewFromMediaWithParameters(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/net/http/content/errors.go
+++ b/net/http/content/errors.go
@@ -1,0 +1,7 @@
+package content
+
+import "github.com/alexfalkowski/go-service/v2/errors"
+
+// ErrUnsupportedRequestMedia is returned when a request body uses a media type
+// that is intentionally not decoded from public HTTP requests.
+var ErrUnsupportedRequestMedia = errors.New("content: unsupported request media")

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -40,7 +40,11 @@ func NewRequestHandler[Req any, Res any](cont *Content, handler RequestHandler[R
 		req := ptr.Zero[Req]()
 
 		request := meta.Request(ctx)
-		mediaType := cont.NewFromContentType(request)
+		mediaType, err := cont.NewFromRequestBody(request)
+		if err != nil {
+			return nil, status.SafeError(http.StatusUnsupportedMediaType, err)
+		}
+
 		if err := mediaType.Encoder.Decode(request.Body, req); err != nil {
 			return nil, status.BadRequestError(err)
 		}

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -32,23 +32,34 @@ func TestNewRequestHandlerPrefersContentType(t *testing.T) {
 	require.JSONEq(t, `{"Greeting":"Hello Bob","Meta":null}`, res.Body.String())
 }
 
-func TestNewRequestHandlerUsesMsgPack(t *testing.T) {
-	handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *test.Request) (*test.Response, error) {
-		return &test.Response{Greeting: "Hello " + req.Name}, nil
-	})
-	body := bytes.NewBuffer(nil)
-	require.NoError(t, test.Encoder.Get("msgpack").Encode(body, &test.Request{Name: "Bob"}))
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", body)
-	req.Header.Set(content.TypeKey, media.MessagePack+"; profile=test")
-	res := httptest.NewRecorder()
+func TestNewRequestHandlerRejectsUnsafeBinaryRequestBody(t *testing.T) {
+	for _, tc := range []struct {
+		mediaType string
+		kind      string
+	}{
+		{mediaType: "application/gob", kind: "gob"},
+		{mediaType: media.MessagePack + "; profile=test", kind: "msgpack"},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			called := false
+			handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *test.Request) (*test.Response, error) {
+				called = true
+				return &test.Response{Greeting: "Hello " + req.Name}, nil
+			})
+			body := bytes.NewBuffer(nil)
+			require.NoError(t, test.Encoder.Get(tc.kind).Encode(body, &test.Request{Name: "Bob"}))
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", body)
+			req.Header.Set(content.TypeKey, tc.mediaType)
+			res := httptest.NewRecorder()
 
-	handler.ServeHTTP(res, req)
+			handler.ServeHTTP(res, req)
 
-	var response test.Response
-	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.MessagePack, res.Header().Get(content.TypeKey))
-	require.NoError(t, test.Encoder.Get("msgpack").Decode(res.Body, &response))
-	require.Equal(t, "Hello Bob", response.Greeting)
+			require.False(t, called)
+			require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
+			require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
+			require.Equal(t, "http: unsupported media type", strings.TrimSpace(res.Body.String()))
+		})
+	}
 }
 
 func TestNewRequestHandlerTreatsInternalErrorContentTypeAsText(t *testing.T) {

--- a/net/http/content/media.go
+++ b/net/http/content/media.go
@@ -8,6 +8,7 @@ import (
 const (
 	jsonKind                 = "json"
 	errorSubtype             = "error"
+	gobSubtype               = "gob"
 	messagePackSubtype       = "msgpack"
 	vendorMessagePackSubtype = "vnd.msgpack"
 )
@@ -49,6 +50,11 @@ type Media struct {
 // IsError reports whether the media subtype represents an error payload.
 func (t Media) IsError() bool {
 	return t.Subtype == errorSubtype
+}
+
+// IsRequestBodySupported reports whether the media type is allowed for decoding HTTP request bodies.
+func (t Media) IsRequestBodySupported() bool {
+	return t.Subtype != gobSubtype && t.Subtype != messagePackSubtype
 }
 
 func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -77,6 +77,9 @@ const StatusTemporaryRedirect = http.StatusTemporaryRedirect
 // StatusTooManyRequests is an alias of http.StatusTooManyRequests.
 const StatusTooManyRequests = http.StatusTooManyRequests
 
+// StatusUnsupportedMediaType is an alias of http.StatusUnsupportedMediaType.
+const StatusUnsupportedMediaType = http.StatusUnsupportedMediaType
+
 // StatusUnauthorized is an alias of http.StatusUnauthorized.
 const StatusUnauthorized = http.StatusUnauthorized
 


### PR DESCRIPTION
## What
- Reject gob and MessagePack request bodies before decoding while keeping the encoders available for internal/media resolution.
- Require JSON/YAML decoders to reject trailing documents/values and add shared trailing-data error handling.
- Enable HJSON duplicate-key rejection and document JSON duplicate-key last-wins behavior in AGENTS.md.

## Why
- Prevent public HTTP request bodies from reaching decoders that are not safe for adversarial binary payloads.
- Make config/request decoding consume a single complete payload instead of silently accepting extra data.
- Avoid future audits re-flagging intentional standard-library JSON duplicate-key behavior.

## Testing
- `go test ./encoding/... ./config ./net/http/content ./net/http/client ./transport/http` - passed
- `go test ./net/http/... ./transport/http/...` - passed
- `go test ./...` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
