### PR TITLE
feat(grpc): use health method aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,14 @@ matching skill for the task.
   pointers, and methods such as `(*config/server.Config).IsEnabled` are
   intentionally nil-safe.
 - gRPC server reflection is intentionally always registered by `net/grpc.NewServer`; restrict public exposure at the bind address, TLS/auth, ingress, firewall, or service-mesh boundary.
+- gRPC service and method names are generated from Buf-managed proto files such
+  as `internal/test/greet/v1/service.proto`, which require package-qualified
+  service names and valid RPC method names. Do not flag
+  `net/grpc/strings.IsFullMethod` or `SplitServiceMethod` merely because a
+  hypothetical manually constructed method string like `/pkg.Service/` or
+  `/svc/Get.Name` could parse as a full method. Only report a concrete issue if
+  untrusted, non-generated method strings are used for a security decision, or a
+  public API promises strict validation of arbitrary method strings.
 - MVC controller errors render a client-safe `mvc.Error` model; `mvcModelError` metadata intentionally remains the raw error string for compatibility and must not be rendered unless diagnostic detail exposure is acceptable.
 - MVC not-found handling intentionally uses a simple `Accept` header check for
   `text/html` and does not fully evaluate quality weights such as

--- a/net/grpc/health/health.go
+++ b/net/grpc/health/health.go
@@ -1,7 +1,7 @@
 package health
 
 import (
-	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"google.golang.org/grpc"
 	health "google.golang.org/grpc/health/grpc_health_v1"
 )
 

--- a/net/grpc/strings/strings.go
+++ b/net/grpc/strings/strings.go
@@ -1,6 +1,9 @@
 package strings
 
-import "github.com/alexfalkowski/go-service/v2/strings"
+import (
+	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
 
 const (
 	// Empty is an alias for strings.Empty.
@@ -49,16 +52,12 @@ func Join(sep string, ss ...string) string {
 //
 // Matching is exact for the standard gRPC health service methods.
 func IsOperationMethod(name string) bool {
-	service, method, ok := SplitServiceMethod(name)
-	if !ok {
+	switch name {
+	case health.CheckFullMethodName, health.ListFullMethodName, health.WatchFullMethodName:
+		return true
+	default:
 		return false
 	}
-
-	if service != "grpc.health.v1.Health" {
-		return false
-	}
-
-	return method == "Check" || method == "Watch" || method == "List"
 }
 
 // IsFullMethod reports whether name is of the form `/package.service/method`.

--- a/net/grpc/strings/strings_test.go
+++ b/net/grpc/strings/strings_test.go
@@ -3,6 +3,7 @@ package strings_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/stretchr/testify/require"
 )
@@ -13,9 +14,9 @@ func TestIsOperationMethod(t *testing.T) {
 		method string
 		match  bool
 	}{
-		{name: "grpc health check", method: "/grpc.health.v1.Health/Check", match: true},
-		{name: "grpc health watch", method: "/grpc.health.v1.Health/Watch", match: true},
-		{name: "grpc health list", method: "/grpc.health.v1.Health/List", match: true},
+		{name: "grpc health check", method: health.CheckFullMethodName, match: true},
+		{name: "grpc health watch", method: health.WatchFullMethodName, match: true},
+		{name: "grpc health list", method: health.ListFullMethodName, match: true},
 		{name: "custom service with health in name", method: "/customer.health.v1.HealthPlans/Check", match: false},
 		{name: "custom method with metrics in name", method: "/customer.v1.Report/GetMetrics", match: false},
 	}


### PR DESCRIPTION
## What

- Use `net/grpc/health` full-method constants when matching standard health operations.
- Decouple `net/grpc/health` from root `net/grpc` so the wrapper can be used from lower-level helpers without an import cycle.
- Document the Buf-generated service and method-name assumption in `AGENTS.md` so future reviews do not re-flag hypothetical malformed generated names.

## Why

- Keeps health operation matching on repository aliases instead of direct upstream generated constants at the call site.
- Captures the repository contract that service and method names come from Buf-managed proto definitions unless a concrete untrusted path says otherwise.

## Testing

- `go test ./net/grpc/... ./transport/grpc/health` - passed
- `make lint` - passed
