### PR TITLE
feat(http): harden redirect and telemetry path handling

### DIFF
--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"net/url"
 	"testing"
 
 	health "github.com/alexfalkowski/go-health/v2/server"
@@ -15,6 +14,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
+	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"

--- a/net/grpc/strings/strings.go
+++ b/net/grpc/strings/strings.go
@@ -2,6 +2,7 @@ package strings
 
 import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
+	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -26,11 +27,6 @@ func Contains(s, substr string) bool {
 // HasPrefix is an alias for strings.HasPrefix.
 func HasPrefix(s, prefix string) bool {
 	return strings.HasPrefix(s, prefix)
-}
-
-// Concat is an alias for strings.Concat.
-func Concat(ss ...string) string {
-	return strings.Concat(ss...)
 }
 
 // Cut is an alias for strings.Cut.
@@ -78,10 +74,5 @@ func SplitServiceMethod(name string) (string, string, bool) {
 	if !IsFullMethod(name) {
 		return "", "", false
 	}
-	return strings.Cut(name[1:], "/")
-}
-
-// ToLower is an alias for strings.ToLower.
-func ToLower(s string) string {
-	return strings.ToLower(s)
+	return url.SplitPath(name)
 }

--- a/net/grpc/strings/strings_test.go
+++ b/net/grpc/strings/strings_test.go
@@ -27,3 +27,29 @@ func TestIsOperationMethod(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitServiceMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		full    string
+		service string
+		method  string
+		ok      bool
+	}{
+		{name: "full method", full: "/greet.v1.Greeter/SayHello", service: "greet.v1.Greeter", method: "SayHello", ok: true},
+		{name: "missing package", full: "/Greeter/SayHello"},
+		{name: "missing leading slash", full: "greet.v1.Greeter/SayHello"},
+		{name: "missing method", full: "/greet.v1.Greeter"},
+		{name: "extra path segment", full: "/greet.v1.Greeter/SayHello/Again"},
+		{name: "empty method", full: "/greet.v1.Greeter/"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, method, ok := strings.SplitServiceMethod(test.full)
+			require.Equal(t, test.service, service)
+			require.Equal(t, test.method, method)
+			require.Equal(t, test.ok, ok)
+		})
+	}
+}

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -3,15 +3,15 @@ package http
 import (
 	"net/http"
 	"net/http/httptrace"
-	"net/url"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/io"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/alexfalkowski/go-service/v2/net/http/telemetry"
+	"github.com/alexfalkowski/go-service/v2/net/url"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -218,6 +218,15 @@ func SameOrigin(prev, next *url.URL) bool {
 	return prev.Scheme == next.Scheme && prev.Host == next.Host
 }
 
+// IsCrossOriginRedirect reports whether req is a redirected request whose previous request used a different origin.
+func IsCrossOriginRedirect(req *Request) bool {
+	if req == nil || req.Response == nil || req.Response.Request == nil {
+		return false
+	}
+
+	return !SameOrigin(req.Response.Request.URL, req.URL)
+}
+
 // SameOriginRedirect allows redirects only when the next request stays on the same scheme and host.
 //
 // It is intended for clients that add credentials or signatures in RoundTripper middleware, where Go's
@@ -326,8 +335,7 @@ func NewServer(options options.Map, timeout time.Duration, handler Handler) *Ser
 //
 //	/<service>/<method>
 //
-// If the request path matches that shape (as determined by net/grpc/strings.SplitServiceMethod),
-// ParseServiceMethod returns the extracted service/method pair.
+// If the request path matches that shape, ParseServiceMethod returns the extracted service/method pair.
 //
 // Otherwise it falls back to:
 //   - method: lower-cased HTTP method (e.g. "get", "post")
@@ -336,7 +344,7 @@ func NewServer(options options.Map, timeout time.Duration, handler Handler) *Ser
 //   - otherwise the path without the leading "/" (e.g. "/health" -> "health")
 func ParseServiceMethod(req *http.Request) (string, string) {
 	path := req.URL.Path
-	if service, method, ok := strings.SplitServiceMethod(path); ok {
+	if service, method, ok := url.SplitPath(path); ok {
 		return service, method
 	}
 

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -2,13 +2,13 @@ package http_test
 
 import (
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -90,9 +90,51 @@ func TestSameOrigin(t *testing.T) {
 	require.False(t, http.SameOrigin(prev, nil))
 }
 
+func TestIsCrossOriginRedirect(t *testing.T) {
+	prev, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/start", http.NoBody)
+	require.NoError(t, err)
+
+	same, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/next", http.NoBody)
+	require.NoError(t, err)
+	same.Response = &http.Response{Request: prev}
+
+	different, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://other.example.com/next", http.NoBody)
+	require.NoError(t, err)
+	different.Response = &http.Response{Request: prev}
+
+	require.False(t, http.IsCrossOriginRedirect(nil))
+	require.False(t, http.IsCrossOriginRedirect(prev))
+	require.False(t, http.IsCrossOriginRedirect(same))
+	require.True(t, http.IsCrossOriginRedirect(different))
+}
+
 func TestIgnoreRedirect(t *testing.T) {
 	err := http.IgnoreRedirect(nil, nil)
 	require.ErrorIs(t, err, http.ErrUseLastResponse)
+}
+
+func TestParseServiceMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		method  string
+		service string
+		action  string
+	}{
+		{name: "service route", method: http.MethodGet, url: "/test/hello", service: "test", action: "hello"},
+		{name: "deep service route", method: http.MethodPost, url: "/test/users/123", service: "test", action: "users/123"},
+		{name: "root", method: http.MethodGet, url: "/", service: "root", action: "get"},
+		{name: "single segment", method: http.MethodPost, url: "/health", service: "health", action: "post"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), test.method, test.url, http.NoBody)
+			service, action := http.ParseServiceMethod(req)
+			require.Equal(t, test.service, service)
+			require.Equal(t, test.action, action)
+		})
+	}
 }
 
 func TestHandleWhenTelemetryDisabled(t *testing.T) {

--- a/net/url/doc.go
+++ b/net/url/doc.go
@@ -1,0 +1,2 @@
+// Package url provides URL helpers used by go-service network packages.
+package url

--- a/net/url/url.go
+++ b/net/url/url.go
@@ -1,0 +1,38 @@
+package url
+
+import (
+	"net/url"
+
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+// URL is an alias for net/url.URL.
+type URL = url.URL
+
+// Parse parses a raw URL into a URL structure.
+func Parse(rawURL string) (*URL, error) {
+	return url.Parse(rawURL)
+}
+
+// JoinPath returns a URL string with the provided path elements joined to base.
+func JoinPath(base string, elem ...string) (string, error) {
+	return url.JoinPath(base, elem...)
+}
+
+// SplitPath splits a slash-prefixed path into its first segment and the remaining path.
+//
+// It accepts paths shaped like "/first/rest" and returns ("first", "rest", true).
+// If the path is not slash-prefixed, lacks a second segment, or has an empty
+// first/rest segment, it returns ("", "", false).
+func SplitPath(path string) (string, string, bool) {
+	if !strings.HasPrefix(path, "/") {
+		return strings.Empty, strings.Empty, false
+	}
+
+	first, rest, ok := strings.Cut(path[1:], "/")
+	if !ok || strings.IsAnyEmpty(first, rest) {
+		return strings.Empty, strings.Empty, false
+	}
+
+	return first, rest, true
+}

--- a/net/url/url_test.go
+++ b/net/url/url_test.go
@@ -1,0 +1,36 @@
+package url_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/url"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		first string
+		rest  string
+		ok    bool
+	}{
+		{name: "pair", path: "/service/method", first: "service", rest: "method", ok: true},
+		{name: "deep rest", path: "/service/users/123", first: "service", rest: "users/123", ok: true},
+		{name: "missing leading slash", path: "service/method"},
+		{name: "missing rest", path: "/service"},
+		{name: "empty first", path: "//method"},
+		{name: "empty rest", path: "/service/"},
+		{name: "root", path: "/"},
+		{name: "empty", path: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			first, rest, ok := url.SplitPath(test.path)
+			require.Equal(t, test.first, first)
+			require.Equal(t, test.rest, rest)
+			require.Equal(t, test.ok, ok)
+		})
+	}
+}

--- a/telemetry/internal/otlp/endpoint.go
+++ b/telemetry/internal/otlp/endpoint.go
@@ -2,9 +2,9 @@ package otlp
 
 import (
 	"net/netip"
-	"net/url"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -312,11 +312,13 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 //   - metadata propagation interceptor (user-agent and request-id)
 //   - any custom interceptors provided via `WithClientUnaryInterceptors`
 //   - a timeout interceptor
+//   - optional limiter interceptor (when configured)
 //   - optional circuit breaker interceptor (when enabled via `WithClientBreaker`)
 //   - optional retry interceptor (when configured)
 //   - optional logging interceptor (when configured)
 //   - optional token injection interceptor (when configured)
-//   - optional limiter interceptor (when configured)
+//
+// The limiter stays before the breaker so local quota denials are not counted as upstream failures.
 func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor {
 	os := options(opts...)
 	unary := []grpc.UnaryClientInterceptor{}
@@ -324,6 +326,10 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 	unary = append(unary, meta.UnaryClientInterceptor(os.userAgent, os.generator))
 	unary = append(unary, os.unary...)
 	unary = append(unary, grpc.TimeoutUnaryClientInterceptor(os.timeout))
+
+	if os.limiter != nil {
+		unary = append(unary, limiter.UnaryClientInterceptor(os.limiter))
+	}
 
 	if os.breaker {
 		unary = append(unary, breaker.UnaryClientInterceptor(os.breakerOptions...))
@@ -339,10 +345,6 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 
 	if os.gen != nil {
 		unary = append(unary, token.UnaryClientInterceptor(os.id, os.gen))
-	}
-
-	if os.limiter != nil {
-		unary = append(unary, limiter.UnaryClientInterceptor(os.limiter))
 	}
 
 	return unary

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -200,16 +200,17 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //
 //   - meta injection (User-Agent, Request-Id)
 //   - logger (optional)
+//   - limiter (optional)
 //   - breaker (optional)
 //   - retry (optional)
 //   - token injection (optional)
-//   - limiter (optional)
 //   - compression (optional)
 //   - base transport
 //
 // Notes:
 //   - `WithClientRoundTripper` short-circuits base transport selection and TLS config construction.
 //   - Token injection remains inside retry so a fresh token is generated for each retry attempt.
+//   - The limiter stays outside the breaker so local quota denials are not counted as upstream failures.
 func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 	os := options(opts...)
 
@@ -222,10 +223,6 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 		hrt = gzhttp.Transport(hrt, gzhttp.TransportEnableGzip(true))
 	}
 
-	if os.limiter != nil {
-		hrt = limiter.NewRoundTripper(os.limiter, hrt)
-	}
-
 	if os.gen != nil {
 		hrt = token.NewRoundTripper(os.id, os.gen, hrt)
 	}
@@ -236,6 +233,10 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 
 	if os.breaker {
 		hrt = breaker.NewRoundTripper(hrt, os.breakerOptions...)
+	}
+
+	if os.limiter != nil {
+		hrt = limiter.NewRoundTripper(os.limiter, hrt)
 	}
 
 	if os.logger != nil {

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -196,6 +196,10 @@ type RoundTripper struct {
 // If the configured hook is nil, RoundTrip delegates directly to the underlying RoundTripper without
 // mutating the request.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if http.IsCrossOriginRedirect(req) {
+		return nil, http.ErrUseLastResponse
+	}
+
 	if r.hook == nil {
 		return r.RoundTripper.RoundTrip(req)
 	}

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -124,6 +124,30 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	require.Nil(t, req.Header)
 }
 
+func TestRoundTripperDoesNotSignCrossOriginRedirect(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
+	called := false
+	rt := hooks.NewRoundTripper(hook, test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	}))
+
+	prev := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://example.com/events", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://attacker.example.com/events", http.NoBody)
+	req.Response = &http.Response{Request: prev}
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, http.ErrUseLastResponse)
+	require.False(t, called)
+	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookID))
+	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookSignature))
+	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookTimestamp))
+}
+
 func TestHandler(t *testing.T) {
 	handler := hooks.NewHandler(nil)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -159,7 +159,7 @@ type RoundTripper struct {
 //   - If token generation fails, it returns an unauthorized status error.
 //   - If token generation returns an empty token, it returns an unauthorized status error with `header.ErrInvalidAuthorization`.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if isCrossOriginRedirect(req) {
+	if http.IsCrossOriginRedirect(req) {
 		return nil, http.ErrUseLastResponse
 	}
 
@@ -180,12 +180,4 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	cloned.Header.Set("Authorization", auth.Value())
 	return r.RoundTripper.RoundTrip(cloned)
-}
-
-func isCrossOriginRedirect(req *http.Request) bool {
-	if req.Response == nil || req.Response.Request == nil {
-		return false
-	}
-
-	return !http.SameOrigin(req.Response.Request.URL, req.URL)
 }


### PR DESCRIPTION
## What

- add a shared URL path splitter for service/method-style paths
- use the splitter for HTTP telemetry parsing and gRPC full-method splitting
- block cross-origin redirect signing for webhook requests and reuse the shared redirect guard for token injection
- keep client-side limiters outside circuit breaker accounting for HTTP and gRPC unary clients

## Why

- standard service-prefixed HTTP routes should produce stable service/method telemetry fields without depending on gRPC path validation
- credential and webhook-signature middleware should not mint fresh secrets for cross-origin redirects
- local quota denials should not be learned by circuit breakers as upstream failures

## Testing

- `go test ./net/url ./strings ./net/grpc/strings ./net/http ./transport/http/telemetry/logger ./transport/http ./transport/grpc` - passed
- `go test ./transport/http/... ./transport/grpc/... ./net/url ./strings ./net/http ./net/grpc/strings` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
