### PR TITLE
test(net): cover low-level lifecycle and metadata behavior

### DIFF
--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -58,6 +58,21 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnaryClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
+	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
+	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+
+	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{"caller-id"}, md.Get("request-id"))
+		require.Equal(t, grpcmeta.String("caller-id"), meta.RequestID(ctx))
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 	ctx := grpcmeta.WithAttributes(t.Context(),
 		grpcmeta.WithUserAgent(grpcmeta.String("current-agent")),
@@ -110,6 +125,25 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 	require.Nil(t, stream)
 }
 
+func TestStreamClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
+	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
+	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{"caller-id"}, md.Get("request-id"))
+		require.Equal(t, grpcmeta.String("caller-id"), meta.RequestID(ctx))
+
+		return nil, nil
+	}
+
+	stream, err := interceptor(
+		ctx, &grpc.StreamDesc{ServerStreams: true}, nil, "/greet.v1.Greeter/SayStreamHello", streamer,
+	)
+	require.NoError(t, err)
+	require.Nil(t, stream)
+}
+
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
@@ -140,6 +174,19 @@ func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 	require.Equal(t, "ok", resp)
 }
 
+func TestUnaryServerInterceptorPreservesIncomingRequestID(t *testing.T) {
+	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
+		require.Equal(t, grpcmeta.String("caller-id"), meta.RequestID(ctx))
+
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+}
+
 func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
@@ -148,6 +195,21 @@ func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
 		require.Equal(t, grpcmeta.String("127.0.0.1"), grpcmeta.IPAddr(ctx))
+
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+}
+
+func TestUnaryServerInterceptorPrefersForwardedIPAddr(t *testing.T) {
+	interceptor := grpcmeta.UnaryServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("x-forwarded-for", "203.0.113.10, 10.0.0.1"))
+	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
+		require.Equal(t, grpcmeta.String("x-forwarded-for"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
+		require.Equal(t, grpcmeta.String("203.0.113.10"), grpcmeta.IPAddr(ctx))
 
 		return "ok", nil
 	})
@@ -185,6 +247,20 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"1", "v2"}, stream.Header.Get("service-version"))
 	require.Equal(t, []string{"generated-id"}, stream.Header.Get("request-id"))
+}
+
+func TestStreamServerInterceptorPreservesIncomingRequestID(t *testing.T) {
+	interceptor := grpcmeta.StreamServerInterceptor(env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
+	stream := &test.MetaServerStream{Ctx: ctx}
+
+	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(_ any, stream grpc.ServerStream) error {
+		require.Equal(t, grpcmeta.String("caller-id"), meta.RequestID(stream.Context()))
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"caller-id"}, stream.Header.Get("request-id"))
 }
 
 func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {

--- a/net/grpc/server/server_test.go
+++ b/net/grpc/server/server_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/server"
@@ -42,8 +43,91 @@ func TestShutdownClosesUnservedListener(t *testing.T) {
 	require.Nil(t, conn)
 }
 
+func TestShutdownStopsServerWhenContextCanceled(t *testing.T) {
+	srv, blocking := newServerWithBlockingGreeter(t)
+	serveErrCh := serve(srv)
+	rpcErrCh := startBlockingSayHello(t, srv, blocking)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.ErrorIs(t, srv.Shutdown(ctx), context.Canceled)
+	require.Error(t, <-rpcErrCh)
+	require.NoError(t, <-serveErrCh)
+}
+
 func TestNewServerWithInvalidNetwork(t *testing.T) {
 	srv, err := server.NewServer(grpc.NewServer(test.ConfigOptions, time.Second), &config.Config{Address: "invalid://:0"})
 	require.Error(t, err)
 	require.Nil(t, srv)
+}
+
+func newServerWithBlockingGreeter(t *testing.T) (*server.Server, *blockingService) {
+	t.Helper()
+
+	grpcServer := grpc.NewServer(test.ConfigOptions, time.Second)
+	blocking := newBlockingService()
+	v1.RegisterGreeterServiceServer(grpcServer, blocking)
+
+	srv, err := server.NewServer(grpcServer, &config.Config{Address: ":0"})
+	require.NoError(t, err)
+
+	return srv, blocking
+}
+
+func serve(srv *server.Server) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve()
+	}()
+
+	return errCh
+}
+
+func startBlockingSayHello(t *testing.T, srv *server.Server, blocking *blockingService) <-chan error {
+	t.Helper()
+
+	conn, err := grpc.NewClient(srv.String(), grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	rpcCtx, cancelRPC := context.WithCancel(t.Context())
+	t.Cleanup(cancelRPC)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := v1.NewGreeterServiceClient(conn).SayHello(rpcCtx, &v1.SayHelloRequest{Name: "test"})
+		errCh <- err
+	}()
+
+	select {
+	case <-blocking.started:
+	case <-time.After(time.Second):
+		cancelRPC()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_ = srv.Shutdown(ctx)
+		require.FailNow(t, "timeout waiting for blocking gRPC method to start")
+	}
+
+	return errCh
+}
+
+type blockingService struct {
+	v1.UnimplementedGreeterServiceServer
+
+	started chan struct{}
+}
+
+func newBlockingService() *blockingService {
+	return &blockingService{started: make(chan struct{})}
+}
+
+func (s *blockingService) SayHello(ctx context.Context, _ *v1.SayHelloRequest) (*v1.SayHelloResponse, error) {
+	close(s.started)
+	<-ctx.Done()
+
+	return nil, ctx.Err()
 }

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/options"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -45,6 +46,46 @@ func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestProtocols(t *testing.T) {
+	protocols := http.Protocols()
+
+	require.True(t, protocols.HTTP1())
+	require.True(t, protocols.HTTP2())
+	require.True(t, protocols.UnencryptedHTTP2())
+}
+
+func TestTransport(t *testing.T) {
+	cfg := &tls.Config{}
+
+	transport := http.Transport(cfg)
+
+	require.NotNil(t, transport.Proxy)
+	require.NotNil(t, transport.DialContext)
+	require.True(t, transport.ForceAttemptHTTP2)
+	require.Equal(t, 100, transport.MaxIdleConns)
+	require.Equal(t, 100, transport.MaxIdleConnsPerHost)
+	require.Equal(t, 100, transport.MaxConnsPerHost)
+	require.Equal(t, (90 * time.Second).Duration(), transport.IdleConnTimeout)
+	require.Equal(t, (10 * time.Second).Duration(), transport.TLSHandshakeTimeout)
+	require.Equal(t, time.Second.Duration(), transport.ExpectContinueTimeout)
+	require.Same(t, cfg, transport.TLSClientConfig)
+	require.NotNil(t, transport.Protocols)
+	require.True(t, transport.Protocols.HTTP1())
+	require.True(t, transport.Protocols.HTTP2())
+	require.True(t, transport.Protocols.UnencryptedHTTP2())
+}
+
+func TestNewServerSetsProtocols(t *testing.T) {
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	server := http.NewServer(options.Map{}, time.Second, handler)
+
+	require.NotNil(t, server.Protocols)
+	require.True(t, server.Protocols.HTTP1())
+	require.True(t, server.Protocols.HTTP2())
+	require.True(t, server.Protocols.UnencryptedHTTP2())
 }
 
 func TestSameOriginRedirect(t *testing.T) {

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -16,7 +16,20 @@ func TestNetworkAddressValue(t *testing.T) {
 }
 
 func TestHost(t *testing.T) {
-	require.Equal(t, "none", net.Host("none"))
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{name: "host port", addr: "localhost:9000", want: "localhost"},
+		{name: "fallback", addr: "none", want: "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, net.Host(tt.addr))
+		})
+	}
 }
 
 func TestSplitAndJoinHostPort(t *testing.T) {

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -35,6 +35,26 @@ func TestRegisterStopErrors(t *testing.T) {
 	require.Equal(t, 1, second.Shutdowns)
 }
 
+func TestRegisterStartsAllServices(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	first := test.NewObservableServer(nil, nil)
+	second := test.NewObservableServer(nil, nil)
+	sh := test.NewShutdowner()
+
+	server.Register(lc, []*server.Service{
+		server.NewService("first", first, nil, sh),
+		server.NewService("second", second, nil, sh),
+	})
+
+	require.NoError(t, lc.Start(t.Context()))
+	waitForRegisteredService(t, first.Done)
+	waitForRegisteredService(t, second.Done)
+
+	require.NoError(t, lc.Stop(t.Context()))
+	require.Equal(t, 1, first.Shutdowns)
+	require.Equal(t, 1, second.Shutdowns)
+}
+
 func TestRegisterSnapshotsServices(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	original := test.NewObservableServer(nil, nil)
@@ -57,4 +77,14 @@ func TestRegisterSnapshotsServices(t *testing.T) {
 	require.NoError(t, lc.Stop(t.Context()))
 	require.Equal(t, 1, original.Shutdowns)
 	require.Equal(t, 0, replacement.Shutdowns)
+}
+
+func waitForRegisteredService(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.Fail(t, "registered service was not started")
+	}
 }

--- a/net/server/service_test.go
+++ b/net/server/service_test.go
@@ -2,10 +2,12 @@ package server_test
 
 import (
 	"testing"
-	"time"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -53,6 +55,20 @@ func TestValidServer(t *testing.T) {
 	require.NoError(t, svc.Stop(t.Context()))
 }
 
+func TestStartReturnsWhileServeIsRunning(t *testing.T) {
+	sh := test.NewShutdowner()
+	srv := newBlockingServer()
+	svc := server.NewService("test", srv, nil, sh)
+
+	startDone := startService(svc)
+
+	requireStartReturned(t, startDone, srv)
+	requireServeStarted(t, srv)
+
+	require.NoError(t, svc.Stop(t.Context()))
+	require.False(t, sh.Called())
+}
+
 func TestInvalidStop(t *testing.T) {
 	sh := test.NewShutdowner()
 	srv := test.NewObservableServer(nil, test.ErrFailed)
@@ -61,4 +77,101 @@ func TestInvalidStop(t *testing.T) {
 	err := svc.Stop(t.Context())
 	require.EqualError(t, err, "test: failed")
 	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestStopPassesContextToServer(t *testing.T) {
+	sh := test.NewShutdowner()
+	srv := &contextServer{}
+	svc := server.NewService("test", srv, nil, sh)
+	ctx := context.WithValue(t.Context(), contextServerKey{}, "caller-value")
+
+	require.NoError(t, svc.Stop(ctx))
+
+	require.Equal(t, "caller-value", srv.ctx.Value(contextServerKey{}))
+}
+
+type blockingServer struct {
+	started chan struct{}
+	stop    chan struct{}
+	once    sync.Once
+}
+
+func newBlockingServer() *blockingServer {
+	return &blockingServer{
+		started: make(chan struct{}),
+		stop:    make(chan struct{}),
+	}
+}
+
+func (s *blockingServer) Serve() error {
+	close(s.started)
+	<-s.stop
+
+	return nil
+}
+
+func (s *blockingServer) Shutdown(context.Context) error {
+	s.release()
+
+	return nil
+}
+
+func (*blockingServer) String() string {
+	return "test"
+}
+
+func (s *blockingServer) release() {
+	s.once.Do(func() { close(s.stop) })
+}
+
+func startService(svc *server.Service) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		svc.Start()
+		close(done)
+	}()
+
+	return done
+}
+
+func requireStartReturned(t *testing.T, done <-chan struct{}, srv *blockingServer) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		srv.release()
+		require.FailNow(t, "timeout waiting for Start to return")
+	}
+}
+
+func requireServeStarted(t *testing.T, srv *blockingServer) {
+	t.Helper()
+
+	select {
+	case <-srv.started:
+	case <-time.After(time.Second):
+		srv.release()
+		require.FailNow(t, "timeout waiting for server to serve")
+	}
+}
+
+type contextServerKey struct{}
+
+type contextServer struct {
+	ctx context.Context
+}
+
+func (*contextServer) Serve() error {
+	return nil
+}
+
+func (s *contextServer) Shutdown(ctx context.Context) error {
+	s.ctx = ctx
+
+	return nil
+}
+
+func (*contextServer) String() string {
+	return "test"
 }


### PR DESCRIPTION
## What

- Added focused coverage for low-level host parsing, HTTP protocol and transport defaults, gRPC metadata preservation, forwarded IP extraction, gRPC shutdown cancellation, and generic server lifecycle behavior.
- Kept the new blocking test doubles local to the tests that need them and removed the stale local net issue ledger.

## Why

- These cases were identified as remaining low-level coverage gaps after accounting for behavior already covered through transport tests.
- The new tests protect request ID continuity, forwarded IP preference, asynchronous server startup, multi-service registration, shutdown context propagation, and canceled gRPC graceful shutdown behavior.

## Testing

- `go test ./net/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
