### PR TITLE
feat(encoding): harden codec decoding

### DIFF
--- a/encoding/bytes/bytes.go
+++ b/encoding/bytes/bytes.go
@@ -3,6 +3,7 @@ package bytes
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/reflect"
 )
 
 // NewEncoder constructs a passthrough encoder for stream-capable types.
@@ -31,12 +32,12 @@ type Encoder struct{}
 // If v does not implement io.WriterTo, Encode returns encoding/errors.ErrInvalidType.
 // Any error returned by WriteTo is returned.
 func (e *Encoder) Encode(w io.Writer, v any) error {
-	to, ok := v.(io.WriterTo)
-	if !ok {
-		return errors.ErrInvalidType
+	to, err := writerTo(v)
+	if err != nil {
+		return err
 	}
 
-	_, err := to.WriteTo(w)
+	_, err = to.WriteTo(w)
 	return err
 }
 
@@ -47,15 +48,33 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // destination is repopulated rather than appended to.
 // Any error returned by ReadFrom is returned.
 func (e *Encoder) Decode(r io.Reader, v any) error {
-	from, ok := v.(io.ReaderFrom)
-	if !ok {
-		return errors.ErrInvalidType
+	from, err := readerFrom(v)
+	if err != nil {
+		return err
 	}
 
-	if reset, ok := v.(io.Resetter); ok {
+	if reset, ok := v.(io.Resetter); ok && !reflect.IsNil(reset) {
 		reset.Reset()
 	}
 
-	_, err := from.ReadFrom(r)
+	_, err = from.ReadFrom(r)
 	return err
+}
+
+func writerTo(v any) (io.WriterTo, error) {
+	to, ok := v.(io.WriterTo)
+	if !ok || reflect.IsNil(to) {
+		return nil, errors.ErrInvalidType
+	}
+
+	return to, nil
+}
+
+func readerFrom(v any) (io.ReaderFrom, error) {
+	from, ok := v.(io.ReaderFrom)
+	if !ok || reflect.IsNil(from) {
+		return nil, errors.ErrInvalidType
+	}
+
+	return from, nil
 }

--- a/encoding/bytes/bytes_test.go
+++ b/encoding/bytes/bytes_test.go
@@ -4,14 +4,16 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	eb "github.com/alexfalkowski/go-service/v2/encoding/bytes"
+	encoding "github.com/alexfalkowski/go-service/v2/encoding/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEncoder(t *testing.T) {
-	encoder := eb.NewEncoder()
+	encoder := encoding.NewEncoder()
 
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
@@ -22,19 +24,43 @@ func TestEncoder(t *testing.T) {
 	var str string
 	require.Error(t, encoder.Encode(buffer, &str))
 
-	var buf bytes.Buffer
-	require.NoError(t, encoder.Decode(bytes.NewBufferString("test"), &buf))
-	require.Equal(t, "test", buf.String())
+	decode := test.Pool.Get()
+	defer test.Pool.Put(decode)
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("test"), decode))
+	require.Equal(t, "test", decode.String())
 
 	require.Error(t, encoder.Decode(bytes.NewBufferString("test"), &str))
 }
 
 func TestDecodeResetsDestination(t *testing.T) {
-	encoder := eb.NewEncoder()
+	encoder := encoding.NewEncoder()
 
-	var buf bytes.Buffer
-	buf.WriteString("stale:")
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
-	require.NoError(t, encoder.Decode(bytes.NewBufferString("fresh"), &buf))
-	require.Equal(t, "fresh", buf.String())
+	buffer.WriteString("stale:")
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("fresh"), buffer))
+	require.Equal(t, "fresh", buffer.String())
+}
+
+func TestInvalidTypedNilEncode(t *testing.T) {
+	encoder := encoding.NewEncoder()
+
+	err := encoder.Encode(io.Discard, (*bytes.Buffer)(nil))
+	require.ErrorIs(t, err, errors.ErrInvalidType)
+}
+
+func TestEncodeReturnsWriteToError(t *testing.T) {
+	encoder := encoding.NewEncoder()
+
+	require.ErrorIs(t, encoder.Encode(io.Discard, test.ErrWriterTo{}), test.ErrFailed)
+}
+
+func TestInvalidTypedNilDecode(t *testing.T) {
+	encoder := encoding.NewEncoder()
+
+	err := encoder.Decode(bytes.NewBufferString("test"), (*bytes.Buffer)(nil))
+	require.ErrorIs(t, err, errors.ErrInvalidType)
 }

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -19,6 +19,10 @@ import "github.com/alexfalkowski/go-service/v2/io"
 // value so the decoder can mutate it (e.g. *MyStruct). Implementations may return an error if v is not
 // a supported type (for example encoding/errors.ErrInvalidType).
 //
+// Structured single-value decoders should reject additional encoded values after the first payload,
+// either by consuming the whole input or by returning encoding/errors.ErrTrailingData. Stream or
+// passthrough encoders may delegate full-consumption semantics to the concrete value they decode into.
+//
 // Some implementations buffer the remaining contents of r before decoding. When r contains untrusted
 // input, callers must bound it before calling Decode. Standard go-service HTTP and cache wiring applies
 // those limits before values reach encoders.

--- a/encoding/gob/gob.go
+++ b/encoding/gob/gob.go
@@ -3,6 +3,7 @@ package gob
 import (
 	"encoding/gob"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -29,7 +30,13 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads gob from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
-// This is a thin wrapper around `gob.NewDecoder(r).Decode(v)`.
+// Decode reads one gob value and rejects additional values in the same stream.
 func (e *Encoder) Decode(r io.Reader, v any) error {
-	return gob.NewDecoder(r).Decode(v)
+	decoder := gob.NewDecoder(r)
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+
+	var extra any
+	return errors.TrailingData(decoder.Decode(&extra))
 }

--- a/encoding/gob/gob_test.go
+++ b/encoding/gob/gob_test.go
@@ -3,6 +3,7 @@ package gob_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/gob"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
@@ -19,4 +20,51 @@ func TestEncoder(t *testing.T) {
 	var msg map[string]string
 	require.NoError(t, encoder.Decode(bytes, &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
+}
+
+func TestEncodeReturnsError(t *testing.T) {
+	encoder := gob.NewEncoder()
+
+	bytes := test.Pool.Get()
+	defer test.Pool.Put(bytes)
+
+	require.Error(t, encoder.Encode(bytes, func() {}))
+}
+
+func TestDecodeReturnsError(t *testing.T) {
+	encoder := gob.NewEncoder()
+
+	var msg map[string]string
+	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &msg))
+}
+
+func TestDecodeRejectsTrailingValue(t *testing.T) {
+	encoder := gob.NewEncoder()
+
+	bytes := test.Pool.Get()
+	defer test.Pool.Put(bytes)
+
+	require.NoError(t, encoder.Encode(bytes, map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Encode(bytes, map[string]string{"extra": "value"}))
+
+	var msg map[string]string
+	err := encoder.Decode(bytes, &msg)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+func TestDecodeRejectsMalformedTrailingData(t *testing.T) {
+	encoder := gob.NewEncoder()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"test": "test"}))
+	_, err := buffer.WriteString("junk")
+	require.NoError(t, err)
+
+	var msg map[string]string
+	err = encoder.Decode(buffer, &msg)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
 }

--- a/encoding/hjson/doc.go
+++ b/encoding/hjson/doc.go
@@ -1,6 +1,7 @@
 // Package hjson provides HJSON encoding helpers and adapters used by go-service.
 //
 // This package integrates HJSON encoding/decoding behind the go-service encoding abstraction.
+// Decode rejects duplicate object keys.
 //
 // Start with the package-level constructors.
 package hjson

--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -30,6 +30,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads HJSON from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
+// Decode rejects duplicate object keys.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	data, _, err := io.ReadAll(r)
 	if err != nil {

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +22,19 @@ func TestEncode(t *testing.T) {
 	require.Contains(t, buf.String(), "test")
 }
 
+func TestEncodeReturnsError(t *testing.T) {
+	encoder := hjson.NewEncoder()
+	buf := &bytes.Buffer{}
+
+	require.Error(t, encoder.Encode(buf, func() {}))
+}
+
+func TestEncodeReturnsWriteError(t *testing.T) {
+	encoder := hjson.NewEncoder()
+
+	require.ErrorIs(t, encoder.Encode(test.ErrWriter{}, &message{Test: "test"}), test.ErrFailed)
+}
+
 func TestDecode(t *testing.T) {
 	encoder := hjson.NewEncoder()
 	msg := &message{}
@@ -34,7 +48,6 @@ func TestDecodeRejectsDuplicateKeys(t *testing.T) {
 	msg := &message{}
 
 	err := encoder.Decode(bytes.NewBufferString("{\n  test: first\n  test: second\n}\n"), msg)
-
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(err.Error()), "duplicate")
 }

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -21,6 +21,15 @@ func TestEncode(t *testing.T) {
 	require.JSONEq(t, "{\"test\":\"test\"}", bytes.String(bytes.TrimSpace(test.Pool.Copy(buffer))))
 }
 
+func TestEncodeReturnsError(t *testing.T) {
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := json.NewEncoder()
+
+	require.Error(t, encoder.Encode(buffer, func() {}))
+}
+
 func TestDecode(t *testing.T) {
 	encoder := json.NewEncoder()
 	var msg map[string]string

--- a/encoding/msgpack/msgpack.go
+++ b/encoding/msgpack/msgpack.go
@@ -2,6 +2,8 @@ package msgpack
 
 import (
 	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -20,7 +22,13 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 
 // Decode reads MessagePack from r and decodes it into v.
 func (e *Encoder) Decode(r io.Reader, v any) error {
-	return msgpack.NewDecoder(r).Decode(v)
+	decoder := msgpack.NewDecoder(r)
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+
+	var extra any
+	return errors.TrailingData(decoder.Decode(&extra))
 }
 
 // Marshal encodes v as MessagePack.
@@ -30,5 +38,5 @@ func Marshal(v any) ([]byte, error) {
 
 // Unmarshal decodes MessagePack data into v.
 func Unmarshal(data []byte, v any) error {
-	return msgpack.Unmarshal(data, v)
+	return NewEncoder().Decode(bytes.NewReader(data), v)
 }

--- a/encoding/msgpack/msgpack_test.go
+++ b/encoding/msgpack/msgpack_test.go
@@ -3,6 +3,7 @@ package msgpack_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/msgpack"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,22 @@ func TestEncodeDecode(t *testing.T) {
 	require.Equal(t, msg, actual)
 }
 
+func TestEncodeReturnsError(t *testing.T) {
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder()
+
+	require.Error(t, encoder.Encode(buffer, func() {}))
+}
+
+func TestDecodeReturnsError(t *testing.T) {
+	encoder := msgpack.NewEncoder()
+
+	var actual map[string]string
+	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &actual))
+}
+
 func TestMarshalUnmarshal(t *testing.T) {
 	msg := map[string]string{"test": "test"}
 
@@ -31,4 +48,64 @@ func TestMarshalUnmarshal(t *testing.T) {
 	var actual map[string]string
 	require.NoError(t, msgpack.Unmarshal(data, &actual))
 	require.Equal(t, msg, actual)
+}
+
+func TestDecodeRejectsTrailingValue(t *testing.T) {
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder()
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"extra": "value"}))
+
+	var actual map[string]string
+	err := encoder.Decode(buffer, &actual)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+func TestDecodeRejectsMalformedTrailingData(t *testing.T) {
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder()
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"test": "test"}))
+	_, err := buffer.WriteString("junk")
+	require.NoError(t, err)
+
+	var actual map[string]string
+	err = encoder.Decode(buffer, &actual)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+func TestUnmarshalRejectsTrailingValue(t *testing.T) {
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder()
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"extra": "value"}))
+
+	var actual map[string]string
+	err := msgpack.Unmarshal(test.Pool.Copy(buffer), &actual)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+func TestUnmarshalReturnsDecodeError(t *testing.T) {
+	var actual map[string]string
+
+	require.Error(t, msgpack.Unmarshal([]byte("junk"), &actual))
+}
+
+func TestUnmarshalRejectsMalformedTrailingData(t *testing.T) {
+	data, err := msgpack.Marshal(map[string]string{"test": "test"})
+	require.NoError(t, err)
+	data = append(data, []byte("junk")...)
+
+	var actual map[string]string
+	err = msgpack.Unmarshal(data, &actual)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
 }

--- a/encoding/proto/binary.go
+++ b/encoding/proto/binary.go
@@ -1,7 +1,6 @@
 package proto
 
 import (
-	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"google.golang.org/protobuf/proto"
 )
@@ -26,9 +25,9 @@ type Binary struct{}
 // If v does not implement proto.Message, Encode returns encoding/errors.ErrInvalidType.
 // Any marshaling error from proto.Marshal and any write error from w.Write is returned.
 func (e *Binary) Encode(w io.Writer, v any) error {
-	msg, ok := v.(proto.Message)
-	if !ok {
-		return errors.ErrInvalidType
+	msg, err := message(v)
+	if err != nil {
+		return err
 	}
 
 	bytes, err := proto.Marshal(msg)
@@ -50,9 +49,9 @@ func (e *Binary) Encode(w io.Writer, v any) error {
 //
 // Any read error from io.ReadAll and any unmarshal error from proto.Unmarshal is returned.
 func (e *Binary) Decode(r io.Reader, v any) error {
-	msg, ok := v.(proto.Message)
-	if !ok {
-		return errors.ErrInvalidType
+	msg, err := message(v)
+	if err != nil {
+		return err
 	}
 
 	bytes, _, err := io.ReadAll(r)

--- a/encoding/proto/json.go
+++ b/encoding/proto/json.go
@@ -1,10 +1,8 @@
 package proto
 
 import (
-	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 // NewJSON constructs a protobuf JSON encoder.
@@ -27,9 +25,9 @@ type JSON struct{}
 // If v does not implement proto.Message, Encode returns encoding/errors.ErrInvalidType.
 // Any marshaling error from protojson.Marshal and any write error from w.Write is returned.
 func (e *JSON) Encode(w io.Writer, v any) error {
-	msg, ok := v.(proto.Message)
-	if !ok {
-		return errors.ErrInvalidType
+	msg, err := message(v)
+	if err != nil {
+		return err
 	}
 
 	bytes, err := protojson.Marshal(msg)
@@ -51,9 +49,9 @@ func (e *JSON) Encode(w io.Writer, v any) error {
 //
 // Any read error from io.ReadAll and any unmarshal error from protojson.Unmarshal is returned.
 func (e *JSON) Decode(r io.Reader, v any) error {
-	msg, ok := v.(proto.Message)
-	if !ok {
-		return errors.ErrInvalidType
+	msg, err := message(v)
+	if err != nil {
+		return err
 	}
 
 	bytes, _, err := io.ReadAll(r)

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -1,0 +1,16 @@
+package proto
+
+import (
+	"github.com/alexfalkowski/go-service/v2/encoding/errors"
+	"github.com/alexfalkowski/go-service/v2/reflect"
+	"google.golang.org/protobuf/proto"
+)
+
+func message(v any) (proto.Message, error) {
+	msg, ok := v.(proto.Message)
+	if !ok || reflect.IsNil(msg) {
+		return nil, errors.ErrInvalidType
+	}
+
+	return msg, nil
+}

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -3,6 +3,7 @@ package proto_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/proto"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -146,6 +147,23 @@ func TestInvalidJSONDecodeDoesNotRead(t *testing.T) {
 	require.Zero(t, reader.Reads)
 }
 
+func TestEncodeReturnsWriteError(t *testing.T) {
+	encoders := []struct {
+		encoder encoding.Encoder
+		name    string
+	}{
+		{encoder: proto.NewBinary(), name: "binary"},
+		{encoder: proto.NewJSON(), name: "json"},
+		{encoder: proto.NewText(), name: "text"},
+	}
+
+	for _, tt := range encoders {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.encoder.Encode(test.ErrWriter{}, &health.Response{Status: health.Serving}))
+		})
+	}
+}
+
 func TestErrBinaryDecode(t *testing.T) {
 	encoder := proto.NewBinary()
 	var msg health.Response
@@ -162,4 +180,46 @@ func TestErrJSONDecode(t *testing.T) {
 	encoder := proto.NewJSON()
 	var msg health.Response
 	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &msg))
+}
+
+func TestInvalidTypedNilEncode(t *testing.T) {
+	encoders := []struct {
+		encoder encoding.Encoder
+		name    string
+	}{
+		{encoder: proto.NewBinary(), name: "binary"},
+		{encoder: proto.NewJSON(), name: "json"},
+		{encoder: proto.NewText(), name: "text"},
+	}
+
+	for _, tt := range encoders {
+		t.Run(tt.name, func(t *testing.T) {
+			var msg *health.Response
+
+			err := tt.encoder.Encode(io.Discard, msg)
+			require.ErrorIs(t, err, errors.ErrInvalidType)
+		})
+	}
+}
+
+func TestInvalidTypedNilDecodeDoesNotRead(t *testing.T) {
+	encoders := []struct {
+		encoder encoding.Encoder
+		name    string
+	}{
+		{encoder: proto.NewBinary(), name: "binary"},
+		{encoder: proto.NewJSON(), name: "json"},
+		{encoder: proto.NewText(), name: "text"},
+	}
+
+	for _, tt := range encoders {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &test.TrackingReader{Err: io.EOF}
+			var msg *health.Response
+
+			err := tt.encoder.Decode(reader, msg)
+			require.ErrorIs(t, err, errors.ErrInvalidType)
+			require.Zero(t, reader.Reads)
+		})
+	}
 }

--- a/encoding/proto/text.go
+++ b/encoding/proto/text.go
@@ -1,10 +1,8 @@
 package proto
 
 import (
-	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"google.golang.org/protobuf/encoding/prototext"
-	"google.golang.org/protobuf/proto"
 )
 
 // NewText constructs a protobuf text encoder.
@@ -27,9 +25,9 @@ type Text struct{}
 // If v does not implement proto.Message, Encode returns encoding/errors.ErrInvalidType.
 // Any marshaling error from prototext.Marshal and any write error from w.Write is returned.
 func (e *Text) Encode(w io.Writer, v any) error {
-	msg, ok := v.(proto.Message)
-	if !ok {
-		return errors.ErrInvalidType
+	msg, err := message(v)
+	if err != nil {
+		return err
 	}
 
 	bytes, err := prototext.Marshal(msg)
@@ -51,9 +49,9 @@ func (e *Text) Encode(w io.Writer, v any) error {
 //
 // Any read error from io.ReadAll and any unmarshal error from prototext.Unmarshal is returned.
 func (e *Text) Decode(r io.Reader, v any) error {
-	msg, ok := v.(proto.Message)
-	if !ok {
-		return errors.ErrInvalidType
+	msg, err := message(v)
+	if err != nil {
+		return err
 	}
 
 	bytes, _, err := io.ReadAll(r)

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -21,6 +21,15 @@ func TestEncode(t *testing.T) {
 	require.Equal(t, `test = "test"`, strings.TrimSpace(bytes.String()))
 }
 
+func TestEncodeReturnsError(t *testing.T) {
+	bytes := test.Pool.Get()
+	defer test.Pool.Put(bytes)
+
+	encoder := toml.NewEncoder()
+
+	require.Error(t, encoder.Encode(bytes, func() {}))
+}
+
 func TestDecode(t *testing.T) {
 	encoder := toml.NewEncoder()
 	var msg map[string]string

--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -21,9 +21,15 @@ type Encoder struct{}
 
 // Encode writes v to w as YAML.
 //
-// This is a thin wrapper around `yaml.NewEncoder(w).Encode(v)`.
+// Encode closes the upstream YAML encoder after writing so final buffered data and
+// finalization errors are handled.
 func (e *Encoder) Encode(w io.Writer, v any) error {
-	return yaml.NewEncoder(w).Encode(v)
+	encoder := yaml.NewEncoder(w)
+	if err := encoder.Encode(v); err != nil {
+		return err
+	}
+
+	return encoder.Close()
 }
 
 // Decode reads YAML from r and decodes it into v.

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -22,6 +22,12 @@ func TestEncode(t *testing.T) {
 	require.Equal(t, "test: test", strings.TrimSpace(bytes.String()))
 }
 
+func TestEncodeReturnsError(t *testing.T) {
+	encoder := yaml.NewEncoder()
+
+	require.Error(t, encoder.Encode(test.ErrWriter{}, map[string]string{"test": "test"}))
+}
+
 func TestDecode(t *testing.T) {
 	encoder := yaml.NewEncoder()
 	var msg map[string]string

--- a/internal/test/io.go
+++ b/internal/test/io.go
@@ -41,3 +41,19 @@ func (r *TrackingReader) Read(_ []byte) (int, error) {
 	r.Reads++
 	return 0, r.Err
 }
+
+// ErrWriter is an io.Writer test double whose writes fail with ErrFailed.
+type ErrWriter struct{}
+
+// Write returns ErrFailed.
+func (ErrWriter) Write([]byte) (int, error) {
+	return 0, ErrFailed
+}
+
+// ErrWriterTo is an io.WriterTo test double whose writes fail with ErrFailed.
+type ErrWriterTo struct{}
+
+// WriteTo returns ErrFailed.
+func (ErrWriterTo) WriteTo(io.Writer) (int64, error) {
+	return 0, ErrFailed
+}

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -16,7 +16,6 @@ func IsNil(value any) bool {
 	}
 
 	rv := reflect.ValueOf(value)
-
 	switch rv.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return rv.IsNil()


### PR DESCRIPTION
## What

- Reject typed-nil protobuf and stream passthrough values before invoking codec methods.
- Make gob and MessagePack decoders reject trailing encoded data after the first payload.
- Close YAML encoders after writes and document decoder full-consumption and HJSON duplicate-key behavior.

## Why

- Prevent nil-target panic edges and silent acceptance of appended serialized data in single-payload codecs.
- Keep codec behavior aligned with the shared encoder contract for untrusted or integrity-sensitive payloads.

## Testing

- `go test ./encoding/...` - passed
- `make lint` - passed
- `make specs` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
