### PR TITLE
feat(meta): add service-method limiter key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,13 @@ matching skill for the task.
   construction to be passed in a single call; repeated calls intentionally
   replace earlier values. Do not flag this as dropped configuration unless a
   public API starts promising accumulation across repeated option helpers.
-- Transport limiter keys are `"user-agent"`, `"ip"`, and `"user-id"`; `"token"` is intentionally not a limiter key. Server limiters run after metadata extraction and token verification, so `"user-id"` is the verified principal (JWT/PASETO subject or SSH key name), and missing, malformed, or invalid auth is rejected before the limiter by design. Do not flag that bypass; use an external edge/gateway/ingress/load-balancer/service-mesh limiter when those attempts need quota enforcement.
+- Transport limiter keys are `"user-agent"`, `"ip"`, `"user-id"`, and
+  `"service-method"`; `"token"` is intentionally not a limiter key. Server
+  limiters run after metadata extraction and token verification, so `"user-id"`
+  is the verified principal (JWT/PASETO subject or SSH key name), and missing,
+  malformed, or invalid auth is rejected before the limiter by design. Do not
+  flag that bypass; use an external edge, gateway, ingress, load balancer, or
+  service mesh limiter when those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
 - HTTP telemetry logger service/method derivation may include request URL path
   segments for non-canonical HTTP routes. This is intentional for client and

--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ Supported key kinds (built-in):
 - `user-agent`
 - `ip`
 - `user-id`
+- `service-method`
 
 Example:
 
@@ -667,6 +668,7 @@ Note:
 - `interval` is parsed as a Go duration string. Invalid values can fail fast.
 - The built-in limiter is an in-memory, per-process safeguard. Use it as a last resort and prefer an external edge, gateway, ingress, load balancer, or service-mesh limiter for production abuse protection.
 - The `user-id` key uses the verified principal stored in metadata. For JWT/PASETO tokens this is the subject claim; for SSH tokens this is the verified key name.
+- The `service-method` key uses HTTP route/path metadata or the gRPC full method name.
 - Server-side HTTP and gRPC limiters run after metadata extraction and token verification, so missing, malformed, or invalid authorization is rejected before it reaches the limiter. This is intentional; enforce quotas for those attempts with an external edge, gateway, ingress, load balancer, or service-mesh limiter.
 
 ---

--- a/meta/attrs.go
+++ b/meta/attrs.go
@@ -23,6 +23,11 @@ const (
 	// For example: an HTTP method name, an RPC method name, or a logical operation name.
 	MethodKey = "method"
 
+	// ServiceMethodKey is the attribute key used for transport service-method names.
+	//
+	// For example: an HTTP route path or a gRPC full method name.
+	ServiceMethodKey = "serviceMethod"
+
 	// CodeKey is the attribute key used for status codes.
 	//
 	// For example: an HTTP status code or a gRPC status code.
@@ -96,6 +101,20 @@ func WithService(value Value) Pair {
 // The pair stores value under MethodKey.
 func WithMethod(value Value) Pair {
 	return NewPair(MethodKey, value)
+}
+
+// WithServiceMethod creates a service-method pair for WithAttributes.
+//
+// The pair stores value under ServiceMethodKey.
+func WithServiceMethod(value Value) Pair {
+	return NewPair(ServiceMethodKey, value)
+}
+
+// ServiceMethod returns the stored service-method attribute from ctx.
+//
+// If no value is present, this returns the zero-value Value.
+func ServiceMethod(ctx context.Context) Value {
+	return Attribute(ctx, ServiceMethodKey)
 }
 
 // WithCode creates a status code pair for WithAttributes.

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -68,6 +68,7 @@ func TestPairHelpers(t *testing.T) {
 		{name: "system", key: meta.SystemKey, value: "system", pair: meta.WithSystem},
 		{name: "service", key: meta.ServiceKey, value: "service", pair: meta.WithService},
 		{name: "method", key: meta.MethodKey, value: "method", pair: meta.WithMethod},
+		{name: "service method", key: meta.ServiceMethodKey, value: "service-method", pair: meta.WithServiceMethod},
 		{name: "code", key: meta.CodeKey, value: "code", pair: meta.WithCode},
 		{name: "duration", key: meta.DurationKey, value: "duration", pair: meta.WithDuration},
 		{name: "user agent", key: meta.UserAgentKey, value: "user-agent", pair: meta.WithUserAgent},
@@ -117,6 +118,11 @@ func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
 func TestUserID(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(), meta.WithUserID(meta.String("user-id")))
 	require.Equal(t, meta.String("user-id"), meta.UserID(ctx))
+}
+
+func TestServiceMethod(t *testing.T) {
+	ctx := meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("service-method")))
+	require.Equal(t, meta.String("service-method"), meta.ServiceMethod(ctx))
 }
 
 func TestGeolocation(t *testing.T) {

--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -27,6 +27,7 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
+			meta.WithServiceMethod(meta.String(fullMethod)),
 		)
 		ctx = NewOutgoingContext(ctx, md)
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
@@ -49,6 +50,7 @@ func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) gr
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
+			meta.WithServiceMethod(meta.String(fullMethod)),
 		)
 		ctx = NewOutgoingContext(ctx, md)
 		return streamer(ctx, desc, conn, fullMethod, opts...)

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -30,6 +30,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
+		require.Equal(t, meta.String("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
 
 		return nil
 	})
@@ -50,6 +51,7 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
 		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
+		require.Equal(t, meta.String("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
 
 		return nil
 	})
@@ -71,6 +73,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
+		require.Equal(t, meta.String("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
 
 		return nil, nil
 	}
@@ -95,6 +98,7 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
 		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
+		require.Equal(t, meta.String("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
 
 		return nil, nil
 	}
@@ -113,6 +117,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
 		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
+		require.Equal(t, meta.String("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
 
 		return "ok", nil
 	})
@@ -172,7 +177,9 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	stream := &test.MetaServerStream{Ctx: ctx}
 
-	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(any, grpc.ServerStream) error {
+	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(_ any, stream grpc.ServerStream) error {
+		require.Equal(t, meta.String("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(stream.Context()))
+
 		return nil
 	})
 	require.NoError(t, err)

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -26,6 +26,7 @@ import (
 //   - copies incoming metadata from the request context
 //   - resolves "user-agent" and "request-id", preferring existing context
 //     attributes and then incoming metadata values
+//   - stores the RPC full method name as the service-method attribute
 //   - derives IP address information from trusted forwarding headers or, if
 //     absent, from the gRPC peer address
 //   - parses the "authorization" header into the request attribute model
@@ -56,6 +57,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
+			meta.WithServiceMethod(meta.String(info.FullMethod)),
 			meta.WithIPAddr(ip),
 			meta.WithIPAddrKind(kind),
 			meta.WithGeolocation(geolocation),
@@ -102,6 +104,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
+			meta.WithServiceMethod(meta.String(info.FullMethod)),
 			meta.WithIPAddr(ip),
 			meta.WithIPAddrKind(kind),
 			meta.WithGeolocation(geolocation),

--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -46,6 +46,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx = meta.WithAttributes(ctx,
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
+		meta.WithServiceMethod(meta.String(req.URL.Path)),
 	)
 
 	cloned := req.Clone(ctx)

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -77,6 +77,24 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	require.Nil(t, req.Header)
 }
 
+func TestRoundTripperStoresServiceMethod(t *testing.T) {
+	roundTripper := httpmeta.NewRoundTripper(
+		env.UserAgent("agent"),
+		test.StaticIDGenerator("request-id"),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, meta.String("/users/123"), meta.ServiceMethod(req.Context()))
+
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/users/123", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+}
+
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
@@ -88,6 +106,29 @@ func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 
 		require.Equal(t, []string{"1", "v2"}, res.Header().Values("Service-Version"))
 		require.Equal(t, []string{"request-id"}, res.Header().Values("Request-Id"))
+	})
+}
+
+func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		require.Equal(t, meta.String("/users/123"), meta.ServiceMethod(req.Context()))
+	})
+}
+
+func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
+	require.NoError(t, err)
+	req.Pattern = "GET /users/{id}"
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		require.Equal(t, meta.String("GET /users/{id}"), meta.ServiceMethod(req.Context()))
 	})
 }
 

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -24,8 +24,8 @@ func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, gen
 
 // Handler extracts request metadata and stores it in the request context.
 //
-// Extracted metadata includes user agent, request id, client IP address (and its source kind), ignored geolocation,
-// and ignored Authorization token value (when present and parseable).
+// Extracted metadata includes user agent, request id, service-method, client IP address (and its source kind),
+// ignored geolocation, and ignored Authorization token value (when present and parseable).
 type Handler struct {
 	generator      id.Generator
 	name           env.Name
@@ -46,6 +46,7 @@ type Handler struct {
 // The handler populates the request context with:
 //   - user agent (from context, request header, or default userAgent parameter)
 //   - request id (from context, request header, or generated via generator)
+//   - service-method (from the matched request pattern, or URL path before routing)
 //   - client IP address and IP address kind (derived from forwarded headers or RemoteAddr)
 //   - geolocation (from "Geolocation" header, stored as ignored)
 //   - authorization value (derived from the "Authorization" header, when present)
@@ -77,6 +78,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	ctx = meta.WithAttributes(ctx,
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
+		meta.WithServiceMethod(serverServiceMethod(req)),
 		meta.WithIPAddr(ip),
 		meta.WithIPAddrKind(kind),
 		meta.WithGeolocation(geolocation),
@@ -116,6 +118,14 @@ func serverRequestID(ctx context.Context, generator id.Generator, req *http.Requ
 	}
 
 	return meta.String(generator.Generate())
+}
+
+func serverServiceMethod(req *http.Request) meta.Value {
+	if !strings.IsEmpty(req.Pattern) {
+		return meta.String(req.Pattern)
+	}
+
+	return meta.String(req.URL.Path)
 }
 
 func serverIP(req *http.Request) (meta.Value, meta.Value) {

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -31,7 +31,7 @@ func TestUnlimited(t *testing.T) {
 }
 
 func TestServerLimiter(t *testing.T) {
-	for _, f := range []string{"user-agent", "ip"} {
+	for _, f := range []string{"user-agent", "ip", "service-method"} {
 		t.Run(f, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),
@@ -75,7 +75,7 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 }
 
 func TestClientLimiter(t *testing.T) {
-	for _, f := range []string{"user-agent", "ip"} {
+	for _, f := range []string{"user-agent", "ip", "service-method"} {
 		t.Run(f, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),

--- a/transport/limiter/config.go
+++ b/transport/limiter/config.go
@@ -7,7 +7,7 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // The limiter is typically constructed by `NewLimiter`, which interprets these fields as:
 //
 //   - Kind: selects how request keys are derived from context metadata (see NewKeyMap for default kinds).
-//     Examples: "user-agent", "ip", "user-id".
+//     Examples: "user-agent", "ip", "user-id", "service-method".
 //
 //   - Interval: a typed duration encoded as a Go duration string (e.g. "1s", "1m")
 //     defining the refill/measurement window used by the underlying token bucket store.

--- a/transport/limiter/doc.go
+++ b/transport/limiter/doc.go
@@ -13,6 +13,7 @@
 //   - "user-agent": meta.UserAgent
 //   - "ip": meta.IPAddr
 //   - "user-id": meta.UserID
+//   - "service-method": meta.ServiceMethod
 //
 // The configured kind is typically provided via `Config.Kind`. If the kind is not present in the KeyMap,
 // limiter construction fails with ErrMissingKey.
@@ -32,6 +33,10 @@
 // The "user-id" key uses the verified principal stored in metadata. For
 // JWT/PASETO tokens this is the subject claim; for SSH tokens this is the
 // verified key name returned by the token verifier.
+//
+// The "service-method" key uses transport metadata populated by the HTTP and
+// gRPC metadata layers. HTTP stores the matched request pattern when available
+// and otherwise the URL path; gRPC stores the full method name.
 //
 // # In-memory behavior and lifecycle
 //

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -16,7 +16,8 @@ import (
 // KeyFunc derives the metadata value used to key rate limits for ctx.
 //
 // The returned meta.Value is expected to yield a stable string via Value() that can be used as a
-// per-request/per-actor limiter key (for example a user-agent, an IP address, or a verified principal).
+// per-request/per-actor limiter key (for example a user-agent, an IP address, a transport method, or a
+// verified principal).
 type KeyFunc func(context.Context) meta.Value
 
 // KeyMap maps a configured kind string to the KeyFunc used to derive the limiter key.
@@ -30,6 +31,7 @@ type KeyMap map[string]KeyFunc
 //   - "user-agent": rate limit per User-Agent header (meta.UserAgent)
 //   - "ip": rate limit per client IP address (meta.IPAddr)
 //   - "user-id": rate limit per verified user/principal identifier (meta.UserID)
+//   - "service-method": rate limit per HTTP route/path or gRPC full method (meta.ServiceMethod)
 //
 // These defaults are intended for controlled service-to-service traffic where user agents,
 // forwarded IP headers, and authorization metadata are supplied by trusted clients or platform
@@ -38,9 +40,10 @@ type KeyMap map[string]KeyFunc
 // for those boundaries.
 func NewKeyMap() KeyMap {
 	return KeyMap{
-		"user-agent": meta.UserAgent,
-		"ip":         meta.IPAddr,
-		"user-id":    meta.UserID,
+		"user-agent":     meta.UserAgent,
+		"ip":             meta.IPAddr,
+		"service-method": meta.ServiceMethod,
+		"user-id":        meta.UserID,
 	}
 }
 

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -28,6 +28,13 @@ func TestValidLimiter(t *testing.T) {
 	require.NoError(t, limiter.Close(t.Context()))
 }
 
+func TestNewKeyMapIncludesServiceMethod(t *testing.T) {
+	key := limiter.NewKeyMap()["service-method"]
+	ctx := meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("GET /users/{id}")))
+
+	require.Equal(t, meta.String("GET /users/{id}"), key(ctx))
+}
+
 func TestMissingLimiter(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{}


### PR DESCRIPTION
## What

- Add a shared service-method metadata attribute and populate it from HTTP and gRPC client/server metadata handlers.
- Add service-method to the built-in transport limiter key map.
- Update limiter docs, README, and agent guidance for the new key.
- Cover metadata propagation and limiter key behavior with focused tests.

## Why

- Services can now limit by HTTP path or gRPC full method in addition to user-agent, IP, and verified user ID.
- The README and internal guidance now match the supported limiter configuration.

## Testing

- `go test ./meta ./net/http/meta ./net/grpc/meta ./transport/limiter ./transport/http ./transport/grpc` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
