### PR TITLE
feat(cli): preserve client shutdown codes

### DIFF
--- a/cli/application.go
+++ b/cli/application.go
@@ -132,7 +132,21 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 				return a.prefix(name, err)
 			}
 
-			return a.prefix(name, app.Stop(a.stopContext(ctx)))
+			var code int
+			select {
+			case signal := <-app.Wait():
+				code = signal.ExitCode
+			default:
+			}
+
+			if err := app.Stop(a.stopContext(ctx)); err != nil {
+				return a.prefix(name, err)
+			}
+			if code > 0 {
+				return a.prefix(name, shutdownError(code))
+			}
+
+			return nil
 		},
 	}
 	runtime.Must(a.register(cmd))

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -273,6 +273,30 @@ func TestApplicationServerShutdownExitCodeIsReturned(t *testing.T) {
 	require.Equal(t, 3, app.RunCode(t.Context()))
 }
 
+func TestApplicationClientShutdownExitCodeIsReturned(t *testing.T) {
+	os.Args = []string{test.Name.String(), "client"}
+	cli.Name = test.Name
+	cli.Version = test.Version
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddClient(
+				"client",
+				"Start the client.",
+				di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
+					lc.Append(di.Hook{
+						OnStart: func(context.Context) error {
+							return sh.Shutdown(di.ExitCode(3))
+						},
+					})
+				}),
+			)
+		},
+	)
+
+	require.Equal(t, 3, app.RunCode(t.Context()))
+}
+
 func TestApplicationServerServeFailureReturnsServeFailureExitCode(t *testing.T) {
 	os.Args = []string{test.Name.String(), "server"}
 	cli.Name = test.Name


### PR DESCRIPTION
## What

- Preserve DI shutdown exit codes returned by client-style commands.
- Added a regression test for a client command that requests a non-zero `di.ExitCode` during startup.

## Why

- `Application.RunCode` documents that DI shutdown exit codes are returned for both command styles, but the client path did not read the Fx shutdown signal before stopping.
- Matching the server path keeps client and server exit-code behavior consistent.

## Testing

- `go test ./cli` - passed
- `gmake lint` - passed
- `git diff --check` - passed
