### PR TITLE
feat(crypto): cover key helper contracts

### DIFF
--- a/crypto/aes/aes_test.go
+++ b/crypto/aes/aes_test.go
@@ -17,6 +17,7 @@ func TestGenerator(t *testing.T) {
 	key, err := gen.Generate()
 	require.NoError(t, err)
 	require.NotEmpty(t, key)
+	require.Len(t, key, 32)
 
 	gen = aes.NewGenerator(rand.NewGenerator(&test.ErrReaderCloser{}))
 	key, err = gen.Generate()
@@ -56,6 +57,11 @@ func TestInvalidCipher(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrMissingKey)
 	require.Nil(t, cipher)
 
+	cipher, err = aes.NewCipher(gen, test.FS, &aes.Config{Key: "env:AES_MISSING"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "env:AES_MISSING")
+	require.Nil(t, cipher)
+
 	cipher, err = aes.NewCipher(gen, test.FS, &aes.Config{Key: test.FilePath("secrets/aes_invalid")})
 	require.NoError(t, err)
 
@@ -89,7 +95,7 @@ func TestInvalidCipher(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cipher.Decrypt(strings.Bytes("test"))
-	require.Error(t, err)
+	require.ErrorIs(t, err, aes.ErrInvalidLength)
 }
 
 func TestEncryptUsesRawNonceBytes(t *testing.T) {

--- a/crypto/bcrypt/bcrypt.go
+++ b/crypto/bcrypt/bcrypt.go
@@ -2,12 +2,20 @@ package bcrypt
 
 import "golang.org/x/crypto/bcrypt"
 
+// DefaultCost is the cost used by Sign.
+const DefaultCost = bcrypt.DefaultCost
+
 // NewSigner constructs a bcrypt-based Signer intended for password hashing.
 //
 // The returned Signer uses bcrypt.DefaultCost when hashing. If you need a different cost or more
 // control over parameters, use golang.org/x/crypto/bcrypt directly.
 func NewSigner() *Signer {
 	return &Signer{}
+}
+
+// Cost returns the hashing cost used to create the provided bcrypt hash.
+func Cost(hash []byte) (int, error) {
+	return bcrypt.Cost(hash)
 }
 
 // Signer hashes and verifies secrets using bcrypt.
@@ -26,7 +34,7 @@ type Signer struct{}
 //
 // This is a thin wrapper around bcrypt.GenerateFromPassword.
 func (s *Signer) Sign(msg []byte) ([]byte, error) {
-	return bcrypt.GenerateFromPassword(msg, bcrypt.DefaultCost)
+	return bcrypt.GenerateFromPassword(msg, DefaultCost)
 }
 
 // Verify checks that sig is a valid bcrypt hash for msg.

--- a/crypto/bcrypt/bcrypt_test.go
+++ b/crypto/bcrypt/bcrypt_test.go
@@ -14,6 +14,11 @@ func TestSigner(t *testing.T) {
 	s, err := signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
 	require.NotEmpty(t, s)
+
+	cost, err := bcrypt.Cost(s)
+	require.NoError(t, err)
+	require.Equal(t, bcrypt.DefaultCost, cost)
+
 	require.NoError(t, signer.Verify(s, strings.Bytes("test")))
 
 	s, err = signer.Sign(strings.Bytes("steve"))

--- a/crypto/config_test.go
+++ b/crypto/config_test.go
@@ -1,0 +1,13 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsEnabled(t *testing.T) {
+	require.False(t, (*crypto.Config)(nil).IsEnabled())
+	require.True(t, (&crypto.Config{}).IsEnabled())
+}

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -21,6 +21,18 @@ func TestGenerator(t *testing.T) {
 	require.NotEmpty(t, pub)
 	require.NotEmpty(t, pri)
 
+	cfg := &ed25519.Config{Public: pub, Private: pri}
+
+	signer, err := ed25519.NewSigner(test.PEM, cfg)
+	require.NoError(t, err)
+
+	verifier, err := ed25519.NewVerifier(test.PEM, cfg)
+	require.NoError(t, err)
+
+	sig, err := signer.Sign(strings.Bytes("test"))
+	require.NoError(t, err)
+	require.NoError(t, verifier.Verify(sig, strings.Bytes("test")))
+
 	gen = ed25519.NewGenerator(rand.NewGenerator(&test.ErrReaderCloser{}))
 	pub, pri, err = gen.Generate()
 	require.Error(t, err)

--- a/crypto/hmac/hmac.go
+++ b/crypto/hmac/hmac.go
@@ -9,6 +9,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
+// Size is the HMAC-SHA-512 signature size in bytes.
+const Size = sha512.Size
+
 // NewSigner constructs an HMAC-SHA-512 Signer when configuration is enabled.
 //
 // Disabled behavior: if cfg is nil (disabled), NewSigner returns (nil, nil).

--- a/crypto/hmac/hmac_test.go
+++ b/crypto/hmac/hmac_test.go
@@ -16,10 +16,12 @@ func TestGenerator(t *testing.T) {
 	key, err := gen.Generate()
 	require.NoError(t, err)
 	require.NotEmpty(t, key)
+	require.Len(t, key, 32)
 
 	gen = hmac.NewGenerator(rand.NewGenerator(&test.ErrReaderCloser{}))
 	key, err = gen.Generate()
 	require.Error(t, err)
+	require.ErrorContains(t, err, "hmac")
 	require.Empty(t, key)
 }
 
@@ -39,6 +41,7 @@ func TestValidSigner(t *testing.T) {
 
 	e, err := signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
+	require.Len(t, e, hmac.Size)
 	require.NoError(t, signer.Verify(e, strings.Bytes("test")))
 
 	signer, err = hmac.NewSigner(nil, nil)
@@ -55,6 +58,11 @@ func TestSignerMissingKey(t *testing.T) {
 
 	signer, err = hmac.NewSigner(test.FS, &hmac.Config{Key: "env:HMAC_EMPTY"})
 	require.ErrorIs(t, err, errors.ErrMissingKey)
+	require.Nil(t, signer)
+
+	signer, err = hmac.NewSigner(test.FS, &hmac.Config{Key: "env:HMAC_MISSING"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "env:HMAC_MISSING")
 	require.Nil(t, signer)
 }
 

--- a/crypto/pem/pem_test.go
+++ b/crypto/pem/pem_test.go
@@ -10,7 +10,19 @@ import (
 )
 
 func TestDecode(t *testing.T) {
-	_, err := test.PEM.Decode(test.FilePath("none"), "n/a")
+	decoded, err := test.PEM.Decode("-----BEGIN TEST KEY-----\nZmlyc3Q=\n-----END TEST KEY-----\n", "TEST KEY")
+	require.NoError(t, err)
+	require.Equal(t, []byte("first"), decoded)
+
+	decoded, err = test.PEM.Decode(
+		"-----BEGIN TEST KEY-----\nZmlyc3Q=\n-----END TEST KEY-----\n"+
+			"-----BEGIN OTHER KEY-----\nc2Vjb25k\n-----END OTHER KEY-----\n",
+		"TEST KEY",
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("first"), decoded)
+
+	_, err = test.PEM.Decode(test.FilePath("none"), "n/a")
 	require.Error(t, err)
 
 	_, err = test.PEM.Decode("", "n/a")

--- a/crypto/rand/rand_test.go
+++ b/crypto/rand/rand_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,8 +21,27 @@ func TestValidRand(t *testing.T) {
 	require.Len(t, s, 32)
 }
 
+func TestGenerateTextUsesAlphanumericAlphabet(t *testing.T) {
+	gen := rand.NewGenerator(rand.NewReader())
+
+	text, err := gen.GenerateText(256)
+	require.NoError(t, err)
+
+	for _, r := range text {
+		require.Contains(t, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", string(r))
+	}
+}
+
 func TestGenerateBytesUsesRawBytes(t *testing.T) {
 	gen := rand.NewGenerator(test.StaticReader{Data: []byte{0x00, 0x01, 0x7f, 0x80, 0xff}})
+
+	data, err := gen.GenerateBytes(5)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x00, 0x01, 0x7f, 0x80, 0xff}, data)
+}
+
+func TestGenerateBytesReadsShortChunksFully(t *testing.T) {
+	gen := rand.NewGenerator(&shortReader{data: []byte{0x00, 0x01, 0x7f, 0x80, 0xff}, size: 2})
 
 	data, err := gen.GenerateBytes(5)
 	require.NoError(t, err)
@@ -56,4 +76,21 @@ func TestInvalidSize(t *testing.T) {
 	})
 	require.Empty(t, text)
 	require.ErrorIs(t, err, rand.ErrInvalidSize)
+}
+
+type shortReader struct {
+	data []byte
+	size int
+}
+
+func (r *shortReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+
+	n := min(len(p), min(r.size, len(r.data)))
+	copy(p, r.data[:n])
+	r.data = r.data[n:]
+
+	return n, nil
 }

--- a/crypto/rsa/decryptor.go
+++ b/crypto/rsa/decryptor.go
@@ -2,7 +2,6 @@ package rsa
 
 import (
 	"crypto/rsa"
-	"crypto/sha512"
 
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
@@ -48,5 +47,5 @@ type Decryptor struct {
 //
 // The randomness source is the injected crypto/rand generator.
 func (d *Decryptor) Decrypt(msg []byte) ([]byte, error) {
-	return rsa.DecryptOAEP(sha512.New(), d.generator, d.privateKey, msg, nil)
+	return DecryptOAEP(d.generator, d.privateKey, msg)
 }

--- a/crypto/rsa/encryptor.go
+++ b/crypto/rsa/encryptor.go
@@ -2,7 +2,6 @@ package rsa
 
 import (
 	"crypto/rsa"
-	"crypto/sha512"
 
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
@@ -48,5 +47,5 @@ type Encryptor struct {
 //
 // The randomness source is the injected generator's reader.
 func (e *Encryptor) Encrypt(msg []byte) ([]byte, error) {
-	return rsa.EncryptOAEP(sha512.New(), e.generator.Reader(), e.publicKey, msg, nil)
+	return EncryptOAEP(e.generator, e.publicKey, msg)
 }

--- a/crypto/rsa/oaep.go
+++ b/crypto/rsa/oaep.go
@@ -1,0 +1,18 @@
+package rsa
+
+import (
+	"crypto/rsa"
+	"crypto/sha512"
+
+	"github.com/alexfalkowski/go-service/v2/crypto/rand"
+)
+
+// EncryptOAEP encrypts msg using RSA-OAEP with SHA-512 and a nil label.
+func EncryptOAEP(generator *rand.Generator, publicKey *rsa.PublicKey, msg []byte) ([]byte, error) {
+	return rsa.EncryptOAEP(sha512.New(), generator.Reader(), publicKey, msg, nil)
+}
+
+// DecryptOAEP decrypts msg using RSA-OAEP with SHA-512 and a nil label.
+func DecryptOAEP(generator *rand.Generator, privateKey *rsa.PrivateKey, msg []byte) ([]byte, error) {
+	return rsa.DecryptOAEP(sha512.New(), generator, privateKey, msg, nil)
+}

--- a/crypto/rsa/rsa_test.go
+++ b/crypto/rsa/rsa_test.go
@@ -56,6 +56,23 @@ func TestValid(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "test", bytes.String(d))
 
+	privateKey, err := cfg.PrivateKey(test.PEM)
+	require.NoError(t, err)
+
+	d, err = rsa.DecryptOAEP(rand, privateKey, e)
+	require.NoError(t, err)
+	require.Equal(t, "test", bytes.String(d))
+
+	publicKey, err := cfg.PublicKey(test.PEM)
+	require.NoError(t, err)
+
+	e, err = rsa.EncryptOAEP(rand, publicKey, strings.Bytes("test"))
+	require.NoError(t, err)
+
+	d, err = dec.Decrypt(e)
+	require.NoError(t, err)
+	require.Equal(t, "test", bytes.String(d))
+
 	enc, err = rsa.NewEncryptor(rand, test.PEM, nil)
 	require.NoError(t, err)
 	require.Nil(t, enc)

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -23,6 +23,18 @@ func TestGenerator(t *testing.T) {
 	require.NotEmpty(t, pub)
 	require.NotEmpty(t, pri)
 
+	cfg := &ssh.Config{Public: pub, Private: pri}
+
+	signer, err := ssh.NewSigner(test.FS, cfg)
+	require.NoError(t, err)
+
+	verifier, err := ssh.NewVerifier(test.FS, cfg)
+	require.NoError(t, err)
+
+	sig, err := signer.Sign(strings.Bytes("test"))
+	require.NoError(t, err)
+	require.NoError(t, verifier.Verify(sig, strings.Bytes("test")))
+
 	gen = ssh.NewGenerator(rand.NewGenerator(&test.ErrReaderCloser{}))
 	pub, pri, err = gen.Generate()
 	require.Error(t, err)
@@ -71,6 +83,9 @@ func TestInvalidConfig(t *testing.T) {
 	require.Error(t, err)
 
 	public := sshPublic(t)
+
+	_, err = ssh.NewVerifier(test.FS, &ssh.Config{Public: public + " generated@example"})
+	require.NoError(t, err)
 
 	_, err = ssh.NewVerifier(test.FS, &ssh.Config{Public: `from="10.0.0.0/8" ` + public})
 	require.ErrorIs(t, err, errors.ErrInvalidKeyFormat)


### PR DESCRIPTION
## What

- Add focused coverage for key generation, PEM decoding, random generation, constructor source errors, and signer/encryptor contracts.
- Expose narrow bcrypt, HMAC, and RSA helper surface so tests stay on project-owned wrappers.
- Route RSA encryption and decryption through local OAEP helpers that preserve SHA-512 and nil-label behavior.

## Why

- Close the crypto test gaps recorded in crypto/ISSUES.md.
- Keep tests aligned with project wrapper ownership instead of importing wrapped upstream packages for small contract checks.

## Testing

- `git diff --check` - passed
- `go test ./crypto/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
