### PR TITLE
feat(telemetry): route telemetry globals through local wrappers

### DIFF
--- a/cache/telemetry/telemetry_test.go
+++ b/cache/telemetry/telemetry_test.go
@@ -7,11 +7,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestInstrumentTracingDisablesRawCommandStatements(t *testing.T) {
@@ -21,8 +20,8 @@ func TestInstrumentTracingDisablesRawCommandStatements(t *testing.T) {
 	})
 
 	exporter := &test.SpanExporter{}
-	provider := trace.NewTracerProvider(trace.WithSyncer(exporter))
-	otel.SetTracerProvider(provider)
+	provider := tracer.NewProvider(tracer.WithSyncer(exporter))
+	tracer.SetProvider(provider)
 	t.Cleanup(func() {
 		require.NoError(t, provider.Shutdown(context.Background()))
 	})

--- a/database/sql/driver/driver_test.go
+++ b/database/sql/driver/driver_test.go
@@ -12,10 +12,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -205,12 +203,12 @@ func setupSpans(t *testing.T) (*test.SpanExporter, func()) {
 	t.Helper()
 
 	exporter := &test.SpanExporter{}
-	provider := trace.NewTracerProvider(trace.WithSyncer(exporter))
-	otel.SetTracerProvider(provider)
+	provider := tracer.NewProvider(tracer.WithSyncer(exporter))
+	tracer.SetProvider(provider)
 
 	return exporter, func() {
 		require.NoError(t, provider.Shutdown(t.Context()))
-		otel.SetTracerProvider(noop.NewTracerProvider())
+		tracer.SetProvider(tracer.NewNoopProvider())
 	}
 }
 

--- a/database/sql/telemetry/telemetry.go
+++ b/database/sql/telemetry/telemetry.go
@@ -5,8 +5,8 @@ import (
 	"database/sql/driver"
 
 	"github.com/XSAM/otelsql"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 )
 
 // Option is an alias of otelsql.Option.
@@ -40,7 +40,7 @@ func WrapDriver(driver driver.Driver, opts ...Option) driver.Driver {
 // WithAttributes adds static attributes to SQL telemetry spans and metrics.
 //
 // This is a thin wrapper around otelsql.WithAttributes.
-func WithAttributes(attrs ...attribute.KeyValue) Option {
+func WithAttributes(attrs ...attributes.KeyValue) Option {
 	return otelsql.WithAttributes(attrs...)
 }
 
@@ -54,7 +54,7 @@ func WithSpanOptions(opts SpanOptions) Option {
 // RegisterDBStatsMetrics registers OpenTelemetry DB stats metrics for db.
 //
 // This is a thin wrapper around otelsql.RegisterDBStatsMetrics.
-func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) (metric.Registration, error) {
+func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) (metrics.Registration, error) {
 	return otelsql.RegisterDBStatsMetrics(db, opts...)
 }
 

--- a/database/sql/telemetry/telemetry_test.go
+++ b/database/sql/telemetry/telemetry_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/database/sql/telemetry"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 )
 
 var driverID sync.Uint64
@@ -109,16 +107,16 @@ func setupSpans(t *testing.T) (*test.SpanExporter, func()) {
 	})
 
 	exporter := &test.SpanExporter{}
-	provider := trace.NewTracerProvider(trace.WithSyncer(exporter))
-	otel.SetTracerProvider(provider)
+	provider := tracer.NewProvider(tracer.WithSyncer(exporter))
+	tracer.SetProvider(provider)
 
 	return exporter, func() {
 		require.NoError(t, provider.Shutdown(t.Context()))
-		otel.SetTracerProvider(noop.NewTracerProvider())
+		tracer.SetProvider(tracer.NewNoopProvider())
 	}
 }
 
-func requireNoRawQueryText(t *testing.T, spans []trace.ReadOnlySpan, query string) {
+func requireNoRawQueryText(t *testing.T, spans []tracer.ReadOnlySpan, query string) {
 	t.Helper()
 
 	for _, span := range spans {
@@ -130,7 +128,7 @@ func requireNoRawQueryText(t *testing.T, spans []trace.ReadOnlySpan, query strin
 	}
 }
 
-func requireRawQueryText(t *testing.T, spans []trace.ReadOnlySpan, query string) {
+func requireRawQueryText(t *testing.T, spans []tracer.ReadOnlySpan, query string) {
 	t.Helper()
 
 	for _, span := range spans {

--- a/internal/test/metrics.go
+++ b/internal/test/metrics.go
@@ -8,88 +8,86 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	hm "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/metrics"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.uber.org/fx/fxtest"
 )
 
 var errInvalid = errors.New("invalid")
 
 // InvalidMeter is an OpenTelemetry meter test double whose constructors always fail.
-type InvalidMeter struct{ embedded.Meter }
+type InvalidMeter struct{ metrics.EmbeddedMeter }
 
-// Int64Counter implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64Counter(string, ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+// Int64Counter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64Counter(string, ...metrics.Int64CounterOption) (metrics.Int64Counter, error) {
 	return nil, errInvalid
 }
 
-// Int64UpDownCounter implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64UpDownCounter(string, ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error) {
+// Int64UpDownCounter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64UpDownCounter(string, ...metrics.Int64UpDownCounterOption) (metrics.Int64UpDownCounter, error) {
 	return nil, errInvalid
 }
 
-// Int64Histogram implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64Histogram(string, ...metric.Int64HistogramOption) (metric.Int64Histogram, error) {
+// Int64Histogram implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64Histogram(string, ...metrics.Int64HistogramOption) (metrics.Int64Histogram, error) {
 	return nil, errInvalid
 }
 
-// Int64ObservableCounter implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64ObservableCounter(string, ...metric.Int64ObservableCounterOption) (metric.Int64ObservableCounter, error) {
+// Int64ObservableCounter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64ObservableCounter(string, ...metrics.Int64ObservableCounterOption) (metrics.Int64ObservableCounter, error) {
 	return nil, errInvalid
 }
 
-// Int64ObservableUpDownCounter implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64ObservableUpDownCounter(string, ...metric.Int64ObservableUpDownCounterOption) (metric.Int64ObservableUpDownCounter, error) {
+// Int64ObservableUpDownCounter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64ObservableUpDownCounter(string, ...metrics.Int64ObservableUpDownCounterOption) (metrics.Int64ObservableUpDownCounter, error) {
 	return nil, errInvalid
 }
 
-// Int64ObservableGauge implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64ObservableGauge(string, ...metric.Int64ObservableGaugeOption) (metric.Int64ObservableGauge, error) {
+// Int64ObservableGauge implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64ObservableGauge(string, ...metrics.Int64ObservableGaugeOption) (metrics.Int64ObservableGauge, error) {
 	return nil, errInvalid
 }
 
-// Int64Gauge implements metric.Meter and always returns an error.
-func (InvalidMeter) Int64Gauge(string, ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
+// Int64Gauge implements metrics.Meter and always returns an error.
+func (InvalidMeter) Int64Gauge(string, ...metrics.Int64GaugeOption) (metrics.Int64Gauge, error) {
 	return nil, errInvalid
 }
 
-// Float64Counter implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64Counter(string, ...metric.Float64CounterOption) (metric.Float64Counter, error) {
+// Float64Counter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64Counter(string, ...metrics.Float64CounterOption) (metrics.Float64Counter, error) {
 	return nil, errInvalid
 }
 
-// Float64UpDownCounter implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64UpDownCounter(string, ...metric.Float64UpDownCounterOption) (metric.Float64UpDownCounter, error) {
+// Float64UpDownCounter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64UpDownCounter(string, ...metrics.Float64UpDownCounterOption) (metrics.Float64UpDownCounter, error) {
 	return nil, errInvalid
 }
 
-// Float64Histogram implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64Histogram(string, ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+// Float64Histogram implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64Histogram(string, ...metrics.Float64HistogramOption) (metrics.Float64Histogram, error) {
 	return nil, errInvalid
 }
 
-// Float64ObservableCounter implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64ObservableCounter(string, ...metric.Float64ObservableCounterOption) (metric.Float64ObservableCounter, error) {
+// Float64ObservableCounter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64ObservableCounter(string, ...metrics.Float64ObservableCounterOption) (metrics.Float64ObservableCounter, error) {
 	return nil, errInvalid
 }
 
-// Float64ObservableUpDownCounter implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64ObservableUpDownCounter(string, ...metric.Float64ObservableUpDownCounterOption) (metric.Float64ObservableUpDownCounter, error) {
+// Float64ObservableUpDownCounter implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64ObservableUpDownCounter(string, ...metrics.Float64ObservableUpDownCounterOption) (metrics.Float64ObservableUpDownCounter, error) {
 	return nil, errInvalid
 }
 
-// Float64ObservableGauge implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64ObservableGauge(string, ...metric.Float64ObservableGaugeOption) (metric.Float64ObservableGauge, error) {
+// Float64ObservableGauge implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64ObservableGauge(string, ...metrics.Float64ObservableGaugeOption) (metrics.Float64ObservableGauge, error) {
 	return nil, errInvalid
 }
 
-// Float64Gauge implements metric.Meter and always returns an error.
-func (InvalidMeter) Float64Gauge(string, ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
+// Float64Gauge implements metrics.Meter and always returns an error.
+func (InvalidMeter) Float64Gauge(string, ...metrics.Float64GaugeOption) (metrics.Float64Gauge, error) {
 	return nil, errInvalid
 }
 
-// RegisterCallback implements metric.Meter and always returns an error.
-func (InvalidMeter) RegisterCallback(metric.Callback, ...metric.Observable) (metric.Registration, error) {
+// RegisterCallback implements metrics.Meter and always returns an error.
+func (InvalidMeter) RegisterCallback(metrics.Callback, ...metrics.Observable) (metrics.Registration, error) {
 	return nil, errInvalid
 }
 
@@ -114,17 +112,17 @@ func NewMeter(lc di.Lifecycle, c *metrics.Config) (metrics.Meter, error) {
 }
 
 // NewOTLPMeterProvider returns a meter provider backed by the shared OTLP metrics config.
-func NewOTLPMeterProvider(lc di.Lifecycle) (metric.MeterProvider, error) {
+func NewOTLPMeterProvider(lc di.Lifecycle) (metrics.MeterProvider, error) {
 	return NewMeterProvider(lc, NewOTLPMetricsConfig())
 }
 
 // NewPrometheusMeterProvider returns a meter provider backed by the shared Prometheus metrics config.
-func NewPrometheusMeterProvider(lc di.Lifecycle) (metric.MeterProvider, error) {
+func NewPrometheusMeterProvider(lc di.Lifecycle) (metrics.MeterProvider, error) {
 	return NewMeterProvider(lc, NewPrometheusMetricsConfig())
 }
 
 // NewMeterProvider creates a meter provider with a reader registered on the supplied lifecycle.
-func NewMeterProvider(lc di.Lifecycle, config *metrics.Config) (metric.MeterProvider, error) {
+func NewMeterProvider(lc di.Lifecycle, config *metrics.Config) (metrics.MeterProvider, error) {
 	r, err := metrics.NewReader(lc, Name, config)
 	if err != nil {
 		return nil, err

--- a/internal/test/tracer.go
+++ b/internal/test/tracer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-sync"
-	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 // RegisterTracer installs the shared test tracer provider on the supplied lifecycle.
@@ -24,12 +23,12 @@ func RegisterTracer(lc di.Lifecycle, config *tracer.Config) {
 
 // SpanExporter records exported spans for test assertions.
 type SpanExporter struct {
-	spans []trace.ReadOnlySpan
+	spans []tracer.ReadOnlySpan
 	mu    sync.Mutex
 }
 
 // ExportSpans records the supplied spans.
-func (e *SpanExporter) ExportSpans(_ context.Context, spans []trace.ReadOnlySpan) error {
+func (e *SpanExporter) ExportSpans(_ context.Context, spans []tracer.ReadOnlySpan) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -38,15 +37,15 @@ func (e *SpanExporter) ExportSpans(_ context.Context, spans []trace.ReadOnlySpan
 	return nil
 }
 
-// Shutdown satisfies trace.SpanExporter.
+// Shutdown satisfies tracer.SpanExporter.
 func (e *SpanExporter) Shutdown(context.Context) error {
 	return nil
 }
 
 // Spans returns a copy of the recorded spans.
-func (e *SpanExporter) Spans() []trace.ReadOnlySpan {
+func (e *SpanExporter) Spans() []tracer.ReadOnlySpan {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	return append([]trace.ReadOnlySpan(nil), e.spans...)
+	return append([]tracer.ReadOnlySpan(nil), e.spans...)
 }

--- a/telemetry/errors/errors.go
+++ b/telemetry/errors/errors.go
@@ -2,7 +2,6 @@ package errors
 
 import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
-	"go.opentelemetry.io/otel"
 )
 
 // Register installs handler as the global OpenTelemetry error handler.
@@ -21,7 +20,7 @@ func Register(handler *Handler) {
 		return
 	}
 
-	otel.SetErrorHandler(handler)
+	SetHandler(handler)
 }
 
 // NewHandler constructs a Handler that logs OpenTelemetry internal errors.

--- a/telemetry/errors/errors_test.go
+++ b/telemetry/errors/errors_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 )
 
 func TestNewHandlerNilLogger(t *testing.T) {
@@ -17,12 +16,12 @@ func TestNewHandlerNilLogger(t *testing.T) {
 }
 
 func TestRegisterNilHandler(t *testing.T) {
-	original := otel.GetErrorHandler()
-	defer otel.SetErrorHandler(original)
+	original := errors.GetHandler()
+	defer errors.SetHandler(original)
 
 	errors.Register(nil)
 
-	require.Same(t, original, otel.GetErrorHandler())
+	require.Same(t, original, errors.GetHandler())
 }
 
 func TestHandleNilHandler(t *testing.T) {

--- a/telemetry/errors/handler.go
+++ b/telemetry/errors/handler.go
@@ -1,0 +1,16 @@
+package errors
+
+import "go.opentelemetry.io/otel"
+
+// ErrorHandler is an alias for otel.ErrorHandler.
+type ErrorHandler = otel.ErrorHandler
+
+// GetHandler returns the global OpenTelemetry error handler.
+func GetHandler() ErrorHandler {
+	return otel.GetErrorHandler()
+}
+
+// SetHandler installs the global OpenTelemetry error handler.
+func SetHandler(handler ErrorHandler) {
+	otel.SetErrorHandler(handler)
+}

--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -2,7 +2,10 @@ package metrics
 
 import (
 	"github.com/alexfalkowski/go-service/v2/env"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/noop"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -15,6 +18,99 @@ type Meter = metric.Meter
 
 // Registration is an alias for metric.Registration.
 type Registration = metric.Registration
+
+// Callback is an alias for metric.Callback.
+type Callback = metric.Callback
+
+// Observable is an alias for metric.Observable.
+type Observable = metric.Observable
+
+// EmbeddedMeter is an alias for embedded.Meter.
+type EmbeddedMeter = embedded.Meter
+
+// Int64Counter is an alias for metric.Int64Counter.
+type Int64Counter = metric.Int64Counter
+
+// Int64CounterOption is an alias for metric.Int64CounterOption.
+type Int64CounterOption = metric.Int64CounterOption
+
+// Int64UpDownCounter is an alias for metric.Int64UpDownCounter.
+type Int64UpDownCounter = metric.Int64UpDownCounter
+
+// Int64UpDownCounterOption is an alias for metric.Int64UpDownCounterOption.
+type Int64UpDownCounterOption = metric.Int64UpDownCounterOption
+
+// Int64Histogram is an alias for metric.Int64Histogram.
+type Int64Histogram = metric.Int64Histogram
+
+// Int64HistogramOption is an alias for metric.Int64HistogramOption.
+type Int64HistogramOption = metric.Int64HistogramOption
+
+// Int64ObservableCounter is an alias for metric.Int64ObservableCounter.
+type Int64ObservableCounter = metric.Int64ObservableCounter
+
+// Int64ObservableCounterOption is an alias for metric.Int64ObservableCounterOption.
+type Int64ObservableCounterOption = metric.Int64ObservableCounterOption
+
+// Int64ObservableUpDownCounter is an alias for metric.Int64ObservableUpDownCounter.
+type Int64ObservableUpDownCounter = metric.Int64ObservableUpDownCounter
+
+// Int64ObservableUpDownCounterOption is an alias for metric.Int64ObservableUpDownCounterOption.
+type Int64ObservableUpDownCounterOption = metric.Int64ObservableUpDownCounterOption
+
+// Int64ObservableGauge is an alias for metric.Int64ObservableGauge.
+type Int64ObservableGauge = metric.Int64ObservableGauge
+
+// Int64ObservableGaugeOption is an alias for metric.Int64ObservableGaugeOption.
+type Int64ObservableGaugeOption = metric.Int64ObservableGaugeOption
+
+// Int64Gauge is an alias for metric.Int64Gauge.
+type Int64Gauge = metric.Int64Gauge
+
+// Int64GaugeOption is an alias for metric.Int64GaugeOption.
+type Int64GaugeOption = metric.Int64GaugeOption
+
+// Float64Counter is an alias for metric.Float64Counter.
+type Float64Counter = metric.Float64Counter
+
+// Float64CounterOption is an alias for metric.Float64CounterOption.
+type Float64CounterOption = metric.Float64CounterOption
+
+// Float64UpDownCounter is an alias for metric.Float64UpDownCounter.
+type Float64UpDownCounter = metric.Float64UpDownCounter
+
+// Float64UpDownCounterOption is an alias for metric.Float64UpDownCounterOption.
+type Float64UpDownCounterOption = metric.Float64UpDownCounterOption
+
+// Float64Histogram is an alias for metric.Float64Histogram.
+type Float64Histogram = metric.Float64Histogram
+
+// Float64HistogramOption is an alias for metric.Float64HistogramOption.
+type Float64HistogramOption = metric.Float64HistogramOption
+
+// Float64ObservableCounter is an alias for metric.Float64ObservableCounter.
+type Float64ObservableCounter = metric.Float64ObservableCounter
+
+// Float64ObservableCounterOption is an alias for metric.Float64ObservableCounterOption.
+type Float64ObservableCounterOption = metric.Float64ObservableCounterOption
+
+// Float64ObservableUpDownCounter is an alias for metric.Float64ObservableUpDownCounter.
+type Float64ObservableUpDownCounter = metric.Float64ObservableUpDownCounter
+
+// Float64ObservableUpDownCounterOption is an alias for metric.Float64ObservableUpDownCounterOption.
+type Float64ObservableUpDownCounterOption = metric.Float64ObservableUpDownCounterOption
+
+// Float64ObservableGauge is an alias for metric.Float64ObservableGauge.
+type Float64ObservableGauge = metric.Float64ObservableGauge
+
+// Float64ObservableGaugeOption is an alias for metric.Float64ObservableGaugeOption.
+type Float64ObservableGaugeOption = metric.Float64ObservableGaugeOption
+
+// Float64Gauge is an alias for metric.Float64Gauge.
+type Float64Gauge = metric.Float64Gauge
+
+// Float64GaugeOption is an alias for metric.Float64GaugeOption.
+type Float64GaugeOption = metric.Float64GaugeOption
 
 // Reader is an alias for sdkmetric.Reader.
 type Reader = sdk.Reader
@@ -46,4 +142,19 @@ func NewMeter(name env.Name, version env.Version, provider MeterProvider) Meter 
 	}
 
 	return provider.Meter(name.String(), metric.WithInstrumentationVersion(version.String()))
+}
+
+// NewNoopMeterProvider constructs a no-op meter provider.
+func NewNoopMeterProvider() MeterProvider {
+	return noop.NewMeterProvider()
+}
+
+// GetMeterProvider returns the global OpenTelemetry meter provider.
+func GetMeterProvider() MeterProvider {
+	return otel.GetMeterProvider()
+}
+
+// SetMeterProvider installs the global OpenTelemetry meter provider.
+func SetMeterProvider(provider MeterProvider) {
+	otel.SetMeterProvider(provider)
 }

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -9,16 +9,13 @@ import (
 	"github.com/alexfalkowski/go-sync"
 	"go.opentelemetry.io/contrib/instrumentation/host"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 var (
 	enabled      sync.Bool
-	noopProvider metric.MeterProvider = noop.NewMeterProvider()
+	noopProvider MeterProvider = NewNoopMeterProvider()
 )
 
 // MeterProviderParams declares the dependencies required by NewMeterProvider.
@@ -71,7 +68,7 @@ type MeterProviderParams struct {
 func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	if !params.Config.IsEnabled() || params.Reader == nil {
 		enabled.Store(false)
-		otel.SetMeterProvider(noopProvider)
+		SetMeterProvider(noopProvider)
 		return noopProvider
 	}
 
@@ -84,7 +81,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		attributes.DeploymentEnvironmentName(params.Environment.String()),
 	)
 	provider := sdk.NewMeterProvider(sdk.WithReader(reader), sdk.WithResource(attrs))
-	otel.SetMeterProvider(provider)
+	SetMeterProvider(provider)
 	enabled.Store(true)
 
 	params.Lifecycle.Append(di.Hook{
@@ -96,7 +93,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		OnStop: func(ctx context.Context) error {
 			// Do not return error as this will stop all others.
 			_ = provider.Shutdown(ctx)
-			otel.SetMeterProvider(noopProvider)
+			SetMeterProvider(noopProvider)
 			enabled.Store(false)
 
 			return nil

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -7,9 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -18,7 +15,7 @@ func TestIsEnabled(t *testing.T) {
 		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	})
 
-	otel.SetMeterProvider(noop.NewMeterProvider())
+	metrics.SetMeterProvider(metrics.NewNoopMeterProvider())
 	require.False(t, metrics.IsEnabled())
 
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
@@ -56,13 +53,13 @@ func TestMeterProviderStopResetsGlobalState(t *testing.T) {
 		Environment: test.Environment,
 	})
 	require.True(t, metrics.IsEnabled())
-	require.Equal(t, provider, otel.GetMeterProvider())
+	require.Equal(t, provider, metrics.GetMeterProvider())
 
 	lc.RequireStart()
 	require.NoError(t, lc.Stop(t.Context()))
 
 	require.False(t, metrics.IsEnabled())
-	require.NotEqual(t, provider, otel.GetMeterProvider())
+	require.NotEqual(t, provider, metrics.GetMeterProvider())
 }
 
 func TestMeterProviderResourceAttributes(t *testing.T) {
@@ -94,8 +91,8 @@ func TestMeterProviderResourceAttributes(t *testing.T) {
 	require.Equal(t, "development", attrs[attributes.DeploymentEnvironmentName("").Key])
 }
 
-func resourceAttributes(rm metrics.ResourceMetrics) map[attribute.Key]string {
-	attrs := make(map[attribute.Key]string)
+func resourceAttributes(rm metrics.ResourceMetrics) map[attributes.Key]string {
+	attrs := make(map[attributes.Key]string)
 	for _, attr := range rm.Resource.Attributes() {
 		attrs[attr.Key] = attr.Value.AsString()
 	}

--- a/telemetry/tracer/provider.go
+++ b/telemetry/tracer/provider.go
@@ -1,0 +1,13 @@
+package tracer
+
+import "go.opentelemetry.io/otel"
+
+// GetProvider returns the global OpenTelemetry tracer provider.
+func GetProvider() Provider {
+	return otel.GetTracerProvider()
+}
+
+// SetProvider installs the global OpenTelemetry tracer provider.
+func SetProvider(provider Provider) {
+	otel.SetTracerProvider(provider)
+}

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-sync"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -21,6 +20,36 @@ var (
 	enabled      sync.Bool
 	noopProvider trace.TracerProvider = noop.NewTracerProvider()
 )
+
+// ReadOnlySpan is an alias for sdktrace.ReadOnlySpan.
+type ReadOnlySpan = sdk.ReadOnlySpan
+
+// SpanExporter is an alias for sdktrace.SpanExporter.
+type SpanExporter = sdk.SpanExporter
+
+// Provider is an alias for trace.TracerProvider.
+type Provider = trace.TracerProvider
+
+// SDKProvider is an alias for sdktrace.TracerProvider.
+type SDKProvider = sdk.TracerProvider
+
+// ProviderOption is an alias for sdktrace.TracerProviderOption.
+type ProviderOption = sdk.TracerProviderOption
+
+// NewProvider constructs an OpenTelemetry SDK tracer provider.
+func NewProvider(opts ...ProviderOption) *SDKProvider {
+	return sdk.NewTracerProvider(opts...)
+}
+
+// WithSyncer configures a tracer provider to export spans synchronously.
+func WithSyncer(exporter SpanExporter) ProviderOption {
+	return sdk.WithSyncer(exporter)
+}
+
+// NewNoopProvider constructs a no-op tracer provider.
+func NewNoopProvider() Provider {
+	return noop.NewTracerProvider()
+}
 
 // TracerParams declares the dependencies required by Register.
 //
@@ -49,13 +78,13 @@ type TracerParams struct {
 	Environment env.Environment
 }
 
-// Register configures and installs a global OpenTelemetry TracerProvider.
+// Register configures and installs a global OpenTelemetry tracer provider.
 //
 // When tracing is configured with kind "otlp", Register:
 //
 //  1. Creates an OTLP/HTTP trace exporter using `Config.URL` and `Config.Headers`.
 //  2. Creates an OpenTelemetry resource describing the running service.
-//  3. Installs a `sdk.TracerProvider` via `otel.SetTracerProvider`.
+//  3. Installs a `sdk.TracerProvider` globally.
 //  4. Appends lifecycle hooks to start the exporter on application start and to
 //     shut down the provider/exporter on application stop.
 //
@@ -66,7 +95,7 @@ type TracerParams struct {
 func Register(params TracerParams) error {
 	if !params.Config.IsEnabled() {
 		enabled.Store(false)
-		otel.SetTracerProvider(noopProvider)
+		SetProvider(noopProvider)
 		return nil
 	}
 
@@ -92,7 +121,7 @@ func Register(params TracerParams) error {
 		)
 
 		provider := sdk.NewTracerProvider(sdk.WithResource(attrs), sdk.WithBatcher(exporter))
-		otel.SetTracerProvider(provider)
+		SetProvider(provider)
 		enabled.Store(true)
 
 		params.Lifecycle.Append(di.Hook{
@@ -103,7 +132,7 @@ func Register(params TracerParams) error {
 				// Do not return error as this will stop all others.
 				_ = provider.Shutdown(ctx)
 				_ = exporter.Shutdown(ctx)
-				otel.SetTracerProvider(noopProvider)
+				SetProvider(noopProvider)
 				enabled.Store(false)
 
 				return nil

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/fx/fxtest"
 )
 
@@ -18,7 +16,7 @@ func TestIsEnabled(t *testing.T) {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})
 
-	otel.SetTracerProvider(noop.NewTracerProvider())
+	tracer.SetProvider(tracer.NewNoopProvider())
 	require.False(t, tracer.IsEnabled())
 
 	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
@@ -55,7 +53,7 @@ func TestRegisterStopResetsGlobalProvider(t *testing.T) {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})
 
-	otel.SetTracerProvider(noop.NewTracerProvider())
+	tracer.SetProvider(tracer.NewNoopProvider())
 	lc := fxtest.NewLifecycle(t)
 	require.NoError(t, tracer.Register(tracer.TracerParams{
 		Lifecycle:   lc,


### PR DESCRIPTION
## What

- Add local wrapper APIs for OpenTelemetry global meter, tracer, and error handler state.
- Route cache, SQL, and telemetry tests through repository telemetry wrappers instead of direct upstream `otel` imports.
- Keep direct upstream `otel` imports limited to the wrapper boundary packages.

## Why

- Keeps telemetry tests and helpers using repository-owned packages consistently.
- Reduces direct coupling to upstream global OpenTelemetry APIs outside the telemetry wrapper layer.
- Code review focused on the public wrapper surface and tightened tracer provider aliases before push.

## Testing

- `go test -count=1 ./telemetry/... ./database/sql/driver ./database/sql/telemetry ./cache/telemetry` - passed
- `make lint` - passed
- `git diff --check` - passed
