### PR TITLE
test(cache): cover fallback, expiry, and tracing guards

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -10,13 +10,16 @@ import (
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	"github.com/alexfalkowski/go-service/v2/compress/errors"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -39,6 +42,38 @@ func TestGenericValidCache(t *testing.T) {
 	require.Equal(t, "hello?", *value)
 
 	require.NoError(t, world.Remove(t.Context(), "test"))
+}
+
+func TestModuleRegistersGenericCache(t *testing.T) {
+	cache.Register(nil)
+	t.Cleanup(func() {
+		cache.Register(nil)
+	})
+
+	app := di.New(
+		di.NoLogger,
+		cache.Module,
+		di.Constructor(func() *logger.Logger { return nil }),
+		fx.Supply(
+			test.NewCacheConfig("sync", "none", "json", "redis"),
+			test.FS,
+			test.Encoder,
+			test.Pool,
+			test.Compressor,
+		),
+	)
+	require.NoError(t, app.Err())
+
+	require.NoError(t, app.Start(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, app.Stop(context.Background()))
+	})
+
+	require.NoError(t, cache.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute))
+
+	value, err := cache.Get[string](t.Context(), "test")
+	require.NoError(t, err)
+	require.Equal(t, "hello?", *value)
 }
 
 func TestGenericDisabledCache(t *testing.T) {
@@ -251,6 +286,21 @@ func TestMissingCache(t *testing.T) {
 	require.Equal(t, "existing", value)
 }
 
+func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
+	cfg := &config.Config{Kind: "sync"}
+	kind := cache.NewCache(cache.CacheParams{
+		Config:     cfg,
+		Compressor: test.Compressor,
+		Encoder:    test.Encoder,
+		Pool:       test.Pool,
+		Driver:     expiredCacheDriver{},
+	})
+	value := "existing"
+
+	require.NoError(t, kind.Get(t.Context(), "expired", &value))
+	require.Equal(t, "existing", value)
+}
+
 func cacheRoundTripCases() []cacheRoundTripCase {
 	compressors := []string{"none", "snappy", "s2", "zstd"}
 	encoders := []string{"json", "hjson", "yaml", "yml", "toml", "gob", "msgpack"}
@@ -280,6 +330,12 @@ func cacheRoundTripCases() []cacheRoundTripCase {
 			persist: func() any { return &v1.SayHelloRequest{Name: "hello?"} },
 			get:     func() any { return &v1.SayHelloRequest{} },
 		},
+		cacheRoundTripCase{
+			name:    "sync/unknown/unknown/request",
+			config:  test.NewCacheConfig("sync", "unknown", "unknown", "redis"),
+			persist: func() any { return &test.Request{Name: "hello?"} },
+			get:     func() any { return &test.Request{} },
+		},
 	)
 
 	for _, compressor := range compressors {
@@ -301,4 +357,22 @@ type cacheRoundTripCase struct {
 	get     func() any
 	config  *config.Config
 	name    string
+}
+
+type expiredCacheDriver struct{}
+
+func (expiredCacheDriver) Delete(context.Context, string) error {
+	return nil
+}
+
+func (expiredCacheDriver) Fetch(context.Context, string) (string, error) {
+	return strings.Empty, driver.ErrExpired
+}
+
+func (expiredCacheDriver) Flush(context.Context) error {
+	return nil
+}
+
+func (expiredCacheDriver) Save(context.Context, string, string, time.Duration) error {
+	return nil
 }

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/cache/config"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,4 +24,10 @@ func TestGetMaxSize(t *testing.T) {
 		cfg := &config.Config{MaxSize: 64}
 		require.Equal(t, bytes.Size(64), cfg.GetMaxSize())
 	})
+}
+
+func TestConfigRejectsNegativeMaxSize(t *testing.T) {
+	cfg := &config.Config{MaxSize: -1}
+
+	require.Error(t, test.Validator.Struct(cfg))
 }

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -16,6 +16,32 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
+func TestNewDriver(t *testing.T) {
+	tests := []struct {
+		config *config.Config
+		err    error
+		name   string
+		nil    bool
+	}{
+		{name: "disabled", nil: true},
+		{name: "sync", config: &config.Config{Kind: "sync"}},
+		{name: "unknown", config: &config.Config{Kind: "unknown"}, err: driver.ErrNotFound, nil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := driver.NewDriver(driver.DriverParams{Config: tt.config})
+			require.ErrorIs(t, err, tt.err)
+			if tt.nil {
+				require.Nil(t, d)
+				return
+			}
+
+			require.NotNil(t, d)
+		})
+	}
+}
+
 func TestIsMissingError(t *testing.T) {
 	cfg := &config.Config{Kind: "sync"}
 
@@ -110,6 +136,23 @@ func TestSyncDriverHonorsCanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorIs(t, d.Delete(ctx, "key"), context.Canceled)
 	require.ErrorIs(t, d.Flush(ctx), context.Canceled)
+}
+
+func TestSyncDriverExpiresEntries(t *testing.T) {
+	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync"}})
+	require.NoError(t, err)
+
+	require.NoError(t, d.Save(t.Context(), "key", "value", time.Nanosecond))
+
+	var expired error
+	require.Eventually(t, func() bool {
+		_, expired = d.Fetch(t.Context(), "key")
+		return driver.IsExpiredError(expired)
+	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
+	require.ErrorIs(t, expired, driver.ErrExpired)
+
+	_, err = d.Fetch(t.Context(), "key")
+	require.ErrorIs(t, err, driver.ErrMissing)
 }
 
 func setupMetrics(t *testing.T) metrics.Reader {

--- a/cache/telemetry/telemetry_test.go
+++ b/cache/telemetry/telemetry_test.go
@@ -1,0 +1,82 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/cache/telemetry"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-sync"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestInstrumentTracingDisablesRawCommandStatements(t *testing.T) {
+	test.ResetTelemetry(t)
+	t.Cleanup(func() {
+		test.ResetTelemetry(t)
+	})
+
+	exporter := &spanExporter{}
+	provider := trace.NewTracerProvider(trace.WithSyncer(exporter))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	client := redis.NewClient(&redis.Options{
+		Addr:         "127.0.0.1:1",
+		DialTimeout:  (10 * time.Millisecond).Duration(),
+		ReadTimeout:  (10 * time.Millisecond).Duration(),
+		MaxRetries:   0,
+		WriteTimeout: (10 * time.Millisecond).Duration(),
+	})
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	require.NoError(t, telemetry.InstrumentTracing(client))
+
+	const secretKey = "secret-cache-key"
+	_ = client.Get(t.Context(), secretKey).Err()
+
+	spans := exporter.Spans()
+	require.NotEmpty(t, spans)
+
+	for _, span := range spans {
+		for _, attr := range span.Attributes() {
+			require.NotEqual(t, "db.statement", string(attr.Key))
+			require.NotEqual(t, "db.query.text", string(attr.Key))
+			require.False(t, strings.Contains(attr.Value.AsString(), secretKey), "redis trace attribute leaked command key")
+		}
+	}
+}
+
+type spanExporter struct {
+	spans []trace.ReadOnlySpan
+	mu    sync.Mutex
+}
+
+func (e *spanExporter) ExportSpans(_ context.Context, spans []trace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.spans = append(e.spans, spans...)
+
+	return nil
+}
+
+func (e *spanExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *spanExporter) Spans() []trace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return append([]trace.ReadOnlySpan(nil), e.spans...)
+}


### PR DESCRIPTION
## What

- Add root coverage for codec fallbacks, expired entries, and Fx module generic registration.
- Add config and driver coverage for negative max size validation, constructor dispatch, and sync expiry deletion.
- Add Redis tracing wrapper regression coverage for command statement suppression.

## Why

- Close the cache test-gap ledger and protect repository-owned cache facade, driver, config, module, and telemetry wrapper behavior.

## Testing

- `go test ./cache/...` - passed
- `make lint` - passed
