### PR TITLE
test(meta): cover value and accessor contracts

### DIFF
--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -129,17 +129,34 @@ func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
 	require.Equal(t, meta.String("user"), meta.Attribute(child, "userId"))
 }
 
-func TestUserID(t *testing.T) {
-	ctx := meta.WithAttributes(t.Context(), meta.WithUserID(meta.String("user-id")))
-	require.Equal(t, meta.String("user-id"), meta.UserID(ctx))
-}
+func TestAccessors(t *testing.T) {
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithRequestID(meta.String("request-id")),
+		meta.WithServiceMethod(meta.String("service-method")),
+		meta.WithUserAgent(meta.String("user-agent")),
+		meta.WithUserID(meta.String("user-id")),
+		meta.WithIPAddr(meta.String("ip-addr")),
+		meta.WithAuthorization(meta.Ignored("authorization")),
+		meta.WithGeolocation(meta.String("geo:47,11")),
+	)
 
-func TestServiceMethod(t *testing.T) {
-	ctx := meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("service-method")))
-	require.Equal(t, meta.String("service-method"), meta.ServiceMethod(ctx))
-}
+	tests := []struct {
+		name string
+		got  meta.Value
+		want meta.Value
+	}{
+		{name: "request id", got: meta.RequestID(ctx), want: meta.String("request-id")},
+		{name: "service method", got: meta.ServiceMethod(ctx), want: meta.String("service-method")},
+		{name: "user agent", got: meta.UserAgent(ctx), want: meta.String("user-agent")},
+		{name: "user id", got: meta.UserID(ctx), want: meta.String("user-id")},
+		{name: "ip addr", got: meta.IPAddr(ctx), want: meta.String("ip-addr")},
+		{name: "authorization", got: meta.Authorization(ctx), want: meta.Ignored("authorization")},
+		{name: "geolocation", got: meta.Geolocation(ctx), want: meta.String("geo:47,11")},
+	}
 
-func TestGeolocation(t *testing.T) {
-	ctx := meta.WithAttributes(t.Context(), meta.WithGeolocation(meta.String("geo:47,11")))
-	require.Equal(t, meta.String("geo:47,11"), meta.Geolocation(ctx))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.got)
+		})
+	}
 }

--- a/meta/value_test.go
+++ b/meta/value_test.go
@@ -9,14 +9,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantValue  string
+		wantString string
+		value      meta.Value
+		wantEmpty  bool
+	}{
+		{name: "string", value: meta.String("visible"), wantValue: "visible", wantString: "visible"},
+		{name: "empty string", value: meta.String(""), wantValue: "", wantString: "", wantEmpty: true},
+		{name: "blank", value: meta.Blank(), wantValue: "", wantString: "", wantEmpty: true},
+		{name: "ignored", value: meta.Ignored("secret"), wantValue: "secret", wantString: ""},
+		{name: "redacted", value: meta.Redacted("secret"), wantValue: "secret", wantString: "******"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.wantValue, test.value.Value())
+			require.Equal(t, test.wantString, test.value.String())
+			require.Equal(t, test.wantEmpty, test.value.IsEmpty())
+		})
+	}
+}
+
 func TestErrorWithNil(t *testing.T) {
 	require.Equal(t, meta.Blank(), meta.Error(nil))
+}
+
+func TestError(t *testing.T) {
+	value := meta.Error(&test.MessageError{Message: "boom"})
+
+	require.Equal(t, "boom", value.Value())
+	require.Equal(t, "boom", value.String())
+	require.False(t, value.IsEmpty())
 }
 
 func TestErrorWithTypedNil(t *testing.T) {
 	var err error = (*test.MessageError)(nil)
 
 	require.Equal(t, meta.Blank(), meta.Error(err))
+}
+
+func TestStringerConversions(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantValue  string
+		wantString string
+		value      meta.Value
+	}{
+		{name: "to string", value: meta.ToString(&test.Stringer{Value: "visible"}), wantValue: "visible", wantString: "visible"},
+		{name: "to redacted", value: meta.ToRedacted(&test.Stringer{Value: "secret"}), wantValue: "secret", wantString: "******"},
+		{name: "to ignored", value: meta.ToIgnored(&test.Stringer{Value: "secret"}), wantValue: "secret", wantString: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.wantValue, test.value.Value())
+			require.Equal(t, test.wantString, test.value.String())
+			require.False(t, test.value.IsEmpty())
+		})
+	}
 }
 
 func TestToStringWithNil(t *testing.T) {


### PR DESCRIPTION
## What

- Add coverage for metadata value raw/rendered semantics, non-nil conversion helpers, and standard accessor mappings.

## Why

- Protect metadata contracts that distinguish stored values from rendered values and ensure public getter helpers keep using the expected keys.

## Testing

- `go test ./meta` - passed
- `make package=meta lint` - passed
- `make package=meta specs` - passed
