### PR TITLE
feat(cache): harden redis instrumentation lifecycle

### DIFF
--- a/cache/telemetry/telemetry.go
+++ b/cache/telemetry/telemetry.go
@@ -19,15 +19,11 @@ func InstrumentTracing(client client.UniversalClient) error {
 
 // InstrumentMetrics instruments a Redis client for OpenTelemetry metrics.
 //
-// This is a thin wrapper around redisotel.InstrumentMetrics. If closeChan is
-// provided, observable callbacks are unregistered when it is closed.
+// This is a thin wrapper around redisotel.InstrumentMetrics that unregisters
+// observable callbacks when closeChan is closed.
 //
 // The provided client is modified in place to emit Redis client metrics. The
 // wrapper does not change upstream behavior or error semantics.
-func InstrumentMetrics(client client.UniversalClient, closeChan ...chan struct{}) error {
-	if len(closeChan) == 0 {
-		return redisotel.InstrumentMetrics(client)
-	}
-
-	return redisotel.InstrumentMetrics(client, redisotel.WithCloseChan(closeChan[0]))
+func InstrumentMetrics(client client.UniversalClient, closeChan chan struct{}) error {
+	return redisotel.InstrumentMetrics(client, redisotel.WithCloseChan(closeChan))
 }


### PR DESCRIPTION
## What

- Sanitize invalid Redis URL parse failures with a stable driver error.
- Wire Redis metrics instrumentation to the driver lifecycle so observable callbacks unregister on stop.
- Keep cache telemetry metrics cleanup explicit with a single lifecycle close channel.
- Add a metrics.ResourceMetrics alias and regression coverage for Redis metric cleanup and URL error redaction.

## Why

- Prevent malformed Redis URLs from exposing resolved credentials through parse errors.
- Avoid stale or duplicated Redis connection metrics after a Redis client is closed.
- Keep metric test helpers on repository telemetry types instead of direct SDK resource metric construction.

## Testing

- `go test ./cache/... ./database/sql/driver ./telemetry/metrics` - passed
- `make lint` - passed
