### PR TITLE
feat(grpc): honor standard health and retry contracts

### DIFF
--- a/retry/doc.go
+++ b/retry/doc.go
@@ -1,0 +1,6 @@
+// Package retry provides shared retry helpers for go-service.
+//
+// It wraps the repository's retry/backoff implementation behind the go-service
+// import path so transport packages can share retry semantics without importing
+// third-party retry primitives directly.
+package retry

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,41 @@
+package retry
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/time"
+	retry "github.com/sethvargo/go-retry"
+)
+
+// Backoff aliases the upstream retry backoff interface.
+type Backoff = retry.Backoff
+
+// RetryFunc aliases the upstream retry function type.
+type RetryFunc = retry.RetryFunc
+
+// RetryFuncValue aliases the upstream retry value function type.
+type RetryFuncValue[T any] = retry.RetryFuncValue[T]
+
+// NewConstant creates a constant backoff.
+func NewConstant(t time.Duration) Backoff {
+	return retry.NewConstant(t.Duration())
+}
+
+// RetryableError marks err as retryable.
+func RetryableError(err error) error {
+	return retry.RetryableError(err)
+}
+
+// WithMaxRetries limits next to attempts retries after the initial attempt.
+func WithMaxRetries(attempts uint64, next Backoff) Backoff {
+	return retry.WithMaxRetries(attempts, next)
+}
+
+// Do wraps f with b and retries retryable errors.
+func Do(ctx context.Context, b Backoff, f RetryFunc) error {
+	return retry.Do(ctx, b, f)
+}
+
+// DoValue wraps f with b and retries retryable errors, returning the produced value.
+func DoValue[T any](ctx context.Context, b Backoff, f RetryFuncValue[T]) (T, error) {
+	return retry.DoValue(ctx, b, f)
+}

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -46,7 +46,7 @@ func TestCheck(t *testing.T) {
 func TestInvalidCheck(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
-	requireObservedHealth(t, world.GRPCHealth, test.Name.String(), false)
+	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -58,6 +58,37 @@ func TestInvalidCheck(t *testing.T) {
 	ctx := meta.NewOutgoingContext(t.Context(), md)
 
 	resp, err := client.Check(ctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, health.NotServing, resp.GetStatus())
+}
+
+func TestOverallCheck(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+
+	resp, err := client.Check(t.Context(), &health.Request{})
+	require.NoError(t, err)
+
+	require.Equal(t, health.Serving, resp.GetStatus())
+}
+
+func TestInvalidOverallCheck(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+
+	resp, err := client.Check(t.Context(), &health.Request{})
 	require.NoError(t, err)
 
 	require.Equal(t, health.NotServing, resp.GetStatus())
@@ -187,7 +218,7 @@ func TestWatchServerLimiter(t *testing.T) {
 func TestInvalidWatch(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
-	requireObservedHealth(t, world.GRPCHealth, test.Name.String(), false)
+	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -199,6 +230,49 @@ func TestInvalidWatch(t *testing.T) {
 	defer cancel()
 
 	wc, err := client.Watch(ctx, req)
+	require.NoError(t, err)
+
+	resp, err := wc.Recv()
+	require.NoError(t, err)
+
+	require.Equal(t, health.NotServing, resp.GetStatus())
+	requireWatchStaysOpen(t, cancel, wc)
+}
+
+func TestOverallWatch(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	wc, err := client.Watch(ctx, &health.Request{})
+	require.NoError(t, err)
+
+	resp, err := wc.Recv()
+	require.NoError(t, err)
+
+	require.Equal(t, health.Serving, resp.GetStatus())
+	requireWatchStaysOpen(t, cancel, wc)
+}
+
+func TestInvalidOverallWatch(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	wc, err := client.Watch(ctx, &health.Request{})
 	require.NoError(t, err)
 
 	resp, err := wc.Recv()
@@ -348,17 +422,13 @@ func requireGRPCConn(t *testing.T, world *test.World) *grpc.ClientConn {
 	return conn
 }
 
-func requireObservedHealth(t *testing.T, server *server.Server, service string, healthy bool) {
+func requireUnhealthyObservedHealth(t *testing.T, server *server.Server, service string) {
 	t.Helper()
 
 	observer, err := server.Observer(service, "grpc")
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		if healthy {
-			return observer.Error() == nil
-		}
-
 		return observer.Error() != nil
 	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
 }

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
@@ -52,7 +53,12 @@ type Server struct {
 //   - If the requested service does not exist, it returns `codes.NotFound`.
 //   - Otherwise, it returns a `Response` whose status is derived from the observer's error state.
 func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response, error) {
-	observer, err := s.server.Observer(req.GetService(), "grpc")
+	service := req.GetService()
+	if strings.IsEmpty(service) {
+		return &health.Response{Status: s.overallStatus()}, nil
+	}
+
+	observer, err := s.server.Observer(service, "grpc")
 	if err != nil {
 		return nil, status.SafeError(codes.NotFound, err)
 	}
@@ -111,7 +117,21 @@ func (s *Server) status(observer *subscriber.Observer) health.Status {
 	return health.Serving
 }
 
+func (s *Server) overallStatus() health.Status {
+	for _, observer := range s.server.Observers("grpc") {
+		if s.status(observer) != health.Serving {
+			return health.NotServing
+		}
+	}
+
+	return health.Serving
+}
+
 func (s *Server) watchStatus(service string) health.Status {
+	if strings.IsEmpty(service) {
+		return s.overallStatus()
+	}
+
 	observer, err := s.server.Observer(service, "grpc")
 	if err != nil {
 		return health.ServiceUnknown

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -4,8 +4,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/stretchr/testify/require"
@@ -193,6 +195,10 @@ func sayStreamHello(t *testing.T, client v1.GreeterServiceClient) error {
 	}
 
 	if err := stream.Send(&v1.SayStreamHelloRequest{Name: "test"}); err != nil {
+		if errors.Is(err, io.EOF) {
+			_, err = stream.Recv()
+		}
+
 		return err
 	}
 

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -5,9 +5,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
+	"github.com/alexfalkowski/go-service/v2/retry"
+	"github.com/alexfalkowski/go-service/v2/time"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 )
 
 // Config is an alias for `github.com/alexfalkowski/go-service/v2/transport/retry.Config`.
@@ -48,19 +50,16 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 
 // UnaryClientInterceptor returns a gRPC unary client interceptor that retries failed calls.
 //
-// The interceptor is built using `go-grpc-middleware`'s retry interceptor and is intended to be used on the
-// client side.
-//
 // Behavior:
 //   - It checks whether the logical RPC is eligible for retry using policies.
 //   - It uses the typed per-attempt timeout from cfg.GetTimeout() and the backoff duration from cfg.
 //   - It retries up to `cfg.MaxAttempts()` total attempts (including the initial attempt).
-//   - It applies a per-attempt timeout (`retry.WithPerRetryTimeout`) so each attempt is bounded.
-//   - It uses a linear backoff strategy with a step duration derived from `cfg.GetBackoff()`.
+//   - It applies a per-attempt timeout so each attempt is bounded.
+//   - It uses a constant backoff duration derived from `cfg.GetBackoff()`.
 //
 // Failure classification:
 // Retries are only attempted for selected gRPC status codes. This implementation currently retries on
-// `codes.Unavailable` (see `retry.WithCodes` in the implementation).
+// `codes.Unavailable`.
 //
 // Policy behavior:
 // When no policy is provided, only side-effect-safe unary RPCs are eligible for retry: AIP-style read methods,
@@ -72,20 +71,38 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 // status codes will not be retried by default.
 func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInterceptor {
 	policy := composePolicy(policies)
-	interceptor := retry.UnaryClientInterceptor(
-		retry.WithCodes(codes.Unavailable),
-		retry.WithMax(uint(cfg.MaxAttempts())),
-		retry.WithBackoff(retry.BackoffLinear(cfg.GetBackoff().Duration())),
-		retry.WithPerRetryTimeout(cfg.GetTimeout().Duration()),
-	)
+	maxAttempts := cfg.MaxAttempts()
+	timeout := cfg.GetTimeout()
+	backoffDuration := cfg.GetBackoff()
 
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if !policy(ctx, fullMethod, req) {
 			return invoker(ctx, fullMethod, req, resp, conn, opts...)
 		}
 
-		return interceptor(ctx, fullMethod, req, resp, conn, invoker, opts...)
+		return invokeWithRetries(ctx, maxAttempts, backoffDuration, func(ctx context.Context) error {
+			attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			return invoker(attemptCtx, fullMethod, req, resp, conn, opts...)
+		})
 	}
+}
+
+func invokeWithRetries(ctx context.Context, maxAttempts uint64, backoffDuration time.Duration, attempt func(context.Context) error) error {
+	if maxAttempts == 0 {
+		return attempt(ctx)
+	}
+
+	retries := retry.WithMaxRetries(maxAttempts-1, retry.NewConstant(backoffDuration))
+	return retry.Do(ctx, retries, func(ctx context.Context) error {
+		err := attempt(ctx)
+		if err == nil || status.Code(err) != codes.Unavailable {
+			return err
+		}
+
+		return retry.RetryableError(err)
+	})
 }
 
 func composePolicy(policies []Policy) Policy {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -31,6 +31,23 @@ func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsZero(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 0,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	})
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
 func TestUnaryClientInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 2,
@@ -104,6 +121,35 @@ func TestUnaryClientInterceptorDoesNotRetryDataLossByDefault(t *testing.T) {
 
 	require.Error(t, err)
 	require.Equal(t, 1, calls)
+}
+
+func TestUnaryClientInterceptorDoesNotRetryContextStatusCodesByDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		code codes.Code
+	}{
+		{name: "deadline exceeded", code: codes.DeadlineExceeded},
+		{name: "canceled", code: codes.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := retry.UnaryClientInterceptor(&config.Config{
+				Attempts: 2,
+				Timeout:  time.Second,
+				Backoff:  time.Millisecond,
+			})
+
+			calls := 0
+			err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				return status.Error(tt.code, tt.name)
+			})
+
+			require.Error(t, err)
+			require.Equal(t, 1, calls)
+		})
+	}
 }
 
 func TestUnaryClientInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) {

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -8,11 +8,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/retry"
 	"github.com/alexfalkowski/go-service/v2/time"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
 	"github.com/alexfalkowski/go-sync"
 	retryable "github.com/hashicorp/go-retryablehttp"
-	"github.com/sethvargo/go-retry"
 )
 
 // Config is an alias for `github.com/alexfalkowski/go-service/v2/transport/retry.Config`.
@@ -76,7 +76,7 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 //
 // Attempts/backoff:
 // `cfg.Attempts` is interpreted as the total attempt count (initial attempt + retries). Since
-// `sethvargo/go-retry` expects a retry count, NewRoundTripper converts it via `cfg.MaxRetries()`
+// the shared retry helper expects a retry count, NewRoundTripper converts it via `cfg.MaxRetries()`
 // before wrapping the constant backoff in `WithMaxRetries`.
 //
 // Policy behavior:
@@ -124,7 +124,7 @@ type RoundTripper struct {
 //   - it clones the request and replays the body when needed,
 //   - it checks whether the response/status error carries a retryable HTTP status code, and
 //   - it uses `retryablehttp.DefaultRetryPolicy` for transport error classification, and
-//   - if retryable, it returns a retryable error (`retry.RetryableError`) so the backoff schedules another attempt.
+//   - if retryable, it returns a retryable error so the backoff schedules another attempt.
 //
 // When the policy deems the result non-retryable, RoundTrip returns the response/error as produced by the
 // underlying transport.
@@ -156,7 +156,7 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 		return r.attempt(ctx, req, attempt)
 	}
 
-	backoff := retry.WithMaxRetries(r.maxRetries, retry.NewConstant(r.backoff.Duration()))
+	backoff := retry.WithMaxRetries(r.maxRetries, retry.NewConstant(r.backoff))
 	res, err := retry.DoValue(req.Context(), backoff, operation)
 	return res, err, false
 }


### PR DESCRIPTION
## What

- Return aggregate health status for empty gRPC health `Check` and `Watch` service names.
- Replace gRPC unary retry handling with a local retry loop backed by the shared retry helper so only `codes.Unavailable` is retried.
- Add a root `retry` wrapper package and update HTTP retry to use the go-service import path.
- Add tests for overall gRPC health behavior and non-retryable context status codes.

## Why

- Standard gRPC health clients use an empty service name to request overall server health.
- Retry classification should match the documented go-service policy instead of retrying `DeadlineExceeded` or `Canceled` through upstream per-attempt timeout behavior.
- Shared retry primitives should be imported through the repository wrapper rather than directly from third-party packages.

## Testing

- `go test ./retry ./transport/http/retry ./transport/grpc/retry ./transport/grpc/health ./transport/grpc` - passed
- `gmake lint` - passed
- `gmake specs` - passed
