### PR TITLE
test(encoding): cover codec registry contracts

### DIFF
--- a/encoding/base64/base64_test.go
+++ b/encoding/base64/base64_test.go
@@ -1,0 +1,71 @@
+package base64_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/base64"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeUsesStandardPaddedBase64(t *testing.T) {
+	tests := []struct {
+		expected string
+		name     string
+		src      []byte
+	}{
+		{name: "empty", src: nil, expected: ""},
+		{name: "one byte", src: []byte("f"), expected: "Zg=="},
+		{name: "two bytes", src: []byte("fo"), expected: "Zm8="},
+		{name: "three bytes", src: []byte("foo"), expected: "Zm9v"},
+		{name: "standard alphabet", src: []byte{0xfb, 0xff}, expected: "+/8="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, base64.Encode(tt.src))
+		})
+	}
+}
+
+func TestDecodeUsesStandardPaddedBase64(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoded  string
+		expected []byte
+	}{
+		{name: "empty", encoded: "", expected: []byte{}},
+		{name: "one byte", encoded: "Zg==", expected: []byte("f")},
+		{name: "two bytes", encoded: "Zm8=", expected: []byte("fo")},
+		{name: "three bytes", encoded: "Zm9v", expected: []byte("foo")},
+		{name: "standard alphabet", encoded: "+/8=", expected: []byte{0xfb, 0xff}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := base64.Decode(tt.encoded)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestEncodedLenUsesStandardPadding(t *testing.T) {
+	tests := []struct {
+		name     string
+		size     bytes.Size
+		expected int64
+	}{
+		{name: "empty", size: 0, expected: 0},
+		{name: "one byte", size: 1, expected: 4},
+		{name: "two bytes", size: 2, expected: 4},
+		{name: "three bytes", size: 3, expected: 4},
+		{name: "four bytes", size: 4, expected: 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, base64.EncodedLen(tt.size))
+		})
+	}
+}

--- a/encoding/bytes/bytes_test.go
+++ b/encoding/bytes/bytes_test.go
@@ -22,7 +22,7 @@ func TestEncoder(t *testing.T) {
 	require.Equal(t, "yes!", strings.TrimSpace(buffer.String()))
 
 	var str string
-	require.Error(t, encoder.Encode(buffer, &str))
+	require.ErrorIs(t, encoder.Encode(buffer, &str), errors.ErrInvalidType)
 
 	decode := test.Pool.Get()
 	defer test.Pool.Put(decode)
@@ -30,7 +30,7 @@ func TestEncoder(t *testing.T) {
 	require.NoError(t, encoder.Decode(bytes.NewBufferString("test"), decode))
 	require.Equal(t, "test", decode.String())
 
-	require.Error(t, encoder.Decode(bytes.NewBufferString("test"), &str))
+	require.ErrorIs(t, encoder.Decode(bytes.NewBufferString("test"), &str), errors.ErrInvalidType)
 }
 
 func TestDecodeResetsDestination(t *testing.T) {
@@ -58,9 +58,21 @@ func TestEncodeReturnsWriteToError(t *testing.T) {
 	require.ErrorIs(t, encoder.Encode(io.Discard, test.ErrWriterTo{}), test.ErrFailed)
 }
 
+func TestDecodeReturnsReadFromError(t *testing.T) {
+	encoder := encoding.NewEncoder()
+
+	require.ErrorIs(t, encoder.Decode(bytes.NewBufferString("test"), errReaderFrom{}), test.ErrFailed)
+}
+
 func TestInvalidTypedNilDecode(t *testing.T) {
 	encoder := encoding.NewEncoder()
 
 	err := encoder.Decode(bytes.NewBufferString("test"), (*bytes.Buffer)(nil))
 	require.ErrorIs(t, err, errors.ErrInvalidType)
+}
+
+type errReaderFrom struct{}
+
+func (errReaderFrom) ReadFrom(io.Reader) (int64, error) {
+	return 0, test.ErrFailed
 }

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -3,8 +3,18 @@ package encoding_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/gob"
+	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/encoding/msgpack"
+	"github.com/alexfalkowski/go-service/v2/encoding/proto"
+	"github.com/alexfalkowski/go-service/v2/encoding/toml"
+	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 )
 
 func TestEncoder(t *testing.T) {
@@ -17,6 +27,90 @@ func TestEncoder(t *testing.T) {
 	for _, k := range []string{"test", "bob"} {
 		t.Run(k, func(t *testing.T) {
 			require.Nil(t, test.Encoder.Get(k))
+		})
+	}
+}
+
+func TestNewMapRegistersDefaultEncoders(t *testing.T) {
+	jsonEncoder := json.NewEncoder()
+	hjsonEncoder := hjson.NewEncoder()
+	yamlEncoder := yaml.NewEncoder()
+	tomlEncoder := toml.NewEncoder()
+	msgpackEncoder := msgpack.NewEncoder()
+	protoBinary := proto.NewBinary()
+	protoText := proto.NewText()
+	protoJSON := proto.NewJSON()
+	gobEncoder := gob.NewEncoder()
+	bytesEncoder := bytes.NewEncoder()
+
+	encoders := encoding.NewMap(encoding.MapParams{
+		JSON:        jsonEncoder,
+		HumanJSON:   hjsonEncoder,
+		YAML:        yamlEncoder,
+		TOML:        tomlEncoder,
+		MessagePack: msgpackEncoder,
+		ProtoBinary: protoBinary,
+		ProtoText:   protoText,
+		ProtoJSON:   protoJSON,
+		GOB:         gobEncoder,
+		Bytes:       bytesEncoder,
+	})
+
+	expected := map[string]encoding.Encoder{
+		"json":         jsonEncoder,
+		"hjson":        hjsonEncoder,
+		"yaml":         yamlEncoder,
+		"yml":          yamlEncoder,
+		"toml":         tomlEncoder,
+		"msgpack":      msgpackEncoder,
+		"pb":           protoBinary,
+		"pbbin":        protoBinary,
+		"proto":        protoBinary,
+		"protobin":     protoBinary,
+		"protobuf":     protoBinary,
+		"pbtxt":        protoText,
+		"prototext":    protoText,
+		"prototxt":     protoText,
+		"protojson":    protoJSON,
+		"pbjson":       protoJSON,
+		"gob":          gobEncoder,
+		"markdown":     bytesEncoder,
+		"octet-stream": bytesEncoder,
+		"plain":        bytesEncoder,
+	}
+
+	for kind, expectedEncoder := range expected {
+		t.Run(kind, func(t *testing.T) {
+			require.Same(t, expectedEncoder, encoders.Get(kind))
+		})
+	}
+}
+
+func TestMapRegister(t *testing.T) {
+	encoders := encoding.NewMap(encoding.MapParams{})
+	custom := test.NewEncoder(test.ErrFailed)
+	replacement := bytes.NewEncoder()
+
+	encoders.Register("custom", custom)
+	require.Same(t, custom, encoders.Get("custom"))
+
+	encoders.Register("custom", replacement)
+	require.Same(t, replacement, encoders.Get("custom"))
+}
+
+func TestModuleProvidesDefaultEncoders(t *testing.T) {
+	var encoders *encoding.Map
+
+	app := fx.New(
+		encoding.Module,
+		fx.Populate(&encoders),
+		fx.NopLogger,
+	)
+
+	require.NoError(t, app.Err())
+	for _, kind := range []string{"json", "hjson", "yaml", "toml", "msgpack", "proto", "prototext", "protojson", "gob", "plain"} {
+		t.Run(kind, func(t *testing.T) {
+			require.NotNil(t, encoders.Get(kind))
 		})
 	}
 }

--- a/encoding/errors/errors_test.go
+++ b/encoding/errors/errors_test.go
@@ -1,0 +1,28 @@
+package errors_test
+
+import (
+	"testing"
+
+	encoding "github.com/alexfalkowski/go-service/v2/encoding/errors"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrailingData(t *testing.T) {
+	parseErr := errors.New("parse failed")
+
+	t.Run("eof", func(t *testing.T) {
+		require.NoError(t, encoding.TrailingData(io.EOF))
+	})
+
+	t.Run("extra value", func(t *testing.T) {
+		require.ErrorIs(t, encoding.TrailingData(nil), encoding.ErrTrailingData)
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		err := encoding.TrailingData(parseErr)
+		require.ErrorIs(t, err, encoding.ErrTrailingData)
+		require.ErrorIs(t, err, parseErr)
+	})
+}

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -43,6 +43,13 @@ func TestDecode(t *testing.T) {
 	require.Equal(t, "test", msg.Test)
 }
 
+func TestDecodeReturnsReadError(t *testing.T) {
+	encoder := hjson.NewEncoder()
+	msg := &message{}
+
+	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, msg), test.ErrFailed)
+}
+
 func TestDecodeRejectsDuplicateKeys(t *testing.T) {
 	encoder := hjson.NewEncoder()
 	msg := &message{}

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -38,6 +38,14 @@ func TestDecode(t *testing.T) {
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
+func TestDecodeAcceptsTrailingWhitespace(t *testing.T) {
+	encoder := json.NewEncoder()
+	var msg map[string]string
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("{\"test\":\"test\"} \n\t"), &msg))
+	require.Equal(t, map[string]string{"test": "test"}, msg)
+}
+
 func TestDecodeRejectsTrailingData(t *testing.T) {
 	for _, input := range []string{
 		`{"test":"test"} garbage`,

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -3,12 +3,14 @@ package proto_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/proto"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +34,7 @@ func TestInvalidBinaryEncode(t *testing.T) {
 	defer test.Pool.Put(bytes)
 
 	var msg string
-	require.Error(t, encoder.Encode(bytes, &msg))
+	require.ErrorIs(t, encoder.Encode(bytes, &msg), errors.ErrInvalidType)
 }
 
 func TestInvalidBinaryDecode(t *testing.T) {
@@ -77,7 +79,7 @@ func TestInvalidTextEncode(t *testing.T) {
 	defer test.Pool.Put(bytes)
 
 	var msg string
-	require.Error(t, encoder.Encode(bytes, &msg))
+	require.ErrorIs(t, encoder.Encode(bytes, &msg), errors.ErrInvalidType)
 }
 
 func TestInvalidTextDecode(t *testing.T) {
@@ -122,7 +124,48 @@ func TestInvalidJSONEncode(t *testing.T) {
 	defer test.Pool.Put(bytes)
 
 	var msg string
-	require.Error(t, encoder.Encode(bytes, &msg))
+	require.ErrorIs(t, encoder.Encode(bytes, &msg), errors.ErrInvalidType)
+}
+
+func TestEncodersUseExpectedWireFormats(t *testing.T) {
+	t.Run("binary", func(t *testing.T) {
+		encoder := proto.NewBinary()
+		buffer := test.Pool.Get()
+		defer test.Pool.Put(buffer)
+
+		require.NoError(t, encoder.Encode(buffer, &health.Response{Status: health.Serving}))
+		require.Equal(t, []byte{0x08, 0x01}, test.Pool.Copy(buffer))
+
+		var decode health.Response
+		require.NoError(t, encoder.Decode(bytes.NewBuffer([]byte{0x08, 0x01}), &decode))
+		require.Equal(t, health.Serving, decode.GetStatus())
+	})
+
+	t.Run("text", func(t *testing.T) {
+		encoder := proto.NewText()
+		buffer := test.Pool.Get()
+		defer test.Pool.Put(buffer)
+
+		require.NoError(t, encoder.Encode(buffer, &health.Response{Status: health.Serving}))
+		require.Equal(t, "status:SERVING", strings.TrimSpace(buffer.String()))
+
+		var decode health.Response
+		require.NoError(t, encoder.Decode(bytes.NewBufferString("status:SERVING"), &decode))
+		require.Equal(t, health.Serving, decode.GetStatus())
+	})
+
+	t.Run("json", func(t *testing.T) {
+		encoder := proto.NewJSON()
+		buffer := test.Pool.Get()
+		defer test.Pool.Put(buffer)
+
+		require.NoError(t, encoder.Encode(buffer, &health.Response{Status: health.Serving}))
+		require.JSONEq(t, `{"status":"SERVING"}`, buffer.String())
+
+		var decode health.Response
+		require.NoError(t, encoder.Decode(bytes.NewBufferString(`{"status":"SERVING"}`), &decode))
+		require.Equal(t, health.Serving, decode.GetStatus())
+	})
 }
 
 func TestInvalidJSONDecode(t *testing.T) {
@@ -159,7 +202,7 @@ func TestEncodeReturnsWriteError(t *testing.T) {
 
 	for _, tt := range encoders {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Error(t, tt.encoder.Encode(test.ErrWriter{}, &health.Response{Status: health.Serving}))
+			require.ErrorIs(t, tt.encoder.Encode(test.ErrWriter{}, &health.Response{Status: health.Serving}), test.ErrFailed)
 		})
 	}
 }
@@ -167,19 +210,19 @@ func TestEncodeReturnsWriteError(t *testing.T) {
 func TestErrBinaryDecode(t *testing.T) {
 	encoder := proto.NewBinary()
 	var msg health.Response
-	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &msg))
+	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
 }
 
 func TestErrTextDecode(t *testing.T) {
 	encoder := proto.NewText()
 	var msg health.Response
-	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &msg))
+	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
 }
 
 func TestErrJSONDecode(t *testing.T) {
 	encoder := proto.NewJSON()
 	var msg health.Response
-	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &msg))
+	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
 }
 
 func TestInvalidTypedNilEncode(t *testing.T) {

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -37,3 +37,15 @@ func TestDecode(t *testing.T) {
 	require.NoError(t, encoder.Decode(bytes.NewBufferString(`test = "test"`), &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
+
+func TestDecodeIgnoresUndecodedMetadata(t *testing.T) {
+	encoder := toml.NewEncoder()
+	msg := &message{}
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("test = \"test\"\nextra = \"ignored\""), msg))
+	require.Equal(t, "test", msg.Test)
+}
+
+type message struct {
+	Test string `toml:"test"`
+}

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -37,10 +37,17 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecodeRejectsTrailingDocument(t *testing.T) {
-	encoder := yaml.NewEncoder()
-	var msg map[string]string
+	for _, input := range []string{
+		"test: test\n---\ntest: other",
+		"test: test\n---\n: invalid",
+	} {
+		t.Run(input, func(t *testing.T) {
+			encoder := yaml.NewEncoder()
+			var msg map[string]string
 
-	err := encoder.Decode(bytes.NewBufferString("test: test\n---\ntest: other"), &msg)
+			err := encoder.Decode(bytes.NewBufferString(input), &msg)
 
-	require.ErrorIs(t, err, errors.ErrTrailingData)
+			require.ErrorIs(t, err, errors.ErrTrailingData)
+		})
+	}
 }


### PR DESCRIPTION
## What

- Add encoding registry tests for default aliases, custom registration, and Fx module wiring.
- Add base64 and trailing-data helper coverage.
- Strengthen codec tests for invalid-type errors, I/O error propagation, protobuf wire formats, TOML metadata discard, JSON whitespace, and YAML trailing data.

## Why

- Close the encoding test-gap ledger with coverage for repository-owned contracts that were previously self-referential or unchecked.
- Make codec behavior harder to regress without depending on upstream library internals.

## Testing

- `go test ./encoding/... ./net/http/content` - passed
- `make lint` - passed
