### PR TITLE
feat(bytes): preserve exact size round trips

### DIFF
--- a/bytes/size.go
+++ b/bytes/size.go
@@ -1,6 +1,8 @@
 package bytes
 
 import (
+	"strconv"
+
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	units "github.com/docker/go-units"
@@ -50,10 +52,9 @@ func (s Size) String() string {
 	return units.HumanSize(float64(s.Bytes()))
 }
 
-// MarshalText encodes s using the same decimal size string returned by
-// [Size.String].
+// MarshalText encodes s as an exact raw byte count with a `B` suffix.
 func (s Size) MarshalText() ([]byte, error) {
-	return []byte(s.String()), nil
+	return []byte(strconv.FormatInt(s.Bytes(), 10) + "B"), nil
 }
 
 // UnmarshalText parses a decimal size string into s.
@@ -70,9 +71,14 @@ func (s *Size) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// MarshalJSON encodes s as a quoted decimal size string, such as `"4MB"`.
+// MarshalJSON encodes s as a quoted exact raw byte count, such as `"4000000B"`.
 func (s Size) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.String())
+	text, err := s.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(string(text))
 }
 
 // UnmarshalJSON decodes a quoted decimal size string into s.

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -17,15 +17,29 @@ func TestDefaultSize(t *testing.T) {
 }
 
 func TestSizeTextRoundTrip(t *testing.T) {
-	size := bytes.MustParseSize("4MB")
+	tests := []struct {
+		name string
+		text string
+		size bytes.Size
+	}{
+		{name: "decimal boundary", size: bytes.MustParseSize("4MB"), text: "4000000B"},
+		{name: "above byte boundary", size: bytes.Size(1001), text: "1001B"},
+		{name: "binary megabyte", size: bytes.Size(1048576), text: "1048576B"},
+		{name: "below decimal megabyte", size: bytes.Size(999999), text: "999999B"},
+		{name: "above decimal megabyte", size: bytes.Size(1000001), text: "1000001B"},
+	}
 
-	text, err := size.MarshalText()
-	require.NoError(t, err)
-	require.Equal(t, "4MB", string(text))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, err := tt.size.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tt.text, string(text))
 
-	var decoded bytes.Size
-	require.NoError(t, decoded.UnmarshalText(text))
-	require.Equal(t, size, decoded)
+			var decoded bytes.Size
+			require.NoError(t, decoded.UnmarshalText(text))
+			require.Equal(t, tt.size, decoded)
+		})
+	}
 }
 
 func TestSizeJSONRoundTrip(t *testing.T) {
@@ -34,6 +48,18 @@ func TestSizeJSONRoundTrip(t *testing.T) {
 	data, err := json.Marshal(size)
 	require.NoError(t, err)
 	require.Equal(t, `"64B"`, string(data))
+
+	var decoded bytes.Size
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, size, decoded)
+}
+
+func TestSizeJSONRoundTripPreservesByteCount(t *testing.T) {
+	size := bytes.Size(1048576)
+
+	data, err := json.Marshal(size)
+	require.NoError(t, err)
+	require.Equal(t, `"1048576B"`, string(data))
 
 	var decoded bytes.Size
 	require.NoError(t, json.Unmarshal(data, &decoded))


### PR DESCRIPTION
## What

- Changed size text and JSON marshaling to emit exact byte-count strings with a `B` suffix.
- Added round-trip coverage for non-decimal-boundary byte counts such as `1048576`.

## Why

- Human-readable formatting can round ordinary byte counts, so using it for serialization could change limits after marshal/unmarshal.
- Keeping `String()` human-readable while making marshal output exact preserves display behavior and fixes persisted/interchanged values.

## Testing

- `go test ./bytes` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
