### PR TITLE
test(strings): cover helper contracts

### DIFF
--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -7,6 +7,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testBytesSink keeps conversion results observable for allocation assertions.
+var testBytesSink []byte
+
+func TestBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+	}{
+		{name: "empty", s: ""},
+		{name: "non empty", s: "hello"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := strings.Bytes(test.s)
+
+			require.Len(t, got, len(test.s))
+			if len(test.s) == 0 {
+				require.Empty(t, got)
+			} else {
+				require.Equal(t, []byte(test.s), got)
+			}
+		})
+	}
+}
+
+func TestBytesDoesNotAllocate(t *testing.T) {
+	s := "hello"
+	allocs := testing.AllocsPerRun(100, func() {
+		testBytesSink = strings.Bytes(s)
+	})
+
+	require.Zero(t, allocs)
+}
+
+func TestIsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{name: "empty", s: "", want: true},
+		{name: "space", s: " ", want: false},
+		{name: "populated", s: "request", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, strings.IsEmpty(test.s))
+		})
+	}
+}
+
 func TestIsAnyEmpty(t *testing.T) {
 	tests := []struct {
 		name string
@@ -22,6 +75,67 @@ func TestIsAnyEmpty(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.want, strings.IsAnyEmpty(test.ss...))
+		})
+	}
+}
+
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		name string
+		sep  string
+		want string
+		ss   []string
+	}{
+		{name: "no strings", sep: "/", ss: []string{}, want: ""},
+		{name: "one string", sep: "/", ss: []string{"service"}, want: "service"},
+		{name: "multiple strings", sep: "/", ss: []string{"service", "admin", "metrics"}, want: "service/admin/metrics"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, strings.Join(test.sep, test.ss...))
+		})
+	}
+}
+
+func TestConcat(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		ss   []string
+	}{
+		{name: "no strings", ss: []string{}, want: ""},
+		{name: "one string", ss: []string{"service"}, want: "service"},
+		{name: "multiple strings", ss: []string{"service", "admin", "metrics"}, want: "serviceadminmetrics"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, strings.Concat(test.ss...))
+		})
+	}
+}
+
+func TestCutColon(t *testing.T) {
+	tests := []struct {
+		name       string
+		s          string
+		wantBefore string
+		wantAfter  string
+	}{
+		{name: "env source", s: "env:NAME", wantBefore: "env", wantAfter: "NAME"},
+		{name: "file source with later colon", s: "file:/tmp/a:b", wantBefore: "file", wantAfter: "/tmp/a:b"},
+		{name: "missing colon", s: "literal", wantBefore: "literal", wantAfter: ""},
+		{name: "leading colon", s: ":value", wantBefore: "", wantAfter: "value"},
+		{name: "trailing colon", s: "env:", wantBefore: "env", wantAfter: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			before, after := strings.CutColon(test.s)
+
+			require.Equal(t, test.wantBefore, before)
+			require.Equal(t, test.wantAfter, after)
 		})
 	}
 }


### PR DESCRIPTION
## What

- Add unit coverage for unsafe byte conversion, emptiness checks, joining helpers, concatenation, and colon splitting.

## Why

- Protect documented helper contracts from regressions, including the unsafe byte-slice aliasing behavior and source-string splitting edge cases.

## Testing

- `make package=strings specs` - passed
- `make package=strings lint` - passed
- `go test ./strings` - passed
