### PR TITLE
feat(feature): respect provider lifecycle contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,14 @@ matching skill for the task.
   credentials; they should contain source references such as `env:NAME` or
   `file:/path`. Do not flag this as a secret leak unless a concrete code path
   starts placing raw secrets into HJSON configuration contrary to that policy.
+- OpenFeature trace event attributes are produced by the upstream
+  `hooks.NewTracesHook` implementation and may include semantic-convention
+  fields such as the evaluation context targeting key and evaluated flag value.
+  Treat this as documented upstream instrumentation behavior; protect telemetry
+  exporter and backend access controls. Do not flag it as a local `feature`
+  issue unless this repository adds local feature trace attribute construction,
+  logs/exports those values independently, or starts promising sanitized feature
+  trace events by default.
 
 ## Testing, Style, And Docs
 

--- a/feature/doc.go
+++ b/feature/doc.go
@@ -11,13 +11,17 @@
 // provided by the consuming service).
 //
 // When a provider is present, `Register` appends lifecycle hooks that:
-//   - call `openfeature.SetProviderAndWait` during application start, and
-//   - call `openfeature.Shutdown` during application stop.
+//   - call `openfeature.SetProviderWithContextAndWait` during application start, and
+//   - call `openfeature.ShutdownWithContext` during application stop.
 //
 // # Telemetry hooks
 //
 // When a metrics provider is available, `Register` installs OpenTelemetry hooks for OpenFeature so
 // evaluations can emit metrics and traces.
+//
+// Trace event attributes are produced by the upstream OpenFeature OpenTelemetry hook. They may include
+// OpenFeature semantic-convention fields such as the targeting key and evaluated flag value. Treat
+// feature trace data as operational telemetry and protect exporter/back-end access accordingly.
 //
 // # Clients
 //

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -42,8 +42,8 @@ type ProviderParams struct {
 //   - If a MetricProvider is available, Register installs OpenTelemetry hooks so evaluations emit metrics
 //     and traces.
 //   - Register appends lifecycle hooks that:
-//   - set the OpenFeature provider during application start (openfeature.SetProviderAndWait), and
-//   - shut down the OpenFeature SDK during application stop (openfeature.Shutdown).
+//   - set the OpenFeature provider during application start, and
+//   - shut down the OpenFeature SDK during application stop.
 func Register(params ProviderParams) {
 	if params.FeatureProvider == nil {
 		return
@@ -57,14 +57,10 @@ func Register(params ProviderParams) {
 	}
 
 	params.Lifecycle.Append(di.Hook{
-		OnStart: func(_ context.Context) error {
-			return openfeature.SetProviderAndWait(params.FeatureProvider)
+		OnStart: func(ctx context.Context) error {
+			return openfeature.SetProviderWithContextAndWait(ctx, params.FeatureProvider)
 		},
-		OnStop: func(_ context.Context) error {
-			openfeature.Shutdown()
-
-			return nil
-		},
+		OnStop: openfeature.ShutdownWithContext,
 	})
 }
 


### PR DESCRIPTION
## What

- Use OpenFeature context-aware provider startup and shutdown APIs from the Fx lifecycle hooks.
- Update feature package docs to describe the context-aware lifecycle calls.
- Document upstream OpenFeature trace-hook attributes in AGENTS.md so future issue passes do not treat that library behavior as a local finding.

## Why

- Provider startup and shutdown should honor lifecycle cancellation and deadlines.
- OpenFeature trace attributes are produced by upstream instrumentation and should be handled as protected telemetry rather than flagged as local feature code leakage.

## Testing

- `go test ./feature` - passed
- `gmake lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
