### PR TITLE
feat(grpc): centralize service method parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,11 +153,11 @@ matching skill for the task.
 - gRPC service and method names are generated from Buf-managed proto files such
   as `internal/test/greet/v1/service.proto`, which require package-qualified
   service names and valid RPC method names. Do not flag
-  `net/grpc/strings.IsFullMethod` or `SplitServiceMethod` merely because a
-  hypothetical manually constructed method string like `/pkg.Service/` or
-  `/svc/Get.Name` could parse as a full method. Only report a concrete issue if
-  untrusted, non-generated method strings are used for a security decision, or a
-  public API promises strict validation of arbitrary method strings.
+  `net/grpc.ParseServiceMethod` merely because a hypothetical manually
+  constructed method string like `/pkg.Service/` or `/svc/Get.Name` could split
+  or fall back to `root`. Only report a concrete issue if untrusted,
+  non-generated method strings are used for a security decision, or a public API
+  promises strict validation of arbitrary method strings.
 - MVC controller errors render a client-safe `mvc.Error` model; `mvcModelError` metadata intentionally remains the raw error string for compatibility and must not be rendered unless diagnostic detail exposure is acceptable.
 - MVC not-found handling intentionally uses a simple `Accept` header check for
   `text/html` and does not fully evaluate quality weights such as

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -11,6 +11,7 @@
 //   - thin helper functions that forward to common constructors and options
 //     such as StatsHandler, Header, ChainUnaryInterceptor, Creds, NewTLS,
 //     NewInsecureCredentials, and UseCompressor
+//   - ParseServiceMethod for deriving service/method names from gRPC full method strings
 //   - a convenience NewServer constructor that applies standard server-side
 //     keepalive configuration and registers gRPC reflection
 //

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"google.golang.org/grpc"
@@ -139,6 +140,18 @@ type TransportCredentials = credentials.TransportCredentials
 // StatusText returns the standard gRPC status text for the code.
 func StatusText(code codes.Code) string {
 	return codes.StatusText(code)
+}
+
+// ParseServiceMethod derives a logical service and method name from a gRPC full method.
+//
+// If name can be split as a slash-prefixed path, ParseServiceMethod returns the extracted service/method pair.
+// Otherwise it returns "root" for both values.
+func ParseServiceMethod(name string) (string, string) {
+	if service, method, ok := url.SplitPath(name); ok {
+		return service, method
+	}
+
+	return "root", "root"
 }
 
 // StatsHandler returns a ServerOption that installs h as the server stats handler.

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -14,6 +14,28 @@ func TestStatusText(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated.String(), grpc.StatusText(codes.Unauthenticated))
 }
 
+func TestParseServiceMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		full    string
+		service string
+		method  string
+	}{
+		{name: "full method", full: "/greet.v1.Greeter/SayHello", service: "greet.v1.Greeter", method: "SayHello"},
+		{name: "missing leading slash", full: "greet.v1.Greeter/SayHello", service: "root", method: "root"},
+		{name: "missing method", full: "/greet.v1.Greeter", service: "root", method: "root"},
+		{name: "empty method", full: "/greet.v1.Greeter/", service: "root", method: "root"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, method := grpc.ParseServiceMethod(test.full)
+			require.Equal(t, test.service, service)
+			require.Equal(t, test.method, method)
+		})
+	}
+}
+
 func TestNewServerWithAdvancedOptions(t *testing.T) {
 	opts := options.Map{
 		"max_concurrent_streams":   "7",

--- a/net/grpc/strings/doc.go
+++ b/net/grpc/strings/doc.go
@@ -1,8 +1,7 @@
 // Package strings provides gRPC-specific string helpers for net-layer middleware.
 //
-// This package contains helpers for parsing gRPC full method names and matching standard transport
-// operation RPCs that selected middleware can treat specially, such as auth, logging, or unary-only limiter
-// bypasses.
+// This package contains helpers for matching standard transport operation RPCs that selected middleware can
+// treat specially, such as auth, logging, or unary-only limiter bypasses.
 //
-// Start with `SplitServiceMethod` and `IsOperationMethod`.
+// Start with `IsOperationMethod`.
 package strings

--- a/net/grpc/strings/strings.go
+++ b/net/grpc/strings/strings.go
@@ -2,7 +2,6 @@ package strings
 
 import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
-	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -54,25 +53,4 @@ func IsOperationMethod(name string) bool {
 	default:
 		return false
 	}
-}
-
-// IsFullMethod reports whether name is of the form `/package.service/method`.
-//
-// This is the canonical shape of gRPC full method names as they appear in interceptors (for example
-// "/helloworld.Greeter/SayHello").
-func IsFullMethod(name string) bool {
-	// Buf-managed protos in this repo require a package, so service names are
-	// expected to include a package-qualified dot, e.g. "/greet.v1.Greeter/SayHello".
-	return strings.HasPrefix(name, "/") && strings.Count(name, "/") == 2 && strings.Count(name, ".") > 0
-}
-
-// SplitServiceMethod splits a gRPC full method name into service and method components.
-//
-// If name is not a valid gRPC full method (see IsFullMethod), it returns ("", "", false).
-// Otherwise it returns ("package.service", "method", true).
-func SplitServiceMethod(name string) (string, string, bool) {
-	if !IsFullMethod(name) {
-		return "", "", false
-	}
-	return url.SplitPath(name)
 }

--- a/net/grpc/strings/strings_test.go
+++ b/net/grpc/strings/strings_test.go
@@ -27,29 +27,3 @@ func TestIsOperationMethod(t *testing.T) {
 		})
 	}
 }
-
-func TestSplitServiceMethod(t *testing.T) {
-	tests := []struct {
-		name    string
-		full    string
-		service string
-		method  string
-		ok      bool
-	}{
-		{name: "full method", full: "/greet.v1.Greeter/SayHello", service: "greet.v1.Greeter", method: "SayHello", ok: true},
-		{name: "missing package", full: "/Greeter/SayHello"},
-		{name: "missing leading slash", full: "greet.v1.Greeter/SayHello"},
-		{name: "missing method", full: "/greet.v1.Greeter"},
-		{name: "extra path segment", full: "/greet.v1.Greeter/SayHello/Again"},
-		{name: "empty method", full: "/greet.v1.Greeter/"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			service, method, ok := strings.SplitServiceMethod(test.full)
-			require.Equal(t, test.service, service)
-			require.Equal(t, test.method, method)
-			require.Equal(t, test.ok, ok)
-		})
-	}
-}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -44,3 +44,22 @@ func TestLastIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestCount(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		substr string
+		want   int
+	}{
+		{name: "matches", s: "/greet.v1.Greeter/SayHello", substr: "/", want: 2},
+		{name: "missing", s: "greet.v1.Greeter", substr: "/", want: 0},
+		{name: "empty substr", s: "service", substr: "", want: 8},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, strings.Count(test.s, test.substr))
+		})
+	}
+}

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -26,7 +26,7 @@ type Policy func(ctx context.Context, fullMethod string, req any) bool
 
 // StandardReadMethods allows retries for AIP-style read methods named Get* or List*.
 func StandardReadMethods(_ context.Context, fullMethod string, _ any) bool {
-	_, method, _ := strings.SplitServiceMethod(fullMethod)
+	_, method := grpc.ParseServiceMethod(fullMethod)
 
 	return strings.HasPrefix(method, "Get") || strings.HasPrefix(method, "List")
 }

--- a/transport/grpc/telemetry/logger/logger.go
+++ b/transport/grpc/telemetry/logger/logger.go
@@ -43,7 +43,7 @@ func UnaryServerInterceptor(log *Logger) grpc.UnaryServerInterceptor {
 			return handler(ctx, req)
 		}
 
-		service, method, _ := strings.SplitServiceMethod(info.FullMethod)
+		service, method := grpc.ParseServiceMethod(info.FullMethod)
 		start := time.Now()
 		resp, err := handler(ctx, req)
 
@@ -85,7 +85,7 @@ func StreamServerInterceptor(log *Logger) grpc.StreamServerInterceptor {
 			return handler(srv, stream)
 		}
 
-		service, method, _ := strings.SplitServiceMethod(info.FullMethod)
+		service, method := grpc.ParseServiceMethod(info.FullMethod)
 		start := time.Now()
 		ctx := stream.Context()
 		err := handler(srv, stream)
@@ -127,7 +127,7 @@ func StreamServerInterceptor(log *Logger) grpc.StreamServerInterceptor {
 // contain credentials, tokens, request data, or other secrets.
 func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		service, method, _ := strings.SplitServiceMethod(fullMethod)
+		service, method := grpc.ParseServiceMethod(fullMethod)
 		start := time.Now()
 		err := invoker(ctx, fullMethod, req, resp, conn, opts...)
 
@@ -172,7 +172,7 @@ func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 // contain credentials, tokens, request data, or other secrets.
 func StreamClientInterceptor(log *Logger) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		service, method, _ := strings.SplitServiceMethod(fullMethod)
+		service, method := grpc.ParseServiceMethod(fullMethod)
 		start := time.Now()
 		stream, err := streamer(ctx, desc, conn, fullMethod, opts...)
 


### PR DESCRIPTION
## What

- Move gRPC service/method parsing to `net/grpc.ParseServiceMethod`.
- Use the shared parser from gRPC telemetry logging and retry policy code.
- Remove the old `net/grpc/strings` full-method parser and its now-obsolete tests.
- Update package docs and agent guidance for the new parser location.

## Why

- gRPC service/method parsing now mirrors the HTTP helper shape by returning stable service and method values directly.
- Callers no longer ignore an `ok` result and instead get a consistent `root` fallback for unparsable method strings.

## Testing

- `go test ./net/grpc ./net/grpc/strings ./transport/grpc/retry ./transport/grpc/telemetry/logger` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
