### PR TITLE
test(transport): cover lifecycle and telemetry gaps

### DIFF
--- a/transport/breaker/breaker_test.go
+++ b/transport/breaker/breaker_test.go
@@ -1,0 +1,39 @@
+package breaker_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/transport/breaker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSettings(t *testing.T) {
+	settings := breaker.DefaultSettings
+
+	require.Equal(t, uint32(3), settings.MaxRequests)
+	require.Equal(t, (30 * time.Second).Duration(), settings.Interval)
+	require.Equal(t, (10 * time.Second).Duration(), settings.Timeout)
+	require.False(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 4}))
+	require.True(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 5}))
+}
+
+func TestNewCircuitBreaker(t *testing.T) {
+	errFailed := errors.New("failed")
+	cb := breaker.NewCircuitBreaker(breaker.Settings{
+		ReadyToTrip: func(counts breaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+	})
+
+	_, err := cb.Execute(func() (any, error) {
+		return nil, errFailed
+	})
+	require.ErrorIs(t, err, errFailed)
+
+	_, err = cb.Execute(func() (any, error) {
+		return "ok", nil
+	})
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+}

--- a/transport/config_test.go
+++ b/transport/config_test.go
@@ -1,0 +1,13 @@
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/transport"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigIsEnabled(t *testing.T) {
+	require.False(t, (*transport.Config)(nil).IsEnabled())
+	require.True(t, (&transport.Config{}).IsEnabled())
+}

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -43,6 +43,28 @@ func TestCheck(t *testing.T) {
 	require.Equal(t, health.Serving, resp.GetStatus())
 }
 
+func TestCheckBypassesServerLimiter(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"),
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
+	)
+	requireGRPCReady(t, world)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+	req := &health.Request{Service: test.Name.String()}
+
+	resp, err := client.Check(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, health.Serving, resp.GetStatus())
+
+	resp, err = client.Check(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, health.Serving, resp.GetStatus())
+}
+
 func TestInvalidCheck(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -8,9 +8,14 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
 )
 
 func TestServerLimiterUnary(t *testing.T) {
@@ -21,11 +26,17 @@ func TestServerLimiterUnary(t *testing.T) {
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
+	header := meta.Map{}
 
-	_, _ = client.SayHello(t.Context(), req)
-	_, err := client.SayHello(t.Context(), req)
+	_, err := client.SayHello(t.Context(), req, grpc.Header(&header))
+	require.NoError(t, err)
+	require.NotEmpty(t, header.Get("ratelimit"))
+
+	rejectedHeader := meta.Map{}
+	_, err = client.SayHello(t.Context(), req, grpc.Header(&rejectedHeader))
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.NotEmpty(t, rejectedHeader.Get("ratelimit"))
 }
 
 func TestServerLimiterStream(t *testing.T) {
@@ -36,10 +47,32 @@ func TestServerLimiterStream(t *testing.T) {
 
 	client := v1.NewGreeterServiceClient(conn)
 
-	_ = sayStreamHello(t, client)
+	require.NoError(t, sayStreamHello(t, client))
 	err := sayStreamHello(t, client)
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestServerLimiterStreamHeader(t *testing.T) {
+	limiter, err := grpclimiter.NewServerLimiter(fxtest.NewLifecycle(t), limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0))
+	require.NoError(t, err)
+	ctx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+	interceptor := grpclimiter.StreamServerInterceptor(limiter)
+
+	allowed := &test.MetaServerStream{Ctx: ctx}
+	err = interceptor(nil, allowed, &grpc.StreamServerInfo{FullMethod: "/greet.v1.GreeterService/SayStreamHello"}, func(any, grpc.ServerStream) error {
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, allowed.Header.Get("ratelimit"))
+
+	rejected := &test.MetaServerStream{Ctx: ctx}
+	err = interceptor(nil, rejected, &grpc.StreamServerInfo{FullMethod: "/greet.v1.GreeterService/SayStreamHello"}, func(any, grpc.ServerStream) error {
+		return nil
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.NotEmpty(t, rejected.Header.Get("ratelimit"))
 }
 
 func TestClientLimiterUnary(t *testing.T) {

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -33,6 +33,20 @@ func TestServer(t *testing.T) {
 	lc.RequireStop()
 }
 
+func TestDisabledServer(t *testing.T) {
+	srv, err := grpc.NewServer(grpc.ServerParams{Config: nil})
+
+	require.NoError(t, err)
+	require.Nil(t, srv)
+}
+
+func TestNilServer(t *testing.T) {
+	var srv *grpc.Server
+
+	require.Nil(t, srv.ServiceRegistrar())
+	require.Nil(t, srv.GetService())
+}
+
 func TestInvalidServer(t *testing.T) {
 	cfg := &grpc.Config{
 		Config: &server.Config{

--- a/transport/grpc/telemetry/logger/logger_test.go
+++ b/transport/grpc/telemetry/logger/logger_test.go
@@ -1,13 +1,143 @@
 package logger_test
 
 import (
+	"log/slog"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
-	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	grpclogger "github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogger(t *testing.T) {
-	require.Equal(t, logger.LevelError, logger.CodeToLevel(codes.DeadlineExceeded))
+func TestUnaryServerInterceptorLogs(t *testing.T) {
+	var logs bytes.Buffer
+	interceptor := grpclogger.UnaryServerInterceptor(newLogger(&logs))
+
+	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.GreeterService/SayHello"}, func(context.Context, any) (any, error) {
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+	require.Contains(t, logs.String(), `"level":"INFO"`)
+	require.Contains(t, logs.String(), `"msg":"grpc: /greet.v1.GreeterService/SayHello"`)
+	require.Contains(t, logs.String(), `"system":"grpc"`)
+	require.Contains(t, logs.String(), `"service":"greet.v1.GreeterService"`)
+	require.Contains(t, logs.String(), `"method":"SayHello"`)
+	require.Contains(t, logs.String(), `"code":"OK"`)
+}
+
+func TestUnaryServerInterceptorSkipsOperationMethod(t *testing.T) {
+	var logs bytes.Buffer
+	interceptor := grpclogger.UnaryServerInterceptor(newLogger(&logs))
+	called := false
+
+	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}, func(context.Context, any) (any, error) {
+		called = true
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+	require.True(t, called)
+	require.Empty(t, logs.String())
+}
+
+func TestStreamServerInterceptorLogs(t *testing.T) {
+	var logs bytes.Buffer
+	interceptor := grpclogger.StreamServerInterceptor(newLogger(&logs))
+	stream := &test.MetaServerStream{Ctx: t.Context()}
+
+	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.GreeterService/SayStreamHello"}, func(any, grpc.ServerStream) error {
+		return status.Error(codes.NotFound, "missing")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, codes.NotFound, status.Code(err))
+	require.Contains(t, logs.String(), `"level":"WARN"`)
+	require.Contains(t, logs.String(), `"msg":"grpc: /greet.v1.GreeterService/SayStreamHello"`)
+	require.Contains(t, logs.String(), `"system":"grpc"`)
+	require.Contains(t, logs.String(), `"service":"greet.v1.GreeterService"`)
+	require.Contains(t, logs.String(), `"method":"SayStreamHello"`)
+	require.Contains(t, logs.String(), `"code":"NotFound"`)
+	require.Contains(t, logs.String(), `"error":"rpc error: code = NotFound desc = missing"`)
+}
+
+func TestUnaryClientInterceptorLogs(t *testing.T) {
+	var logs bytes.Buffer
+	interceptor := grpclogger.UnaryClientInterceptor(newLogger(&logs))
+	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
+
+	err = interceptor(t.Context(), "/greet.v1.GreeterService/SayHello", nil, nil, conn, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+	require.Contains(t, logs.String(), `"level":"ERROR"`)
+	require.Contains(t, logs.String(), `"msg":"grpc: passthrough:///backend/greet.v1.GreeterService/SayHello"`)
+	require.Contains(t, logs.String(), `"system":"grpc"`)
+	require.Contains(t, logs.String(), `"service":"greet.v1.GreeterService"`)
+	require.Contains(t, logs.String(), `"method":"SayHello"`)
+	require.Contains(t, logs.String(), `"code":"Unavailable"`)
+	require.Contains(t, logs.String(), `"error":"rpc error: code = Unavailable desc = unavailable"`)
+}
+
+func TestStreamClientInterceptorLogs(t *testing.T) {
+	var logs bytes.Buffer
+	interceptor := grpclogger.StreamClientInterceptor(newLogger(&logs))
+	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
+
+	streamer := func(context.Context, *grpc.StreamDesc, *grpc.ClientConn, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+		return nil, status.Error(codes.InvalidArgument, "invalid")
+	}
+
+	stream, err := interceptor(t.Context(), &grpc.StreamDesc{ServerStreams: true}, conn, "/greet.v1.GreeterService/SayStreamHello", streamer)
+
+	require.Nil(t, stream)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, logs.String(), `"level":"WARN"`)
+	require.Contains(t, logs.String(), `"msg":"grpc: passthrough:///backend/greet.v1.GreeterService/SayStreamHello"`)
+	require.Contains(t, logs.String(), `"system":"grpc"`)
+	require.Contains(t, logs.String(), `"service":"greet.v1.GreeterService"`)
+	require.Contains(t, logs.String(), `"method":"SayStreamHello"`)
+	require.Contains(t, logs.String(), `"code":"InvalidArgument"`)
+	require.Contains(t, logs.String(), `"error":"rpc error: code = InvalidArgument desc = invalid"`)
+}
+
+func TestCodeToLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level logger.Level
+		code  codes.Code
+	}{
+		{name: "ok", code: codes.OK, level: logger.LevelInfo},
+		{name: "warn", code: codes.InvalidArgument, level: logger.LevelWarn},
+		{name: "error", code: codes.DeadlineExceeded, level: logger.LevelError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.level, grpclogger.CodeToLevel(tt.code))
+		})
+	}
+}
+
+func newLogger(logs *bytes.Buffer) *grpclogger.Logger {
+	return &grpclogger.Logger{Logger: slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{}))}
 }

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"log/slog"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -12,6 +14,56 @@ import (
 	httplogger "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/stretchr/testify/require"
 )
+
+func TestHandlerLogsResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		level string
+		code  int
+	}{
+		{name: "success", code: http.StatusOK, level: "INFO"},
+		{name: "client error", code: http.StatusBadRequest, level: "WARN"},
+		{name: "server error", code: http.StatusInternalServerError, level: "ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+			handler := httplogger.NewHandler(test.Name, &logger.Logger{Logger: slogLogger})
+			res := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/greeter/say-hello", http.NoBody)
+
+			handler.ServeHTTP(res, req, func(res http.ResponseWriter, _ *http.Request) {
+				res.WriteHeader(tt.code)
+			})
+
+			require.Contains(t, logs.String(), `"level":"`+tt.level+`"`)
+			require.Contains(t, logs.String(), `"msg":"http: say-hello greeter"`)
+			require.Contains(t, logs.String(), `"system":"http"`)
+			require.Contains(t, logs.String(), `"service":"greeter"`)
+			require.Contains(t, logs.String(), `"method":"say-hello"`)
+			require.Contains(t, logs.String(), `"code":`+strconv.Itoa(tt.code))
+		})
+	}
+}
+
+func TestHandlerSkipsOperationPath(t *testing.T) {
+	var logs bytes.Buffer
+	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+	handler := httplogger.NewHandler(test.Name, &logger.Logger{Logger: slogLogger})
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test/metrics", http.NoBody)
+	called := false
+
+	handler.ServeHTTP(res, req, func(res http.ResponseWriter, _ *http.Request) {
+		called = true
+		res.WriteHeader(http.StatusNoContent)
+	})
+
+	require.True(t, called)
+	require.Empty(t, logs.String())
+}
 
 func TestRoundTripperLogsTransportError(t *testing.T) {
 	var logs bytes.Buffer

--- a/transport/http/telemetry/metrics/metrics_test.go
+++ b/transport/http/telemetry/metrics/metrics_test.go
@@ -1,0 +1,36 @@
+package metrics_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	transportmetrics "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterDisabled(t *testing.T) {
+	mux := http.NewServeMux()
+
+	transportmetrics.Register(test.Name, nil, mux)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test/metrics", http.NoBody)
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+}
+
+func TestRegisterNonPrometheus(t *testing.T) {
+	mux := http.NewServeMux()
+
+	transportmetrics.Register(test.Name, &metrics.Config{Kind: "otlp"}, mux)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test/metrics", http.NoBody)
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+}

--- a/transport/http/token_test.go
+++ b/transport/http/token_test.go
@@ -3,9 +3,14 @@ package http_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
+	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
+	"github.com/alexfalkowski/go-service/v2/transport/http/token"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
 )
 
 func TestNewControllerWithoutTokenConfig(t *testing.T) {
@@ -14,7 +19,51 @@ func TestNewControllerWithoutTokenConfig(t *testing.T) {
 	require.Nil(t, controller)
 }
 
+func TestNewControllerWithTokenConfig(t *testing.T) {
+	cfg := test.NewHTTPTransportConfig()
+	cfg.Token = test.NewToken("jwt")
+	cfg.Token.Access = test.NewAccessConfig()
+
+	controller, err := http.NewController(cfg, test.FS)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+}
+
 func TestNewTokenWithoutTokenConfig(t *testing.T) {
 	tkn := http.NewToken(test.Name, test.NewHTTPTransportConfig(), nil, nil, nil, nil)
 	require.Nil(t, tkn)
+}
+
+func TestNewTokenWithTokenConfig(t *testing.T) {
+	cfg := test.NewHTTPTransportConfig()
+	cfg.Token = test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, err := ed25519.NewSigner(test.PEM, ec)
+	require.NoError(t, err)
+	verifier, err := ed25519.NewVerifier(test.PEM, ec)
+	require.NoError(t, err)
+	gen := uuid.NewGenerator()
+
+	tkn := http.NewToken(test.Name, cfg, test.FS, signer, verifier, gen)
+
+	require.NotNil(t, tkn)
+	require.NotNil(t, token.NewGenerator(tkn))
+	require.NotNil(t, token.NewVerifier(tkn))
+}
+
+func TestNewServerLimiter(t *testing.T) {
+	cfg := test.NewHTTPTransportConfig()
+	cfg.Limiter = test.NewLimiterConfig("user-agent", "1s", 1)
+
+	server, err := http.NewServerLimiter(fxtest.NewLifecycle(t), limiter.NewKeyMap(), cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+}
+
+func TestNewServerLimiterDisabled(t *testing.T) {
+	server, err := http.NewServerLimiter(fxtest.NewLifecycle(t), limiter.NewKeyMap(), nil)
+
+	require.NoError(t, err)
+	require.Nil(t, server)
 }

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -28,6 +28,27 @@ func TestValidLimiter(t *testing.T) {
 	require.NoError(t, limiter.Close(t.Context()))
 }
 
+func TestTake(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 2, Interval: time.Second}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+
+	ok, header, err := limiter.Take(ctx)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "limit=2, remaining=1", header)
+}
+
 func TestNewKeyMapIncludesServiceMethod(t *testing.T) {
 	key := limiter.NewKeyMap()["service-method"]
 	ctx := meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("GET /users/{id}")))

--- a/transport/server_test.go
+++ b/transport/server_test.go
@@ -1,0 +1,33 @@
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/debug"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/transport"
+	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServers(t *testing.T) {
+	require.Empty(t, transport.NewServers(transport.ServersParams{}))
+
+	httpService := newService("http")
+	grpcService := newService("grpc")
+	debugService := newService("debug")
+
+	services := transport.NewServers(transport.ServersParams{
+		HTTP:  &transporthttp.Server{Service: httpService},
+		GRPC:  &transportgrpc.Server{Service: grpcService},
+		Debug: &debug.Server{Service: debugService},
+	})
+
+	require.Equal(t, []*server.Service{httpService, grpcService, debugService}, services)
+}
+
+func newService(name string) *server.Service {
+	return server.NewService(name, &test.NoopServer{}, nil, test.NewShutdowner())
+}


### PR DESCRIPTION
## What

- Added root transport tests for config enablement and server aggregation.
- Added shared breaker and limiter tests for default settings, constructor behavior, and rate-limit header formatting.
- Added HTTP coverage for token/controller/limiter constructors, metrics registration no-op behavior, and server telemetry logging.
- Added gRPC coverage for health limiter bypass, limiter metadata, telemetry logger interceptors, and disabled server wiring.

## Why

- These tests close the confirmed transport coverage gaps recorded during the test-gap pass.
- The new coverage protects DI wiring, operation endpoint behavior, quota diagnostics, and transport observability from silent regressions.

## Testing

- `git diff --check` - passed
- `go test ./transport/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
