### PR TITLE
feat(net): handle charset parameters case-insensitively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ matching skill for the task.
   deduplicate by request id when duplicate processing would be unsafe. Do not
   flag the default HTTP/gRPC retry policy merely because metadata injects
   request ids before retry.
+- `net/http/status.Code(err)` usually returns a valid HTTP status code because
+  repository code should construct HTTP status errors with the constants exposed
+  by `net/http` (for example `http.StatusBadRequest`) or intentionally supported
+  valid custom codes such as `499`. Do not flag hypothetical invalid
+  `WriteHeader` panics from manually constructed bogus codes unless a concrete
+  public API path accepts untrusted status codes or starts promising validation.
 - gRPC client constructor options use the package's last-wins functional option
   convention. `WithClientDialOption`, `WithClientUnaryInterceptors`, and
   `WithClientStreamInterceptors` expect all custom values for one client

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -79,25 +79,36 @@ func TypeByExtension(ext string) string {
 //
 // Parameters are ignored because content negotiation only uses the base media type.
 func Parse(value string) (string, string, error) {
-	mediaType, _, _ := strings.Cut(value, ";")
-	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
-
-	_, subtype, ok := strings.Cut(mediaType, "/")
-	if !ok || strings.IsEmpty(subtype) {
-		return strings.Empty, strings.Empty, ErrInvalidType
-	}
-
-	return mediaType, subtype, nil
+	mediaType, subtype, _, err := parse(value)
+	return mediaType, subtype, err
 }
 
 // WithUTF8 appends a UTF-8 charset parameter to text media types.
 //
 // Non-text media types and media types that already contain a charset parameter are returned unchanged.
 func WithUTF8(mediaType string) string {
-	value, _, err := Parse(mediaType)
-	if err != nil || !strings.HasPrefix(value, "text/") || strings.Contains(mediaType, "charset=") {
+	value, _, params, err := parse(mediaType)
+	if err != nil || !strings.HasPrefix(value, "text/") {
+		return mediaType
+	}
+
+	if _, ok := params["charset"]; ok {
 		return mediaType
 	}
 
 	return strings.Concat(mediaType, "; ", "charset=utf-8")
+}
+
+func parse(value string) (string, string, map[string]string, error) {
+	mediaType, params, err := mime.ParseMediaType(value)
+	if err != nil {
+		return strings.Empty, strings.Empty, nil, ErrInvalidType
+	}
+
+	_, subtype, ok := strings.Cut(mediaType, "/")
+	if !ok || strings.IsEmpty(subtype) {
+		return strings.Empty, strings.Empty, nil, ErrInvalidType
+	}
+
+	return mediaType, subtype, params, nil
 }

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -3,16 +3,18 @@ package media_test
 import (
 	"testing"
 
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseInvalidMediaType(t *testing.T) {
 	_, _, err := media.Parse("json")
-
 	require.ErrorIs(t, err, media.ErrInvalidType)
-	require.True(t, errors.Is(err, media.ErrInvalidType))
+}
+
+func TestParseInvalidMediaTypeParameter(t *testing.T) {
+	_, _, err := media.Parse("text/plain; charset")
+	require.ErrorIs(t, err, media.ErrInvalidType)
 }
 
 func TestParseNormalizesMediaTypeCase(t *testing.T) {
@@ -36,6 +38,7 @@ func TestWithUTF8(t *testing.T) {
 		{name: "text", mediaType: media.Text, expected: "text/plain; charset=utf-8"},
 		{name: "html", mediaType: media.HTML, expected: "text/html; charset=utf-8"},
 		{name: "existing charset", mediaType: "text/plain; charset=utf-8", expected: "text/plain; charset=utf-8"},
+		{name: "existing charset with case variant", mediaType: "text/plain; Charset=utf-8", expected: "text/plain; Charset=utf-8"},
 		{name: "parameter", mediaType: "text/plain; profile=test", expected: "text/plain; profile=test; charset=utf-8"},
 		{name: "json", mediaType: media.JSON, expected: media.JSON},
 		{name: "msgpack", mediaType: media.MessagePack, expected: media.MessagePack},


### PR DESCRIPTION
## What

- Update `media.WithUTF8` to parse media types once with `mime.ParseMediaType`, preserving existing charset parameters regardless of parameter casing.
- Add regression coverage for `Charset=` casing.
- Document that repository status errors should use valid HTTP constants so invalid `WriteHeader` panic reports need a concrete untrusted-code path.

## Why

- MIME parameter names are case-insensitive, so `WithUTF8` should not append a duplicate `charset=utf-8` when callers provide `Charset=` or other case variants.
- The AGENTS note captures the status-code review guidance from this issue pass.

## Testing

- `go test ./net/http/media` - passed
- `make lint` - passed
- `make specs` - passed
