### PR TITLE
feat(http): preserve exact operation path checks

### DIFF
--- a/net/http/strings/strings.go
+++ b/net/http/strings/strings.go
@@ -48,8 +48,11 @@ func Join(sep string, ss ...string) string {
 // Matching is exact so application routes such as "/admin/metrics" are not
 // treated as transport operation endpoints for auth or rate-limit bypasses.
 func IsOperationPath(name env.Name, path string) bool {
-	path = strings.Trim(path, "/")
-	service, operation, ok := strings.Cut(path, "/")
+	if strings.IsEmpty(path) || path[0] != '/' {
+		return false
+	}
+
+	service, operation, ok := strings.Cut(path[1:], "/")
 	if !ok || service != name.String() {
 		return false
 	}

--- a/net/http/strings/strings_test.go
+++ b/net/http/strings/strings_test.go
@@ -22,6 +22,11 @@ func TestIsOperationPath(t *testing.T) {
 		{name: "wrong service healthz", path: "/admin/healthz", match: false},
 		{name: "nested metrics", path: "/service/admin/metrics", match: false},
 		{name: "bare metrics", path: "/metrics", match: false},
+		{name: "no leading slash metrics", path: "service/metrics", match: false},
+		{name: "trailing slash metrics", path: "/service/metrics/", match: false},
+		{name: "double leading slash metrics", path: "//service/metrics", match: false},
+		{name: "double trailing slash metrics", path: "/service/metrics//", match: false},
+		{name: "double leading and trailing slash metrics", path: "//service/metrics//", match: false},
 		{name: "favicon ico", path: "/favicon.ico", match: false},
 	}
 


### PR DESCRIPTION
## What

- make operation path detection exact without trimming leading or trailing slashes
- avoid building reserved operation path strings on each middleware call
- add regression coverage for trailing slash, double slash, and missing leading slash variants

## Why

- near-match application routes should not be classified as service-owned operation endpoints that bypass auth, limiting, logging, or metadata extraction
- the hot-path check should stay allocation-conscious while preserving the security boundary

## Testing

- `go test ./net/http/strings ./transport/http/token ./transport/http/limiter ./transport/http/telemetry/logger ./net/http/... ./transport/http/... ./net/...` - passed
- `make lint` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
