### PR TITLE
test(compress): cover registry contracts and size boundaries

### DIFF
--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -5,11 +5,16 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress"
 	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/none"
+	"github.com/alexfalkowski/go-service/v2/compress/s2"
+	"github.com/alexfalkowski/go-service/v2/compress/snappy"
 	"github.com/alexfalkowski/go-service/v2/compress/zstd"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 )
 
 func TestMap(t *testing.T) {
@@ -31,6 +36,84 @@ func TestMap(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			cmp := test.Compressor.Get(key)
 			require.Nil(t, cmp)
+		})
+	}
+}
+
+func TestNewMapRegistersDefaultCompressors(t *testing.T) {
+	zstdCompressor := zstd.NewCompressor()
+	s2Compressor := s2.NewCompressor()
+	snappyCompressor := snappy.NewCompressor()
+	noneCompressor := none.NewCompressor()
+
+	compressors := compress.NewMap(compress.MapParams{
+		Zstd:   zstdCompressor,
+		S2:     s2Compressor,
+		Snappy: snappyCompressor,
+		None:   noneCompressor,
+	})
+
+	require.Same(t, zstdCompressor, compressors.Get("zstd"))
+	require.Same(t, s2Compressor, compressors.Get("s2"))
+	require.Same(t, snappyCompressor, compressors.Get("snappy"))
+	require.Same(t, noneCompressor, compressors.Get("none"))
+}
+
+func TestMapRegister(t *testing.T) {
+	compressors := compress.NewMap(compress.MapParams{})
+	custom := test.NewCompressor(test.ErrFailed)
+	replacement := none.NewCompressor()
+
+	compressors.Register("custom", custom)
+	require.Same(t, custom, compressors.Get("custom"))
+
+	compressors.Register("custom", replacement)
+	require.Same(t, replacement, compressors.Get("custom"))
+}
+
+func TestModuleProvidesDefaultCompressors(t *testing.T) {
+	var compressors *compress.Map
+
+	app := fx.New(
+		compress.Module,
+		fx.Populate(&compressors),
+		fx.NopLogger,
+	)
+
+	require.NoError(t, app.Err())
+	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+		t.Run(kind, func(t *testing.T) {
+			require.NotNil(t, compressors.Get(kind))
+		})
+	}
+}
+
+func TestNoneCompressorReturnsDataUnchanged(t *testing.T) {
+	cmp := none.NewCompressor()
+	data := strings.Bytes("hello")
+
+	compressed, err := cmp.Compress(data, bytes.Size(len(data)))
+	require.NoError(t, err)
+	require.Equal(t, data, compressed)
+
+	decompressed, err := cmp.Decompress(data, bytes.Size(len(data)))
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+func TestExactSizeLimits(t *testing.T) {
+	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+		t.Run(kind, func(t *testing.T) {
+			cmp := test.Compressor.Get(kind)
+			data := strings.Bytes("hello")
+			size := bytes.Size(len(data))
+
+			compressed, err := cmp.Compress(data, size)
+			require.NoError(t, err)
+
+			decompressed, err := cmp.Decompress(compressed, size)
+			require.NoError(t, err)
+			require.Equal(t, data, decompressed)
 		})
 	}
 }


### PR DESCRIPTION
## What

- Add compressor registry tests for default kind mapping and Register replacement.
- Add Fx module wiring coverage for the default compressor map.
- Add no-op and exact-size boundary coverage across the default compressors.

## Why

- Protect documented compression selection and size-limit contracts from regressions that existing round-trip tests could miss.

## Testing

- `go test ./compress/...` - passed
- `make package=compress specs` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
