### PR TITLE
docs(config): document default lookup environment contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ matching skill for the task.
 
 - `config.NewDecoder` resolves `-i` as `file:<path>`, `env:<ENV_VAR>`, or a default config file named for the service.
 - Default file lookup checks the executable directory, `$XDG_CONFIG_HOME/<serviceName>/`, and `/etc/<serviceName>/`.
+  When default lookup reaches the user config directory candidate, HOME or
+  XDG_CONFIG_HOME is expected to be available; missing both is treated as a
+  misconfigured runtime. Do not flag the resulting `os.UserConfigDir` panic as
+  a config issue. Services that do not want this environment contract should
+  pass an explicit `-i file:<path>` or `-i env:<ENV_VAR>` source.
 - Many config fields use source strings through `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
 - Service configuration files should contain configuration values and secret
   source references, not raw passwords or credentials.

--- a/config/default.go
+++ b/config/default.go
@@ -42,6 +42,10 @@ type Default struct {
 //
 // The first match is opened and decoded using the encoder keyed by the discovered kind/extension.
 // If no configuration file is found, Decode returns ErrLocationMissing.
+// If default lookup reaches the user config directory candidate, the runtime is
+// expected to provide HOME or XDG_CONFIG_HOME so os.UserConfigDir can resolve.
+// Missing both is treated as a misconfigured runtime; use an explicit
+// "file:<path>" or "env:<ENV_VAR>" source to avoid the default lookup contract.
 //
 // Note: this decoder assumes the encoding.Map contains decoders for the supported kinds. In the standard
 // go-service module graph, those encoders are registered for you (for example via `encoding.Module` in

--- a/config/doc.go
+++ b/config/doc.go
@@ -15,6 +15,11 @@
 //   - otherwise: uses the default lookup, searching for "<serviceName>.{yaml,yml,hjson,toml,json}" in common
 //     locations (executable directory, user config dir, and /etc).
 //
+// Default lookup intentionally requires a valid user configuration directory environment when it reaches
+// the user config directory candidate. Runtimes using default lookup should provide HOME or
+// XDG_CONFIG_HOME. Services that do not want that environment contract should pass an explicit source
+// with "file:<path>" or "env:<ENV_VAR>".
+//
 // # Decoding and validation
 //
 // For typed configuration, use `NewConfig[T]`, which:


### PR DESCRIPTION
## What

- Documented that default config lookup expects HOME or XDG_CONFIG_HOME when it reaches the user config directory candidate.
- Pointed services that do not want that runtime contract to explicit `file:` or `env:` config sources.
- Added review guidance so the intentional `os.UserConfigDir` panic is not resurfaced as a config issue.

## Why

- Missing HOME/XDG_CONFIG_HOME is considered a misconfigured runtime for default lookup.
- The docs now match the intended fail-fast policy instead of implying the user config directory is optional in that environment.

## Testing

- `go test ./config/...` - passed
- `gmake lint` - passed
- `git diff --check` - passed
