### PR TITLE
feat(http): retry timed-out attempts

### DIFF
--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -153,16 +153,16 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *roundTripAttempt) (*http.Response, error) {
-	ctx, cancel := r.withAttemptTimeout(ctx)
+	attemptCtx, cancel := r.withAttemptTimeout(ctx)
 	defer cancel()
 
-	attemptReq, err := attempt.request(req, ctx)
+	attemptReq, err := attempt.request(req, attemptCtx)
 	if err != nil {
 		return nil, err
 	}
 
 	res, err := r.RoundTripper.RoundTrip(attemptReq)
-	if retryErr := attempt.retry(ctx, req, res, err, r.maxRetries); retryErr != nil {
+	if retryErr := attempt.retry(ctx, attemptCtx, req, res, err, r.maxRetries); retryErr != nil {
 		return nil, retryErr
 	}
 
@@ -205,8 +205,8 @@ func (a *roundTripAttempt) request(req *http.Request, ctx context.Context) (*htt
 	return attemptReq, nil
 }
 
-func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *http.Response, err error, maxRetries uint64) error {
-	ok, retryErr := shouldRetryAttempt(ctx, res, err)
+func (a *roundTripAttempt) retry(ctx, attemptCtx context.Context, req *http.Request, res *http.Response, err error, maxRetries uint64) error {
+	ok, retryErr := shouldRetryAttempt(ctx, attemptCtx, res, err)
 	if !ok {
 		return nil
 	}
@@ -228,9 +228,14 @@ func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *ht
 	return retry.RetryableError(retryErr)
 }
 
-func shouldRetryAttempt(ctx context.Context, res *http.Response, err error) (bool, error) {
+func shouldRetryAttempt(ctx, attemptCtx context.Context, res *http.Response, err error) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
+	}
+
+	if err := attemptCtx.Err(); err != nil {
+		cause := context.Cause(attemptCtx)
+		return errors.Is(cause, ErrAttemptTimeout), cause
 	}
 
 	if isTransportError(res, err) {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -335,6 +335,28 @@ func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
 	require.Equal(t, []string{"hello"}, rt.Bodies)
 }
 
+func TestRoundTripperReturnsGetBodyError(t *testing.T) {
+	wantErr := test.ErrFailed
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("hello"))
+	require.NoError(t, err)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, wantErr
+	}
+
+	res, err := retrying.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 1, rt.Calls)
+}
+
 func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
 	rt := &test.ErrorRoundTripper{Err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
 	retrying := retry.NewRoundTripper(&retry.Config{
@@ -367,6 +389,31 @@ func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
 	require.Nil(t, res)
 	require.ErrorIs(t, err, wantErr)
 	require.Equal(t, 2, rt.Calls)
+}
+
+func TestRoundTripperRetriesAttemptTimeout(t *testing.T) {
+	var calls int
+	transport := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+
+		return test.ResponseWithStatus(http.StatusOK), nil
+	})
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  50 * time.Millisecond,
+		Backoff:  time.Millisecond,
+	}, transport)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 2, calls)
 }
 
 func TestRoundTripperDoesNotRetryUnhandledTransportError(t *testing.T) {


### PR DESCRIPTION
## What

- Keep retry-loop and per-attempt contexts separate when classifying retry outcomes.
- Retry configured per-attempt timeout causes while preserving parent request cancellation as terminal.
- Add regression coverage for a timed-out first attempt followed by a successful retry.
- Add regression coverage for `GetBody` replay failures on retry attempts.

## Why

- A per-attempt timeout should consume retry budget rather than ending the whole logical request while the parent context is still active.
- Failed request-body replay should stop cleanly with the original `GetBody` error.

## Testing

- `go test ./transport/http/retry -count=1` - passed
- `go test ./transport/...` - passed
- `go test -race ./transport/http/retry -count=1` - passed
- `govulncheck ./transport/...` - passed
- `make lint` - failed: BSD make could not parse `bin/build/make/git.mak`
- `gmake lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)