### PR TITLE
docs(agents): tighten review finding criteria

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ matching skill for the task.
     `$security-audit`.
   - After all agents finish, aggregate all confirmed findings into
     `FINDINGS.md` before making fixes.
+  - Findings must be concrete bugs, security issues, compatibility breaks, or
+    violated public contracts with user-visible impact. Do not report optional
+    regression tests, unused convenience aliases, API symmetry, or documentation
+    polish as findings by themselves; list them only as testing gaps or
+    optional follow-up notes.
   - Present `FINDINGS.md` and a proposed fix plan to the user.
   - Do not fix findings in the same pass unless the user explicitly asks to
     proceed after reviewing `FINDINGS.md`, or already requested automatic fixes.


### PR DESCRIPTION
## What

- Added review workflow guidance that limits deep-review findings to concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
- Clarified that optional regression tests, unused convenience aliases, API symmetry, and documentation polish belong in testing gaps or follow-up notes instead of findings.

## Why

- Keeps secure code review output focused on actionable confirmed findings.
- Prevents optional improvements from being promoted into fix-tracking items.

## Testing

- `make lint` - passed
