### PR TITLE
test(config): cover focused runtime contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,15 @@ matching skill for the task.
 ## Testing, Style, And Docs
 
 - Tests commonly use `stretchr/testify/require`.
+- When adding test coverage, first follow the existing test shape in the
+  package. Prefer extending current fixture/table/assertion helpers over adding
+  standalone tests for behavior already exercised nearby.
+- Config tests usually use fixture-driven `config.NewConfig` coverage plus
+  `verifyConfig`; do not add separate decoder-routing or Fx projection tests
+  unless they cover a distinct repository-owned behavior not already exercised
+  by those fixture tests.
+- Do not add build-tagged or architecture-specific tests unless CI actually
+  runs that build tag or architecture.
 - Go files use tabs; YAML uses 2 spaces per `.editorconfig`.
 - Every exported identifier, including under `internal/test/**`, needs a GoDoc comment.
 - GoDoc comments should start with the identifier name or `Deprecated:`.

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -85,6 +85,16 @@ func TestNewConfigWithCAOnly(t *testing.T) {
 	require.NotNil(t, tlsConfig.RootCAs)
 }
 
+func TestNewConfigWithServerNameOnly(t *testing.T) {
+	tlsConfig, err := client.NewConfig(test.FS, &config.Config{ServerName: "localhost"})
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	require.Empty(t, tlsConfig.Certificates)
+	require.Nil(t, tlsConfig.RootCAs)
+	require.Equal(t, "localhost", tlsConfig.ServerName)
+}
+
 func TestNewConfigInvalidKeyPair(t *testing.T) {
 	_, err := client.NewConfig(test.FS, &config.Config{
 		Cert: test.FilePath("certs/client-cert.pem"),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -206,6 +206,14 @@ func TestInvalidKindConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNewConfigRejectsEmptyDecodedConfig(t *testing.T) {
+	_, err := config.NewConfig[config.Config](decoderFunc(func(any) error {
+		return nil
+	}), test.Validator)
+
+	require.ErrorIs(t, err, config.ErrInvalidConfig)
+}
+
 //nolint:funlen,gosec
 func verifyConfig(t *testing.T, config *config.Config) {
 	t.Helper()
@@ -236,6 +244,10 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "development", config.Environment.String())
 	require.True(t, config.Feature.IsEnabled())
 	require.Equal(t, "localhost:9000", config.Feature.Address)
+	require.Equal(t, 10*time.Second, config.Feature.Timeout)
+	require.Equal(t, 100*time.Millisecond, config.Feature.Retry.Backoff)
+	require.Equal(t, time.Second, config.Feature.Retry.Timeout)
+	require.Equal(t, uint64(3), config.Feature.Retry.Attempts)
 	require.Equal(t, "uuid", config.ID.Kind)
 	require.Equal(t, "file:../test/secrets/hooks", config.Hooks.Secret)
 	require.Len(t, config.SQL.PG.Masters, 1)
@@ -261,6 +273,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "1234567890", config.Transport.GRPC.Token.JWT.KeyID)
 	require.True(t, config.Transport.GRPC.Config.IsEnabled())
 	require.Equal(t, "tcp://localhost:12000", config.Transport.GRPC.Address)
+	require.Equal(t, 10*time.Second, config.Transport.GRPC.Timeout)
 	require.Equal(t, 3*bytes.MB, config.Transport.GRPC.MaxReceiveSize)
 	require.Equal(t, "user-agent", config.Transport.GRPC.Limiter.Kind)
 	require.Equal(t, 10, int(config.Transport.GRPC.Limiter.Tokens))
@@ -291,6 +304,7 @@ func verifyConfig(t *testing.T, config *config.Config) {
 	require.Equal(t, "1234567890", config.Transport.HTTP.Token.JWT.KeyID)
 	require.True(t, config.Transport.HTTP.Config.IsEnabled())
 	require.Equal(t, "tcp://localhost:11000", config.Transport.HTTP.Address)
+	require.Equal(t, 10*time.Second, config.Transport.HTTP.Timeout)
 	require.Equal(t, 2*bytes.MB, config.Transport.HTTP.MaxReceiveSize)
 	require.Equal(t, "user-agent", config.Transport.HTTP.Limiter.Kind)
 	require.Equal(t, 10, int(config.Transport.HTTP.Limiter.Tokens))
@@ -306,4 +320,10 @@ func verifyConfig(t *testing.T, config *config.Config) {
 		config.Transport.HTTP.Options,
 	)
 	require.False(t, config.Transport.HTTP.TLS.IsEnabled())
+}
+
+type decoderFunc func(any) error
+
+func (f decoderFunc) Decode(v any) error {
+	return f(v)
 }

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -131,6 +131,26 @@ func TestNewConfigWithCAOnly(t *testing.T) {
 	require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
 }
 
+func TestNewConfigRejectsIncompleteKeyPair(t *testing.T) {
+	tests := []struct {
+		config *config.Config
+		name   string
+	}{
+		{name: "cert only", config: &config.Config{Cert: test.FilePath("certs/cert.pem")}},
+		{name: "key only", config: &config.Config{Key: test.FilePath("certs/key.pem")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tlsConfig, err := server.NewConfig(test.FS, tt.config)
+			require.ErrorIs(t, err, server.ErrMissingKeyPair)
+			require.Empty(t, tlsConfig.Certificates)
+			require.Nil(t, tlsConfig.ClientCAs)
+			require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+		})
+	}
+}
+
 func TestNewConfigInvalidKeyPair(t *testing.T) {
 	_, err := server.NewConfig(test.FS, &config.Config{
 		Cert: test.FilePath("certs/cert.pem"),


### PR DESCRIPTION
## What

- Add focused coverage for empty decoded configuration rejection, fixture timeout and retry fields, client TLS server-name-only setup, and server TLS incomplete key-pair errors.
- Add repository testing guidance to prefer existing fixture and assertion shapes and avoid unrun architecture-specific tests.

## Why

- Protect repository-owned configuration contracts without adding duplicate decoder-routing, Fx plumbing, validator-library, or non-executed architecture tests.

## Testing

- `go test ./config/...` - passed
- `make package=config specs` - passed
- `make lint` - passed
- `git diff --check` - passed
