### PR TITLE
feat(crypto): support rsa fips-only encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,8 +841,9 @@ on clients when the dial address differs from the certificate DNS name.
 
 Important note:
 
-- If you are using `go-service-template` or composing the standard bundles such as `module.Server`, `module.Client`, or `transport.Module`, the required transport registration is handled for you by DI.
-- You only need to call transport-level `Register(...)` functions yourself when you intentionally wire transports manually or compose lower-level packages outside the standard module graph.
+- If you are using `go-service-template` or composing server transport bundles such as `module.Server` or `transport.Module`, the required transport registration is handled for you by DI.
+- `module.Client` does not wire transports by default. Add `transport.Module`, the relevant transport submodule, or call the transport-level `Register(...)` functions when a client process constructs HTTP or gRPC TLS config from source strings such as `file:`.
+- You only need to call transport-level `Register(...)` functions yourself when you intentionally wire transports manually or compose lower-level packages outside the transport module graph.
 - If you are wiring server lifecycle manually, use `net/server.Register(...)`.
 
 ### Forwarded IPs and reflection

--- a/crypto/rand/rand.go
+++ b/crypto/rand/rand.go
@@ -1,6 +1,7 @@
 package rand
 
 import (
+	"crypto/fips140"
 	"crypto/rand"
 	"math/big"
 
@@ -19,13 +20,16 @@ var ErrInvalidSize = errors.New("rand: invalid size")
 //
 // This is a thin wrapper around crypto/rand.Reader.
 func NewReader() Reader {
-	return rand.Reader
+	if fips140.Enforced() {
+		return rand.Reader
+	}
+
+	return Reader(rand.Reader)
 }
 
 // Reader is a cryptographically secure random source.
 //
-// It is defined as an aliasable type so it can be injected/mocked in tests while still behaving like
-// an io.Reader.
+// It is intentionally the same shape as io.Reader while remaining part of this package's crypto API.
 type Reader io.Reader
 
 // NewGenerator constructs a Generator that draws randomness from reader.
@@ -41,6 +45,11 @@ func NewGenerator(reader Reader) *Generator {
 // bytes or random text.
 type Generator struct {
 	reader Reader
+}
+
+// Reader returns the source used by the Generator.
+func (g *Generator) Reader() Reader {
+	return g.reader
 }
 
 // Read fills b with random bytes read from the underlying Reader.

--- a/crypto/rsa/encryptor.go
+++ b/crypto/rsa/encryptor.go
@@ -46,7 +46,7 @@ type Encryptor struct {
 //   - hash: SHA-512
 //   - label: nil
 //
-// The randomness source is the injected crypto/rand generator.
+// The randomness source is the injected generator's reader.
 func (e *Encryptor) Encrypt(msg []byte) ([]byte, error) {
-	return rsa.EncryptOAEP(sha512.New(), e.generator, e.publicKey, msg, nil)
+	return rsa.EncryptOAEP(sha512.New(), e.generator.Reader(), e.publicKey, msg, nil)
 }

--- a/module/doc.go
+++ b/module/doc.go
@@ -15,7 +15,7 @@
 //     server-side transports, telemetry, debugging, health checks, and common integrations).
 //
 //   - `Client`: a typical client composition (builds on Library and adds configuration decoding,
-//     client-side transports/integrations, telemetry, and common client helpers).
+//     telemetry, and common client integrations/helpers). It does not wire transports by default.
 //
 // # Enablement and configuration
 //

--- a/os/os.go
+++ b/os/os.go
@@ -40,6 +40,11 @@ func LookupEnv(key string) (string, bool) {
 	return os.LookupEnv(key)
 }
 
+// Environ returns a copy of strings representing the environment.
+func Environ() []string {
+	return os.Environ()
+}
+
 // Setenv sets the value of the environment variable named by key to value.
 func Setenv(key, value string) error {
 	return os.Setenv(key, value)

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -16,6 +16,7 @@ func TestEnv(t *testing.T) {
 	value, ok := os.LookupEnv(key)
 	require.True(t, ok)
 	require.Equal(t, "test", value)
+	require.Contains(t, os.Environ(), key+"=test")
 	require.NoError(t, os.Unsetenv(key))
 	value, ok = os.LookupEnv(key)
 	require.False(t, ok)


### PR DESCRIPTION
## What

- Route RSA-OAEP encryption through the random generator's exposed reader so standard wiring can pass the approved reader in FIPS-only mode.
- Preserve the exact standard-library crypto/rand.Reader from the rand package when FIPS-only mode is enforced.
- Add os.Environ to the repository os wrapper and cover it in the existing environment test.
- Clarify that module.Client does not wire transport registration by default for source-backed TLS config.

## Why

- Go FIPS-only mode rejects RSA-OAEP randomness unless the approved standard-library reader reaches the crypto operation.
- Client transport documentation should match the actual module.Client wiring contract.
- The os wrapper should cover the environment helpers used by repository code.

## Testing

- go test ./crypto/rand ./crypto/rsa ./module ./os - passed
- GODEBUG=fips140=only go test ./crypto/rsa -run TestValid -count=1 - passed
- make lint - passed

AI-assisted-by: [Codex](https://openai.com/codex/)