### PR TITLE
test(telemetry): cover signal lifecycle edge cases

### DIFF
--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -1,10 +1,57 @@
 package test
 
 import (
+	"log/slog"
+
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 )
+
+// CapturedRecord is a slog record captured by CaptureHandler.
+type CapturedRecord struct {
+	Attrs   map[string]slog.Value
+	Message string
+	Level   slog.Level
+}
+
+// CaptureHandler records slog records for tests.
+type CaptureHandler struct {
+	Records []CapturedRecord
+}
+
+// Enabled reports whether the handler accepts records at level.
+func (h *CaptureHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// Handle records a slog record.
+func (h *CaptureHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make(map[string]slog.Value)
+	record.Attrs(func(attr slog.Attr) bool {
+		if attr.Key != "" {
+			attrs[attr.Key] = attr.Value.Resolve()
+		}
+		return true
+	})
+	h.Records = append(h.Records, CapturedRecord{
+		Level:   record.Level,
+		Message: record.Message,
+		Attrs:   attrs,
+	})
+	return nil
+}
+
+// WithAttrs returns a handler with attrs.
+func (h *CaptureHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+// WithGroup returns a handler with group.
+func (h *CaptureHandler) WithGroup(string) slog.Handler {
+	return h
+}
 
 // NewLogger constructs a test logger bound to the supplied lifecycle and logger config.
 func NewLogger(lc di.Lifecycle, config *logger.Config) (*logger.Logger, error) {

--- a/telemetry/errors/errors_test.go
+++ b/telemetry/errors/errors_test.go
@@ -1,10 +1,13 @@
 package errors_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 )
@@ -28,4 +31,17 @@ func TestHandleNilHandler(t *testing.T) {
 	require.NotPanics(t, func() {
 		handler.Handle(context.Canceled)
 	})
+}
+
+func TestHandleLogsError(t *testing.T) {
+	capture := &test.CaptureHandler{}
+	handler := errors.NewHandler(&logger.Logger{Logger: slog.New(capture)})
+	require.NotNil(t, handler)
+
+	handler.Handle(context.Canceled)
+
+	require.Len(t, capture.Records, 1)
+	require.Equal(t, slog.LevelError, capture.Records[0].Level)
+	require.Equal(t, "telemetry: global error", capture.Records[0].Message)
+	require.Equal(t, context.Canceled, capture.Records[0].Attrs["error"].Any())
 }

--- a/telemetry/header/header_test.go
+++ b/telemetry/header/header_test.go
@@ -13,8 +13,30 @@ import (
 )
 
 func TestSecrets(t *testing.T) {
-	require.NoError(t, header.Map{"test": test.FilePath("secrets/hooks")}.Secrets(test.FS))
+	headers := header.Map{
+		"file":    test.FilePath("secrets/hooks"),
+		"literal": "literal-token",
+	}
+
+	require.NoError(t, headers.Secrets(test.FS))
+	require.Equal(t, header.Map{
+		"file":    "QW4xbEphNWtxa09TMWdUY1MydmJybHlKR04zTG5aSEU=",
+		"literal": "literal-token",
+	}, headers)
 	require.Error(t, header.Map{"test": test.FilePath("none")}.Secrets(test.ErrFS))
+}
+
+func TestMustSecrets(t *testing.T) {
+	headers := header.Map{"test": test.FilePath("secrets/hooks")}
+
+	require.NotPanics(t, func() {
+		headers.MustSecrets(test.FS)
+	})
+	require.Equal(t, header.Map{"test": "QW4xbEphNWtxa09TMWdUY1MydmJybHlKR04zTG5aSEU="}, headers)
+
+	require.Panics(t, func() {
+		header.Map{"test": test.FilePath("none")}.MustSecrets(test.ErrFS)
+	})
 }
 
 func TestSecretsDoNotPartiallyMutateOnError(t *testing.T) {

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -83,7 +83,7 @@ func TestInvalidLogger(t *testing.T) {
 	}
 
 	log, err := logger.NewLogger(params)
-	require.Error(t, err)
+	require.ErrorIs(t, err, logger.ErrNotFound)
 	require.Nil(t, log)
 
 	require.NotPanics(t, func() {
@@ -94,6 +94,42 @@ func TestInvalidLogger(t *testing.T) {
 		log.Warn("hello")
 		log.Error("hello")
 	})
+}
+
+func TestDisabledLogger(t *testing.T) {
+	original := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+	replacement := slog.New(&test.CaptureHandler{})
+	slog.SetDefault(replacement)
+
+	log, err := logger.NewLogger(logger.LoggerParams{})
+
+	require.NoError(t, err)
+	require.Nil(t, log)
+	require.Same(t, replacement, slog.Default())
+}
+
+func TestLogAddsMetadataAndError(t *testing.T) {
+	handler := &test.CaptureHandler{}
+	log := &logger.Logger{Logger: slog.New(handler)}
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+
+	log.Log(ctx, logger.NewText("plain"), logger.String("component", "test"))
+	log.LogAttrs(ctx, logger.LevelWarn, logger.NewMessage("failed", context.Canceled), logger.String("component", "test"))
+
+	require.Len(t, handler.Records, 2)
+	require.Equal(t, slog.LevelInfo, handler.Records[0].Level)
+	require.Equal(t, "plain", handler.Records[0].Message)
+	require.Equal(t, "test", handler.Records[0].Attrs["component"].String())
+	require.Equal(t, "request-id", handler.Records[0].Attrs[meta.RequestIDKey].String())
+
+	require.Equal(t, slog.LevelWarn, handler.Records[1].Level)
+	require.Equal(t, "failed", handler.Records[1].Message)
+	require.Equal(t, "test", handler.Records[1].Attrs["component"].String())
+	require.Equal(t, "request-id", handler.Records[1].Attrs[meta.RequestIDKey].String())
+	require.Equal(t, context.Canceled, handler.Records[1].Attrs["error"].Any())
 }
 
 func TestInvalidLevel(t *testing.T) {

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -36,4 +39,66 @@ func TestIsEnabled(t *testing.T) {
 
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	require.False(t, metrics.IsEnabled())
+}
+
+func TestMeterProviderStopResetsGlobalState(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	lc := fxtest.NewLifecycle(t)
+	provider := metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   lc,
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+	require.True(t, metrics.IsEnabled())
+	require.Equal(t, provider, otel.GetMeterProvider())
+
+	lc.RequireStart()
+	require.NoError(t, lc.Stop(t.Context()))
+
+	require.False(t, metrics.IsEnabled())
+	require.NotEqual(t, provider, otel.GetMeterProvider())
+}
+
+func TestMeterProviderResourceAttributes(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	reader := metrics.NewManualReader()
+	provider := metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(t),
+		Config:      &metrics.Config{},
+		Reader:      reader,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+	counter, err := provider.Meter(test.Name.String()).Int64Counter("requests")
+	require.NoError(t, err)
+	counter.Add(t.Context(), 1)
+
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	attrs := resourceAttributes(rm)
+
+	require.Equal(t, test.ID.String(), attrs[attributes.HostID("").Key])
+	require.Equal(t, test.Name.String(), attrs[attributes.ServiceName("").Key])
+	require.Equal(t, test.Version.String(), attrs[attributes.ServiceVersion("").Key])
+	require.Equal(t, "development", attrs[attributes.DeploymentEnvironmentName("").Key])
+}
+
+func resourceAttributes(rm metricdata.ResourceMetrics) map[attribute.Key]string {
+	attrs := make(map[attribute.Key]string)
+	for _, attr := range rm.Resource.Attributes() {
+		attrs[attr.Key] = attr.Value.AsString()
+	}
+	return attrs
 }

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -19,6 +19,17 @@ func TestInvalidReader(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestReaderShutdownIgnoresAlreadyShutdownReader(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	reader, err := metrics.NewReader(lc, test.Name, &metrics.Config{Kind: "prometheus"})
+	require.NoError(t, err)
+
+	lc.RequireStart()
+	require.NoError(t, reader.Shutdown(t.Context()))
+
+	require.NoError(t, lc.Stop(t.Context()))
+}
+
 func TestInvalidOTLPEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -50,6 +50,29 @@ func TestConfigIsEnabled(t *testing.T) {
 	require.True(t, (&tracer.Config{Kind: "otlp"}).IsEnabled())
 }
 
+func TestRegisterStopResetsGlobalProvider(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
+	})
+
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	lc := fxtest.NewLifecycle(t)
+	require.NoError(t, tracer.Register(tracer.TracerParams{
+		Lifecycle:   lc,
+		Config:      &tracer.Config{Kind: "otlp", URL: "https://localhost:4318/v1/traces"},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}))
+	require.True(t, tracer.IsEnabled())
+
+	lc.RequireStart()
+	require.NoError(t, lc.Stop(t.Context()))
+
+	require.False(t, tracer.IsEnabled())
+}
+
 func TestRegisterInvalidKind(t *testing.T) {
 	err := tracer.Register(tracer.TracerParams{
 		Lifecycle: fxtest.NewLifecycle(t),
@@ -72,6 +95,45 @@ func TestRegisterInvalidOTLPEndpoint(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestRegisterOTLPEndpointLoopbackIPs(t *testing.T) {
+	headers := header.Map{"Authorization": "Bearer token"}
+	tests := []struct {
+		wantErr error
+		name    string
+		url     string
+	}{
+		{name: "IPv6 loopback", url: "http://[::1]:4318/v1/traces"},
+		{name: "private IPv4", url: "http://10.0.0.10:4318/v1/traces", wantErr: otlp.ErrInsecureEndpoint},
+		{name: "unique local IPv6", url: "http://[fd00::1]:4318/v1/traces", wantErr: otlp.ErrInsecureEndpoint},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := fxtest.NewLifecycle(t)
+			err := tracer.Register(tracer.TracerParams{
+				Lifecycle: lc,
+				Config: &tracer.Config{
+					Kind:    "otlp",
+					URL:     tt.url,
+					Headers: headers,
+				},
+				ID:          test.ID,
+				Name:        test.Name,
+				Version:     test.Version,
+				Environment: test.Environment,
+			})
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				lc.RequireStart()
+				require.NoError(t, lc.Stop(t.Context()))
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestRegisterMissingOTLPEndpointIgnoresEnv(t *testing.T) {


### PR DESCRIPTION
## What

- Add focused coverage for header secret resolution, logger enrichment, metrics lifecycle/resource metadata, tracer lifecycle cleanup, and OTLP endpoint boundary behavior.
- Tighten unsupported logger kind assertions to protect the public error contract.

## Why

- These paths own local mapping, lifecycle, and error-handling behavior around telemetry setup and were previously covered mostly by smoke tests or not covered at all.

## Testing

- `go test ./telemetry/...` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
