### PR TITLE
docs(id): clarify generator registry contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,14 @@ matching skill for the task.
   issue unless this repository adds local feature trace attribute construction,
   logs/exports those values independently, or starts promising sanitized feature
   trace events by default.
+- The UUIDv7 generator intentionally calls `google/uuid.EnableRandPool` at
+  package init time. UUID is the default ID generator and sits on request
+  metadata hot paths; the process-wide heap-backed random pool tradeoff is
+  accepted for these operational identifiers, which are not secrets or bearer
+  tokens. Do not flag this as a global-state or security issue unless the
+  generator starts being used for secret material, the upstream pool semantics
+  change materially, or a public API starts promising no `google/uuid` global
+  mutation.
 
 ## Testing, Style, And Docs
 

--- a/id/id.go
+++ b/id/id.go
@@ -46,8 +46,8 @@ type MapParams struct {
 //   - "nanoid"
 //   - "xid"
 //
-// Callers can add additional kinds or override existing kinds by mutating the returned Map
-// (this package does not currently expose a Register method; the map is typically fixed by wiring).
+// The map is fixed by standard wiring. Services that need custom generator kinds should provide
+// custom DI wiring for Map or Generator selection.
 func NewMap(params MapParams) *Map {
 	return &Map{
 		generators: map[string]Generator{


### PR DESCRIPTION
## What

- Clarify that the ID generator map is fixed by standard wiring and custom kinds should use custom DI or generator selection.
- Document the intentional `google/uuid` random-pool tradeoff for UUIDv7 so future reviews do not flag the default hot-path optimization as a local issue.

## Why

- The previous `NewMap` docs implied callers could mutate the returned registry even though the map has no public mutation API.
- UUID is the default operational ID generator and sits on request metadata hot paths, so the process-wide random-pool optimization is an accepted documented tradeoff.

## Testing

- `go test ./id/...` - passed
- `gmake lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
