### PR TITLE
feat(token): harden tls and expiration validation

### DIFF
--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	// Expiration is the duration used to set token expiration.
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
-	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gte=0"`
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gt=0"`
 }
 
 // IsEnabled reports whether PASETO configuration is present.

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -51,6 +51,9 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 	if t.signer == nil || len(t.signer.PrivateKey) == 0 || t.generator == nil {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
+	if t.cfg.Expiration <= 0 {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
 
 	now := time.Now()
 	token := paseto.NewToken()

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -26,6 +26,10 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 			name:   "negative expiration",
 			config: &paseto.Config{Issuer: "iss", Expiration: -time.Second},
 		},
+		{
+			name:   "zero expiration",
+			config: &paseto.Config{Issuer: "iss"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -101,6 +105,18 @@ func TestInvalidVerifyExpirationConfig(t *testing.T) {
 
 	sub, err := verifierToken.Verify(tkn, "hello")
 	require.Empty(t, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidConfig)
+}
+
+func TestInvalidGenerateExpirationConfig(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	token := paseto.NewToken(&paseto.Config{Issuer: cfg.Paseto.Issuer}, signer, verifier, uuid.NewGenerator())
+
+	tkn, err := token.Generate("hello", test.UserID.String())
+	require.Empty(t, tkn)
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 

--- a/token/ssh/config.go
+++ b/token/ssh/config.go
@@ -56,7 +56,7 @@ type Config struct {
 	// Expiration is the duration used to set token expiration.
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "1h".
-	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gte=0"`
+	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"gt=0"`
 }
 
 // IsEnabled reports whether SSH token configuration is enabled.

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -15,9 +15,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigRejectsNegativeExpiration(t *testing.T) {
-	cfg := &ssh.Config{Expiration: -time.Second}
-	require.Error(t, test.Validator.Struct(cfg))
+func TestConfigRejectsInvalidExpiration(t *testing.T) {
+	tests := []struct {
+		config *ssh.Config
+		name   string
+	}{
+		{name: "negative", config: &ssh.Config{Expiration: -time.Second}},
+		{name: "zero", config: &ssh.Config{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, test.Validator.Struct(tt.config))
+		})
+	}
 }
 
 func TestValid(t *testing.T) {

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -135,8 +135,9 @@ func WithClientBreaker(opts ...breaker.Option) ClientOption {
 
 // WithClientTLS enables TLS for the client connection using sec.
 //
-// TLS configuration is materialized when building dial options. If TLS is enabled, source strings may be
-// resolved via the package-registered filesystem (see the package `Register` function).
+// TLS configuration is materialized when building dial options. A non-nil sec enables TLS, including an
+// empty config that relies on system roots and the target host name. Source strings may be resolved via the
+// package-registered filesystem (see the package `Register` function).
 func WithClientTLS(sec *tls.Config) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.security = sec
@@ -235,7 +236,7 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //   - if keepalive ping or timeout are not set (0), they default to the resolved timeout.
 //
 // Transport security:
-//   - if TLS is enabled, TLS config is constructed using the package-registered filesystem (see `Register`)
+//   - if TLS is requested, TLS config is constructed using the package-registered filesystem (see `Register`)
 //     to resolve TLS source strings.
 //   - otherwise, insecure transport credentials are used.
 //     This default is intended for local and in-cluster/container traffic where transport security is provided
@@ -252,7 +253,7 @@ func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
 	}
 
 	var security grpc.DialOption
-	if os.security.IsEnabled() {
+	if os.security != nil {
 		conf, err := client.NewConfig(fs, os.security)
 		if err != nil {
 			return nil, err

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -5,6 +5,8 @@ import (
 
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/net"
 	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
 )
@@ -17,4 +19,17 @@ func TestClient(t *testing.T) {
 
 	_, err = transportgrpc.NewClient("none", transportgrpc.WithClientTLS(&tls.Config{}))
 	require.NoError(t, err)
+}
+
+func TestClientEmptyTLSConfigUsesTLS(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldGRPC())
+	_, target := net.ListenNetworkAddress(world.TransportConfig.GRPC.Address)
+
+	conn, err := transportgrpc.NewClient(target, transportgrpc.WithClientTLS(&tls.Config{}))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+	_, err = client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
+	require.Error(t, err)
 }


### PR DESCRIPTION
## What

- enable grpc client tls whenever a non-nil tls config is provided, including empty configs that use system roots
- reject zero expiration for paseto and ssh configs and guard paseto generation against non-positive expiration
- add regression coverage for empty grpc tls configs and invalid expiration values

## Why

- callers using an empty tls config should not silently fall back to insecure grpc credentials
- startup validation should match runtime token behavior and reject unusable expiration settings

## Testing

- `go test ./transport/grpc ./transport/http ./token/... ./config/...` - passed
- `make lint` - passed
- `make sec` - passed
- `make specs` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
