### PR TITLE
feat(media): carry parsed content types through responses

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -235,7 +235,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 		return errors.Prefix("http: new request", err)
 	}
 
-	request.Header.Set(content.TypeKey, mediaType.Type)
+	request.Header.Set(content.TypeKey, mediaType.String())
 
 	response, err := c.client.Do(request)
 	if err != nil {

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -3,7 +3,6 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-sync"
 )
@@ -68,7 +67,7 @@ func (c *Content) NewFromContentType(req *http.Request) Media {
 // request-body decoding.
 func (c *Content) NewFromRequestBody(req *http.Request) (Media, error) {
 	media := c.NewFromContentType(req)
-	if !media.IsRequestBodySupported() {
+	if !media.CanDecodeRequest() {
 		return media, ErrUnsupportedRequestMedia
 	}
 
@@ -90,7 +89,7 @@ func firstMediaType(value string) string {
 func (c *Content) newRequestMedia(mediaType string) Media {
 	m := NewMedia(mediaType, c.enc)
 	if m.IsError() {
-		return newMedia(media.Text, "plain", c.enc)
+		return newKnownMedia(textType, "plain", c.enc)
 	}
 
 	return m

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -15,7 +16,7 @@ func TestNewFromMedia(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			media := test.Content.NewFromMedia(tc.mediaType)
 
-			require.Equal(t, tc.subtype, media.Subtype)
+			require.Equal(t, tc.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tc.kind), media.Encoder)
 		})
 	}
@@ -29,7 +30,7 @@ func TestNewFromRequest(t *testing.T) {
 
 			media := test.Content.NewFromRequest(req)
 
-			require.Equal(t, tc.subtype, media.Subtype)
+			require.Equal(t, tc.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tc.kind), media.Encoder)
 		})
 	}
@@ -42,7 +43,7 @@ func TestNewFromRequestPrefersContentType(t *testing.T) {
 
 	media := test.Content.NewFromRequest(req)
 
-	require.Equal(t, "toml", media.Subtype)
+	require.Equal(t, "toml", media.Subtype())
 	require.Same(t, test.Encoder.Get("toml"), media.Encoder)
 }
 
@@ -52,7 +53,7 @@ func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 
 	media := test.Content.NewFromRequest(req)
 
-	require.Equal(t, "yaml", media.Subtype)
+	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
 }
 
@@ -62,7 +63,7 @@ func TestNewFromRequestNormalizesMediaTypeCase(t *testing.T) {
 
 	media := test.Content.NewFromRequest(req)
 
-	require.Equal(t, "yaml", media.Subtype)
+	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
 }
 
@@ -72,7 +73,7 @@ func TestNewFromRequestNormalizesAcceptMediaTypeCase(t *testing.T) {
 
 	media := test.Content.NewFromRequest(req)
 
-	require.Equal(t, "yaml", media.Subtype)
+	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
 }
 
@@ -82,7 +83,7 @@ func TestNewFromRequestFallsBackFromInternalErrorMedia(t *testing.T) {
 
 	media := test.Content.NewFromRequest(req)
 
-	require.Equal(t, "plain", media.Subtype)
+	require.Equal(t, "plain", media.Subtype())
 	require.Same(t, test.Encoder.Get("plain"), media.Encoder)
 }
 
@@ -94,7 +95,7 @@ func TestNewFromContentType(t *testing.T) {
 
 			media := test.Content.NewFromContentType(req)
 
-			require.Equal(t, tc.subtype, media.Subtype)
+			require.Equal(t, tc.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tc.kind), media.Encoder)
 		})
 	}
@@ -106,7 +107,7 @@ func TestNewFromContentTypeFallsBackFromInternalErrorMedia(t *testing.T) {
 
 	media := test.Content.NewFromContentType(req)
 
-	require.Equal(t, "plain", media.Subtype)
+	require.Equal(t, "plain", media.Subtype())
 	require.Same(t, test.Encoder.Get("plain"), media.Encoder)
 }
 
@@ -119,7 +120,7 @@ func TestNewFromRequestBodyRejectsUnsafeBinaryMedia(t *testing.T) {
 			media, err := test.Content.NewFromRequestBody(req)
 
 			require.ErrorIs(t, err, content.ErrUnsupportedRequestMedia)
-			require.False(t, media.IsRequestBodySupported())
+			require.False(t, media.CanDecodeRequest())
 		})
 	}
 }
@@ -140,8 +141,8 @@ func TestNewFromMediaWithParameters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			media := test.Content.NewFromMedia(tt.mediaType)
 
-			require.Equal(t, tt.expected, media.Type)
-			require.Equal(t, tt.subtype, media.Subtype)
+			require.Equal(t, tt.expected, media.String())
+			require.Equal(t, tt.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tt.kind), media.Encoder)
 		})
 	}
@@ -150,7 +151,16 @@ func TestNewFromMediaWithParameters(t *testing.T) {
 func TestNewFromMediaPreservesInternalErrorMedia(t *testing.T) {
 	media := test.Content.NewFromMedia(media.Error)
 
-	require.Equal(t, "error", media.Subtype)
+	require.Equal(t, "error", media.Subtype())
+	require.Nil(t, media.Encoder)
+}
+
+func TestNewMediaFallsBackToJSONWhenKnownEncoderIsMissing(t *testing.T) {
+	enc := &encoding.Map{}
+	media := content.NewMedia(media.HumanJSON, enc)
+
+	require.Equal(t, "json", media.Subtype())
+	require.Equal(t, "application/json", media.String())
 	require.Nil(t, media.Encoder)
 }
 

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -3,7 +3,6 @@ package content
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/ptr"
@@ -84,7 +83,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 
 		mediaType := cont.NewFromRequest(req)
 		ctx = meta.WithContent(ctx, req, res, mediaType.Encoder)
-		res.Header().Set(TypeKey, media.WithUTF8(mediaType.Type))
+		res.Header().Set(TypeKey, mediaType.WithUTF8())
 
 		data, err := handler(ctx)
 		if err != nil {

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -28,7 +28,7 @@ func TestNewRequestHandlerPrefersContentType(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.WithUTF8(media.JSON), res.Header().Get(content.TypeKey))
+	require.Equal(t, media.JSON, res.Header().Get(content.TypeKey))
 	require.JSONEq(t, `{"Greeting":"Hello Bob","Meta":null}`, res.Body.String())
 }
 
@@ -56,7 +56,7 @@ func TestNewRequestHandlerRejectsUnsafeBinaryRequestBody(t *testing.T) {
 
 			require.False(t, called)
 			require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
-			require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
+			require.Equal(t, "text/error; charset=utf-8", res.Header().Get(content.TypeKey))
 			require.Equal(t, "http: unsupported media type", strings.TrimSpace(res.Body.String()))
 		})
 	}
@@ -74,7 +74,7 @@ func TestNewRequestHandlerTreatsInternalErrorContentTypeAsText(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.WithUTF8(media.Text), res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header().Get(content.TypeKey))
 	require.Equal(t, "Hello Bob", res.Body.String())
 }
 
@@ -90,7 +90,7 @@ func TestNewHandlerTreatsInternalErrorAcceptAsText(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.WithUTF8(media.Text), res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header().Get(content.TypeKey))
 	require.Equal(t, "Hello Bob", res.Body.String())
 }
 
@@ -107,7 +107,7 @@ func TestNewHandlerReplacesExistingContentType(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, []string{media.WithUTF8(media.Text)}, res.Header().Values(content.TypeKey))
+	require.Equal(t, []string{"text/plain; charset=utf-8"}, res.Header().Values(content.TypeKey))
 	require.Equal(t, "Hello Bob", res.Body.String())
 }
 
@@ -127,7 +127,7 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
-	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(content.TypeKey))
 	require.Equal(t, "http: internal server error", strings.TrimSpace(res.Body.String()))
 	require.NotContains(t, res.Body.String(), "partial")
 }
@@ -138,6 +138,6 @@ func TestNotFoundHandlerWritesStatusError(t *testing.T) {
 
 	require.True(t, content.NotFoundHandler()(res, req))
 	require.Equal(t, http.StatusNotFound, res.Code)
-	require.Equal(t, media.WithUTF8(media.Error), res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(content.TypeKey))
 	require.Equal(t, "http: not found", strings.TrimSpace(res.Body.String()))
 }

--- a/net/http/content/media.go
+++ b/net/http/content/media.go
@@ -6,11 +6,23 @@ import (
 )
 
 const (
-	jsonKind                 = "json"
-	errorSubtype             = "error"
-	gobSubtype               = "gob"
-	messagePackSubtype       = "msgpack"
-	vendorMessagePackSubtype = "vnd.msgpack"
+	jsonKind           = "json"
+	errorSubtype       = "error"
+	gobSubtype         = "gob"
+	messagePackSubtype = "msgpack"
+)
+
+var (
+	errorType        = media.MustParse(media.Error)
+	humanJSONType    = media.MustParse(media.HumanJSON)
+	jsonType         = media.MustParse(media.JSON)
+	messagePackType  = media.MustParse(media.MessagePack)
+	protobufType     = media.MustParse(media.Protobuf)
+	protobufJSONType = media.MustParse(media.ProtobufJSON)
+	protobufTextType = media.MustParse(media.ProtobufText)
+	textType         = media.MustParse(media.Text)
+	tomlType         = media.MustParse(media.TOML)
+	yamlType         = media.MustParse(media.YAML)
 )
 
 // NewMedia builds a Media from a media type string and encoder map.
@@ -24,68 +36,79 @@ func NewMedia(mediaType string, enc *encoding.Map) Media {
 		return media
 	}
 
-	value, subtype, err := media.Parse(mediaType)
+	value, err := media.Parse(mediaType)
 	if err != nil {
 		return jsonMedia(enc)
 	}
 
-	return newMedia(value, subtype, enc)
+	return newMedia(value, enc)
 }
 
 // Media describes an HTTP media type and its associated encoder.
 //
-// Type is the base media type string. Subtype is the parsed media subtype used for encoder lookup.
-// Encoder may be nil when Subtype is "error".
+// Type is the parsed media type. Encoder may be nil when Subtype is "error".
 type Media struct {
 	// Encoder is the encoder/decoder associated with the media subtype.
 	Encoder encoding.Encoder
 
-	// Type is the base media type string (for example "application/json", "application/hjson", or "text/plain").
-	Type string
-
-	// Subtype is the parsed subtype (for example "json", "hjson", or "plain").
-	Subtype string
+	// Type is the parsed media type.
+	media.Type
 }
 
 // IsError reports whether the media subtype represents an error payload.
 func (t Media) IsError() bool {
-	return t.Subtype == errorSubtype
+	return t.Subtype() == errorSubtype
 }
 
-// IsRequestBodySupported reports whether the media type is allowed for decoding HTTP request bodies.
-func (t Media) IsRequestBodySupported() bool {
-	return t.Subtype != gobSubtype && t.Subtype != messagePackSubtype
+// CanDecodeRequest reports whether the media type is allowed for decoding HTTP request bodies.
+func (t Media) CanDecodeRequest() bool {
+	subtype := t.Subtype()
+	return subtype != gobSubtype && subtype != messagePackSubtype
+}
+
+// WithUTF8 returns the media type with a UTF-8 charset parameter for text media types.
+func (t Media) WithUTF8() string {
+	return t.Type.WithUTF8()
 }
 
 func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {
 	// Exact built-in media types avoid the general parser on hot request paths.
 	// Parameterized values still use the parser so their normalized Type string stays unchanged.
 	switch mediaType {
+	case media.Error:
+		return newKnownMedia(errorType, errorSubtype, enc), true
+	case media.HumanJSON:
+		return newKnownMedia(humanJSONType, "hjson", enc), true
 	case media.JSON:
 		return jsonMedia(enc), true
-	case media.HumanJSON:
-		return Media{Type: media.HumanJSON, Subtype: "hjson", Encoder: enc.Get("hjson")}, true
-	case media.YAML:
-		return Media{Type: media.YAML, Subtype: "yaml", Encoder: enc.Get("yaml")}, true
-	case media.TOML:
-		return Media{Type: media.TOML, Subtype: "toml", Encoder: enc.Get("toml")}, true
 	case media.MessagePack:
-		return newMedia(media.MessagePack, messagePackSubtype, enc), true
+		return newKnownMedia(messagePackType, messagePackSubtype, enc), true
+	case media.TOML:
+		return newKnownMedia(tomlType, "toml", enc), true
+	case media.YAML:
+		return newKnownMedia(yamlType, "yaml", enc), true
+	default:
+		return knownProtoMedia(mediaType, enc)
+	}
+}
+
+func knownProtoMedia(mediaType string, enc *encoding.Map) (Media, bool) {
+	switch mediaType {
 	case media.Protobuf:
-		return Media{Type: media.Protobuf, Subtype: "protobuf", Encoder: enc.Get("protobuf")}, true
+		return newKnownMedia(protobufType, "protobuf", enc), true
 	case media.ProtobufJSON:
-		return Media{Type: media.ProtobufJSON, Subtype: "pbjson", Encoder: enc.Get("pbjson")}, true
+		return newKnownMedia(protobufJSONType, "pbjson", enc), true
 	case media.ProtobufText:
-		return Media{Type: media.ProtobufText, Subtype: "pbtxt", Encoder: enc.Get("pbtxt")}, true
+		return newKnownMedia(protobufTextType, "pbtxt", enc), true
 	default:
 		return Media{}, false
 	}
 }
 
-func newMedia(value, subtype string, enc *encoding.Map) Media {
-	subtype = normalizeSubtype(subtype)
+func newMedia(mediaType media.Type, enc *encoding.Map) Media {
+	subtype := mediaType.Subtype()
 	if subtype == errorSubtype {
-		return Media{Type: value, Subtype: subtype}
+		return Media{Type: mediaType}
 	}
 
 	e := enc.Get(subtype)
@@ -93,16 +116,22 @@ func newMedia(value, subtype string, enc *encoding.Map) Media {
 		return jsonMedia(enc)
 	}
 
-	return Media{Type: value, Subtype: subtype, Encoder: e}
+	return Media{Type: mediaType, Encoder: e}
+}
+
+func newKnownMedia(mediaType media.Type, subtype string, enc *encoding.Map) Media {
+	if subtype == errorSubtype {
+		return Media{Type: mediaType}
+	}
+
+	e := enc.Get(subtype)
+	if e == nil {
+		return jsonMedia(enc)
+	}
+
+	return Media{Type: mediaType, Encoder: e}
 }
 
 func jsonMedia(enc *encoding.Map) Media {
-	return Media{Type: media.JSON, Subtype: jsonKind, Encoder: enc.Get(jsonKind)}
-}
-
-func normalizeSubtype(subtype string) string {
-	if subtype == vendorMessagePackSubtype {
-		return messagePackSubtype
-	}
-	return subtype
+	return Media{Type: jsonType, Encoder: enc.Get(jsonKind)}
 }

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -4,6 +4,7 @@ import (
 	"mime"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -67,6 +68,68 @@ const YAML = "application/yaml"
 // ErrInvalidType is returned when a media type cannot be parsed.
 var ErrInvalidType = errors.New("media: invalid type")
 
+// Parse parses value into a Type.
+func Parse(value string) (Type, error) {
+	mediaType, params, err := mime.ParseMediaType(value)
+	if err != nil {
+		return Type{}, ErrInvalidType
+	}
+
+	_, subtype, ok := strings.Cut(mediaType, "/")
+	if !ok || strings.IsEmpty(subtype) {
+		return Type{}, ErrInvalidType
+	}
+
+	_, hasCharset := params["charset"]
+	subtype = normalizeSubtype(subtype)
+
+	return Type{hasCharset: hasCharset, source: value, subtype: subtype, value: mediaType}, nil
+}
+
+// MustParse parses value into a Type and panics if parsing fails.
+func MustParse(value string) Type {
+	mediaType, err := Parse(value)
+	runtime.Must(err)
+
+	return mediaType
+}
+
+// Type is a parsed media type.
+type Type struct {
+	source     string
+	subtype    string
+	value      string
+	hasCharset bool
+}
+
+// IsZero reports whether the type has not been initialized.
+func (t Type) IsZero() bool {
+	return strings.IsEmpty(t.value)
+}
+
+// String returns the normalized base media type.
+func (t Type) String() string {
+	return t.value
+}
+
+// Subtype returns the parsed media subtype.
+func (t Type) Subtype() string {
+	return t.subtype
+}
+
+// WithUTF8 appends a UTF-8 charset parameter to text media types.
+func (t Type) WithUTF8() string {
+	if !strings.HasPrefix(t.value, "text/") {
+		return t.source
+	}
+
+	if t.hasCharset {
+		return t.source
+	}
+
+	return strings.Concat(t.source, "; ", "charset=utf-8")
+}
+
 // TypeByExtension returns the media type associated with ext.
 //
 // It wraps mime.TypeByExtension so HTTP packages can use the shared media package
@@ -75,40 +138,10 @@ func TypeByExtension(ext string) string {
 	return mime.TypeByExtension(ext)
 }
 
-// Parse parses value into a base media type and subtype.
-//
-// Parameters are ignored because content negotiation only uses the base media type.
-func Parse(value string) (string, string, error) {
-	mediaType, subtype, _, err := parse(value)
-	return mediaType, subtype, err
-}
-
-// WithUTF8 appends a UTF-8 charset parameter to text media types.
-//
-// Non-text media types and media types that already contain a charset parameter are returned unchanged.
-func WithUTF8(mediaType string) string {
-	value, _, params, err := parse(mediaType)
-	if err != nil || !strings.HasPrefix(value, "text/") {
-		return mediaType
+func normalizeSubtype(subtype string) string {
+	if subtype == "vnd.msgpack" {
+		return "msgpack"
 	}
 
-	if _, ok := params["charset"]; ok {
-		return mediaType
-	}
-
-	return strings.Concat(mediaType, "; ", "charset=utf-8")
-}
-
-func parse(value string) (string, string, map[string]string, error) {
-	mediaType, params, err := mime.ParseMediaType(value)
-	if err != nil {
-		return strings.Empty, strings.Empty, nil, ErrInvalidType
-	}
-
-	_, subtype, ok := strings.Cut(mediaType, "/")
-	if !ok || strings.IsEmpty(subtype) {
-		return strings.Empty, strings.Empty, nil, ErrInvalidType
-	}
-
-	return mediaType, subtype, params, nil
+	return subtype
 }

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -8,28 +8,44 @@ import (
 )
 
 func TestParseInvalidMediaType(t *testing.T) {
-	_, _, err := media.Parse("json")
+	_, err := media.Parse("json")
 	require.ErrorIs(t, err, media.ErrInvalidType)
 }
 
 func TestParseInvalidMediaTypeParameter(t *testing.T) {
-	_, _, err := media.Parse("text/plain; charset")
+	_, err := media.Parse("text/plain; charset")
 	require.ErrorIs(t, err, media.ErrInvalidType)
 }
 
 func TestParseNormalizesMediaTypeCase(t *testing.T) {
-	value, subtype, err := media.Parse("Application/YAML; profile=test")
+	mediaType, err := media.Parse("Application/YAML; profile=test")
 
 	require.NoError(t, err)
-	require.Equal(t, media.YAML, value)
-	require.Equal(t, "yaml", subtype)
+	require.False(t, mediaType.IsZero())
+	require.Equal(t, media.YAML, mediaType.String())
+	require.Equal(t, "yaml", mediaType.Subtype())
+}
+
+func TestParseStripsVendorSubtypePrefix(t *testing.T) {
+	mediaType, err := media.Parse(media.MessagePack)
+
+	require.NoError(t, err)
+	require.Equal(t, media.MessagePack, mediaType.String())
+	require.Equal(t, "msgpack", mediaType.Subtype())
+}
+
+func TestTypeWithUTF8(t *testing.T) {
+	mediaType, err := media.Parse("TEXT/PLAIN; Charset=utf-8")
+
+	require.NoError(t, err)
+	require.Equal(t, "TEXT/PLAIN; Charset=utf-8", mediaType.WithUTF8())
 }
 
 func TestTypeByExtension(t *testing.T) {
 	require.Equal(t, "image/svg+xml", media.TypeByExtension(".svg"))
 }
 
-func TestWithUTF8(t *testing.T) {
+func TestTypeWithUTF8Values(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		mediaType string
@@ -42,10 +58,12 @@ func TestWithUTF8(t *testing.T) {
 		{name: "parameter", mediaType: "text/plain; profile=test", expected: "text/plain; profile=test; charset=utf-8"},
 		{name: "json", mediaType: media.JSON, expected: media.JSON},
 		{name: "msgpack", mediaType: media.MessagePack, expected: media.MessagePack},
-		{name: "invalid", mediaType: "json", expected: "json"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, media.WithUTF8(tc.mediaType))
+			mediaType, err := media.Parse(tc.mediaType)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, mediaType.WithUTF8())
 		})
 	}
 }

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -17,6 +17,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
+var htmlContentType = media.MustParse(media.HTML).WithUTF8()
+
 // NotFound registers controller as the MVC not-found renderer.
 //
 // It returns false when MVC is not defined (see IsDefined).
@@ -74,7 +76,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 	}
 
 	handler := func(res http.ResponseWriter, req *http.Request) {
-		res.Header().Set(content.TypeKey, media.WithUTF8(media.HTML))
+		res.Header().Set(content.TypeKey, htmlContentType)
 
 		ctx := req.Context()
 		ctx = meta.WithContent(ctx, req, res, nil)
@@ -173,7 +175,7 @@ func staticStatusCode(err error) int {
 func setStaticContentType(res http.ResponseWriter, name string) {
 	mediaType := media.TypeByExtension(path.Ext(name))
 	if !strings.IsEmpty(mediaType) {
-		res.Header().Set(content.TypeKey, media.WithUTF8(mediaType))
+		res.Header().Set(content.TypeKey, media.MustParse(mediaType).WithUTF8())
 	}
 }
 
@@ -196,7 +198,7 @@ func writeNotFound(req *http.Request, res http.ResponseWriter) {
 	}
 
 	err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
-	res.Header().Set(content.TypeKey, media.WithUTF8(media.HTML))
+	res.Header().Set(content.TypeKey, htmlContentType)
 	ctx := req.Context()
 	ctx = meta.WithContent(ctx, req, res, nil)
 	ctx = meta.WithAttributes(ctx, meta.NewPair("mvcModelError", meta.Error(err)))

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -247,7 +247,7 @@ func TestRouteRenderErrorDoesNotUseNotFoundController(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	require.Empty(t, res.Body.String())
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header().Get(content.TypeKey))
 }
 
 func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
@@ -305,7 +305,7 @@ func TestNotFoundHandlesNotFound(t *testing.T) {
 	mvc.NewHandler(mux).ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusNotFound, res.Code)
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header().Get(content.TypeKey))
 	require.Contains(t, res.Body.String(), "404 Not Found")
 }
 
@@ -403,7 +403,7 @@ func TestFallback(t *testing.T) {
 			}
 
 			require.Equal(t, http.StatusNotFound, res.Code)
-			require.Equal(t, media.WithUTF8(media.HTML), res.Header().Get(content.TypeKey))
+			require.Equal(t, "text/html; charset=utf-8", res.Header().Get(content.TypeKey))
 			require.Contains(t, res.Body.String(), "404 Not Found")
 		})
 	}

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -8,6 +8,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 )
 
+var (
+	errorContentType = media.MustParse(media.Error).WithUTF8()
+	textContentType  = media.MustParse(media.Text).WithUTF8()
+)
+
 // WriteError writes an error response to res.
 //
 // Content-Type:
@@ -33,7 +38,7 @@ import (
 func WriteError(res http.ResponseWriter, err error) error {
 	header := res.Header()
 	header.Del("Content-Length")
-	header.Set("Content-Type", media.WithUTF8(media.Error))
+	header.Set("Content-Type", errorContentType)
 	header.Set("X-Content-Type-Options", "nosniff")
 
 	code := Code(err)
@@ -54,7 +59,7 @@ func WriteError(res http.ResponseWriter, err error) error {
 func WriteText(res http.ResponseWriter, text string) error {
 	header := res.Header()
 	header.Del("Content-Length")
-	header.Set("Content-Type", media.WithUTF8(media.Text))
+	header.Set("Content-Type", textContentType)
 	header.Set("X-Content-Type-Options", "nosniff")
 
 	res.WriteHeader(http.StatusOK)

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -55,7 +55,7 @@ func TestReadinessNoop(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, "SERVING", body)
-	require.Equal(t, media.WithUTF8(media.Text), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(content.TypeKey))
 }
 
 func TestInvalidHealth(t *testing.T) {
@@ -72,7 +72,7 @@ func TestInvalidHealth(t *testing.T) {
 
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.Equal(t, "http: service unavailable", body)
-	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
 }
 
 func TestMissingHealth(t *testing.T) {

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -40,7 +40,7 @@ func TestRouteSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestRoutePartialViewSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestRouteError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestNotFoundUsesContentFallbackWithoutHTMLAccept(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, header, http.NoBody)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
 	require.Equal(t, "http: not found", body)
 }
 
@@ -152,7 +152,7 @@ func TestNotFoundHandlesHTMXRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.HTML), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestStaticFileSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.Text), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(content.TypeKey))
 }
 
 func TestStaticFileError(t *testing.T) {
@@ -202,7 +202,7 @@ func TestStaticPathValueSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.Text), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(content.TypeKey))
 }
 
 func TestStaticPathValueError(t *testing.T) {

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -67,7 +67,7 @@ func TestRestNotFound(t *testing.T) {
 	res, body, err := world.GetBody(t.Context(), world.NamedServerURL("http", "missing"), header)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
 	require.Equal(t, "http: not found", body)
 }
 

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -185,7 +185,7 @@ func TestRPCNotFound(t *testing.T) {
 	res, body, err := world.ResponseWithBody(t.Context(), world.PathServerURL("http", "missing"), http.MethodPost, header, http.NoBody)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, media.WithUTF8(media.Error), res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
 	require.Equal(t, "http: not found", body)
 }
 


### PR DESCRIPTION
## What

- Replace the tuple-style parser and package-level UTF-8 helper with `media.Parse`, `media.MustParse`, and parsed `media.Type` values.
- Carry parsed content types through `content.Media`, response handlers, the HTTP client, status responses, and MVC rendering so UTF-8 formatting reuses the existing parse result.
- Pre-parse built-in content types once and use a lookup table for exact known values.
- Update HTTP, content, MVC, and transport tests to assert headers through parsed content type helpers.

## Why

- The response lifecycle was parsing the same content type more than once when selecting encoders and later adding UTF-8 charset parameters.
- Passing parsed content types keeps MIME parameter handling case-insensitive while avoiding duplicate parse work for known and already-negotiated values.
- `content.Media.Type` now exposes the parsed type instead of the raw string, so callers should use `Type.String()` when they need the normalized media type string.

## Testing

- `go test ./net/http/... ./transport/http/...` - passed
- `make lint` - passed
- `git diff --check` - passed
