### PR TITLE
feat(http): close canceled retry bodies

### DIFF
--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -137,8 +137,17 @@ type RoundTripper struct {
 // this implementation relies on `req.GetBody`; when it is nil for a request with a body, the first attempt
 // is still executed but any retryable result is treated as non-retryable to avoid reusing a consumed body.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
+}
+
+func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
+	if err := req.Context().Err(); err != nil {
+		return nil, err, true
+	}
+
 	if r.policy != nil && !r.policy(req) {
-		return r.RoundTripper.RoundTrip(req)
+		res, err := r.RoundTripper.RoundTrip(req)
+		return res, err, false
 	}
 
 	attempt := &roundTripAttempt{}
@@ -149,7 +158,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	backoff := retry.WithMaxRetries(r.maxRetries, retry.NewConstant(r.backoff.Duration()))
 	res, err := retry.DoValue(req.Context(), backoff, operation)
-	return res, err
+	return res, err, false
 }
 
 func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *roundTripAttempt) (*http.Response, error) {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -357,6 +357,30 @@ func TestRoundTripperReturnsGetBodyError(t *testing.T) {
 	require.Equal(t, 1, rt.Calls)
 }
 
+func TestRoundTripperClosesBodyWhenContextAlreadyCanceled(t *testing.T) {
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusOK}}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	body := &test.TrackedBody{Reader: strings.NewReader("hello")}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", body)
+	require.NoError(t, err)
+	req.Body = body
+
+	res, err := retrying.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 0, rt.Calls)
+	require.True(t, body.Closed)
+}
+
 func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
 	rt := &test.ErrorRoundTripper{Err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
 	retrying := retry.NewRoundTripper(&retry.Config{


### PR DESCRIPTION
## What

- Close retry request bodies when the request context is already canceled before any attempt delegates to the underlying transport.
- Add a regression test that verifies pre-canceled retry requests do not call the transport and do close the body.

## Why

- The retry wrapper can return before go-retry invokes the attempt function, so no delegated RoundTripper owns the body in that path.
- Matching the existing ClosingRoundTripper ownership pattern prevents resource leaks for file, pipe, or pooled request bodies.

## Testing

- go test ./transport/http/retry ./transport/http/body ./transport/http/breaker ./transport/http - passed
- gmake lint - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
