### PR TITLE
feat(cache): harden redis instrumentation lifecycle

### DIFF
--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -30,6 +30,9 @@ var ErrMissing = errors.New("cache: missing")
 // ErrNotFound is returned when the configured cache driver kind is unknown.
 var ErrNotFound = errors.New("cache: driver not found")
 
+// ErrInvalidURL is returned when a cache backend URL cannot be parsed.
+var ErrInvalidURL = errors.New("cache: invalid driver url")
+
 // DriverParams defines dependencies for constructing a Driver.
 type DriverParams struct {
 	di.In
@@ -81,43 +84,54 @@ func NewDriver(params DriverParams) (Driver, error) {
 
 	switch cfg.Kind {
 	case "redis":
-		data, err := params.FS.ReadSource(cfg.Options["url"].(string))
-		if err != nil {
-			return nil, err
-		}
-
-		opts, err := client.ParseURL(bytes.String(data))
-		if err != nil {
-			return nil, err
-		}
-
-		opts.MaintNotificationsConfig = &notifications.Config{
-			Mode: notifications.ModeDisabled,
-		}
-		if params.Logger != nil {
-			client.SetLogger(redisLogger{logger: params.Logger})
-		}
-
-		redisClient := client.NewClient(opts)
-		if tracer.IsEnabled() {
-			runtime.Must(telemetry.InstrumentTracing(redisClient))
-		}
-		if metrics.IsEnabled() {
-			runtime.Must(telemetry.InstrumentMetrics(redisClient))
-		}
-
-		params.Lifecycle.Append(di.Hook{
-			OnStop: func(context.Context) error {
-				return redisClient.Close()
-			},
-		})
-
-		return &redisDriver{client: redisClient}, nil
+		return newRedisDriver(params)
 	case "sync":
 		return &syncDriver{}, nil
 	default:
 		return nil, ErrNotFound
 	}
+}
+
+func newRedisDriver(params DriverParams) (Driver, error) {
+	data, err := params.FS.ReadSource(params.Config.Options["url"].(string))
+	if err != nil {
+		return nil, err
+	}
+
+	opts, err := client.ParseURL(bytes.String(data))
+	if err != nil {
+		return nil, ErrInvalidURL
+	}
+
+	opts.MaintNotificationsConfig = &notifications.Config{
+		Mode: notifications.ModeDisabled,
+	}
+	if params.Logger != nil {
+		client.SetLogger(redisLogger{logger: params.Logger})
+	}
+
+	redisClient := client.NewClient(opts)
+	if tracer.IsEnabled() {
+		runtime.Must(telemetry.InstrumentTracing(redisClient))
+	}
+
+	var metricsClose chan struct{}
+	if metrics.IsEnabled() {
+		metricsClose = make(chan struct{})
+		runtime.Must(telemetry.InstrumentMetrics(redisClient, metricsClose))
+	}
+
+	params.Lifecycle.Append(di.Hook{
+		OnStop: func(context.Context) error {
+			if metricsClose != nil {
+				close(metricsClose)
+			}
+
+			return redisClient.Close()
+		},
+	})
+
+	return &redisDriver{client: redisClient}, nil
 }
 
 // Driver is the minimal cache backend interface used by the cache facade.

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/time"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
@@ -50,6 +53,52 @@ func TestRedisClientClosesOnStop(t *testing.T) {
 	require.ErrorIs(t, err, redis.ErrClosed)
 }
 
+func TestRedisParseURLDoesNotLeakCredentials(t *testing.T) {
+	url := "redis://user:" + "secret%zz@localhost:6379"
+	cfg := &config.Config{
+		Kind: "redis",
+		Options: map[string]any{
+			"url": url,
+		},
+	}
+
+	_, err := driver.NewDriver(driver.DriverParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		FS:        test.FS,
+		Config:    cfg,
+	})
+
+	require.ErrorIs(t, err, driver.ErrInvalidURL)
+	require.NotContains(t, err.Error(), "secret")
+	require.NotContains(t, err.Error(), "redis://user")
+}
+
+func TestRedisMetricsUnregisterOnStop(t *testing.T) {
+	reader := setupMetrics(t)
+	lc := fxtest.NewLifecycle(t)
+	cfg := &config.Config{
+		Kind: "redis",
+		Options: map[string]any{
+			"url": "redis://localhost:6379",
+		},
+	}
+
+	_, err := driver.NewDriver(driver.DriverParams{
+		Lifecycle: lc,
+		FS:        test.FS,
+		Config:    cfg,
+	})
+	require.NoError(t, err)
+
+	lc.RequireStart()
+	require.Positive(t, redisMetricCount(t, reader))
+
+	lc.RequireStop()
+	require.Eventually(t, func() bool {
+		return redisMetricCount(t, reader) == 0
+	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
+}
+
 func TestSyncDriverHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -61,4 +110,44 @@ func TestSyncDriverHonorsCanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorIs(t, d.Delete(ctx, "key"), context.Canceled)
 	require.ErrorIs(t, d.Flush(ctx), context.Canceled)
+}
+
+func setupMetrics(t *testing.T) metrics.Reader {
+	t.Helper()
+
+	test.ResetTelemetry(t)
+	t.Cleanup(func() {
+		test.ResetTelemetry(t)
+	})
+
+	reader := metrics.NewManualReader()
+	metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(t),
+		Config:      &metrics.Config{},
+		Reader:      reader,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+
+	return reader
+}
+
+func redisMetricCount(t *testing.T, reader metrics.Reader) int {
+	t.Helper()
+
+	got := &metrics.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), got))
+
+	count := 0
+	for _, scope := range got.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if strings.HasPrefix(metric.Name, "db.client.connections.") {
+				count++
+			}
+		}
+	}
+
+	return count
 }

--- a/cache/telemetry/telemetry.go
+++ b/cache/telemetry/telemetry.go
@@ -19,10 +19,15 @@ func InstrumentTracing(client client.UniversalClient) error {
 
 // InstrumentMetrics instruments a Redis client for OpenTelemetry metrics.
 //
-// This is a thin wrapper around redisotel.InstrumentMetrics.
+// This is a thin wrapper around redisotel.InstrumentMetrics. If closeChan is
+// provided, observable callbacks are unregistered when it is closed.
 //
 // The provided client is modified in place to emit Redis client metrics. The
 // wrapper does not change upstream behavior or error semantics.
-func InstrumentMetrics(client client.UniversalClient) error {
-	return redisotel.InstrumentMetrics(client)
+func InstrumentMetrics(client client.UniversalClient, closeChan ...chan struct{}) error {
+	if len(closeChan) == 0 {
+		return redisotel.InstrumentMetrics(client)
+	}
+
+	return redisotel.InstrumentMetrics(client, redisotel.WithCloseChan(closeChan[0]))
 }

--- a/database/sql/driver/driver_test.go
+++ b/database/sql/driver/driver_test.go
@@ -118,7 +118,7 @@ func registerDriver(t *testing.T) string {
 func requireDBStatsMetrics(t *testing.T, reader metrics.Reader) {
 	t.Helper()
 
-	got := &metricdata.ResourceMetrics{}
+	got := &metrics.ResourceMetrics{}
 	require.NoError(t, reader.Collect(t.Context(), got))
 	require.Len(t, got.ScopeMetrics, 1)
 	require.Len(t, got.ScopeMetrics[0].Metrics, 7)
@@ -127,7 +127,7 @@ func requireDBStatsMetrics(t *testing.T, reader metrics.Reader) {
 func requireNoDBStatsMetrics(t *testing.T, reader metrics.Reader) {
 	t.Helper()
 
-	got := &metricdata.ResourceMetrics{}
+	got := &metrics.ResourceMetrics{}
 	require.NoError(t, reader.Collect(t.Context(), got))
 	require.Empty(t, got.ScopeMetrics)
 }
@@ -135,7 +135,7 @@ func requireNoDBStatsMetrics(t *testing.T, reader metrics.Reader) {
 func requireDBSystemName(t *testing.T, reader metrics.Reader, name string) {
 	t.Helper()
 
-	got := &metricdata.ResourceMetrics{}
+	got := &metrics.ResourceMetrics{}
 	require.NoError(t, reader.Collect(t.Context(), got))
 
 	for _, scope := range got.ScopeMetrics {

--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"go.opentelemetry.io/otel/metric"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // MeterProvider is an alias for metric.MeterProvider.
@@ -17,6 +18,9 @@ type Registration = metric.Registration
 
 // Reader is an alias for sdkmetric.Reader.
 type Reader = sdk.Reader
+
+// ResourceMetrics is an alias for metricdata.ResourceMetrics.
+type ResourceMetrics = metricdata.ResourceMetrics
 
 // NewMeter returns a Meter from provider using the service name and version.
 //


### PR DESCRIPTION
## What

- Sanitize invalid Redis URL parse failures with a stable driver error.
- Wire Redis metrics instrumentation to the driver lifecycle so observable callbacks unregister on stop.
- Add a metrics.ResourceMetrics alias and regression coverage for Redis metric cleanup and URL error redaction.

## Why

- Prevent malformed Redis URLs from exposing resolved credentials through parse errors.
- Avoid stale or duplicated Redis connection metrics after a Redis client is closed.
- Keep metric test helpers on repository telemetry types instead of direct SDK resource metric construction.

## Testing

- `go test ./cache/... ./database/sql/driver ./telemetry/metrics` - passed
- `make lint` - passed
