### PR TITLE
test(token): cover wrapper behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,12 @@ matching skill for the task.
   real client, route, or deployment contract that depends on strict weighted
   `Accept` negotiation for MVC 404 responses.
 - JWT verification requires both the expected algorithm and a `kid` header.
+- Token tests should focus on repository-owned wrapper behavior. Do not flag or
+  add tests that require hand-crafting upstream JWT/PASETO internals solely to
+  prove library-owned parsing, signature, expiration, not-before, or
+  missing-claim behavior. Prefer tests through this repository's
+  `Generate`/`Verify` APIs. Only test crafted tokens when the repository adds
+  local validation logic or a public contract beyond upstream library behavior.
 - `telemetry/header.Map.MustSecrets` can panic if secret resolution fails during config projection.
 - Health registration helpers require `*net/http.ServeMux`.
 - Shared metadata, header, and string helpers live under `net/...`, not `transport/...`.

--- a/token/access/access_test.go
+++ b/token/access/access_test.go
@@ -27,9 +27,27 @@ func TestHasAccess(t *testing.T) {
 	controller, err := access.NewController(config, test.FS)
 	require.NoError(t, err)
 
-	ok, err := controller.HasAccess("alice", "service", "read")
-	require.NoError(t, err)
-	require.True(t, ok)
+	tests := []struct {
+		name   string
+		user   string
+		system string
+		action string
+		access bool
+	}{
+		{name: "allowed read", user: "alice", system: "service", action: "read", access: true},
+		{name: "denied wrong action", user: "alice", system: "service", action: "write"},
+		{name: "denied wrong user", user: "bob", system: "service", action: "read"},
+		{name: "denied unknown user", user: "carol", system: "service", action: "read"},
+		{name: "denied unknown system", user: "alice", system: "other", action: "read"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, err := controller.HasAccess(tt.user, tt.system, tt.action)
+			require.NoError(t, err)
+			require.Equal(t, tt.access, ok)
+		})
+	}
 }
 
 func TestNewControllerErrors(t *testing.T) {

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
+	"github.com/alexfalkowski/go-service/v2/crypto/rand"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/jwt"
-	v4 "github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,6 +133,29 @@ func TestInvalid(t *testing.T) {
 	})
 }
 
+func TestInvalidSignature(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	token := jwt.NewToken(cfg.JWT, signer, verifier, gen)
+
+	_, wrongPrivate, err := ed25519.NewGenerator(rand.NewGenerator(rand.NewReader())).Generate()
+	require.NoError(t, err)
+
+	wrongSigner, err := ed25519.NewSigner(test.PEM, &ed25519.Config{Private: wrongPrivate})
+	require.NoError(t, err)
+
+	wrong := jwt.NewToken(cfg.JWT, wrongSigner, verifier, gen)
+	tkn, err := wrong.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	sub, err := token.Verify(tkn, "hello")
+	require.Empty(t, sub)
+	require.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
+}
+
 func TestInvalidKeyID(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	ec := test.NewEd25519()
@@ -153,71 +175,6 @@ func TestInvalidKeyID(t *testing.T) {
 		require.Empty(t, sub)
 		require.ErrorIs(t, err, errors.ErrInvalidKeyID)
 	})
-
-	t.Run("missing key id", func(t *testing.T) {
-		jwtToken := v4.NewWithClaims(v4.SigningMethodEdDSA, &v4.RegisteredClaims{})
-		tkn, err := jwtToken.SignedString(signer.PrivateKey)
-		require.NoError(t, err)
-		require.NotEmpty(t, tkn)
-
-		sub, err := token.Verify(tkn, "hello")
-		require.Empty(t, sub)
-		require.ErrorIs(t, err, errors.ErrInvalidKeyID)
-	})
-}
-
-func TestInvalidMissingClaims(t *testing.T) {
-	cfg := test.NewToken("jwt")
-	ec := test.NewEd25519()
-	signer, _ := ed25519.NewSigner(test.PEM, ec)
-	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
-	gen := uuid.NewGenerator()
-	token := jwt.NewToken(cfg.JWT, signer, verifier, gen)
-
-	now := time.Now()
-	tests := []struct {
-		err    error
-		mutate func(*v4.RegisteredClaims)
-		name   string
-	}{
-		{
-			name:   "missing expiration",
-			err:    errors.ErrInvalidTime,
-			mutate: func(claims *v4.RegisteredClaims) { claims.ExpiresAt = nil },
-		},
-		{
-			name:   "missing issued at",
-			err:    errors.ErrInvalidTime,
-			mutate: func(claims *v4.RegisteredClaims) { claims.IssuedAt = nil },
-		},
-		{
-			name:   "missing not before",
-			err:    errors.ErrInvalidTime,
-			mutate: func(claims *v4.RegisteredClaims) { claims.NotBefore = nil },
-		},
-		{
-			name:   "missing subject",
-			err:    errors.ErrInvalidSubject,
-			mutate: func(claims *v4.RegisteredClaims) { claims.Subject = strings.Empty },
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			claims := validClaims(cfg.JWT, gen, now)
-			tt.mutate(claims)
-
-			jwtToken := v4.NewWithClaims(v4.SigningMethodEdDSA, claims)
-			jwtToken.Header["kid"] = cfg.JWT.KeyID
-
-			tkn, err := jwtToken.SignedString(signer.PrivateKey)
-			require.NoError(t, err)
-
-			sub, err := token.Verify(tkn, "hello")
-			require.Empty(t, sub)
-			require.ErrorIs(t, err, tt.err)
-		})
-	}
 }
 
 func TestInvalidLifetimeExceedsConfig(t *testing.T) {
@@ -319,33 +276,4 @@ func TestInvalidPrivateKeyDoesNotPanic(t *testing.T) {
 	tkn, err := token.Generate("hello", test.UserID.String())
 	require.Empty(t, tkn)
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
-}
-
-func TestInvalidAlgorithm(t *testing.T) {
-	cfg := test.NewToken("jwt")
-	ec := test.NewEd25519()
-	signer, _ := ed25519.NewSigner(test.PEM, ec)
-	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
-	gen := uuid.NewGenerator()
-	token := jwt.NewToken(cfg.JWT, signer, verifier, gen)
-
-	jwtToken := v4.NewWithClaims(v4.SigningMethodHS256, &v4.RegisteredClaims{})
-	tkn, err := jwtToken.SignedString([]byte("secret"))
-	require.NoError(t, err)
-	require.NotEmpty(t, tkn)
-
-	_, err = token.Verify(tkn, "hello")
-	require.ErrorIs(t, err, errors.ErrInvalidAlgorithm)
-}
-
-func validClaims(cfg *jwt.Config, gen *uuid.Generator, now time.Time) *v4.RegisteredClaims {
-	return &v4.RegisteredClaims{
-		ExpiresAt: &v4.NumericDate{Time: now.Add(time.Hour.Duration())},
-		ID:        gen.Generate(),
-		IssuedAt:  &v4.NumericDate{Time: now},
-		Issuer:    cfg.Issuer,
-		NotBefore: &v4.NumericDate{Time: now},
-		Audience:  []string{"hello"},
-		Subject:   test.UserID.String(),
-	}
 }

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -91,6 +91,23 @@ func TestInvalidLifetimeExceedsConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
+func TestInvalidIssuer(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	generator := paseto.NewToken(&paseto.Config{Issuer: "other", Expiration: time.Hour}, signer, verifier, gen)
+	verifierToken := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+
+	tkn, err := generator.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	sub, err := verifierToken.Verify(tkn, "hello")
+	require.Empty(t, sub)
+	require.Error(t, err)
+}
+
 func TestInvalidVerifyExpirationConfig(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	ec := test.NewEd25519()
@@ -222,5 +239,33 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 		sub, err := token.Verify(tkn, "hello")
 		require.Empty(t, sub)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+}
+
+func TestInvalidKeyMaterialDoesNotPanic(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+
+	t.Run("generate with malformed private key", func(t *testing.T) {
+		token := paseto.NewToken(cfg.Paseto, &ed25519.Signer{PrivateKey: []byte("short")}, verifier, gen)
+
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.Empty(t, tkn)
+		require.Error(t, err)
+	})
+
+	t.Run("verify with malformed public key", func(t *testing.T) {
+		valid := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+		tkn, err := valid.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+
+		token := paseto.NewToken(cfg.Paseto, signer, &ed25519.Verifier{PublicKey: []byte("short")}, gen)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.Error(t, err)
 	})
 }

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -105,27 +105,130 @@ func TestInvalidLifetimeExceedsConfig(t *testing.T) {
 
 func TestInvalidMissingIssuedAt(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
-	signer, err := cryptossh.NewSigner(test.FS, cfg.Key.Config)
-	require.NoError(t, err)
-
 	claims := map[string]any{
 		"ver": "v1",
 		"kid": cfg.Key.Name,
 		"aud": "/service.Method",
 		"exp": time.Now().Add(time.Hour.Duration()).UnixNano(),
 	}
-	encoded, err := json.Marshal(claims)
-	require.NoError(t, err)
-
-	signature, err := signer.Sign(encoded)
-	require.NoError(t, err)
 
 	token := ssh.NewToken(cfg, test.FS)
-	tkn := strings.Join(".", base64.Encode(encoded), base64.Encode(signature))
+	tkn := signedSSHToken(t, cfg, claims)
 
 	sub, err := token.Verify(tkn, "/service.Method")
 	require.Empty(t, sub)
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
+}
+
+func TestInvalidSignedClaims(t *testing.T) {
+	cfg := test.NewToken("ssh").SSH
+	token := ssh.NewToken(cfg, test.FS)
+	now := time.Now()
+
+	tests := []struct {
+		err    error
+		claims map[string]any
+		name   string
+	}{
+		{
+			name: "invalid version",
+			err:  crypto.ErrInvalidMatch,
+			claims: map[string]any{
+				"ver": "v2",
+				"kid": cfg.Key.Name,
+				"aud": "/service.Method",
+				"iat": now.UnixNano(),
+				"exp": now.Add(time.Hour.Duration()).UnixNano(),
+			},
+		},
+		{
+			name: "issued at in future",
+			err:  errors.ErrInvalidTime,
+			claims: map[string]any{
+				"ver": "v1",
+				"kid": cfg.Key.Name,
+				"aud": "/service.Method",
+				"iat": now.Add(time.Minute.Duration()).UnixNano(),
+				"exp": now.Add(time.Hour.Duration()).UnixNano(),
+			},
+		},
+		{
+			name: "expiration before issued at",
+			err:  errors.ErrInvalidTime,
+			claims: map[string]any{
+				"ver": "v1",
+				"kid": cfg.Key.Name,
+				"aud": "/service.Method",
+				"iat": now.UnixNano(),
+				"exp": now.UnixNano(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tkn := signedSSHToken(t, cfg, tt.claims)
+
+			sub, err := token.Verify(tkn, "/service.Method")
+			require.Empty(t, sub)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestInvalidMalformedTokens(t *testing.T) {
+	cfg := test.NewToken("ssh").SSH
+	token := ssh.NewToken(cfg, test.FS)
+	now := time.Now()
+
+	tests := []struct {
+		err   error
+		name  string
+		token string
+	}{
+		{
+			name:  "invalid claims base64",
+			token: "%%%." + base64.Encode([]byte("signature")),
+			err:   crypto.ErrInvalidMatch,
+		},
+		{
+			name:  "invalid claims json",
+			token: base64.Encode([]byte("{")) + "." + base64.Encode([]byte("signature")),
+			err:   crypto.ErrInvalidMatch,
+		},
+		{
+			name: "missing key id",
+			token: encodedSSHToken(t, map[string]any{
+				"ver": "v1",
+				"aud": "/service.Method",
+				"iat": now.UnixNano(),
+				"exp": now.Add(time.Hour.Duration()).UnixNano(),
+			}, base64.Encode([]byte("signature"))),
+			err: crypto.ErrInvalidMatch,
+		},
+		{
+			name: "invalid signature base64",
+			token: encodedSSHToken(t, map[string]any{
+				"ver": "v1",
+				"kid": cfg.Key.Name,
+				"aud": "/service.Method",
+				"iat": now.UnixNano(),
+				"exp": now.Add(time.Hour.Duration()).UnixNano(),
+			}, "%%%"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, err := token.Verify(tt.token, "/service.Method")
+			require.Empty(t, sub)
+			require.Error(t, err)
+
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+			}
+		})
+	}
 }
 
 func TestValidNameWithDash(t *testing.T) {
@@ -240,13 +343,16 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 		require.Empty(t, tkn)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
 	})
+}
 
+func TestInvalidVerifyConfigDoesNotPanic(t *testing.T) {
 	t.Run("verify with matching key missing config", func(t *testing.T) {
 		valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 		tkn, err := valid.Generate(strings.Empty, strings.Empty)
 		require.NoError(t, err)
 
 		token := ssh.NewToken(&ssh.Config{
+			Expiration: time.Hour,
 			Keys: ssh.Keys{
 				&ssh.Key{Name: test.UserID.String()},
 			},
@@ -255,6 +361,26 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 		sub, err := token.Verify(tkn, strings.Empty)
 		require.Empty(t, sub)
 		require.ErrorIs(t, err, errors.ErrInvalidConfig)
+	})
+
+	t.Run("verify with invalid matching key config", func(t *testing.T) {
+		valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
+		tkn, err := valid.Generate(strings.Empty, strings.Empty)
+		require.NoError(t, err)
+
+		token := ssh.NewToken(&ssh.Config{
+			Expiration: time.Hour,
+			Keys: ssh.Keys{
+				&ssh.Key{
+					Name:   test.UserID.String(),
+					Config: test.NewSSH("secrets/none", "secrets/ssh_private"),
+				},
+			},
+		}, test.FS)
+
+		sub, err := token.Verify(tkn, strings.Empty)
+		require.Empty(t, sub)
+		require.Error(t, err)
 	})
 }
 
@@ -270,4 +396,28 @@ func TestKeysGetIgnoresNilEntries(t *testing.T) {
 	require.NotNil(t, key)
 	require.Equal(t, "test", key.Name)
 	require.Nil(t, ssh.Keys{nil, nil}.Get("missing"))
+}
+
+func signedSSHToken(t *testing.T, cfg *ssh.Config, claims map[string]any) string {
+	t.Helper()
+
+	signer, err := cryptossh.NewSigner(test.FS, cfg.Key.Config)
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(claims)
+	require.NoError(t, err)
+
+	signature, err := signer.Sign(encoded)
+	require.NoError(t, err)
+
+	return strings.Join(".", base64.Encode(encoded), base64.Encode(signature))
+}
+
+func encodedSSHToken(t *testing.T, claims map[string]any, signature string) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(claims)
+	require.NoError(t, err)
+
+	return strings.Join(".", base64.Encode(encoded), signature)
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,12 +3,16 @@ package token_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/token"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
+	"github.com/alexfalkowski/go-service/v2/token/jwt"
+	"github.com/alexfalkowski/go-service/v2/token/paseto"
+	"github.com/alexfalkowski/go-service/v2/token/ssh"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,21 +56,72 @@ func TestVerify(t *testing.T) {
 		})
 	}
 
-	for _, kind := range []string{"ssh"} {
-		t.Run(kind, func(t *testing.T) {
-			cfg := test.NewToken(kind)
-			tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
+	t.Run("ssh", func(t *testing.T) {
+		cfg := test.NewToken("ssh")
+		tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
 
-			gen, err := tkn.Generate("hello", strings.Empty)
-			require.NoError(t, err)
+		gen, err := tkn.Generate("hello", strings.Empty)
+		require.NoError(t, err)
 
-			_, err = tkn.Verify(gen, "hello")
-			require.NoError(t, err)
+		sshToken := ssh.NewToken(cfg.SSH, test.FS)
+		sub, err := sshToken.Verify(bytes.String(gen), "hello")
+		require.NoError(t, err)
+		require.Equal(t, test.UserID.String(), sub)
 
-			_, err = tkn.Verify(gen, "other")
-			require.ErrorIs(t, err, errors.ErrInvalidAudience)
-		})
-	}
+		sub, err = tkn.Verify(gen, "hello")
+		require.NoError(t, err)
+		require.Equal(t, test.UserID.String(), sub)
+
+		_, err = tkn.Verify(gen, "other")
+		require.ErrorIs(t, err, errors.ErrInvalidAudience)
+	})
+}
+
+func TestVerifyDispatchesJWTToConcreteImplementation(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	tkn := token.NewToken(test.Name, cfg, test.FS, signer, verifier, gen)
+
+	raw, err := tkn.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	jwtToken := jwt.NewToken(cfg.JWT, nil, verifier, gen)
+	sub, err := jwtToken.Verify(bytes.String(raw), "hello")
+	require.NoError(t, err)
+	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestVerifyDispatchesPasetoToConcreteImplementation(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	tkn := token.NewToken(test.Name, cfg, test.FS, signer, verifier, gen)
+
+	raw, err := tkn.Generate("hello", test.UserID.String())
+	require.NoError(t, err)
+
+	pasetoToken := paseto.NewToken(cfg.Paseto, nil, verifier, gen)
+	sub, err := pasetoToken.Verify(bytes.String(raw), "hello")
+	require.NoError(t, err)
+	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestVerifyDispatchesSSHToConcreteImplementation(t *testing.T) {
+	cfg := test.NewToken("ssh")
+	tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
+
+	raw, err := tkn.Generate("hello", strings.Empty)
+	require.NoError(t, err)
+
+	sshToken := ssh.NewToken(cfg.SSH, test.FS)
+	sub, err := sshToken.Verify(bytes.String(raw), "hello")
+	require.NoError(t, err)
+	require.Equal(t, test.UserID.String(), sub)
 }
 
 func TestVerifyRejectsPasetoEmptySubject(t *testing.T) {


### PR DESCRIPTION
## What

- Add wrapper-focused token tests for access denials, facade dispatch, JWT wrong-key verification, PASETO issuer/key-material failures, and SSH claim/config rejection paths.
- Document that token tests should avoid hand-crafting upstream JWT/PASETO internals just to prove library-owned behavior.

## Why

- Strengthen repository-owned token behavior without coupling tests to upstream token library internals.

## Testing

- `go test ./token/...` - passed
- `make lint` - passed
- `git diff --check` - passed
