### PR TITLE
feat(cache): harden redis diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,12 @@ matching skill for the task.
   return the raw serve error from `Stop`.
 - `telemetry.Register()` installs the global OpenTelemetry propagator.
 - `cache.Register(...)` sets the package-level cache used by generic cache helpers.
+  It is intentionally called by the supported wiring path during startup/test
+  setup, not as a concurrent runtime reconfiguration API. Do not flag
+  unsynchronized global-state or nil-pointer issues based solely on hypothetical
+  concurrent manual `cache.Register`, `cache.Get`, or `cache.Persist` calls
+  unless a concrete public API path starts promising concurrent manual
+  re-registration or the repository adds such a runtime path.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - PostgreSQL DSN security options, including TLS/`sslmode`, are intentionally
   part of the DSN supplied by the service configuration. `database/sql/pg`

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -35,6 +36,9 @@ type DriverParams struct {
 	Lifecycle di.Lifecycle
 	FS        *os.FS
 	Config    *cache.Config
+
+	// Logger routes Redis client logs through the go-service logger when configured.
+	Logger *logger.Logger
 }
 
 // NewDriver constructs a cache Driver for the configured backend.
@@ -89,6 +93,9 @@ func NewDriver(params DriverParams) (Driver, error) {
 
 		opts.MaintNotificationsConfig = &notifications.Config{
 			Mode: notifications.ModeDisabled,
+		}
+		if params.Logger != nil {
+			client.SetLogger(redisLogger{logger: params.Logger})
 		}
 
 		redisClient := client.NewClient(opts)

--- a/cache/driver/logger.go
+++ b/cache/driver/logger.go
@@ -1,17 +1,16 @@
 package driver
 
 import (
+	"fmt"
+
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/redis/go-redis/v9"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 )
 
-type logger struct{}
-
-// Printf implements the redis.Logger interface and is intentionally a no-op.
-func (logger) Printf(_ context.Context, _ string, _ ...any) {
-	// Do nothing here
+type redisLogger struct {
+	logger *logger.Logger
 }
 
-func init() {
-	redis.SetLogger(&logger{})
+func (l redisLogger) Printf(ctx context.Context, format string, args ...any) {
+	l.logger.LogAttrs(ctx, logger.LevelWarn, logger.NewText("redis: "+fmt.Sprintf(format, args...)))
 }

--- a/cache/driver/sync.go
+++ b/cache/driver/sync.go
@@ -36,7 +36,7 @@ func (d *syncDriver) Fetch(ctx context.Context, key string) (string, error) {
 	}
 
 	if !value.expiresAt.IsZero() && time.Now().After(value.expiresAt) {
-		d.items.Delete(key)
+		d.items.CompareAndDelete(key, value)
 
 		return "", ErrExpired
 	}

--- a/cache/telemetry/telemetry.go
+++ b/cache/telemetry/telemetry.go
@@ -7,13 +7,14 @@ import (
 
 // InstrumentTracing instruments a Redis client for OpenTelemetry tracing.
 //
-// This is a thin wrapper around redisotel.InstrumentTracing.
+// This is a thin wrapper around redisotel.InstrumentTracing with raw command
+// statement capture disabled.
 //
 // The provided client is modified in place to emit tracing data for supported
 // Redis operations. The wrapper does not change upstream behavior or error
 // semantics.
 func InstrumentTracing(client client.UniversalClient) error {
-	return redisotel.InstrumentTracing(client)
+	return redisotel.InstrumentTracing(client, redisotel.WithDBStatement(false))
 }
 
 // InstrumentMetrics instruments a Redis client for OpenTelemetry metrics.


### PR DESCRIPTION
## What

- Disable Redis tracing raw command statement capture so cache keys and encoded values are not exported as span attributes.
- Route go-redis logs through the go-service logger when the Redis driver is constructed instead of installing a no-op logger at package import time.
- Make the in-memory driver delete only the observed expired entry during lazy expiry.
- Document the supported cache registration wiring so future reviews do not flag unsupported concurrent manual re-registration scenarios.

## Why

- Cache values can contain sensitive application data and should not be copied into tracing backends through Redis command statements.
- Redis diagnostics should remain available through the service logger without surprising unrelated clients at import time.
- A stale expiry fetch should not be able to delete a fresh replacement stored by another goroutine.
- The review guidance now reflects the supported DI/startup wiring path for package-level cache helpers.

## Testing

- `go test ./cache/...` - passed
- `go test -race ./cache/driver` - passed
- `make lint` - passed with the existing gomodguard deprecation warning and 0 issues
