### PR TITLE
test(health): cover lifecycle and checker edges

### DIFF
--- a/health/checker/db_test.go
+++ b/health/checker/db_test.go
@@ -1,12 +1,17 @@
 package checker_test
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/database/sql"
+	"github.com/alexfalkowski/go-service/v2/database/sql/driver"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/health/checker"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,4 +36,80 @@ func TestDBCheckerReturnsPingError(t *testing.T) {
 	check := checker.NewDBChecker(world.DB, time.Second)
 	require.NoError(t, world.DB.Destroy())
 	require.Error(t, check.Check(t.Context()))
+}
+
+func TestDBCheckerPingsMastersAndSlaves(t *testing.T) {
+	driverName := registerPingDriver(t)
+	db, errs := sql.ConnectMasterSlaves(driverName, []string{"master"}, []string{"slave"})
+	require.Empty(t, errs)
+	defer func() {
+		require.NoError(t, db.Destroy())
+	}()
+
+	check := checker.NewDBChecker(db, time.Second)
+	err := check.Check(t.Context())
+	require.ErrorIs(t, err, errMasterPing)
+	require.ErrorIs(t, err, errSlavePing)
+}
+
+func TestDBCheckerReturnsTimeoutCause(t *testing.T) {
+	driverName := registerPingDriver(t)
+	db, errs := sql.ConnectMasterSlaves(driverName, []string{"timeout"}, nil)
+	require.Empty(t, errs)
+	defer func() {
+		require.NoError(t, db.Destroy())
+	}()
+
+	check := checker.NewDBChecker(db, time.Millisecond)
+	require.ErrorIs(t, check.Check(t.Context()), checker.ErrPingTimeout)
+}
+
+var (
+	errMasterPing = errors.New("master ping")
+	errSlavePing  = errors.New("slave ping")
+	pingDriverID  sync.Uint64
+)
+
+func registerPingDriver(t *testing.T) string {
+	t.Helper()
+
+	name := "health-checker-" + strconv.FormatUint(pingDriverID.Add(1), 10)
+	require.NoError(t, driver.Register(name, pingDriver{}))
+	return name
+}
+
+type pingDriver struct{}
+
+func (pingDriver) Open(name string) (driver.Conn, error) {
+	return pingConn{name: name}, nil
+}
+
+type pingConn struct {
+	name string
+}
+
+func (pingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (pingConn) Close() error {
+	return nil
+}
+
+func (pingConn) Begin() (driver.Tx, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c pingConn) Ping(ctx context.Context) error {
+	switch c.name {
+	case "master":
+		return errMasterPing
+	case "slave":
+		return errSlavePing
+	case "timeout":
+		<-ctx.Done()
+		return context.Cause(ctx)
+	default:
+		return nil
+	}
 }

--- a/health/server_test.go
+++ b/health/server_test.go
@@ -1,0 +1,75 @@
+package health_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-health/v2/server"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/health"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-sync"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestNewServerStopsWithLifecycle(t *testing.T) {
+	checker := newLifecycleChecker()
+	reg := server.NewRegistration("lifecycle", time.Millisecond.Duration(), checker)
+	lc := fxtest.NewLifecycle(t)
+	srv := health.NewServer(lc)
+
+	srv.Register("test", reg)
+	require.NoError(t, srv.Observe("test", "healthz", "lifecycle"))
+
+	require.NoError(t, lc.Start(t.Context()))
+	checker.waitForRunning(t)
+
+	require.NoError(t, lc.Stop(t.Context()))
+	checker.waitForStopped(t)
+}
+
+type lifecycleChecker struct {
+	running     chan struct{}
+	stopped     chan struct{}
+	calls       sync.Int64
+	runningOnce sync.Once
+	stoppedOnce sync.Once
+}
+
+func newLifecycleChecker() *lifecycleChecker {
+	return &lifecycleChecker{
+		running: make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (c *lifecycleChecker) Check(ctx context.Context) error {
+	if c.calls.Add(1) == 1 {
+		return nil
+	}
+
+	c.runningOnce.Do(func() { close(c.running) })
+	<-ctx.Done()
+	c.stoppedOnce.Do(func() { close(c.stopped) })
+	return ctx.Err()
+}
+
+func (c *lifecycleChecker) waitForRunning(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-c.running:
+	case <-time.After(time.Second):
+		require.Fail(t, "health checker did not run")
+	}
+}
+
+func (c *lifecycleChecker) waitForStopped(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-c.stopped:
+	case <-time.After(time.Second):
+		require.Fail(t, "health checker was not stopped")
+	}
+}


### PR DESCRIPTION
## What

- Add coverage for lifecycle stop wiring on the root health server.
- Add deterministic DB checker coverage for master/slave ping aggregation and timeout causes.

## Why

- Close the health test gaps recorded in health/ISSUES.md.
- Protect repository-owned health lifecycle and DB checker contracts without relying on live database failure modes for the edge cases.

## Testing

- `git diff --check` - passed
- `go test ./health/... ./sync` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
