### PR TITLE
feat(meta): isolate request attributes

### DIFF
--- a/meta/meta.go
+++ b/meta/meta.go
@@ -8,7 +8,11 @@ import (
 // NoPrefix is a convenience constant for passing an empty prefix to export helpers.
 const NoPrefix = strings.Empty
 
-const meta = context.Key("meta")
+// contextKey is the package-private type used for metadata context storage.
+type contextKey struct{}
+
+// metaKey keeps metadata storage isolated from exported string-backed context keys.
+var metaKey contextKey
 
 // WithAttributes returns a copy of ctx with all provided attributes stored.
 //
@@ -20,7 +24,7 @@ func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
 		return ctx
 	}
 
-	return context.WithValue(ctx, meta, attributes(ctx).AddPairs(pairs...))
+	return context.WithValue(ctx, metaKey, attributes(ctx).AddPairs(pairs...))
 }
 
 // Attribute returns the stored attribute value for key.

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -3,6 +3,7 @@ package meta_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +56,19 @@ func TestWithAttributesReturnsSameContextWithoutPairs(t *testing.T) {
 	ctx := t.Context()
 
 	require.Same(t, ctx, meta.WithAttributes(ctx))
+}
+
+func TestWithAttributesDoesNotCollideWithStringContextKey(t *testing.T) {
+	ctx := context.WithValue(t.Context(), context.Key("meta"), "bad")
+
+	require.NotPanics(t, func() {
+		require.True(t, meta.Attribute(ctx, meta.RequestIDKey).IsEmpty())
+	})
+
+	ctx = meta.WithAttributes(ctx, meta.WithRequestID(meta.String("request-id")))
+
+	require.Equal(t, "bad", ctx.Value(context.Key("meta")))
+	require.Equal(t, meta.String("request-id"), meta.Attribute(ctx, meta.RequestIDKey))
 }
 
 func TestPairHelpers(t *testing.T) {

--- a/meta/storage.go
+++ b/meta/storage.go
@@ -79,7 +79,7 @@ func (s Storage) key(prefix, key string) string {
 }
 
 func attributes(ctx context.Context) Storage {
-	m := ctx.Value(meta)
+	m := ctx.Value(metaKey)
 	if m == nil {
 		// Nil Storage avoids allocating on read-only paths; map reads, ranges, and the first AddPairs call are nil-safe.
 		return nil


### PR DESCRIPTION
## What

- Store metadata with a package-private context key to prevent collisions with external string-backed keys.
- Add regression coverage for the former context.Key("meta") collision path.

## Why

- Avoid panics or forged metadata when callers pass contexts containing a colliding key.

## Testing

- `go test ./meta ./net/http/meta ./net/grpc/meta ./telemetry/logger ./transport/limiter` - passed
- `make lint` - passed
- `make specs` - passed
