### PR TITLE
feat(http): close rejected request bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,11 @@ matching skill for the task.
   attribute construction, logging/export code that records queries directly, or
   a supported upstream option that can sanitize this behavior without mutating
   the outbound request.
+- HTTP client `RoundTripper` implementations that can return locally before
+  delegating to another `RoundTripper` must make request-body ownership explicit
+  with `net/http.ClosingRoundTripper`. Return the closing adapter's close-body
+  flag as true only for local rejection paths, and false after delegating
+  because the delegated transport owns `req.Body` closure.
 - gRPC telemetry logging intentionally records raw error values for operator
   diagnostics. Client-facing safety is handled by gRPC status/error rendering;
   logs are backend observability data and should be protected by deployment log

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -162,6 +162,23 @@ type ResponseWriter = http.ResponseWriter
 // standard library semantics.
 type RoundTripper = http.RoundTripper
 
+// ClosingRoundTripper adapts a function to RoundTripper while making request-body ownership explicit.
+//
+// The function's third return value reports whether ClosingRoundTripper should close req.Body before returning.
+// Return true when the function rejects the request locally without delegating to another RoundTripper.
+// Return false after delegating because the delegated RoundTripper owns the request body.
+type ClosingRoundTripper func(req *Request) (*Response, error, bool)
+
+// RoundTrip calls s and closes req.Body when s asks it to.
+func (s ClosingRoundTripper) RoundTrip(req *Request) (*Response, error) {
+	res, err, closeBody := s(req)
+	if closeBody && req != nil && req.Body != nil && req.Body != NoBody {
+		_ = req.Body.Close()
+	}
+
+	return res, err
+}
+
 // DefaultTransport is an alias for http.DefaultTransport.
 var DefaultTransport = http.DefaultTransport
 

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/url"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -106,6 +108,34 @@ func TestIsCrossOriginRedirect(t *testing.T) {
 	require.False(t, http.IsCrossOriginRedirect(prev))
 	require.False(t, http.IsCrossOriginRedirect(same))
 	require.True(t, http.IsCrossOriginRedirect(different))
+}
+
+func TestClosingRoundTripperClosesBodyWhenRequested(t *testing.T) {
+	rt := http.ClosingRoundTripper(func(*http.Request) (*http.Response, error, bool) {
+		return nil, io.ErrUnexpectedEOF, true
+	})
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.True(t, body.Closed)
+}
+
+func TestClosingRoundTripperLeavesDelegatedBodyOpen(t *testing.T) {
+	rt := http.ClosingRoundTripper(func(*http.Request) (*http.Response, error, bool) {
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil, false
+	})
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.False(t, body.Closed)
 }
 
 func TestIgnoreRedirect(t *testing.T) {

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -84,6 +84,10 @@ type RoundTripper struct {
 //   - Responses that match the configured failure-status predicate are counted as failures for breaker
 //     accounting, but the response is still returned to the caller with a nil error.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
+}
+
+func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
 	cb := r.get(req)
 	v, err := cb.Execute(func() (any, error) {
 		resp, err := r.RoundTripper.RoundTrip(req)
@@ -99,12 +103,13 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	})
 	if err != nil {
 		if re, ok := errors.AsType[responseError](err); ok {
-			return re.resp, nil
+			return re.resp, nil, false
 		}
 
-		return nil, err
+		return nil, err, errors.Is(err, breaker.ErrOpenState) || errors.Is(err, breaker.ErrTooManyRequests)
 	}
-	return v.(*http.Response), nil
+
+	return v.(*http.Response), nil, false
 }
 
 func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
 	"github.com/stretchr/testify/require"
 )
@@ -30,6 +31,32 @@ func TestRoundTripperOpensOnTransportError(t *testing.T) {
 	res, err = rt.RoundTrip(req)
 	require.Nil(t, res)
 	require.ErrorIs(t, err, breaker.ErrOpenState)
+}
+
+func TestRoundTripperClosesBodyWhenBreakerIsOpen(t *testing.T) {
+	rt := breaker.NewRoundTripper(
+		&test.StatusRoundTripper{Status: http.StatusInternalServerError},
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+	)
+	first, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(first)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", body)
+	require.NoError(t, err)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+	require.True(t, body.Closed)
 }
 
 func TestRoundTripperOpensOnFailureStatus(t *testing.T) {

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -196,12 +196,17 @@ type RoundTripper struct {
 // If the configured hook is nil, RoundTrip delegates directly to the underlying RoundTripper without
 // mutating the request.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
+}
+
+func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
 	if http.IsCrossOriginRedirect(req) {
-		return nil, http.ErrUseLastResponse
+		return nil, http.ErrUseLastResponse, true
 	}
 
 	if r.hook == nil {
-		return r.RoundTripper.RoundTrip(req)
+		res, err := r.RoundTripper.RoundTrip(req)
+		return res, err, false
 	}
 
 	cloned := req.Clone(req.Context())
@@ -209,11 +214,12 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := r.hook.Sign(cloned); err != nil {
 		closeBody(body)
 
-		return nil, err
+		return nil, err, false
 	}
 	closeBody(body)
 
-	return r.RoundTripper.RoundTrip(cloned)
+	res, err := r.RoundTripper.RoundTrip(cloned)
+	return res, err, false
 }
 
 func closeBody(body io.ReadCloser) {

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/hooks"
 	webhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
 	"github.com/stretchr/testify/require"
@@ -136,7 +137,8 @@ func TestRoundTripperDoesNotSignCrossOriginRedirect(t *testing.T) {
 	}))
 
 	prev := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://example.com/events", http.NoBody)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://attacker.example.com/events", http.NoBody)
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://attacker.example.com/events", body)
 	req.Response = &http.Response{Request: prev}
 
 	res, err := rt.RoundTrip(req)
@@ -146,6 +148,7 @@ func TestRoundTripperDoesNotSignCrossOriginRedirect(t *testing.T) {
 	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookID))
 	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookSignature))
 	require.Empty(t, req.Header.Values(webhooks.HeaderWebhookTimestamp))
+	require.True(t, body.Closed)
 }
 
 func TestHandler(t *testing.T) {

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -130,16 +130,21 @@ type RoundTripper struct {
 //   - If the request is not allowed, it returns an HTTP 429 status error.
 //   - Otherwise, it delegates to the underlying RoundTripper.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
+}
+
+func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
 	ctx := req.Context()
 
 	ok, _, err := r.limiter.Take(ctx)
 	if err != nil {
-		return nil, err
+		return nil, err, true
 	}
 
 	if !ok {
-		return nil, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests))
+		return nil, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests)), true
 	}
 
-	return r.RoundTripper.RoundTrip(req)
+	res, err := r.RoundTripper.RoundTrip(req)
+	return res, err, false
 }

--- a/transport/http/limiter/limiter_test.go
+++ b/transport/http/limiter/limiter_test.go
@@ -1,0 +1,55 @@
+package limiter_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripperClosesBodyOnLimiterError(t *testing.T) {
+	client, err := httplimiter.NewClientLimiter(test.NoopLifecycle{}, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 1))
+	require.NoError(t, err)
+	require.NoError(t, client.Close(t.Context()))
+
+	rt := httplimiter.NewRoundTripper(client, test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unexpected round trip")
+		return nil, nil
+	}))
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/hello", body)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.True(t, body.Closed)
+}
+
+func TestRoundTripperClosesBodyOnLimiterDenial(t *testing.T) {
+	client, err := httplimiter.NewClientLimiter(test.NoopLifecycle{}, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 1))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+	rt := httplimiter.NewRoundTripper(client, test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+	}))
+	first, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	res, err := rt.RoundTrip(first)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/hello", body)
+	require.NoError(t, err)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.True(t, body.Closed)
+}

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -159,16 +159,20 @@ type RoundTripper struct {
 //   - If token generation fails, it returns an unauthorized status error.
 //   - If token generation returns an empty token, it returns an unauthorized status error with `header.ErrInvalidAuthorization`.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
+}
+
+func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
 	if http.IsCrossOriginRedirect(req) {
-		return nil, http.ErrUseLastResponse
+		return nil, http.ErrUseLastResponse, true
 	}
 
 	token, err := r.generator.Generate(req.URL.Path, r.id.String())
 	if err != nil {
-		return nil, status.UnauthorizedError(err)
+		return nil, status.UnauthorizedError(err), true
 	}
 	if len(token) == 0 {
-		return nil, status.UnauthorizedError(header.ErrInvalidAuthorization)
+		return nil, status.UnauthorizedError(header.ErrInvalidAuthorization), true
 	}
 
 	auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))
@@ -179,5 +183,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		cloned.Header = http.Header{}
 	}
 	cloned.Header.Set("Authorization", auth.Value())
-	return r.RoundTripper.RoundTrip(cloned)
+
+	res, err := r.RoundTripper.RoundTrip(cloned)
+	return res, err, false
 }

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,45 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
 	require.Nil(t, req.Header)
+}
+
+func TestRoundTripperClosesBodyOnGenerateError(t *testing.T) {
+	roundTripper := token.NewRoundTripper(
+		env.UserID("service-user"),
+		test.NewGenerator("", test.ErrGenerate),
+		test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("unexpected round trip")
+			return nil, nil
+		}),
+	)
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/hello", body)
+	require.NoError(t, err)
+
+	res, err := roundTripper.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.True(t, body.Closed)
+}
+
+func TestRoundTripperClosesBodyOnCrossOriginRedirect(t *testing.T) {
+	roundTripper := token.NewRoundTripper(
+		env.UserID("service-user"),
+		test.NewGenerator("fresh-token", nil),
+		test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("unexpected round trip")
+			return nil, nil
+		}),
+	)
+	prev, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://other.example.com/hello", body)
+	require.NoError(t, err)
+	req.Response = &http.Response{Request: prev}
+
+	res, err := roundTripper.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, http.ErrUseLastResponse)
+	require.True(t, body.Closed)
 }


### PR DESCRIPTION
## What

- Add net/http.ClosingRoundTripper to centralize request body closure for local RoundTripper rejections.
- Apply the adapter to token, limiter, breaker, and hooks client middleware.
- Add tests for close-on-reject paths and document the pattern in AGENTS.md.

## Why

- RoundTrippers that return before delegation must close req.Body themselves, because no inner transport receives ownership.

## Testing

- `go test ./net/http ./transport/http/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
