### PR TITLE
docs(bytes): clarify size parser compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,18 @@ matching skill for the task.
   passing absurd configured `bytes.Size` values directly to it; callers that
   compare configuration-sized limits, such as cache decode size guards, must
   guard those limits before calling it.
+- `bytes.ParseSize` intentionally delegates human-readable size parsing to
+  `github.com/docker/go-units` for compatibility with existing configuration
+  values. Do not flag upstream float-to-int range behavior from absurdly large
+  size strings as a local issue unless this repository adds a public promise to
+  reject every representability edge case or a concrete supported path shows an
+  unsafe limit being applied from such a value. Do not flag accepted suffix
+  spellings such as `MiB` merely because `go-units.FromHumanSize` treats them
+  as decimal multipliers; that compatibility is documented local behavior. Do
+  not flag `bytes.Size` marshal/unmarshal round-trip failures for exabyte-scale
+  values solely because `go-units.HumanSize` can format suffixes that
+  `go-units.FromHumanSize` does not parse; that is accepted upstream behavior
+  unless this repository adds a strict round-trip promise for those values.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
 - PostgreSQL DSN security options, including TLS/`sslmode`, are intentionally
   part of the DSN supplied by the service configuration. `database/sql/pg`

--- a/bytes/size.go
+++ b/bytes/size.go
@@ -31,8 +31,12 @@ const PB Size = Size(units.PB)
 // It is a named type over int64 so it can expose config-friendly text and JSON
 // marshaling helpers while remaining easy to convert at API boundaries.
 //
-// Size uses the SI units understood by `github.com/docker/go-units`, such as
-// `B`, `kB`, `MB`, `GB`, and `TB`, rather than IEC binary units like `MiB`.
+// Size uses the decimal units understood by `github.com/docker/go-units`, such
+// as `B`, `kB`, `MB`, `GB`, and `TB`.
+//
+// Formatting and parsing intentionally follow go-units compatibility behavior.
+// They are not a strict inverse for exabyte-scale values because go-units can
+// format larger suffixes than FromHumanSize parses.
 type Size int64
 
 // Bytes returns s as a raw byte count.
@@ -84,16 +88,18 @@ func (s *Size) UnmarshalJSON(data []byte) error {
 	return s.UnmarshalText([]byte(text))
 }
 
-// ParseSize parses a human-readable SI size string.
+// ParseSize parses a human-readable decimal size string.
 //
-// The input uses decimal SI units such as `64B`, `2MB`, or `4GB`. Parsing is
-// delegated to `github.com/docker/go-units`.
+// The input uses the suffix compatibility rules from
+// `github.com/docker/go-units.FromHumanSize`. Parsed values are decimal sizes,
+// so accepted suffix spellings such as `MB` and `MiB` both use the decimal `M`
+// multiplier.
 func ParseSize(s string) (Size, error) {
 	size, err := units.FromHumanSize(s)
 	return Size(size), err
 }
 
-// MustParseSize parses s as a human-readable SI size string and panics if parsing fails.
+// MustParseSize parses s as a human-readable decimal size string and panics if parsing fails.
 //
 // This helper is intended for strict startup/configuration paths where an invalid
 // size is considered a fatal configuration/programming error. It panics by

--- a/config/options/options.go
+++ b/config/options/options.go
@@ -70,8 +70,8 @@ func (m Map) Uint32(key string, fallback uint32) uint32 {
 
 // Size returns a byte-size option for key if present; otherwise it returns fallback.
 //
-// The stored value must be a human-readable SI size string accepted by bytes.ParseSize, such as "64B",
-// "2MB", or "4GB".
+// The stored value must be a human-readable decimal size string accepted by bytes.ParseSize, such
+// as "64B", "2MB", or "4GB".
 //
 // Failure mode: if key is present but the value cannot be parsed as a size, Size will panic because
 // it uses bytes.MustParseSize. Use this helper only when the option values are validated or come from


### PR DESCRIPTION
## What

- Documented that human-readable size parsing follows `go-units.FromHumanSize` compatibility behavior.
- Clarified that accepted suffix spellings such as `MB` and `MiB` use decimal multipliers.
- Added review guidance so upstream `go-units` range and exabyte-scale formatter/parser asymmetries do not resurface as local findings without a stricter repo contract.

## Why

- The previous docs implied stricter SI-only parsing and strict marshal/unmarshal symmetry than the delegated upstream behavior provides.
- Keeping the behavior documented preserves compatibility with existing configuration values while avoiding repeated false-positive review findings.

## Testing

- `go test ./bytes ./config/options` - passed
- `make lint` - failed locally because BSD make cannot parse the GNU make include
- `gmake lint` - passed
