### PR TITLE
feat(telemetry): require explicit otlp endpoints and honor log levels

### DIFF
--- a/internal/test/benchmark.go
+++ b/internal/test/benchmark.go
@@ -38,7 +38,7 @@ func EnableTracer(tb testing.TB) {
 
 	require.NoError(tb, tracer.Register(tracer.TracerParams{
 		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{Kind: "otlp"},
+		Config:      &tracer.Config{Kind: "otlp", URL: "https://localhost:4318/v1/traces"},
 		ID:          ID,
 		Name:        Name,
 		Version:     Version,

--- a/telemetry/internal/otlp/endpoint.go
+++ b/telemetry/internal/otlp/endpoint.go
@@ -8,8 +8,20 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
+// ErrMissingEndpoint is returned when an OTLP exporter is enabled without an explicit endpoint.
+var ErrMissingEndpoint = errors.New("otlp: missing endpoint")
+
 // ErrInsecureEndpoint is returned when secret headers would be sent over a non-local HTTP endpoint.
 var ErrInsecureEndpoint = errors.New("otlp: insecure endpoint")
+
+// ValidateRequiredEndpoint validates an explicitly configured OTLP endpoint.
+func ValidateRequiredEndpoint(rawURL string, headers map[string]string) error {
+	if strings.IsEmpty(rawURL) {
+		return ErrMissingEndpoint
+	}
+
+	return ValidateEndpoint(rawURL, headers)
+}
 
 // ValidateEndpoint rejects accidental cleartext OTLP endpoints when exporter headers are configured.
 func ValidateEndpoint(rawURL string, headers map[string]string) error {

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -26,3 +26,21 @@ func TestValidateEndpointInvalidURL(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
+
+func TestValidateRequiredEndpoint(t *testing.T) {
+	headers := map[string]string{"Authorization": "Bearer token"}
+
+	require.ErrorIs(t, otlp.ValidateRequiredEndpoint("", headers), otlp.ErrMissingEndpoint)
+	require.NoError(t, otlp.ValidateRequiredEndpoint("https://collector.example.com/v1/traces", headers))
+
+	err := otlp.ValidateRequiredEndpoint("http://collector.example.com/v1/traces", headers)
+	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestValidateRequiredEndpointIgnoresEnv(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector.example.com/v1/traces")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
+
+	err := otlp.ValidateRequiredEndpoint("", map[string]string{"Authorization": "Bearer token"})
+	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
+}

--- a/telemetry/logger/config.go
+++ b/telemetry/logger/config.go
@@ -37,8 +37,8 @@ type Config struct {
 
 	// URL is the destination endpoint for the selected Kind, when applicable.
 	//
-	// For "otlp", this is the OTLP/HTTP logs endpoint URL. It must be a valid HTTP URL
-	// when set.
+	// For "otlp", this is the required OTLP/HTTP logs endpoint URL. It must be a
+	// valid HTTP URL.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`
 
 	// Level is the minimum log level to emit.

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -133,3 +133,59 @@ func TestInvalidOTLPEndpoint(t *testing.T) {
 	_, err := logger.NewLogger(params)
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
+
+func TestMissingOTLPEndpointIgnoresEnv(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://collector.example.com/v1/logs")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
+
+	lc := fxtest.NewLifecycle(t)
+	cfg := &logger.Config{
+		Kind: "otlp",
+		Headers: header.Map{
+			"Authorization": "Bearer token",
+		},
+	}
+	params := logger.LoggerParams{
+		Lifecycle:   lc,
+		Config:      cfg,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}
+
+	_, err := logger.NewLogger(params)
+	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
+}
+
+func TestOTLPLoggerUsesConfiguredLevel(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := &logger.Config{
+		Kind:  "otlp",
+		Level: "error",
+		URL:   "https://localhost:4318/v1/logs",
+	}
+	params := logger.LoggerParams{
+		Lifecycle:   lc,
+		Config:      cfg,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}
+
+	log, err := logger.NewLogger(params)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	require.False(t, log.Enabled(ctx, slog.LevelInfo))
+	require.False(t, log.Enabled(ctx, slog.LevelWarn))
+	require.True(t, log.Enabled(ctx, slog.LevelError))
+
+	child := log.With("component", "test").WithGroup("otlp")
+	require.False(t, child.Enabled(ctx, slog.LevelWarn))
+	require.True(t, child.Enabled(ctx, slog.LevelError))
+	require.NotPanics(t, func() {
+		child.ErrorContext(ctx, "exported")
+	})
+}

--- a/telemetry/logger/otlp.go
+++ b/telemetry/logger/otlp.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
-	if err := otlp.ValidateEndpoint(params.Config.URL, params.Config.Headers); err != nil {
+	if err := otlp.ValidateRequiredEndpoint(params.Config.URL, params.Config.Headers); err != nil {
 		return nil, err
 	}
 
@@ -51,5 +51,28 @@ func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
 		},
 	})
 
-	return otelslog.NewLogger(params.Name.String(), otelslog.WithLoggerProvider(provider)), nil
+	handler := otelslog.NewHandler(params.Name.String(), otelslog.WithLoggerProvider(provider))
+
+	return slog.New(&levelHandler{handler: handler, level: level(params.Config)}), nil
+}
+
+type levelHandler struct {
+	handler slog.Handler
+	level   slog.Level
+}
+
+func (h *levelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= h.level && h.handler.Enabled(ctx, level)
+}
+
+func (h *levelHandler) Handle(ctx context.Context, record slog.Record) error {
+	return h.handler.Handle(ctx, record)
+}
+
+func (h *levelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &levelHandler{handler: h.handler.WithAttrs(attrs), level: h.level}
+}
+
+func (h *levelHandler) WithGroup(name string) slog.Handler {
+	return &levelHandler{handler: h.handler.WithGroup(name), level: h.level}
 }

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -28,8 +28,8 @@ type Config struct {
 
 	// URL is the destination endpoint for the selected Kind, when applicable.
 	//
-	// For "otlp", this is the OTLP/HTTP metrics endpoint URL. It must be a valid HTTP URL
-	// when set.
+	// For "otlp", this is the required OTLP/HTTP metrics endpoint URL. It must be a
+	// valid HTTP URL.
 	//
 	// For "prometheus", URL is typically ignored by the exporter/reader implementation.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`

--- a/telemetry/metrics/reader.go
+++ b/telemetry/metrics/reader.go
@@ -49,7 +49,7 @@ func NewReader(lc di.Lifecycle, name env.Name, cfg *Config) (metric.Reader, erro
 func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
 	switch cfg.Kind {
 	case "otlp":
-		if err := otlp.ValidateEndpoint(cfg.URL, cfg.Headers); err != nil {
+		if err := otlp.ValidateRequiredEndpoint(cfg.URL, cfg.Headers); err != nil {
 			return nil, prefix(err)
 		}
 

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -32,3 +32,19 @@ func TestInvalidOTLPEndpoint(t *testing.T) {
 	_, err := metrics.NewReader(lc, test.Name, cfg)
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
+
+func TestMissingOTLPEndpointIgnoresEnv(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://collector.example.com/v1/metrics")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
+
+	lc := fxtest.NewLifecycle(t)
+	cfg := &metrics.Config{
+		Kind: "otlp",
+		Headers: header.Map{
+			"Authorization": "Bearer token",
+		},
+	}
+
+	_, err := metrics.NewReader(lc, test.Name, cfg)
+	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
+}

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -23,8 +23,8 @@ type Config struct {
 
 	// URL is the destination endpoint for the selected Kind, when applicable.
 	//
-	// For "otlp", this is the OTLP/HTTP traces endpoint URL. It must be a valid HTTP URL
-	// when set.
+	// For "otlp", this is the required OTLP/HTTP traces endpoint URL. It must be a
+	// valid HTTP URL.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`
 }
 

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -72,7 +72,7 @@ func Register(params TracerParams) error {
 
 	switch params.Config.Kind {
 	case "otlp":
-		if err := otlp.ValidateEndpoint(params.Config.URL, params.Config.Headers); err != nil {
+		if err := otlp.ValidateRequiredEndpoint(params.Config.URL, params.Config.Headers); err != nil {
 			return prefix(err)
 		}
 

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -32,7 +32,7 @@ func TestIsEnabled(t *testing.T) {
 
 	require.NoError(t, tracer.Register(tracer.TracerParams{
 		Lifecycle:   fxtest.NewLifecycle(t),
-		Config:      &tracer.Config{Kind: "otlp"},
+		Config:      &tracer.Config{Kind: "otlp", URL: "https://localhost:4318/v1/traces"},
 		ID:          test.ID,
 		Name:        test.Name,
 		Version:     test.Version,
@@ -72,4 +72,21 @@ func TestRegisterInvalidOTLPEndpoint(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestRegisterMissingOTLPEndpointIgnoresEnv(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://collector.example.com/v1/traces")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
+
+	err := tracer.Register(tracer.TracerParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config: &tracer.Config{
+			Kind: "otlp",
+			Headers: header.Map{
+				"Authorization": "Bearer token",
+			},
+		},
+	})
+
+	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
 }


### PR DESCRIPTION
## What

- Require explicit OTLP endpoint URLs for logs, metrics, and traces instead of falling back to OpenTelemetry endpoint environment variables.
- Apply the configured minimum log level to OTLP slog output.
- Update OTLP config comments and add coverage for missing endpoints, env fallback prevention, and OTLP log level filtering.

## Why

- Service telemetry configuration should come from the configured file values, not implicit OTEL endpoint environment variables.
- OTLP logging should respect the same level contract as the stdout and tint logger paths.

## Testing

- `go test ./internal/test ./telemetry/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
