### PR TITLE
feat(http): reject typed nil rpc payloads

### DIFF
--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
+	"github.com/alexfalkowski/go-service/v2/reflect"
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
@@ -106,10 +107,10 @@ type Client struct {
 //
 // The res parameter is typically a pointer to the destination value (for example *MyResponse).
 func (c *Client) Post(ctx context.Context, path string, req, res any) error {
-	if req == nil {
+	if reflect.IsNil(req) {
 		return ErrInvalidRequest
 	}
-	if res == nil {
+	if reflect.IsNil(res) {
 		return ErrInvalidResponse
 	}
 

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -1,0 +1,39 @@
+package rpc_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostRequiresRequest(t *testing.T) {
+	client := rpc.NewClient("http://example.com")
+
+	var res test.Response
+	require.ErrorIs(t, client.Post(t.Context(), "/hello", nil, &res), rpc.ErrInvalidRequest)
+}
+
+func TestPostRequiresNonNilTypedRequest(t *testing.T) {
+	client := rpc.NewClient("http://example.com")
+
+	var req *test.Request
+	var res test.Response
+	require.ErrorIs(t, client.Post(t.Context(), "/hello", req, &res), rpc.ErrInvalidRequest)
+}
+
+func TestPostRequiresResponse(t *testing.T) {
+	client := rpc.NewClient("http://example.com")
+
+	req := &test.Request{Name: "Bob"}
+	require.ErrorIs(t, client.Post(t.Context(), "/hello", req, nil), rpc.ErrInvalidResponse)
+}
+
+func TestPostRequiresNonNilTypedResponse(t *testing.T) {
+	client := rpc.NewClient("http://example.com")
+
+	req := &test.Request{Name: "Bob"}
+	var res *test.Response
+	require.ErrorIs(t, client.Post(t.Context(), "/hello", req, res), rpc.ErrInvalidResponse)
+}


### PR DESCRIPTION
## What

- Validate RPC request and response payloads with reflect.IsNil so typed nil values are rejected.
- Add RPC client tests for nil and typed nil request/response values.
- Remove the resolved review ledger after fixing the finding.

## Why

- Preserve the documented Client.Post contract that invalid payloads return ErrInvalidRequest or ErrInvalidResponse instead of codec-specific encode/decode errors.

## Testing

- `go test ./net/http/rpc ./net/http/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
