### PR TITLE
feat(time): add timer constructor

### DIFF
--- a/time/doc.go
+++ b/time/doc.go
@@ -8,7 +8,8 @@
 //     go-service can consistently import go-service packages while still using the
 //     underlying time semantics.
 //
-//     Exported types include Time (an alias of time.Time), Duration (a named type over
+//     Exported types include Time (an alias of time.Time), Timer and Ticker
+//     (aliases of time.Timer and time.Ticker), Duration (a named type over
 //     time.Duration), common duration constants (Second, Minute, Hour, etc.), and RFC3339.
 //
 //  2. Optional network time sourcing.
@@ -24,8 +25,9 @@
 //   - Time aliases time.Time.
 //   - Duration wraps time.Duration and adds Text/JSON marshaling helpers while preserving
 //     Go duration string semantics.
-//   - Now, Since, Sleep, and ParseDuration forward to time.Now, time.Since,
-//     time.Sleep, and time.ParseDuration respectively.
+//   - Now, Since, Sleep, NewTimer, NewTicker, and ParseDuration forward to
+//     time.Now, time.Since, time.Sleep, time.NewTimer, time.NewTicker, and
+//     time.ParseDuration respectively.
 //   - Constants such as Second, Minute, Hour, and RFC3339 mirror the standard library
 //     values.
 //

--- a/time/time.go
+++ b/time/time.go
@@ -13,6 +13,12 @@ const RFC3339 = time.RFC3339
 // set to the standard library type.
 type Ticker = time.Ticker
 
+// Timer is the go-service timer type used across the repository.
+//
+// It is a type alias of time.Timer, meaning it has identical semantics and method
+// set to the standard library type.
+type Timer = time.Timer
+
 // Time is the go-service time type used across the repository.
 //
 // It is a type alias of time.Time, meaning it has identical semantics and method
@@ -25,6 +31,13 @@ type Time = time.Time
 // This is a thin wrapper around time.After and does not change semantics.
 func After(d Duration) <-chan Time {
 	return time.After(d.Duration())
+}
+
+// NewTimer returns a new [Timer] that will send the current time on its channel after at least duration d.
+//
+// This is a thin wrapper around time.NewTimer and does not change semantics.
+func NewTimer(d Duration) *Timer {
+	return time.NewTimer(d.Duration())
 }
 
 // NewTicker returns a new [Ticker] containing a channel that will send the current time on the channel after each tick.

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,0 +1,21 @@
+package time_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTimer(t *testing.T) {
+	timer := time.NewTimer(time.Nanosecond)
+	require.NotNil(t, timer)
+	defer timer.Stop()
+
+	select {
+	case tm := <-timer.C:
+		require.False(t, tm.IsZero())
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for timer")
+	}
+}


### PR DESCRIPTION
## What

- Added a go-service `Timer` alias for the standard library timer type.
- Added `NewTimer` as a thin wrapper around `time.NewTimer` that accepts the repository `Duration` type.
- Updated package documentation and added a focused test covering timer creation and delivery.

## Why

- Callers can stay on the go-service time package for timer construction, matching the existing `NewTicker`, `After`, `Now`, `Since`, and `Sleep` wrappers.

## Testing

- `go test ./time` - passed
- `make lint` - passed with 0 issues; emitted the existing gomodguard deprecation warning.

AI-assisted-by: [Codex](https://openai.com/codex/)
