### PR TITLE
feat(net): guard credential redirects by origin

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -83,7 +83,10 @@ func WithMaxResponseSize(size bytes.Size) ClientOption {
 
 // WithRedirect sets the redirect policy used by the underlying http.Client.
 //
-// If not provided, NewClient uses RedirectFollow, which preserves standard library redirect behavior.
+// If not provided, NewClient uses RedirectSameOrigin so credential/signature
+// middleware supplied through WithRoundTripper cannot be replayed to a different
+// origin by an upstream redirect. Use RedirectFollow to opt into standard
+// library cross-origin redirect behavior.
 func WithRedirect(redirect Redirect) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.redirect = redirect
@@ -293,7 +296,7 @@ func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {
 }
 
 func options(opts ...ClientOption) *clientOpts {
-	os := &clientOpts{}
+	os := &clientOpts{redirect: RedirectSameOrigin}
 	for _, o := range opts {
 		o.apply(os)
 	}

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -163,28 +163,34 @@ func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	require.JSONEq(t, `{"Name":"Bob"}`, string(data))
 }
 
-func TestDoRedirectFollowAllowsCrossOriginCredentialRoundTrip(t *testing.T) {
+func TestDoDefaultRedirectRejectsCrossOriginCredentialRoundTrip(t *testing.T) {
 	var urls []string
 	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		urls = append(urls, req.URL.String())
-		if len(urls) == 1 {
-			return &http.Response{
-				StatusCode: http.StatusTemporaryRedirect,
-				Header:     http.Header{"Location": []string{"https://other.example.com/target"}},
-				Body:       http.NoBody,
-				Request:    req,
-			}, nil
-		}
-
-		require.Equal(t, "Bearer secret", req.Header.Get("Authorization"))
 		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{content.TypeKey: []string{media.Text}},
-			Body:       io.NopCloser(strings.NewReader("ok")),
+			StatusCode: http.StatusTemporaryRedirect,
+			Header:     http.Header{"Location": []string{"https://other.example.com/target"}},
+			Body:       http.NoBody,
 			Request:    req,
 		}, nil
 	})
 	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(authRoundTripper{RoundTripper: rt}))
+
+	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://example.com/start"}, urls)
+}
+
+func TestDoRedirectFollowAllowsExplicitCrossOriginCredentialRoundTrip(t *testing.T) {
+	var urls []string
+	rt := redirectingAuthRoundTripper(t, &urls, "https://other.example.com/target")
+	c := client.NewClient(
+		test.Content,
+		test.Pool,
+		client.WithRoundTripper(authRoundTripper{RoundTripper: rt}),
+		client.WithRedirect(client.RedirectFollow),
+	)
 
 	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
 
@@ -218,25 +224,7 @@ func TestDoRedirectSameOriginRejectsCrossOriginCredentialRoundTrip(t *testing.T)
 
 func TestDoRedirectSameOriginAllowsSameOriginCredentialRoundTrip(t *testing.T) {
 	var urls []string
-	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		urls = append(urls, req.URL.String())
-		if len(urls) == 1 {
-			return &http.Response{
-				StatusCode: http.StatusTemporaryRedirect,
-				Header:     http.Header{"Location": []string{"https://example.com/target"}},
-				Body:       http.NoBody,
-				Request:    req,
-			}, nil
-		}
-
-		require.Equal(t, "Bearer secret", req.Header.Get("Authorization"))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{content.TypeKey: []string{media.Text}},
-			Body:       io.NopCloser(strings.NewReader("ok")),
-			Request:    req,
-		}, nil
-	})
+	rt := redirectingAuthRoundTripper(t, &urls, "https://example.com/target")
 	c := client.NewClient(
 		test.Content,
 		test.Pool,
@@ -282,4 +270,28 @@ func (r authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	cloned := req.Clone(req.Context())
 	cloned.Header.Set("Authorization", "Bearer secret")
 	return r.RoundTripper.RoundTrip(cloned)
+}
+
+func redirectingAuthRoundTripper(t *testing.T, urls *[]string, target string) http.RoundTripper {
+	t.Helper()
+
+	return test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		*urls = append(*urls, req.URL.String())
+		if len(*urls) == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTemporaryRedirect,
+				Header:     http.Header{"Location": []string{target}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		}
+
+		require.Equal(t, "Bearer secret", req.Header.Get("Authorization"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{content.TypeKey: []string{media.Text}},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    req,
+		}, nil
+	})
 }


### PR DESCRIPTION
## What

- default the content-aware HTTP client to same-origin redirects.
- keep cross-origin redirect following available through explicit `RedirectFollow`.
- add redirect regression coverage for default rejection and explicit opt-in behavior.

## Why

- prevent auth/signing round trippers from minting credentials for attacker-controlled redirect origins.
- preserve same-origin redirect compatibility while making cross-origin follow an explicit choice.

## Testing

- `go test ./net/http/client` - passed
- `go test ./net/...` - passed
- `make lint` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
