### PR TITLE
feat(sql): close partial connection pools on startup errors

### DIFF
--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -131,6 +131,10 @@ func Open(lc di.Lifecycle, name string, fs *os.FS, cfg *config.Config, opts ...t
 func ConnectMasterSlaves(name string, masterDSNs, slaveDSNs []string) (*DBs, []error) {
 	db, errs := mssqlx.ConnectMasterSlaves(name, masterDSNs, slaveDSNs)
 	if errors.Join(errs...) != nil {
+		if db != nil {
+			errs = append(errs, db.Destroy()...)
+		}
+
 		return nil, errs
 	}
 
@@ -185,6 +189,10 @@ func connectDBs(name string, masterDSNs, slaveDSNs []string, opts ...telemetry.O
 
 	db, errs := mssqlx.ConnectMasterSlaves(name, masterDSNs, slaveDSNs)
 	if err := errors.Join(errs...); err != nil {
+		if db != nil {
+			err = errors.Join(err, errors.Join(db.Destroy()...))
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
## What

- Close partially opened master/slave pool collections when connection setup reports errors.
- Preserve the original connection error while also including cleanup errors if pool destruction fails.

## Why

- Prevent startup or reload retries with mixed valid/invalid DSNs from leaking database pool resources.
- Keep the fix small without adding tests that depend on unexported package or standard-library internals.

## Testing

- `make lint` - passed
- `go test ./database/sql/... ./bytes ./runtime` - passed
- `govulncheck -test ./database/sql/... ./bytes ./runtime` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)