### PR TITLE
test(transport): exercise middleware edge cases

### DIFF
--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -1,17 +1,23 @@
 package grpc_test
 
 import (
+	"slices"
 	"strconv"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/transport/breaker"
+	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	grpcbreaker "github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
@@ -26,13 +32,13 @@ func TestServerLimiterUnary(t *testing.T) {
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
-	header := meta.Map{}
+	header := grpcmeta.Map{}
 
 	_, err := client.SayHello(t.Context(), req, grpc.Header(&header))
 	require.NoError(t, err)
 	require.NotEmpty(t, header.Get("ratelimit"))
 
-	rejectedHeader := meta.Map{}
+	rejectedHeader := grpcmeta.Map{}
 	_, err = client.SayHello(t.Context(), req, grpc.Header(&rejectedHeader))
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
@@ -56,7 +62,7 @@ func TestServerLimiterStream(t *testing.T) {
 func TestServerLimiterStreamHeader(t *testing.T) {
 	limiter, err := grpclimiter.NewServerLimiter(fxtest.NewLifecycle(t), limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0))
 	require.NoError(t, err)
-	ctx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+	ctx := grpcmeta.WithAttributes(t.Context(), grpcmeta.WithUserAgent(grpcmeta.String("test-agent")))
 	interceptor := grpclimiter.StreamServerInterceptor(limiter)
 
 	allowed := &test.MetaServerStream{Ctx: ctx}
@@ -88,6 +94,39 @@ func TestClientLimiterUnary(t *testing.T) {
 	_, err := client.SayHello(t.Context(), req)
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestClientLimiterDenialDoesNotOpenBreaker(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	client, err := grpclimiter.NewClientLimiter(lc, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer func() {
+		require.NoError(t, client.Close(t.Context()))
+	}()
+
+	interceptors := transportgrpc.UnaryClientInterceptors(
+		transportgrpc.WithClientLimiter(client),
+		transportgrpc.WithClientBreaker(grpcbreaker.WithSettings(grpcbreaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		})),
+	)
+	calls := 0
+	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return nil
+	}
+	first := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("first-agent")))
+	second := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("second-agent")))
+
+	require.NoError(t, invokeUnaryClient(first, interceptors, invoker))
+	err = invokeUnaryClient(first, interceptors, invoker)
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.NoError(t, invokeUnaryClient(second, interceptors, invoker))
+	require.Equal(t, 2, calls)
 }
 
 func TestClientLimiterStream(t *testing.T) {
@@ -217,6 +256,18 @@ func TestClientClosedLimiterUnary(t *testing.T) {
 	_, err := client.SayHello(t.Context(), req)
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+func invokeUnaryClient(ctx context.Context, interceptors []grpc.UnaryClientInterceptor, invoker grpc.UnaryInvoker) error {
+	chained := invoker
+	for _, interceptor := range slices.Backward(interceptors) {
+		next := chained
+		chained = func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return interceptor(ctx, fullMethod, req, resp, conn, next, opts...)
+		}
+	}
+
+	return chained(ctx, "/test.Service/GetHello", nil, nil, nil)
 }
 
 func sayStreamHello(t *testing.T, client v1.GreeterServiceClient) error {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -89,6 +89,29 @@ func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestUnaryClientInterceptorSetsDeadlineForEachAttempt(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	})
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		calls++
+		_, ok := ctx.Deadline()
+		require.True(t, ok, "attempt %d should have a deadline", calls)
+		if calls == 1 {
+			return status.Error(codes.Unavailable, "unavailable")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
 func TestUnaryClientInterceptorDoesNotRetryUnsafeMethodByDefault(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 2,
@@ -188,6 +211,46 @@ func TestUnaryClientInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
+}
+
+func TestUnaryClientInterceptorComposesMultiplePolicies(t *testing.T) {
+	allow := retry.Policy(func(context.Context, string, any) bool { return true })
+	deny := retry.Policy(func(context.Context, string, any) bool { return false })
+
+	tests := []struct {
+		name     string
+		policies []retry.Policy
+		calls    int
+	}{
+		{name: "deny wins", policies: []retry.Policy{allow, deny}, calls: 1},
+		{name: "nil policies are ignored", policies: []retry.Policy{allow, nil, allow}, calls: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := retry.UnaryClientInterceptor(&config.Config{
+				Attempts: 2,
+				Timeout:  time.Second,
+				Backoff:  time.Millisecond,
+			}, tt.policies...)
+
+			calls := 0
+			err := interceptor(t.Context(), "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				if calls == 1 {
+					return status.Error(codes.Unavailable, "unavailable")
+				}
+
+				return nil
+			})
+			if tt.calls == 1 {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.calls, calls)
+		})
+	}
 }
 
 func TestUnaryClientInterceptorRetriesWhenPolicyAllowsRequestID(t *testing.T) {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/time"
 	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
+	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,4 +71,26 @@ func TestRoundTripperWithTokenDoesNotSendAuthorizationToCrossOriginRedirect(t *t
 	require.Nil(t, res)
 	require.Equal(t, "Bearer secret", trustedAuthorization)
 	require.Empty(t, attackerAuthorization)
+}
+
+func TestRoundTripperGeneratesTokenPerRetryAttempt(t *testing.T) {
+	base := &test.AuthRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
+	rt, err := transporthttp.NewRoundTripper(
+		transporthttp.WithClientRoundTripper(base),
+		transporthttp.WithClientRetry(&retry.Config{
+			Attempts: 2,
+			Timeout:  time.Second,
+			Backoff:  time.Millisecond,
+		}),
+		transporthttp.WithClientTokenGenerator(env.UserID("service-user"), &test.SequenceGenerator{}),
+	)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, base.AuthValues)
+	require.Equal(t, []int{1, 1}, base.AuthCounts)
 }

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -151,6 +151,26 @@ func TestRoundTripperDoesNotSignCrossOriginRedirect(t *testing.T) {
 	require.True(t, body.Closed)
 }
 
+func TestRoundTripperClosesBodyOnSignError(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
+	called := false
+	rt := hooks.NewRoundTripper(hook, test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, nil
+	}))
+	body := &errTrackedBody{TrackedBody: &test.TrackedBody{Reader: strings.NewReader("body")}}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, test.ErrFailed)
+	require.False(t, called)
+	require.True(t, body.Closed)
+}
+
 func TestHandler(t *testing.T) {
 	handler := hooks.NewHandler(nil)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
@@ -163,4 +183,12 @@ func TestHandler(t *testing.T) {
 
 	require.True(t, called)
 	require.Equal(t, http.StatusOK, res.Code)
+}
+
+type errTrackedBody struct {
+	*test.TrackedBody
+}
+
+func (*errTrackedBody) Read([]byte) (int, error) {
+	return 0, test.ErrFailed
 }

--- a/transport/http/metrics_test.go
+++ b/transport/http/metrics_test.go
@@ -15,7 +15,7 @@ func TestPrometheusHTTP(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("prometheus"),
 		test.WithWorldPGConfig(nil),
-		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
 		test.WithWorldHTTP(),
 	)
 
@@ -47,7 +47,7 @@ func TestPrometheusAuthHTTP(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("prometheus"),
 		test.WithWorldPGConfig(nil),
-		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
 		test.WithWorldToken(tkn, tkn),
 		test.WithWorldHTTP(),
 	)

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -81,3 +81,36 @@ func TestRoundTripperLogsTransportError(t *testing.T) {
 	require.Contains(t, logs.String(), `"level":"ERROR"`)
 	require.Contains(t, logs.String(), `"error":"dial failed"`)
 }
+
+func TestRoundTripperLogsResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		level string
+		code  int
+	}{
+		{name: "success", code: http.StatusOK, level: "INFO"},
+		{name: "client error", code: http.StatusBadRequest, level: "WARN"},
+		{name: "server error", code: http.StatusInternalServerError, level: "ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			base := &test.StatusRoundTripper{Status: tt.code}
+			slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+			rt := httplogger.NewRoundTripper(&logger.Logger{Logger: slogLogger}, base)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/users", http.NoBody)
+			require.NoError(t, err)
+
+			res, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, tt.code, res.StatusCode)
+			require.Contains(t, logs.String(), `"level":"`+tt.level+`"`)
+			require.Contains(t, logs.String(), `"msg":"http: get users"`)
+			require.Contains(t, logs.String(), `"system":"http"`)
+			require.Contains(t, logs.String(), `"service":"users"`)
+			require.Contains(t, logs.String(), `"method":"get"`)
+			require.Contains(t, logs.String(), `"code":`+strconv.Itoa(tt.code))
+		})
+	}
+}

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,26 @@ func TestRoundTripperClosesBodyOnGenerateError(t *testing.T) {
 	res, err := roundTripper.RoundTrip(req)
 	require.Nil(t, res)
 	require.Error(t, err)
+	require.True(t, body.Closed)
+}
+
+func TestRoundTripperClosesBodyOnEmptyToken(t *testing.T) {
+	roundTripper := token.NewRoundTripper(
+		env.UserID("service-user"),
+		test.NewGenerator("", nil),
+		test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("unexpected round trip")
+			return nil, nil
+		}),
+	)
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/hello", body)
+	require.NoError(t, err)
+
+	res, err := roundTripper.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnauthorized, status.Code(err))
 	require.True(t, body.Closed)
 }
 

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -3,6 +3,7 @@ package limiter_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -31,7 +32,7 @@ func TestValidLimiter(t *testing.T) {
 func TestTake(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
-	config := &limiter.Config{Kind: "user-agent", Tokens: 2, Interval: time.Second}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Second}
 
 	limiter, err := limiter.NewLimiter(lc, m, config)
 	require.NoError(t, err)
@@ -40,20 +41,77 @@ func TestTake(t *testing.T) {
 		require.NoError(t, limiter.Close(t.Context()))
 	}()
 
-	ctx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+	first := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("first-agent")))
+	second := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("second-agent")))
 
-	ok, header, err := limiter.Take(ctx)
+	ok, header, err := limiter.Take(first)
 
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "limit=2, remaining=1", header)
+	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(first)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(second)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
 }
 
-func TestNewKeyMapIncludesServiceMethod(t *testing.T) {
-	key := limiter.NewKeyMap()["service-method"]
-	ctx := meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("GET /users/{id}")))
+func TestNewKeyMap(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want meta.Value
+	}{
+		{
+			name: "user-agent",
+			ctx:  meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent"))),
+			want: meta.String("test-agent"),
+		},
+		{
+			name: "ip",
+			ctx:  meta.WithAttributes(t.Context(), meta.WithIPAddr(meta.String("192.0.2.1"))),
+			want: meta.String("192.0.2.1"),
+		},
+		{
+			name: "user-id",
+			ctx:  meta.WithAttributes(t.Context(), meta.WithUserID(meta.String("test-user"))),
+			want: meta.String("test-user"),
+		},
+		{
+			name: "service-method",
+			ctx:  meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("GET /users/{id}"))),
+			want: meta.String("GET /users/{id}"),
+		},
+	}
 
-	require.Equal(t, meta.String("GET /users/{id}"), key(ctx))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := limiter.NewKeyMap()[tt.name]
+			require.NotNil(t, key)
+			require.Equal(t, tt.want, key(tt.ctx))
+		})
+	}
+}
+
+func TestLifecycleStopsLimiter(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Second}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+
+	lc.RequireStart()
+	lc.RequireStop()
+
+	_, _, err = limiter.Take(t.Context())
+	require.Error(t, err)
 }
 
 func TestMissingLimiter(t *testing.T) {

--- a/transport/server_test.go
+++ b/transport/server_test.go
@@ -13,19 +13,61 @@ import (
 )
 
 func TestNewServers(t *testing.T) {
-	require.Empty(t, transport.NewServers(transport.ServersParams{}))
-
 	httpService := newService("http")
 	grpcService := newService("grpc")
 	debugService := newService("debug")
 
-	services := transport.NewServers(transport.ServersParams{
-		HTTP:  &transporthttp.Server{Service: httpService},
-		GRPC:  &transportgrpc.Server{Service: grpcService},
-		Debug: &debug.Server{Service: debugService},
-	})
+	tests := []struct {
+		name   string
+		params transport.ServersParams
+		want   []*server.Service
+	}{
+		{name: "none", want: []*server.Service{}},
+		{
+			name: "http only",
+			params: transport.ServersParams{
+				HTTP: &transporthttp.Server{Service: httpService},
+			},
+			want: []*server.Service{httpService},
+		},
+		{
+			name: "grpc only",
+			params: transport.ServersParams{
+				GRPC: &transportgrpc.Server{Service: grpcService},
+			},
+			want: []*server.Service{grpcService},
+		},
+		{
+			name: "debug only",
+			params: transport.ServersParams{
+				Debug: &debug.Server{Service: debugService},
+			},
+			want: []*server.Service{debugService},
+		},
+		{
+			name: "http and debug",
+			params: transport.ServersParams{
+				HTTP:  &transporthttp.Server{Service: httpService},
+				Debug: &debug.Server{Service: debugService},
+			},
+			want: []*server.Service{httpService, debugService},
+		},
+		{
+			name: "all",
+			params: transport.ServersParams{
+				HTTP:  &transporthttp.Server{Service: httpService},
+				GRPC:  &transportgrpc.Server{Service: grpcService},
+				Debug: &debug.Server{Service: debugService},
+			},
+			want: []*server.Service{httpService, grpcService, debugService},
+		},
+	}
 
-	require.Equal(t, []*server.Service{httpService, grpcService, debugService}, services)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, transport.NewServers(tt.params))
+		})
+	}
 }
 
 func newService(name string) *server.Service {


### PR DESCRIPTION
## What

- Add tests for server collection, limiter keys, limiter isolation, lifecycle cleanup, HTTP body closure, token retry ordering, metrics limiter bypass, HTTP response logging, and gRPC retry/interceptor composition.

## Why

- Close the confirmed transport test gaps around repository-owned middleware behavior and composition order.

## Testing

- `go test ./transport/...` - passed
- `make lint` - passed
