### PR TITLE
feat(transport): log dependency operation calls

### DIFF
--- a/net/http/strings/doc.go
+++ b/net/http/strings/doc.go
@@ -1,8 +1,8 @@
 // Package strings provides HTTP-specific string helpers for net-layer middleware.
 //
 // This package contains small helpers used by HTTP middleware and telemetry code, including matching
-// well-known operational endpoints such as health and metrics routes that are typically ignored by
+// service-owned operational endpoints such as health and metrics routes that are typically ignored by
 // auth, limiter, and logging middleware.
 //
-// Start with `IsIgnorable`.
+// Start with `IsOperationPath`.
 package strings

--- a/net/http/strings/strings.go
+++ b/net/http/strings/strings.go
@@ -2,18 +2,8 @@ package strings
 
 import (
 	"github.com/alexfalkowski/go-service/v2/env"
-	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
-
-var ignorablePaths = []string{
-	"healthz",
-	"livez",
-	"readyz",
-	"metrics",
-	"favicon",
-	"favicon.ico",
-}
 
 const (
 	// Empty is an alias for strings.Empty.
@@ -51,27 +41,6 @@ func IsEmpty(s string) bool {
 // Join is an alias for strings.Join.
 func Join(sep string, ss ...string) string {
 	return strings.Join(sep, ss...)
-}
-
-// IsIgnorable reports whether path should be treated as ignorable by HTTP middleware.
-//
-// Matching is exact by path segment so only well-known operational endpoints such as
-// `/<service>/healthz` or `/<service>/metrics` are ignored.
-func IsIgnorable(path string) bool {
-	path = strings.Trim(path, "/")
-	if strings.IsEmpty(path) {
-		return false
-	}
-	if strings.Count(path, "/") > 1 {
-		return false
-	}
-
-	last := path
-	if idx := strings.LastIndex(path, "/"); idx >= 0 {
-		last = path[idx+1:]
-	}
-
-	return slices.Contains(ignorablePaths, last)
 }
 
 // IsOperationPath reports whether path is a service-owned operational endpoint.

--- a/net/http/strings/strings_test.go
+++ b/net/http/strings/strings_test.go
@@ -8,28 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsIgnorablePath(t *testing.T) {
-	tests := []struct {
-		name  string
-		path  string
-		match bool
-	}{
-		{name: "service healthz", path: "/service/healthz", match: true},
-		{name: "service metrics", path: "/service/metrics", match: true},
-		{name: "favicon ico", path: "/favicon.ico", match: true},
-		{name: "nested exact metrics endpoint", path: "/service/api/metrics", match: false},
-		{name: "nested health plan", path: "/v1/customer-health-plans", match: false},
-		{name: "metrics substring only", path: "/v1/metrics-dashboard", match: false},
-		{name: "health substring only", path: "/v1/healthcare", match: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.match, strings.IsIgnorable(tt.path))
-		})
-	}
-}
-
 func TestIsOperationPath(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -89,3 +89,19 @@ func TestClip(t *testing.T) {
 	require.Equal(t, []string{"first", "next"}, first)
 	require.Equal(t, []string{"second"}, second)
 }
+
+func TestContains(t *testing.T) {
+	type names []string
+
+	t.Run("present", func(t *testing.T) {
+		require.True(t, slices.Contains(names{"alice", "bob"}, "bob"))
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		require.False(t, slices.Contains(names{"alice", "bob"}, "eve"))
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		require.False(t, slices.Contains(names{}, "alice"))
+	})
+}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -25,3 +25,22 @@ func TestIsAnyEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestLastIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		substr string
+		want   int
+	}{
+		{name: "last match", s: "/service/admin/metrics", substr: "/", want: 14},
+		{name: "missing", s: "service", substr: "/", want: -1},
+		{name: "empty substr", s: "service", substr: "", want: 7},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, strings.LastIndex(test.s, test.substr))
+		})
+	}
+}

--- a/transport/grpc/telemetry/logger/logger.go
+++ b/transport/grpc/telemetry/logger/logger.go
@@ -107,8 +107,6 @@ func StreamServerInterceptor(log *Logger) grpc.StreamServerInterceptor {
 
 // UnaryClientInterceptor returns a gRPC unary client interceptor that logs the RPC outcome.
 //
-// Operation RPC methods (health/metrics/etc.) bypass logging (see `net/grpc/strings.IsOperationMethod`).
-//
 // Logged attributes include:
 //   - system: "grpc"
 //   - service/method: derived from the gRPC full method name
@@ -129,10 +127,6 @@ func StreamServerInterceptor(log *Logger) grpc.StreamServerInterceptor {
 // contain credentials, tokens, request data, or other secrets.
 func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		if strings.IsOperationMethod(fullMethod) {
-			return invoker(ctx, fullMethod, req, resp, conn, opts...)
-		}
-
 		service, method, _ := strings.SplitServiceMethod(fullMethod)
 		start := time.Now()
 		err := invoker(ctx, fullMethod, req, resp, conn, opts...)
@@ -153,8 +147,6 @@ func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 }
 
 // StreamClientInterceptor returns a gRPC stream client interceptor that logs stream creation.
-//
-// Operation RPC methods (health/metrics/etc.) bypass logging (see `net/grpc/strings.IsOperationMethod`).
 //
 // It logs whether the client stream was opened successfully. Terminal stream
 // status may surface later through RecvMsg, SendMsg, or generated helpers such
@@ -180,10 +172,6 @@ func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 // contain credentials, tokens, request data, or other secrets.
 func StreamClientInterceptor(log *Logger) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		if strings.IsOperationMethod(fullMethod) {
-			return streamer(ctx, desc, conn, fullMethod, opts...)
-		}
-
 		service, method, _ := strings.SplitServiceMethod(fullMethod)
 		start := time.Now()
 		stream, err := streamer(ctx, desc, conn, fullMethod, opts...)

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -54,7 +54,7 @@ type Handler struct {
 
 // ServeHTTP enforces the configured limiter.
 //
-// Ignorable paths (health/metrics/etc.) bypass limiting (see `net/http/strings.IsIgnorable`).
+// Service-owned operation paths (health/metrics/etc.) bypass limiting (see `net/http/strings.IsOperationPath`).
 //
 // Behavior:
 //   - If `Take` returns an error, it writes an internal server error response.

--- a/transport/http/telemetry/logger/logger.go
+++ b/transport/http/telemetry/logger/logger.go
@@ -19,7 +19,7 @@ type Logger = logger.Logger
 // NewHandler constructs HTTP server logging middleware.
 //
 // The returned handler logs the outcome of each request after next has completed, including duration
-// and response status code. Ignorable paths (health/metrics/etc.) are skipped.
+// and response status code. Service-owned operation paths (health/metrics/etc.) are skipped.
 func NewHandler(name env.Name, logger *Logger) *Handler {
 	return &Handler{name: name, logger: logger}
 }
@@ -32,7 +32,7 @@ type Handler struct {
 
 // ServeHTTP logs the request outcome after next completes.
 //
-// Ignorable paths (health/metrics/etc.) bypass logging (see `net/http/strings.IsIgnorable`).
+// Service-owned operation paths (health/metrics/etc.) bypass logging (see `net/http/strings.IsOperationPath`).
 //
 // Logged attributes include:
 //   - system: "http"
@@ -68,7 +68,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 // NewRoundTripper constructs HTTP client logging middleware.
 //
 // The returned RoundTripper logs request outcomes (duration and status) and then delegates to the
-// underlying transport. Ignorable paths (health/metrics/etc.) are skipped.
+// underlying transport.
 func NewRoundTripper(logger *Logger, r http.RoundTripper) *RoundTripper {
 	return &RoundTripper{logger: logger, RoundTripper: r}
 }
@@ -80,8 +80,6 @@ type RoundTripper struct {
 }
 
 // RoundTrip logs the request outcome and delegates to the underlying RoundTripper.
-//
-// Ignorable paths (health/metrics/etc.) bypass logging (see `net/http/strings.IsIgnorable`).
 //
 // Logged attributes include:
 //   - system: "http"
@@ -98,10 +96,6 @@ type RoundTripper struct {
 // If resp is nil (for example, due to a transport error), it is treated as HTTP 500 for level selection.
 // The log message includes the derived method and service.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if strings.IsIgnorable(req.URL.Path) {
-		return r.RoundTripper.RoundTrip(req)
-	}
-
 	service, method := http.ParseServiceMethod(req)
 	start := time.Now()
 	ctx := req.Context()

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -87,7 +87,7 @@ type Handler struct {
 
 // ServeHTTP verifies the request Authorization token and stores the verified subject in the context.
 //
-// Ignorable paths (health/metrics/etc.) bypass verification (see `net/http/strings.IsIgnorable`).
+// Service-owned operation paths (health/metrics/etc.) bypass verification (see `net/http/strings.IsOperationPath`).
 //
 // The handler expects an Authorization value to be available in the request context (typically injected by
 // `net/http/meta.Handler`). It verifies the token using verifier, scoping verification to the request path.


### PR DESCRIPTION
## What

- Log HTTP client requests instead of skipping operation-like paths.
- Log gRPC client unary and stream calls for health methods while preserving server-side operation log skips.
- Clarify HTTP server logging comments around service-owned operation paths.

## Why

- Keeps client dependency telemetry and audit visibility consistent across HTTP and gRPC.
- Preserves server-side probe and scrape noise reduction for service-owned operation endpoints.

## Testing

- `go test ./transport/http/...` - passed
- `go test ./transport/grpc/...` - passed
- `make lint` - passed
