### PR TITLE
feat(slices): generalize zero-value append helper

### DIFF
--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -23,3 +23,15 @@ func IsNil(value any) bool {
 		return false
 	}
 }
+
+// IsZero reports whether value is the zero value for its type.
+//
+// It returns true for nil interfaces and typed nil values, and it supports
+// non-comparable values such as slices, maps, funcs, and structs containing them.
+func IsZero(value any) bool {
+	if value == nil {
+		return true
+	}
+
+	return reflect.ValueOf(value).IsZero()
+}

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -25,3 +25,17 @@ func TestIsNilWithValue(t *testing.T) {
 func TestIsNilWithNonNillableKind(t *testing.T) {
 	require.False(t, reflect.IsNil(42))
 }
+
+func TestIsZero(t *testing.T) {
+	require.True(t, reflect.IsZero(nil))
+}
+
+func TestIsZeroWithTypedNil(t *testing.T) {
+	var err error = (*test.NilError)(nil)
+
+	require.True(t, reflect.IsZero(err))
+}
+
+func TestIsZeroWithValue(t *testing.T) {
+	require.False(t, reflect.IsZero("value"))
+}

--- a/slices/doc.go
+++ b/slices/doc.go
@@ -11,18 +11,12 @@
 //
 // # Conditional append helpers
 //
-// AppendNotZero appends elements to a slice while skipping elements that are the
-// zero value of the element type.
+// AppendNotZero appends elements to a slice while skipping elements that are nil
+// or the zero value of the element type.
 //
 // This is useful when building option lists, attribute sets, or filter lists where
 // zero values should be treated as “not provided”.
-//
-// AppendNotNil appends pointer elements to a slice while skipping nil pointers.
-//
-// This is useful when building slices of optional pointers where nil indicates the
-// absence of a value.
-//
-// Both helpers preserve the relative order of the elements they append and return
+// The helper preserves the relative order of the elements it appends and returns
 // the resulting slice.
 //
 // # Searching helpers
@@ -43,7 +37,7 @@
 //
 // These helpers are designed to be predictable and side-effect free aside from
 // modifying the returned slice as normal for append-style operations. They do not
-// mutate elements (beyond appending) and they do not perform deep equality checks;
-// “zero” is defined by Go’s == comparison against the zero value for comparable
-// types.
+// mutate elements beyond appending them. “Zero” is defined by reflect.IsZero, so
+// nil slices and maps are skipped, while non-nil empty slices and maps are
+// appended.
 package slices

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -4,13 +4,13 @@ import (
 	"iter"
 	"slices"
 
-	"github.com/alexfalkowski/go-service/v2/structs"
+	"github.com/alexfalkowski/go-service/v2/reflect"
 )
 
-// AppendNotZero appends elems to slice, skipping elements that are the zero value for T.
+// AppendNotZero appends elems to slice, skipping nil and zero elements.
 //
-// “Zero” is determined using structs.IsZero, which compares the element against the
-// type’s zero value using == (therefore T must be comparable).
+// Zero values are determined using reflect.IsZero, which supports non-comparable
+// values such as slices, maps, funcs, and structs containing them.
 //
 // This helper preserves the relative order of appended elements and returns the
 // resulting slice.
@@ -20,31 +20,9 @@ import (
 //	var out []string
 //	out = slices.AppendNotZero(out, "", "a", "", "b")
 //	// out == []string{"a", "b"}
-func AppendNotZero[T comparable](slice []T, elems ...T) []T {
+func AppendNotZero[T any](slice []T, elems ...T) []T {
 	for _, elem := range elems {
-		if structs.IsZero(elem) {
-			continue
-		}
-		slice = append(slice, elem)
-	}
-	return slice
-}
-
-// AppendNotNil appends elems to slice, skipping nil elements.
-//
-// This helper is useful when building slices of optional pointer values where nil
-// indicates “not provided”. It preserves the relative order of appended elements
-// and returns the resulting slice.
-//
-// Example:
-//
-//	var out []*int
-//	var a = 1
-//	out = slices.AppendNotNil(out, nil, &a, nil)
-//	// out contains only &a
-func AppendNotNil[T any](slice []*T, elems ...*T) []*T {
-	for _, elem := range elems {
-		if structs.IsNil(elem) {
+		if reflect.IsZero(elem) {
 			continue
 		}
 		slice = append(slice, elem)

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -3,12 +3,14 @@ package slices_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/stretchr/testify/require"
 )
 
-func TestEmptyAppendZero(t *testing.T) {
+func TestAppendEmpty(t *testing.T) {
 	for _, elem := range []*int{nil} {
 		t.Run("nil pointer", func(t *testing.T) {
 			require.Empty(t, slices.AppendNotZero([]*int{}, elem))
@@ -20,17 +22,26 @@ func TestEmptyAppendZero(t *testing.T) {
 			require.Empty(t, slices.AppendNotZero([]int{}, elem))
 		})
 	}
+
+	t.Run("typed nil interface", func(t *testing.T) {
+		var writer *test.ErrWriter
+		var elem io.Writer = writer
+
+		require.Empty(t, slices.AppendNotZero([]io.Writer{}, elem))
+	})
+
+	t.Run("nil slice", func(t *testing.T) {
+		var elem []string
+
+		require.Empty(t, slices.AppendNotZero([][]string{}, elem))
+	})
+
+	t.Run("zero non-comparable struct", func(t *testing.T) {
+		require.Empty(t, slices.AppendNotZero([]test.Page{}, test.Page{}))
+	})
 }
 
-func TestEmptyAppendNil(t *testing.T) {
-	for _, elem := range []*int{nil} {
-		t.Run("nil pointer", func(t *testing.T) {
-			require.Empty(t, slices.AppendNotNil([]*int{}, elem))
-		})
-	}
-}
-
-func TestAppendZero(t *testing.T) {
+func TestAppendNotZero(t *testing.T) {
 	integer := 2
 
 	for _, elem := range []*int{&integer} {
@@ -38,16 +49,22 @@ func TestAppendZero(t *testing.T) {
 			require.NotEmpty(t, slices.AppendNotZero([]*int{}, elem))
 		})
 	}
-}
-
-func TestAppendNil(t *testing.T) {
-	integer := 2
 
 	for _, elem := range []*int{&integer} {
 		t.Run("non-nil pointer", func(t *testing.T) {
-			require.NotEmpty(t, slices.AppendNotNil([]*int{}, elem))
+			require.NotEmpty(t, slices.AppendNotZero([]*int{}, elem))
 		})
 	}
+
+	t.Run("empty slice", func(t *testing.T) {
+		require.NotEmpty(t, slices.AppendNotZero([][]string{}, []string{}))
+	})
+
+	t.Run("non-zero non-comparable struct", func(t *testing.T) {
+		value := test.Page{Title: "test"}
+
+		require.NotEmpty(t, slices.AppendNotZero([]test.Page{}, value))
+	})
 }
 
 func TestElemFunc(t *testing.T) {

--- a/transport/server.go
+++ b/transport/server.go
@@ -31,5 +31,5 @@ type ServersParams struct {
 // It returns a slice of `*server.Service` that excludes nil services, so it is safe to pass the returned slice
 // to `Register` for lifecycle wiring.
 func NewServers(params ServersParams) []*server.Service {
-	return slices.AppendNotNil([]*server.Service{}, params.HTTP.GetService(), params.GRPC.GetService(), params.Debug.GetService())
+	return slices.AppendNotZero([]*server.Service{}, params.HTTP.GetService(), params.GRPC.GetService(), params.Debug.GetService())
 }


### PR DESCRIPTION
## What

- Replace the pointer-only append helper with a single AppendNotZero helper that accepts any element type.
- Add reflect.IsZero for nil, typed-nil, and non-comparable zero checks.
- Update transport server collection and slice helper tests/docs for the new behavior.

## Why

- Keep one append helper for nil and zero filtering while allowing non-comparable values.
- Preserve typed nil handling without requiring callers to use pointer-only APIs.

## Testing

- `go test ./...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
