### PR TITLE
feat(sql): suppress query text in telemetry

### DIFF
--- a/database/sql/telemetry/telemetry.go
+++ b/database/sql/telemetry/telemetry.go
@@ -15,19 +15,26 @@ import (
 // attributes and metric/tracing options.
 type Option = otelsql.Option
 
+// SpanOptions is an alias of otelsql.SpanOptions.
+//
+// It configures SQL tracing span behavior.
+type SpanOptions = otelsql.SpanOptions
+
 // Open opens a `database/sql` DB handle with OpenTelemetry instrumentation.
 //
-// This is a thin wrapper around otelsql.Open.
+// Raw SQL query text capture is disabled by default. Callers that need raw
+// statements in spans may opt in with WithSpanOptions.
 func Open(driverName, dataSourceName string, options ...Option) (*sql.DB, error) {
-	return otelsql.Open(driverName, dataSourceName, options...)
+	return otelsql.Open(driverName, dataSourceName, optionsWithDefaults(options)...)
 }
 
 // WrapDriver wraps a `database/sql/driver.Driver` with OpenTelemetry
 // instrumentation.
 //
-// This is a thin wrapper around otelsql.WrapDriver.
+// Raw SQL query text capture is disabled by default. Callers that need raw
+// statements in spans may opt in with WithSpanOptions.
 func WrapDriver(driver driver.Driver, opts ...Option) driver.Driver {
-	return otelsql.WrapDriver(driver, opts...)
+	return otelsql.WrapDriver(driver, optionsWithDefaults(opts)...)
 }
 
 // WithAttributes adds static attributes to SQL telemetry spans and metrics.
@@ -37,9 +44,24 @@ func WithAttributes(attrs ...attribute.KeyValue) Option {
 	return otelsql.WithAttributes(attrs...)
 }
 
+// WithSpanOptions configures SQL tracing span behavior.
+//
+// This is a thin wrapper around otelsql.WithSpanOptions.
+func WithSpanOptions(opts SpanOptions) Option {
+	return otelsql.WithSpanOptions(opts)
+}
+
 // RegisterDBStatsMetrics registers OpenTelemetry DB stats metrics for db.
 //
 // This is a thin wrapper around otelsql.RegisterDBStatsMetrics.
 func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) (metric.Registration, error) {
 	return otelsql.RegisterDBStatsMetrics(db, opts...)
+}
+
+func optionsWithDefaults(options []Option) []Option {
+	opts := make([]Option, 0, len(options)+1)
+	opts = append(opts, WithSpanOptions(SpanOptions{DisableQuery: true}))
+	opts = append(opts, options...)
+
+	return opts
 }


### PR DESCRIPTION
## What

- Disable raw query text capture by default for database instrumentation.
- Expose SQL span options through the go-service telemetry wrapper so callers can explicitly opt back in when needed.
- Update telemetry GoDoc to describe the safer default.

## Why

- Query strings can contain literals or comments with sensitive data, and those should not be exported to tracing backends by default.
- Existing instrumentation and metrics stay available while raw statements require an explicit opt-in.

## Testing

- `go test ./database/sql/...` - passed
- `make lint` - passed with the existing gomodguard deprecation warning and 0 issues
