### PR TITLE
feat(cache): limit oversized encoded entries

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -140,6 +140,10 @@ func (c *Cache) encode(value any) (string, error) {
 }
 
 func (c *Cache) decode(value string, field any) error {
+	if int64(len(value)) > base64.EncodedLen(c.cfg.GetMaxSize()) {
+		return errors.ErrTooLarge
+	}
+
 	decoded, err := base64.Decode(value)
 	if err != nil {
 		return err

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -93,6 +93,18 @@ func TestMaxSizeOnGetAllowsEncodedValueLargerThanLimit(t *testing.T) {
 	require.Equal(t, "ok", *value)
 }
 
+func TestMaxSizeOnGetRejectsEncodedValueTooLarge(t *testing.T) {
+	cfg := test.NewCacheConfig("sync", "none", "json", "redis")
+	cfg.MaxSize = 4
+	world := test.NewStartedWorld(t,
+		test.WithWorldCacheConfig(cfg),
+		test.WithWorldCacheDriver(&test.Cache{Value: base64.Encode(make([]byte, 7))}),
+	)
+
+	err := world.Get(t.Context(), "test", ptr.Zero[string]())
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
 func TestExpiredCache(t *testing.T) {
 	config := test.NewCacheConfig("sync", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())

--- a/encoding/base64/base64.go
+++ b/encoding/base64/base64.go
@@ -2,6 +2,7 @@ package base64
 
 import (
 	"encoding/base64"
+	"math"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -15,6 +16,16 @@ func Encode(src []byte) string {
 	base64.StdEncoding.Encode(buf, src)
 
 	return bytes.String(buf)
+}
+
+// EncodedLen returns the length in bytes of the standard base64 encoding of size.
+func EncodedLen(size bytes.Size) int64 {
+	n := size.Bytes()
+	if n > math.MaxInt {
+		return math.MaxInt64
+	}
+
+	return int64(base64.StdEncoding.EncodedLen(int(n)))
 }
 
 // Decode decodes a standard base64-encoded string s into a byte slice.


### PR DESCRIPTION
## What

- Reject stored base64 cache values whose encoded wrapper is too large for the configured maximum payload size before decoding them.
- Add a base64 encoded-length helper that works from the repository size type without narrowing through int.
- Add regression coverage for oversized backend values while preserving valid base64 overhead on reads.

## Why

- Prevent corrupted or externally poisoned cache backend values from allocating decoded buffers before cache size limits are enforced.
- Keep the existing write-side compressed/decompressed size contract intact while bounding the read-side base64 wrapper.

## Testing

- `make lint` - passed
- `go test ./cache ./encoding/base64 ./encoding/...` - passed
- `govulncheck -test ./cache ./encoding/...` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
