### PR TITLE
feat(token): enforce signed credential invariants

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -1,0 +1,6 @@
+package ed25519
+
+import "crypto/ed25519"
+
+// PrivateKeySize is the size, in bytes, of an Ed25519 private key.
+const PrivateKeySize = ed25519.PrivateKeySize

--- a/token/doc.go
+++ b/token/doc.go
@@ -18,6 +18,23 @@
 // Concrete packages document their own token formats, claims, cryptographic
 // algorithms, and validation semantics.
 //
+// # Cross-kind verification consistency
+//
+// The supported token kinds intentionally share the same high-level verification
+// contract where their formats overlap:
+//
+//   - generated tokens bind the requested audience to the token,
+//   - verification requires the expected audience to match,
+//   - generated tokens include an issued-at time and expiration,
+//   - verification rejects tokens that are not currently valid, and
+//   - verification rejects tokens whose signed lifetime exceeds the verifier's
+//     configured Expiration.
+//
+// For JWT and PASETO, the returned identity is the non-empty subject claim
+// ("sub"). For SSH-style tokens, the returned identity is the non-empty key id
+// ("kid"), because that format authenticates a signing key name rather than a
+// subject claim.
+//
 // # Facade behavior and unknown kinds
 //
 // The Token facade is intentionally conservative when Config.Kind is unknown:

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -52,7 +52,7 @@ type Token struct {
 //
 //   - kid: from cfg.KeyID
 func (t *Token) Generate(aud, sub string) (string, error) {
-	if t.signer == nil || len(t.signer.PrivateKey) == 0 || t.generator == nil {
+	if t.signer == nil || len(t.signer.PrivateKey) != ed25519.PrivateKeySize || t.generator == nil {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
 
@@ -82,12 +82,16 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 //   - The issuer claim ("iss") matches cfg.Issuer.
 //   - The audience claim ("aud") contains the expected aud.
 //   - Registered claim time validity using jwt.RegisteredClaims.Valid (exp/nbf/iat).
+//   - The signed lifetime (exp - iat) does not exceed cfg.Expiration.
 //
 // This method returns sentinel errors from token/errors for some common classes of
 // failures (issuer/audience mismatches and validate-time algorithm/kid mismatches).
 // Parse/validation errors produced by the upstream JWT library may be returned as-is.
 func (t *Token) Verify(token, aud string) (string, error) {
 	if t.verifier == nil || len(t.verifier.PublicKey) == 0 {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
+	if t.cfg.Expiration <= 0 {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
 
@@ -111,6 +115,9 @@ func (t *Token) Verify(token, aud string) (string, error) {
 	}
 
 	if err := validateRequiredClaims(claims); err != nil {
+		return strings.Empty, err
+	}
+	if err := validateLifetime(claims, t.cfg.Expiration); err != nil {
 		return strings.Empty, err
 	}
 
@@ -141,6 +148,14 @@ func validateRequiredClaims(claims *jwt.RegisteredClaims) error {
 
 	if strings.IsEmpty(claims.Subject) {
 		return errors.ErrInvalidSubject
+	}
+
+	return nil
+}
+
+func validateLifetime(claims *jwt.RegisteredClaims, maxLifetime time.Duration) error {
+	if !claims.ExpiresAt.After(claims.IssuedAt.Time) || claims.ExpiresAt.Sub(claims.IssuedAt.Time) > maxLifetime.Duration() {
+		return errors.ErrInvalidTime
 	}
 
 	return nil

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -198,6 +198,40 @@ func TestInvalidMissingClaims(t *testing.T) {
 	}
 }
 
+func TestInvalidLifetimeExceedsConfig(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	generator := jwt.NewToken(&jwt.Config{Issuer: cfg.JWT.Issuer, Expiration: time.Hour, KeyID: cfg.JWT.KeyID}, signer, verifier, gen)
+	verifierToken := jwt.NewToken(&jwt.Config{Issuer: cfg.JWT.Issuer, Expiration: time.Minute, KeyID: cfg.JWT.KeyID}, signer, verifier, gen)
+
+	tkn, err := generator.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	sub, err := verifierToken.Verify(tkn, "hello")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidTime)
+}
+
+func TestInvalidVerifyExpirationConfig(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	generator := jwt.NewToken(cfg.JWT, signer, verifier, gen)
+	verifierToken := jwt.NewToken(&jwt.Config{Issuer: cfg.JWT.Issuer, KeyID: cfg.JWT.KeyID}, signer, verifier, gen)
+
+	tkn, err := generator.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	sub, err := verifierToken.Verify(tkn, "hello")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidConfig)
+}
+
 func TestInvalidConfigDoesNotPanic(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	ec := test.NewEd25519()
@@ -252,6 +286,17 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 		require.Empty(t, sub)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
 	})
+}
+
+func TestInvalidPrivateKeyDoesNotPanic(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	token := jwt.NewToken(cfg.JWT, &ed25519.Signer{PrivateKey: []byte("short")}, verifier, uuid.NewGenerator())
+
+	tkn, err := token.Generate("hello", test.UserID.String())
+	require.Empty(t, tkn)
+	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
 func validClaims(cfg *jwt.Config, gen *uuid.Generator, now time.Time) *v4.RegisteredClaims {

--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	Secret string `yaml:"secret,omitempty" json:"secret,omitempty" toml:"secret,omitempty"`
 
 	// Issuer is written to and verified against the `iss` claim.
-	Issuer string `yaml:"iss,omitempty" json:"iss,omitempty" toml:"iss,omitempty"`
+	Issuer string `yaml:"iss,omitempty" json:"iss,omitempty" toml:"iss,omitempty" validate:"required"`
 
 	// Expiration is the duration used to set token expiration.
 	//

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -80,11 +80,15 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 //   - token is not expired
 //   - token is valid at the current time (iat/nbf semantics as defined by the upstream library)
 //   - audience matches aud (aud)
+//   - the signed lifetime (exp - iat) does not exceed cfg.Expiration
 //
 // On failure, this method returns errors from the upstream PASETO library or from key
 // construction. It does not currently map failures onto shared sentinel errors.
 func (t *Token) Verify(token, aud string) (string, error) {
 	if t.verifier == nil || len(t.verifier.PublicKey) == 0 {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
+	if t.cfg.Expiration <= 0 {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
 
@@ -104,5 +108,37 @@ func (t *Token) Verify(token, aud string) (string, error) {
 		return strings.Empty, err
 	}
 
-	return to.GetSubject()
+	if err := validateLifetime(to, t.cfg.Expiration); err != nil {
+		return strings.Empty, err
+	}
+
+	return subject(to)
+}
+
+func subject(token *paseto.Token) (string, error) {
+	sub, err := token.GetSubject()
+	if err != nil {
+		return strings.Empty, err
+	}
+	if strings.IsEmpty(sub) {
+		return strings.Empty, errors.ErrInvalidSubject
+	}
+
+	return sub, nil
+}
+
+func validateLifetime(token *paseto.Token, maxLifetime time.Duration) error {
+	issuedAt, err := token.GetIssuedAt()
+	if err != nil {
+		return err
+	}
+	expiresAt, err := token.GetExpiration()
+	if err != nil {
+		return err
+	}
+	if !expiresAt.After(issuedAt) || expiresAt.Sub(issuedAt) > maxLifetime.Duration() {
+		return errors.ErrInvalidTime
+	}
+
+	return nil
 }

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -13,9 +13,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigRejectsNegativeExpiration(t *testing.T) {
-	cfg := &paseto.Config{Expiration: -time.Second}
-	require.Error(t, test.Validator.Struct(cfg))
+func TestConfigRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		config *paseto.Config
+		name   string
+	}{
+		{
+			name:   "missing issuer",
+			config: &paseto.Config{Expiration: time.Hour},
+		},
+		{
+			name:   "negative expiration",
+			config: &paseto.Config{Issuer: "iss", Expiration: -time.Second},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, test.Validator.Struct(tt.config))
+		})
+	}
+
+	cfg := &paseto.Config{Issuer: "iss", Expiration: time.Hour}
+	require.NoError(t, test.Validator.Struct(cfg))
 }
 
 func TestValid(t *testing.T) {
@@ -32,6 +52,56 @@ func TestValid(t *testing.T) {
 	sub, err := paseto.Verify(token, "hello")
 	require.NoError(t, err)
 	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestInvalidEmptySubject(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	token := paseto.NewToken(cfg.Paseto, signer, verifier, uuid.NewGenerator())
+
+	tkn, err := token.Generate("hello", strings.Empty)
+	require.NoError(t, err)
+
+	sub, err := token.Verify(tkn, "hello")
+
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidSubject)
+}
+
+func TestInvalidLifetimeExceedsConfig(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	generator := paseto.NewToken(&paseto.Config{Issuer: cfg.Paseto.Issuer, Expiration: time.Hour}, signer, verifier, gen)
+	verifierToken := paseto.NewToken(&paseto.Config{Issuer: cfg.Paseto.Issuer, Expiration: time.Minute}, signer, verifier, gen)
+
+	tkn, err := generator.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	sub, err := verifierToken.Verify(tkn, "hello")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidTime)
+}
+
+func TestInvalidVerifyExpirationConfig(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	generator := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+	verifierToken := paseto.NewToken(&paseto.Config{Issuer: cfg.Paseto.Issuer}, signer, verifier, gen)
+
+	tkn, err := generator.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	sub, err := verifierToken.Verify(tkn, "hello")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
 func TestInvalid(t *testing.T) {

--- a/token/ssh/claims.go
+++ b/token/ssh/claims.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	token "github.com/alexfalkowski/go-service/v2/token/errors"
 )
 
@@ -39,7 +40,7 @@ func parseClaims(tkn string) (*claims, []byte, string, error) {
 	return c, encoded, rawSignature, nil
 }
 
-func validateClaims(c *claims, aud string, now int64) error {
+func validateClaims(c *claims, aud string, now int64, maxLifetime time.Duration) error {
 	if c.Audience != aud {
 		return token.ErrInvalidAudience
 	}
@@ -47,6 +48,9 @@ func validateClaims(c *claims, aud string, now int64) error {
 		return crypto.ErrInvalidMatch
 	}
 	if c.IssuedAt <= 0 || c.IssuedAt > now || c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt {
+		return token.ErrInvalidTime
+	}
+	if c.ExpiresAt-c.IssuedAt > maxLifetime.Duration().Nanoseconds() {
 		return token.ErrInvalidTime
 	}
 

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -146,6 +146,10 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 // On success, Verify returns the extracted key name. On failure, it always
 // returns an empty name alongside the error.
 func (t *Token) Verify(tkn, aud string) (string, error) {
+	if t.cfg.Expiration <= 0 {
+		return strings.Empty, token.ErrInvalidConfig
+	}
+
 	data, encoded, key, err := parseClaims(tkn)
 	if err != nil {
 		return strings.Empty, err
@@ -174,7 +178,7 @@ func (t *Token) Verify(tkn, aud string) (string, error) {
 		return strings.Empty, err
 	}
 
-	if err := validateClaims(data, aud, time.Now().UnixNano()); err != nil {
+	if err := validateClaims(data, aud, time.Now().UnixNano(), t.cfg.Expiration); err != nil {
 		return strings.Empty, err
 	}
 

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -75,6 +75,23 @@ func TestInvalidExpired(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
+func TestInvalidLifetimeExceedsConfig(t *testing.T) {
+	genCfg := test.NewToken("ssh").SSH
+	genCfg.Expiration = time.Hour
+	generator := ssh.NewToken(genCfg, test.FS)
+
+	verifyCfg := test.NewToken("ssh").SSH
+	verifyCfg.Expiration = time.Minute
+	verifier := ssh.NewToken(verifyCfg, test.FS)
+
+	tkn, err := generator.Generate("/service.Method", strings.Empty)
+	require.NoError(t, err)
+
+	sub, err := verifier.Verify(tkn, "/service.Method")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidTime)
+}
+
 func TestInvalidMissingIssuedAt(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
 	signer, err := cryptossh.NewSigner(test.FS, cfg.Key.Config)
@@ -152,6 +169,7 @@ func TestInvalid(t *testing.T) {
 	require.NoError(t, err)
 
 	token = ssh.NewToken(&ssh.Config{
+		Expiration: time.Hour,
 		Keys: ssh.Keys{
 			&ssh.Key{
 				Name:   "other",

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -69,6 +69,22 @@ func TestVerify(t *testing.T) {
 	}
 }
 
+func TestVerifyRejectsPasetoEmptySubject(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	tkn := token.NewToken(test.Name, cfg, test.FS, signer, verifier, gen)
+
+	raw, err := tkn.Generate("hello", strings.Empty)
+	require.NoError(t, err)
+
+	sub, err := tkn.Verify(raw, "hello")
+	require.Equal(t, strings.Empty, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidSubject)
+}
+
 func TestUnknownKindConfig(t *testing.T) {
 	cfg := test.NewToken("none")
 	tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)


### PR DESCRIPTION
## What

- enforce maximum signed lifetimes consistently across JWT, PASETO, and SSH verification.
- reject empty PASETO subjects and require PASETO issuer configuration.
- expose the Ed25519 private key size through the local crypto package and reject malformed JWT signer keys.
- document the shared verification contract across supported credential formats.

## Why

- keep generated and accepted credential lifetimes aligned with verifier configuration.
- prevent authenticated requests from carrying an empty PASETO principal.
- fail malformed manual signer construction with `ErrInvalidConfig` instead of allowing a panic.
- make the cross-format security behavior explicit for maintainers and callers.

## Testing

- `go test ./crypto/ed25519 ./token/...` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
