### PR TITLE
feat(cli): preserve shutdown exit codes on stop failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,13 @@ matching skill for the task.
 - `cli.RunCode` returns `os.ExitCodeSuccess` on success, preserves non-zero
   shutdown exit codes requested through `di.ExitCode(...)`, and otherwise
   returns `os.ExitCodeFailure`.
+- `cli.Application.Run` intentionally sanitizes Go test harness `-test.*`
+  arguments before handing `os.Args` to the command runner because this
+  repository commonly exercises CLI applications through Go test binaries. Do
+  not flag this solely because a hypothetical downstream command could define a
+  user-facing flag with the reserved `test.` prefix; report only concrete
+  breakage in a supported CLI contract or an explicit public promise to
+  preserve `-test.*` command flags.
 - `net/server.Service` intentionally logs asynchronous `Server.Serve` errors
   and requests shutdown with `di.ExitCode(os.ExitCodeServeFailure)`; it does not
   return the raw serve error from `Stop`.

--- a/cli/application.go
+++ b/cli/application.go
@@ -85,11 +85,8 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 			case <-ctx.Done():
 			}
 
-			if err := app.Stop(a.stopContext(ctx)); err != nil {
-				return a.prefix(name, err)
-			}
-			if code > 0 {
-				return a.prefix(name, shutdownError(code))
+			if err := a.shutdownError(name, app.Stop(a.stopContext(ctx)), code); err != nil {
+				return err
 			}
 
 			return nil
@@ -139,11 +136,8 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 			default:
 			}
 
-			if err := app.Stop(a.stopContext(ctx)); err != nil {
-				return a.prefix(name, err)
-			}
-			if code > 0 {
-				return a.prefix(name, shutdownError(code))
+			if err := a.shutdownError(name, app.Stop(a.stopContext(ctx)), code); err != nil {
+				return err
 			}
 
 			return nil
@@ -207,6 +201,14 @@ func (a *Application) register(command cmd.Command) error {
 
 func (a *Application) prefix(prefix string, err error) error {
 	return errors.Prefix(prefix+": failed to run", di.RootCause(err))
+}
+
+func (a *Application) shutdownError(name string, err error, code int) error {
+	if code > 0 {
+		err = errors.Join(err, shutdownError(code))
+	}
+
+	return a.prefix(name, err)
 }
 
 func (a *Application) code(err error) int {

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/cli"
@@ -273,6 +274,22 @@ func TestApplicationServerShutdownExitCodeIsReturned(t *testing.T) {
 	require.Equal(t, 3, app.RunCode(t.Context()))
 }
 
+func TestApplicationServerShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) {
+	os.Args = []string{test.Name.String(), "server"}
+	cli.Name = test.Name
+	cli.Version = test.Version
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddServer("server", "Start the server.", shutdownExitCodeAndStopErrorOption(3))
+		},
+	)
+
+	err := app.Run(t.Context())
+	require.ErrorIs(t, err, test.ErrFailed)
+	require.Equal(t, 3, app.RunCode(t.Context()))
+}
+
 func TestApplicationClientShutdownExitCodeIsReturned(t *testing.T) {
 	os.Args = []string{test.Name.String(), "client"}
 	cli.Name = test.Name
@@ -294,6 +311,22 @@ func TestApplicationClientShutdownExitCodeIsReturned(t *testing.T) {
 		},
 	)
 
+	require.Equal(t, 3, app.RunCode(t.Context()))
+}
+
+func TestApplicationClientShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) {
+	os.Args = []string{test.Name.String(), "client"}
+	cli.Name = test.Name
+	cli.Version = test.Version
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddClient("client", "Start the client.", shutdownExitCodeAndStopErrorOption(3))
+		},
+	)
+
+	err := app.Run(t.Context())
+	require.ErrorIs(t, err, test.ErrFailed)
 	require.Equal(t, 3, app.RunCode(t.Context()))
 }
 
@@ -335,4 +368,21 @@ func TestApplicationInvalidClient(t *testing.T) {
 			require.Contains(t, err.Error(), "unknown port")
 		})
 	}
+}
+
+func shutdownExitCodeAndStopErrorOption(code int) di.Option {
+	return di.Module(
+		di.NoLogger,
+		di.Constructor(slog.Default),
+		di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
+			lc.Append(di.Hook{
+				OnStart: func(context.Context) error {
+					return sh.Shutdown(di.ExitCode(code))
+				},
+				OnStop: func(context.Context) error {
+					return test.ErrFailed
+				},
+			})
+		}),
+	)
 }


### PR DESCRIPTION
## What

- Preserve requested shutdown exit codes when CLI application stop hooks also return errors.
- Add server and client regression coverage for shutdown exit code plus stop failure paths.
- Document the intentional CLI test-harness argument sanitization behavior in AGENTS.md.

## Why

- Keep RunCode aligned with its public contract to return non-zero di.ExitCode values even when shutdown cleanup also fails.
- Keep future issue passes from re-raising the accepted -test.* argument sanitization behavior without concrete supported-contract breakage.

## Testing

- `go test ./cli` - passed
- `make lint` - passed
