### PR TITLE
feat(crypto): harden invalid key and size handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ matching skill for the task.
   insecure DSN could be supplied; only report concrete bugs such as accidental
   DSN rewriting, secret leakage, or a public API promise to enforce secure DSN
   policy.
+- RSA public-key loading intentionally validates the repository's key-size
+  policy and delegates deeper RSA parameter checks, such as public exponent
+  usability, to the standard library operations that consume the key. Do not
+  flag `crypto/rsa.Config.PublicKey` merely because `Encrypt` can later return a
+  standard-library error for an unusual parsed key parameter; only report
+  concrete bugs such as panics, accepted weak key sizes, secret leakage, or a
+  public API promise to fully validate every RSA parameter at load time.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
 - `net/header.ForwardedIPs` is intentionally an exported mutable list, similar

--- a/crypto/aes/aes.go
+++ b/crypto/aes/aes.go
@@ -14,6 +14,15 @@ import (
 // ErrInvalidLength is returned when a ciphertext is too short to contain the required nonce prefix.
 var ErrInvalidLength = errors.New("aes: invalid length")
 
+// ErrInvalidPlaintextLength is returned when plaintext exceeds AES-GCM's per-nonce maximum.
+var ErrInvalidPlaintextLength = errors.New("aes: invalid plaintext length")
+
+// maxGCMPlaintextSize is GCM's per-nonce plaintext limit: 2^32 - 2 AES blocks.
+//
+// GCM uses a 32-bit counter internally and reserves counter values, so the standard-library
+// implementation panics above this limit. Check it before Seal so Encrypt can return an error.
+const maxGCMPlaintextSize = ((1 << 32) - 2) * aes.BlockSize
+
 // NewCipher constructs an AES-GCM Cipher when configuration is enabled.
 //
 // Disabled behavior: if cfg is nil (disabled), NewCipher returns (nil, nil).
@@ -59,8 +68,13 @@ type Cipher struct {
 // A fresh nonce is generated for each call and is prefixed to the returned byte slice so Decrypt can recover it.
 // The returned slice includes the GCM authentication tag as produced by cipher.AEAD.Seal.
 //
-// Errors are returned if nonce generation fails or if the configured key is invalid for AES.
+// Errors are returned if plaintext exceeds AES-GCM's per-nonce maximum, nonce generation fails,
+// or the configured key is invalid for AES.
 func (c *Cipher) Encrypt(msg []byte) ([]byte, error) {
+	if int64(len(msg)) > maxGCMPlaintextSize {
+		return nil, ErrInvalidPlaintextLength
+	}
+
 	aead, err := c.aead()
 	if err != nil {
 		return nil, err

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -10,13 +10,28 @@ import (
 // PrivateKeySize is the size, in bytes, of an Ed25519 private key.
 const PrivateKeySize = ed25519.PrivateKeySize
 
+// PublicKeySize is the size, in bytes, of an Ed25519 public key.
+const PublicKeySize = ed25519.PublicKeySize
+
 // PrivateKey is the type of an Ed25519 private key.
 type PrivateKey = ed25519.PrivateKey
+
+// PublicKey is the type of an Ed25519 public key.
+type PublicKey = ed25519.PublicKey
 
 // ValidatePrivateKey reports whether key has the Ed25519 private-key size required for signing.
 func ValidatePrivateKey(key ed25519.PrivateKey) error {
 	if len(key) != PrivateKeySize {
 		return fmt.Errorf("ed25519: invalid private key size %d: %w", len(key), errors.ErrInvalidKeySize)
+	}
+
+	return nil
+}
+
+// ValidatePublicKey reports whether key has the Ed25519 public-key size required for verification.
+func ValidatePublicKey(key ed25519.PublicKey) error {
+	if len(key) != PublicKeySize {
+		return fmt.Errorf("ed25519: invalid public key size %d: %w", len(key), errors.ErrInvalidKeySize)
 	}
 
 	return nil

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -141,6 +141,27 @@ func TestInvalidSignerPrivateKey(t *testing.T) {
 	}
 }
 
+func TestInvalidVerifierPublicKey(t *testing.T) {
+	tests := []struct {
+		verifier *ed25519.Verifier
+		name     string
+	}{
+		{name: "nil verifier", verifier: nil},
+		{name: "zero value verifier", verifier: &ed25519.Verifier{}},
+		{name: "short public key", verifier: &ed25519.Verifier{PublicKey: []byte("short")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				err = tt.verifier.Verify(strings.Bytes("sig"), strings.Bytes("test"))
+			})
+			require.ErrorIs(t, err, errors.ErrInvalidKeySize)
+		})
+	}
+}
+
 func TestInvalidKeyType(t *testing.T) {
 	public, private, err := rsa.NewGenerator(rand.NewGenerator(rand.NewReader())).Generate()
 	require.NoError(t, err)

--- a/crypto/ed25519/verifier.go
+++ b/crypto/ed25519/verifier.go
@@ -43,6 +43,13 @@ type Verifier struct {
 // Note: Ed25519 verification is a boolean check and does not return an error on failure. This method
 // returns a sentinel error to provide a uniform verification API across crypto implementations.
 func (v *Verifier) Verify(sig, msg []byte) error {
+	if v == nil {
+		return crypto.ErrInvalidKeySize
+	}
+	if err := ValidatePublicKey(v.PublicKey); err != nil {
+		return err
+	}
+
 	ok := ed25519.Verify(v.PublicKey, msg, sig)
 	if !ok {
 		return crypto.ErrInvalidMatch

--- a/crypto/rand/rand.go
+++ b/crypto/rand/rand.go
@@ -5,11 +5,15 @@ import (
 	"math/big"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// ErrInvalidSize is returned when a random value size is negative.
+var ErrInvalidSize = errors.New("rand: invalid size")
 
 // NewReader returns a cryptographically secure random Reader.
 //
@@ -51,6 +55,10 @@ func (g *Generator) Read(b []byte) (int, error) {
 // The returned bytes are read directly from the underlying Reader and may span
 // the full 0-255 byte range.
 func (g *Generator) GenerateBytes(size int) ([]byte, error) {
+	if size < 0 {
+		return nil, ErrInvalidSize
+	}
+
 	data := make([]byte, size)
 	_, err := g.Read(data)
 	if err != nil {
@@ -66,6 +74,10 @@ func (g *Generator) GenerateBytes(size int) ([]byte, error) {
 // suitable for text tokens but not a substitute for GenerateBytes when binary
 // randomness is required.
 func (g *Generator) GenerateText(size int) (string, error) {
+	if size < 0 {
+		return strings.Empty, ErrInvalidSize
+	}
+
 	data := make([]byte, size)
 	length := int64(len(letters))
 

--- a/crypto/rand/rand_test.go
+++ b/crypto/rand/rand_test.go
@@ -38,3 +38,22 @@ func TestInvalidRand(t *testing.T) {
 	_, err = gen.GenerateText(5)
 	require.Error(t, err)
 }
+
+func TestInvalidSize(t *testing.T) {
+	gen := rand.NewGenerator(rand.NewReader())
+
+	var data []byte
+	var err error
+	require.NotPanics(t, func() {
+		data, err = gen.GenerateBytes(-1)
+	})
+	require.Nil(t, data)
+	require.ErrorIs(t, err, rand.ErrInvalidSize)
+
+	var text string
+	require.NotPanics(t, func() {
+		text, err = gen.GenerateText(-1)
+	})
+	require.Empty(t, text)
+	require.ErrorIs(t, err, rand.ErrInvalidSize)
+}

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -136,6 +136,27 @@ func TestInvalidSignerPrivateKey(t *testing.T) {
 	}
 }
 
+func TestInvalidVerifierPublicKey(t *testing.T) {
+	tests := []struct {
+		verifier *ssh.Verifier
+		name     string
+	}{
+		{name: "nil verifier", verifier: nil},
+		{name: "zero value verifier", verifier: &ssh.Verifier{}},
+		{name: "short public key", verifier: &ssh.Verifier{PublicKey: []byte("short")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				err = tt.verifier.Verify(strings.Bytes("sig"), strings.Bytes("test"))
+			})
+			require.ErrorIs(t, err, errors.ErrInvalidKeySize)
+		})
+	}
+}
+
 func TestInvalidKeyType(t *testing.T) {
 	public, private, err := rsa.NewGenerator(rand.NewGenerator(rand.NewReader())).Generate()
 	require.NoError(t, err)

--- a/crypto/ssh/verifier.go
+++ b/crypto/ssh/verifier.go
@@ -45,6 +45,13 @@ type Verifier struct {
 // Note: Ed25519 verification is a boolean check and does not return an error on failure. This method
 // returns a sentinel error to provide a uniform verification API across crypto implementations.
 func (v *Verifier) Verify(sig, msg []byte) error {
+	if v == nil {
+		return crypto.ErrInvalidKeySize
+	}
+	if len(v.PublicKey) != ed25519.PublicKeySize {
+		return crypto.ErrInvalidKeySize
+	}
+
 	ok := ed25519.Verify(v.PublicKey, msg, sig)
 	if !ok {
 		return crypto.ErrInvalidMatch


### PR DESCRIPTION
## What

- Return explicit errors for invalid Ed25519 and SSH verifier public-key state before standard Ed25519 verification.
- Reject oversized AES-GCM plaintext and negative random helper sizes before operations that can panic.
- Document that RSA public-key exponent prevalidation is intentionally delegated to standard-library operations.

## Why

- Keep public error-returning helpers from panicking on invalid direct-use inputs.
- Prevent a previously dismissed RSA prevalidation preference from resurfacing as an issue finding.

## Testing

- `go test ./crypto/...` - passed
- `make lint` - passed
