### PR TITLE
docs(telemetry): clarify sql span option review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,13 @@ matching skill for the task.
   insecure DSN could be supplied; only report concrete bugs such as accidental
   DSN rewriting, secret leakage, or a public API promise to enforce secure DSN
   policy.
+- SQL OpenTelemetry query text capture is disabled by the supported
+  `database/sql/pg` DI wiring, and ping spans are disabled by the upstream
+  zero-value `otelsql.SpanOptions`. Do not flag lower-level manual
+  `database/sql/telemetry.WithSpanOptions` use solely because a caller could
+  replace those defaults unless a supported config/DI path exposes that option,
+  raw SQL text is emitted by repository code, or the public API starts promising
+  safe merging of arbitrary span options.
 - RSA public-key loading intentionally validates the repository's key-size
   policy and delegates deeper RSA parameter checks, such as public exponent
   usability, to the standard library operations that consume the key. Do not


### PR DESCRIPTION
## What

- Added AGENTS guidance for SQL OpenTelemetry span option review.
- Documented that supported PostgreSQL DI wiring disables query text capture and leaves ping spans disabled through upstream zero values.

## Why

- Prevent future issue-finding passes from flagging lower-level manual span option replacement when the supported config/DI path does not expose it.
- Keep the guidance narrow so real SQL text emission, supported config exposure, or changed public API promises can still be reported.

## Testing

- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
