### PR TITLE
feat(http): protect credentialed redirects and signed events

### DIFF
--- a/internal/test/events.go
+++ b/internal/test/events.go
@@ -8,11 +8,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/events"
 	httphooks "github.com/alexfalkowski/go-service/v2/transport/http/hooks"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/cloudevents/sdk-go/v2/client"
 )
 
 // NewEvents builds a webhook-backed CloudEvents receiver and sender using the shared hook fixture.
-func NewEvents(mux *http.ServeMux, rt http.RoundTripper, generator id.Generator) (*events.Receiver, client.Client, error) {
+func NewEvents(mux *http.ServeMux, rt http.RoundTripper, generator id.Generator) (*events.Receiver, *events.Sender, error) {
 	h, err := hooks.NewHook(FS, NewHook())
 	if err != nil {
 		return nil, nil, err
@@ -20,10 +19,7 @@ func NewEvents(mux *http.ServeMux, rt http.RoundTripper, generator id.Generator)
 
 	receiver := events.NewReceiver(mux, httphooks.NewWebhook(h, generator))
 
-	sender, err := events.NewSender(httphooks.NewWebhook(h, generator), events.WithSenderRoundTripper(rt))
-	if err != nil {
-		return nil, nil, err
-	}
+	sender := events.NewSender(httphooks.NewWebhook(h, generator), events.WithSenderRoundTripper(rt))
 
 	return receiver, sender, nil
 }

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -23,7 +23,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/events"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/cloudevents/sdk-go/v2/client"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -153,7 +152,7 @@ type World struct {
 	*cloudevents.Event
 	*events.Receiver
 	*cache.Cache
-	Sender client.Client
+	Sender *events.Sender
 	Rest   *rest.Client
 
 	DB         *sql.DBs

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
@@ -52,6 +53,9 @@ const StatusGatewayTimeout = http.StatusGatewayTimeout
 
 // StatusOK is an alias of http.StatusOK.
 const StatusOK = http.StatusOK
+
+// StatusNoContent is an alias of http.StatusNoContent.
+const StatusNoContent = http.StatusNoContent
 
 // StatusRequestEntityTooLarge is an alias of http.StatusRequestEntityTooLarge.
 const StatusRequestEntityTooLarge = http.StatusRequestEntityTooLarge
@@ -205,6 +209,15 @@ func IgnoreRedirect(_ *Request, _ []*Request) error {
 	return ErrUseLastResponse
 }
 
+// SameOrigin reports whether prev and next use the same URL scheme and host.
+func SameOrigin(prev, next *url.URL) bool {
+	if prev == nil || next == nil {
+		return false
+	}
+
+	return prev.Scheme == next.Scheme && prev.Host == next.Host
+}
+
 // SameOriginRedirect allows redirects only when the next request stays on the same scheme and host.
 //
 // It is intended for clients that add credentials or signatures in RoundTripper middleware, where Go's
@@ -217,7 +230,7 @@ func SameOriginRedirect(req *Request, via []*Request) error {
 
 	prev := via[len(via)-1].URL
 	next := req.URL
-	if prev.Scheme == next.Scheme && prev.Host == next.Host {
+	if SameOrigin(prev, next) {
 		return nil
 	}
 

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -2,6 +2,7 @@ package http_test
 
 import (
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
@@ -71,6 +72,22 @@ func TestSameOriginRedirect(t *testing.T) {
 			require.ErrorIs(t, err, tt.want)
 		})
 	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	prev, err := url.Parse("https://example.com/start")
+	require.NoError(t, err)
+
+	same, err := url.Parse("https://example.com/next")
+	require.NoError(t, err)
+
+	different, err := url.Parse("https://other.example.com/next")
+	require.NoError(t, err)
+
+	require.True(t, http.SameOrigin(prev, same))
+	require.False(t, http.SameOrigin(prev, different))
+	require.False(t, http.SameOrigin(nil, same))
+	require.False(t, http.SameOrigin(prev, nil))
 }
 
 func TestIgnoreRedirect(t *testing.T) {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -1,6 +1,7 @@
 package http_test
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
@@ -41,4 +42,32 @@ func TestClientWithTokenDoesNotFollowCrossOriginRedirect(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ErrorIs(t, client.CheckRedirect(next, []*http.Request{prev}), http.ErrUseLastResponse)
+}
+
+func TestRoundTripperWithTokenDoesNotSendAuthorizationToCrossOriginRedirect(t *testing.T) {
+	var attackerAuthorization string
+	attacker := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		attackerAuthorization = req.Header.Get("Authorization")
+	}))
+	t.Cleanup(attacker.Close)
+
+	var trustedAuthorization string
+	trusted := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		trustedAuthorization = req.Header.Get("Authorization")
+		res.Header().Set("Location", attacker.URL+"/target")
+		res.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(trusted.Close)
+
+	rt, err := transporthttp.NewRoundTripper(
+		transporthttp.WithClientTokenGenerator(env.UserID("service-user"), test.NewGenerator("secret", nil)),
+	)
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: rt}
+	res, err := client.Get(trusted.URL + "/start")
+	require.ErrorIs(t, err, http.ErrUseLastResponse)
+	require.Nil(t, res)
+	require.Equal(t, "Bearer secret", trustedAuthorization)
+	require.Empty(t, attackerAuthorization)
 }

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/hooks"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	transportevents "github.com/alexfalkowski/go-service/v2/transport/http/events"
@@ -96,8 +97,7 @@ func TestSenderWithWebhookDoesNotFollowCrossOriginRedirect(t *testing.T) {
 	hook, err := hooks.NewHook(test.FS, test.NewHook())
 	require.NoError(t, err)
 
-	sender, err := transportevents.NewSender(httphooks.NewWebhook(hook, uuid.NewGenerator()))
-	require.NoError(t, err)
+	sender := transportevents.NewSender(httphooks.NewWebhook(hook, uuid.NewGenerator()))
 
 	e := events.NewEvent()
 	e.SetSource("example/uri")
@@ -108,6 +108,41 @@ func TestSenderWithWebhookDoesNotFollowCrossOriginRedirect(t *testing.T) {
 	require.True(t, protocol.IsNACK(result))
 	require.NotEmpty(t, trustedSignature)
 	require.Empty(t, attackerSignature)
+}
+
+func TestSenderUsesStructuredEncoding(t *testing.T) {
+	contentTypes := make(chan string, 1)
+	specVersions := make(chan string, 1)
+	bodies := make(chan string, 1)
+	readErrors := make(chan error, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		data, _, err := io.ReadAll(req.Body)
+		contentTypes <- req.Header.Get("Content-Type")
+		specVersions <- req.Header.Get("Ce-Specversion")
+		bodies <- bytes.String(data)
+		readErrors <- err
+
+		res.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	sender := transportevents.NewSender(nil)
+
+	e := events.NewEvent()
+	e.SetID("event-1")
+	e.SetSource("example/uri")
+	e.SetType("example.type")
+	require.NoError(t, e.SetData(events.TextPlain, "test"))
+
+	result := sender.Send(events.ContextWithTarget(t.Context(), server.URL+"/events"), e)
+	require.NoError(t, <-readErrors)
+	require.True(t, protocol.IsACK(result))
+	require.Equal(t, "application/cloudevents+json", <-contentTypes)
+	require.Empty(t, <-specVersions)
+	body := <-bodies
+	require.Contains(t, body, `"id":"event-1"`)
+	require.Contains(t, body, `"type":"example.type"`)
 }
 
 func TestReceiveUsesServerMaxReceiveSizeBeforeWebhookVerification(t *testing.T) {

--- a/transport/http/events/hooks/hooks.go
+++ b/transport/http/events/hooks/hooks.go
@@ -1,9 +1,15 @@
 package hooks
 
 import (
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/hooks"
 )
+
+// ErrBinaryEncoding is returned when a webhook-protected event uses binary HTTP encoding.
+var ErrBinaryEncoding = errors.New("events: binary encoding is not supported for webhooks")
 
 // Webhook is an alias for `transport/http/hooks.Webhook`.
 //
@@ -21,6 +27,10 @@ type Webhook = hooks.Webhook
 //
 // If hook is nil, the returned handler behaves as a pass-through wrapper.
 func NewHandler(hook *Webhook, handler http.Handler) *Handler {
+	if hook == nil {
+		return &Handler{Handler: handler}
+	}
+
 	return &Handler{handler: hooks.NewHandler(hook), Handler: handler}
 }
 
@@ -28,8 +38,8 @@ func NewHandler(hook *Webhook, handler http.Handler) *Handler {
 //
 // When webhook support is disabled, Handler becomes a pass-through wrapper.
 type Handler struct {
-	handler *hooks.Handler
 	http.Handler
+	handler *hooks.Handler
 }
 
 // ServeHTTP verifies the webhook signature and then delegates to the wrapped handler.
@@ -49,5 +59,20 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if hasBinaryHeaders(req.Header) {
+		_ = status.WriteError(resp, status.BadRequestError(ErrBinaryEncoding))
+		return
+	}
+
 	h.handler.ServeHTTP(resp, req, h.Handler.ServeHTTP)
+}
+
+func hasBinaryHeaders(header http.Header) bool {
+	for key := range header {
+		if strings.HasPrefix(strings.ToLower(key), "ce-") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/transport/http/events/hooks/hooks_test.go
+++ b/transport/http/events/hooks/hooks_test.go
@@ -5,13 +5,15 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/transport/http/events/hooks"
+	eventhooks "github.com/alexfalkowski/go-service/v2/transport/http/events/hooks"
+	httphooks "github.com/alexfalkowski/go-service/v2/transport/http/hooks"
+	webhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHandlerWithNilHook(t *testing.T) {
 	called := false
-	handler := hooks.NewHandler(nil, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	handler := eventhooks.NewHandler(nil, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		called = true
 	}))
 
@@ -24,4 +26,26 @@ func TestHandlerWithNilHook(t *testing.T) {
 
 	require.True(t, called)
 	require.Equal(t, http.StatusOK, res.Code)
+}
+
+func TestHandlerRejectsBinaryCloudEventsWithWebhook(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	called := false
+	handler := eventhooks.NewHandler(
+		httphooks.NewWebhook(webhook, nil),
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			called = true
+		}),
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
+	req.Header.Set("Ce-Specversion", "1.0")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.False(t, called)
+	require.Equal(t, http.StatusBadRequest, res.Code)
 }

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -1,10 +1,13 @@
 package events
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/hooks"
 	events "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/client"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 	transport "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
@@ -45,12 +48,23 @@ func WithSenderRoundTripper(rt http.RoundTripper) SenderOption {
 //
 // Note: the provided hook must be configured appropriately (for example with the expected secret) for
 // signing to succeed.
-func NewSender(hook *hooks.Webhook, opts ...SenderOption) (client.Client, error) {
+func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {
 	os := options(opts...)
 	rt := hooks.NewRoundTripper(hook, os.roundTripper)
-	client := http.Client{Transport: rt, CheckRedirect: http.SameOriginRedirect}
+	httpClient := http.Client{Transport: rt, CheckRedirect: http.SameOriginRedirect}
 
-	return events.NewClientHTTP(transport.WithClient(client))
+	sender, _ := events.NewClientHTTP(transport.WithClient(httpClient))
+	return &Sender{client: sender}
+}
+
+// Sender wraps a CloudEvents client and forces structured HTTP encoding for outbound events.
+type Sender struct {
+	client client.Client
+}
+
+// Send transmits event using structured CloudEvents encoding.
+func (s *Sender) Send(ctx context.Context, event events.Event) protocol.Result {
+	return s.client.Send(binding.WithForceStructured(ctx), event)
 }
 
 func options(opts ...SenderOption) *senderOptions {

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"log/slog"
-	"net/http"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	httplogger "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/stretchr/testify/require"

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -159,6 +159,10 @@ type RoundTripper struct {
 //   - If token generation fails, it returns an unauthorized status error.
 //   - If token generation returns an empty token, it returns an unauthorized status error with `header.ErrInvalidAuthorization`.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if isCrossOriginRedirect(req) {
+		return nil, http.ErrUseLastResponse
+	}
+
 	token, err := r.generator.Generate(req.URL.Path, r.id.String())
 	if err != nil {
 		return nil, status.UnauthorizedError(err)
@@ -176,4 +180,12 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	cloned.Header.Set("Authorization", auth.Value())
 	return r.RoundTripper.RoundTrip(cloned)
+}
+
+func isCrossOriginRedirect(req *http.Request) bool {
+	if req.Response == nil || req.Response.Request == nil {
+		return false
+	}
+
+	return !http.SameOrigin(req.Response.Request.URL, req.URL)
 }


### PR DESCRIPTION
## What

- Force CloudEvents webhook sends to structured encoding and reject webhook-protected binary CloudEvents so signed metadata stays inside the signed payload.
- Add a reusable same-origin URL helper and block token generation on cross-origin redirect follow-up requests.
- Add regression coverage for structured CloudEvents, binary webhook rejection, same-origin comparison, and direct token RoundTripper redirects.

## Why

- Prevent signed CloudEvents metadata from being tampered through unauthenticated ce-* headers.
- Prevent token-generating transports from minting bearer credentials for cross-origin redirect targets when used directly with a default client.

## Testing

- go test ./transport/http/events ./net/http
- make lint
- make specs
