### PR TITLE
feat(grpc): ignore blank outgoing metadata

### DIFF
--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -89,7 +90,7 @@ func clientUserAgent(ctx context.Context, md metadata.MD, userAgent env.UserAgen
 	if ua := meta.UserAgent(ctx); !ua.IsEmpty() {
 		return ua
 	}
-	if ua := md.Get("user-agent"); len(ua) > 0 {
+	if ua := md.Get("user-agent"); len(ua) > 0 && !strings.IsEmpty(ua[0]) {
 		return meta.String(ua[0])
 	}
 
@@ -100,7 +101,7 @@ func clientRequestID(ctx context.Context, generator id.Generator, md metadata.MD
 	if id := meta.RequestID(ctx); !id.IsEmpty() {
 		return id
 	}
-	if id := md.Get("request-id"); len(id) > 0 {
+	if id := md.Get("request-id"); len(id) > 0 && !strings.IsEmpty(id[0]) {
 		return meta.String(id[0])
 	}
 

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -36,6 +36,26 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
+	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs(
+		"user-agent", "",
+		"request-id", "",
+	))
+	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+
+	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{"fallback-agent"}, md.Get("user-agent"))
+		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
+		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
+		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 	ctx := grpcmeta.WithAttributes(t.Context(),
 		grpcmeta.WithUserAgent(grpcmeta.String("current-agent")),
@@ -51,6 +71,30 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
+
+		return nil, nil
+	}
+
+	stream, err := interceptor(
+		ctx, &grpc.StreamDesc{ServerStreams: true}, nil, "/greet.v1.Greeter/SayStreamHello", streamer,
+	)
+	require.NoError(t, err)
+	require.Nil(t, stream)
+}
+
+func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
+	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs(
+		"user-agent", "",
+		"request-id", "",
+	))
+	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{"fallback-agent"}, md.Get("user-agent"))
+		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
+		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
+		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
 
 		return nil, nil
 	}


### PR DESCRIPTION
## What

- Treat blank outgoing gRPC `user-agent` and `request-id` metadata as absent so defaults are restored.
- Add unary and stream client metadata regression tests for blank outgoing values.

## Why

- Prevent empty metadata from suppressing generated request IDs and configured user agents on the gRPC client path.
- Keep retry eligibility tied to a real generated request ID instead of a blank outgoing value.

## Testing

- `go test ./transport/grpc/... ./net/grpc/meta` - passed
- `make lint` - passed
- `make specs` - passed
