### PR TITLE
feat(debug): apply server timeout defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,15 @@ matching skill for the task.
   wires `debug.Module`; do not flag `transport.NewServers` requiring
   `*debug.Server` unless a public API starts promising standalone
   `transport.Module` composition without the standard `module.Server` bundle.
+- Server defaults that use `net.DefaultAddress`, including the debug server's
+  `tcp://:6060` fallback, intentionally bind all interfaces so containerized
+  workloads remain reachable through Kubernetes Services, probes, ingress
+  controllers, and sidecars. Do not flag this solely because debug endpoints can
+  be reached remotely when the debug server is enabled; restrict exposure with
+  explicit addresses, TLS/mTLS, NetworkPolicy, ingress/firewall, or
+  service-mesh policy. Only report concrete bugs such as accidental listener
+  changes, ignored explicit addresses, missing documented protections, or a
+  public API promise of localhost-only debug binding.
 - `cli.RunCode` returns `os.ExitCodeSuccess` on success, preserves non-zero
   shutdown exit codes requested through `di.ExitCode(...)`, and otherwise
   returns `os.ExitCodeFailure`.

--- a/debug/server.go
+++ b/debug/server.go
@@ -56,7 +56,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, nil
 	}
 
-	httpServer := http.NewServer(params.Config.Options, params.Config.Timeout, params.Mux)
+	httpServer := http.NewServer(params.Config.Options, params.Config.GetTimeout(), params.Mux)
 
 	cfg, err := newConfig(params.FS, params.Config)
 	if err != nil {


### PR DESCRIPTION
## What

- Use the shared server timeout fallback when constructing the debug HTTP server.
- Document that all-interface server defaults from net.DefaultAddress are intentional for Kubernetes/container reachability and should not be flagged by review by themselves.

## Why

- Keep enabled debug servers from inheriting zero HTTP read/write/idle/header timeouts when timeout is omitted.
- Prevent future secure-code reviews from reporting the intentional all-interface bind default without a concrete bug.

## Testing

- `make lint` - passed
- `go test ./debug/...` - passed
- `govulncheck -test ./debug/...` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
