### PR TITLE
feat(config): rename source selection flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,13 @@ matching skill for the task.
 
 ## Configuration
 
-- `config.NewDecoder` resolves `-i` as `file:<path>`, `env:<ENV_VAR>`, or a default config file named for the service.
+- `config.NewDecoder` resolves `-config`/`-c` as `file:<path>`, `env:<ENV_VAR>`, or a default config file named for the service.
 - Default file lookup checks the executable directory, `$XDG_CONFIG_HOME/<serviceName>/`, and `/etc/<serviceName>/`.
   When default lookup reaches the user config directory candidate, HOME or
   XDG_CONFIG_HOME is expected to be available; missing both is treated as a
   misconfigured runtime. Do not flag the resulting `os.UserConfigDir` panic as
   a config issue. Services that do not want this environment contract should
-  pass an explicit `-i file:<path>` or `-i env:<ENV_VAR>` source.
+  pass an explicit `-config file:<path>` or `-config env:<ENV_VAR>` source.
 - Many config fields use source strings through `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
 - Service configuration files should contain configuration values and secret
   source references, not raw passwords or credentials.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import (
 func main() {
     app := cli.NewApplication(func(commander cli.Commander) {
         serve := commander.AddServer("serve", "Run the service", module.Server)
-        serve.AddInput("file:./config.yml") // adds the `-i` config input flag with this default
+        serve.AddConfig("file:./config.yml") // adds the `-config` / `-c` config flag with this default
     })
 
     os.Exit(app.RunCode(context.Background()))
@@ -104,9 +104,9 @@ The config decoder supports:
 - TOML (`github.com/BurntSushi/toml`)
 - YAML (`go.yaml.in/yaml/v3`)
 
-### Selecting the config source (`-i` flag)
+### Selecting the config source (`-config` / `-c` flags)
 
-Config input is routed by a flag called `-i`:
+Config input is routed by flags called `-config` and `-c`:
 
 - `file:<path>`
   Read config from a file at `<path>`; parser is selected from the file extension (`.json`, `.hjson`, `.yaml`, `.yml`, `.toml`).
@@ -123,13 +123,13 @@ Config input is routed by a flag called `-i`:
   ```sh
   # Linux (GNU base64)
   export SERVICE_CONFIG="yaml:$(base64 -w 0 < ./config.yml)"
-  ./your-service serve -i env:SERVICE_CONFIG
+  ./your-service serve -config env:SERVICE_CONFIG
   ```
 
   ```sh
   # macOS/BSD base64
   export SERVICE_CONFIG="yaml:$(base64 < ./config.yml | tr -d '\n')"
-  ./your-service serve -i env:SERVICE_CONFIG
+  ./your-service serve -c env:SERVICE_CONFIG
   ```
 
   HJSON works the same way, for example `hjson:<base64-content>`.
@@ -146,7 +146,7 @@ Config input is routed by a flag called `-i`:
   - `/etc/<serviceName>/`
 
 > [!IMPORTANT]
-> Because the user config directory is part of that search, runtimes using default lookup are expected to provide `HOME` or `XDG_CONFIG_HOME`. Services that cannot rely on those environment variables should pass an explicit `-i file:<path>` or `-i env:<ENV_VAR>` source.
+> Because the user config directory is part of that search, runtimes using default lookup are expected to provide `HOME` or `XDG_CONFIG_HOME`. Services that cannot rely on those environment variables should pass an explicit `-config file:<path>` or `-config env:<ENV_VAR>` source.
 
 ### Typed decoding and validation
 

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -18,14 +18,14 @@ import (
 func TestApplicationRun(t *testing.T) {
 	config := test.FilePath("configs/config.yml")
 
-	os.Args = []string{test.Name.String(), "server", "-i", config}
+	os.Args = []string{test.Name.String(), "server", "-config", config}
 	cli.Name = test.Name
 	cli.Version = test.Version
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddServer("server", "Start the server.", test.Options()...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 	require.NoError(t, app.Run(t.Context()))
@@ -34,12 +34,12 @@ func TestApplicationRun(t *testing.T) {
 func TestApplicationRunCodeWithError(t *testing.T) {
 	config := test.FilePath("configs/invalid_http.config.yml")
 
-	os.Args = []string{test.Name.String(), "server", "-i", config}
+	os.Args = []string{test.Name.String(), "server", "-config", config}
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddServer("server", "Start the server.", test.Options()...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 
@@ -68,7 +68,7 @@ func TestApplicationRunWithInvalidFlag(t *testing.T) {
 	app := cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddServer("server", "Start the server.", test.Options()...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 	require.Error(t, app.Run(t.Context()))
@@ -80,7 +80,7 @@ func TestApplicationRunWithInvalidFlag(t *testing.T) {
 	app = cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddClient("client", "Start the client.", test.Options()...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 	require.Error(t, app.Run(t.Context()))
@@ -109,14 +109,14 @@ func TestApplicationDuplicateCommand(t *testing.T) {
 func TestApplicationRunWithInvalidParams(t *testing.T) {
 	config := test.FilePath("configs/config.yml")
 
-	os.Args = []string{test.Name.String(), "server", "-i", config}
+	os.Args = []string{test.Name.String(), "server", "-config", config}
 	cli.Name = test.Name
 	cli.Version = test.Version
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddServer("server", "Start the server.", test.Options()...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 	require.NoError(t, app.Run(t.Context()))
@@ -131,14 +131,14 @@ func TestApplicationInvalid(t *testing.T) {
 
 	for _, config := range configs {
 		t.Run(config, func(t *testing.T) {
-			os.Args = []string{test.Name.String(), "server", "-i", config}
+			os.Args = []string{test.Name.String(), "server", "-config", config}
 			cli.Name = test.Name
 			cli.Version = test.Version
 
 			app := cli.NewApplication(
 				func(c cli.Commander) {
 					cmd := c.AddServer("server", "Start the server.", test.Options()...)
-					cmd.AddInput(strings.Empty)
+					cmd.AddConfig(strings.Empty)
 				},
 			)
 
@@ -150,14 +150,14 @@ func TestApplicationInvalid(t *testing.T) {
 }
 
 func TestApplicationDisabled(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server", "-i", test.FilePath("configs/disabled.config.yml")}
+	os.Args = []string{test.Name.String(), "server", "-config", test.FilePath("configs/disabled.config.yml")}
 	cli.Name = test.Name
 	cli.Version = test.Version
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddServer("server", "Start the server.", test.Options()...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 	require.NoError(t, app.Run(t.Context()))
@@ -172,7 +172,7 @@ func TestApplicationClient(t *testing.T) {
 	app := cli.NewApplication(
 		func(c cli.Commander) {
 			cmd := c.AddClient("client", "Start the client.", opts...)
-			cmd.AddInput(strings.Empty)
+			cmd.AddConfig(strings.Empty)
 		},
 	)
 	require.NoError(t, app.Run(t.Context()))
@@ -352,14 +352,14 @@ func TestApplicationInvalidClient(t *testing.T) {
 
 	for _, config := range configs {
 		t.Run(config, func(t *testing.T) {
-			os.Args = []string{test.Name.String(), "client", "-i", config}
+			os.Args = []string{test.Name.String(), "client", "-config", config}
 			cli.Name = test.Name
 			cli.Version = test.Version
 
 			app := cli.NewApplication(
 				func(c cli.Commander) {
 					cmd := c.AddClient("client", "Start the client.", test.Options()...)
-					cmd.AddInput(strings.Empty)
+					cmd.AddConfig(strings.Empty)
 				},
 			)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,7 @@ func TestValidFileConfig(t *testing.T) {
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			set := flag.NewFlagSet("test")
-			set.AddInput(file)
+			set.AddConfig(file)
 
 			decoder := test.NewDecoder(set)
 
@@ -45,7 +45,7 @@ func TestValidHomeFileConfig(t *testing.T) {
 	require.NoError(t, test.FS.WriteFile(test.FS.Join(home, "config.yml"), data, 0o600))
 
 	set := flag.NewFlagSet("test")
-	set.AddInput("file:~/config.yml")
+	set.AddConfig("file:~/config.yml")
 
 	decoder := test.NewDecoder(set)
 
@@ -68,7 +68,7 @@ func TestInvalidFileConfig(t *testing.T) {
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			set := flag.NewFlagSet("test")
-			set.AddInput(file)
+			set.AddConfig(file)
 
 			decoder := test.NewDecoder(set)
 
@@ -97,7 +97,7 @@ func TestValidEnvConfig(t *testing.T) {
 			t.Setenv("CONFIG", tt.kind+":"+base64.Encode(d))
 
 			set := flag.NewFlagSet("test")
-			set.AddInput("env:CONFIG")
+			set.AddConfig("env:CONFIG")
 
 			decoder := test.NewDecoder(set)
 
@@ -110,7 +110,7 @@ func TestValidEnvConfig(t *testing.T) {
 
 func TestInvalidEnvMissingConfig(t *testing.T) {
 	set := flag.NewFlagSet("test")
-	set.AddInput("env:CONFIG")
+	set.AddConfig("env:CONFIG")
 
 	decoder := test.NewDecoder(set)
 
@@ -125,7 +125,7 @@ func TestInvalidEnvKindConfig(t *testing.T) {
 	t.Setenv("CONFIG", "what:"+base64.Encode(d))
 
 	set := flag.NewFlagSet("test")
-	set.AddInput("env:CONFIG")
+	set.AddConfig("env:CONFIG")
 
 	decoder := test.NewDecoder(set)
 
@@ -137,7 +137,7 @@ func TestInvalidEnvDataConfig(t *testing.T) {
 	t.Setenv("CONFIG", "yaml:not_good")
 
 	set := flag.NewFlagSet("test")
-	set.AddInput("env:CONFIG")
+	set.AddConfig("env:CONFIG")
 
 	decoder := test.NewDecoder(set)
 
@@ -173,7 +173,7 @@ func TestValidCommonConfig(t *testing.T) {
 			require.NoError(t, test.FS.WriteFile(test.FS.Join(path, test.Name.String()+tt.ext), data, 0o600))
 
 			set := flag.NewFlagSet("test")
-			set.AddInput(strings.Empty)
+			set.AddConfig(strings.Empty)
 
 			decoder := test.NewDecoder(set)
 
@@ -188,7 +188,7 @@ func TestValidCommonConfig(t *testing.T) {
 
 func TestInvalidCommonConfig(t *testing.T) {
 	set := flag.NewFlagSet("test")
-	set.AddInput(strings.Empty)
+	set.AddConfig(strings.Empty)
 
 	decoder := test.NewDecoder(set)
 
@@ -198,7 +198,7 @@ func TestInvalidCommonConfig(t *testing.T) {
 
 func TestInvalidKindConfig(t *testing.T) {
 	set := flag.NewFlagSet("test")
-	set.AddInput("test:test")
+	set.AddConfig("test:test")
 
 	decoder := test.NewDecoder(set)
 

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -15,8 +15,8 @@ import (
 type DecoderParams struct {
 	di.In
 
-	// Flags is the parsed flag set used to select the configuration input source.
-	// NewDecoder reads the "-i" flag via Flags.GetInput.
+	// Flags is the parsed flag set used to select the configuration source.
+	// NewDecoder reads the "-config" / "-c" flag via Flags.GetConfig.
 	Flags *flag.FlagSet
 
 	// Encoder is the registry of decoders keyed by kind/extension (e.g. "yaml", "json", "hjson", "toml").
@@ -32,7 +32,7 @@ type DecoderParams struct {
 
 // NewDecoder constructs a Decoder based on the configured input source.
 //
-// Routing is controlled by the "-i" flag (see flag.FlagSet.GetInput). The value supports a
+// Routing is controlled by the "-config" / "-c" flag (see flag.FlagSet.GetConfig). The value supports a
 // "kind:location" format:
 //
 //   - "file:<path>": uses the file decoder to read from <path>. The file extension determines which
@@ -45,7 +45,7 @@ type DecoderParams struct {
 // The returned Decoder is safe for repeated calls to Decode; underlying behavior depends on the
 // selected implementation.
 func NewDecoder(params DecoderParams) Decoder {
-	kind, location := strings.CutColon(params.Flags.GetInput())
+	kind, location := strings.CutColon(params.Flags.GetConfig())
 	switch kind {
 	case "file":
 		return NewFile(location, params.Encoder, params.FS)

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,12 +1,12 @@
 // Package config provides configuration decoding, validation, and DI wiring for go-service.
 //
 // This package exposes a `Decoder` abstraction and multiple decoder implementations that load
-// configuration from different sources. The source is selected by the "-i" flag (see `NewDecoder` and
-// `flag.FlagSet.GetInput`).
+// configuration from different sources. The source is selected by the "-config" / "-c" flag (see `NewDecoder` and
+// `flag.FlagSet.GetConfig`).
 //
-// # Input routing (-i flag)
+// # Config routing (-config / -c flag)
 //
-// `NewDecoder` dispatches based on the value of "-i":
+// `NewDecoder` dispatches based on the value of "-config" / "-c":
 //
 //   - "file:<path>": loads configuration from the file at <path>. The decoder chooses the parser based
 //     on the file extension.

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -34,7 +34,7 @@ func ExampleNewConfig() {
 	}
 
 	flags := flag.NewFlagSet("serve")
-	flags.AddInput("file:" + path)
+	flags.AddConfig("file:" + path)
 
 	decoder := config.NewDecoder(config.DecoderParams{
 		Flags:   flags,

--- a/config/module.go
+++ b/config/module.go
@@ -6,7 +6,7 @@ import "github.com/alexfalkowski/go-service/v2/di"
 //
 // It provides the core configuration components:
 //   - Validator (NewValidator) used to validate decoded config structs.
-//   - Decoder (NewDecoder) that dispatches config loading based on the "-i" flag.
+//   - Decoder (NewDecoder) that dispatches config loading based on the "-config" / "-c" flag.
 //   - *config.Config (NewConfig[Config]) as the standard top-level configuration.
 //
 // It also provides a set of small "projection" constructors that extract commonly-used sub-configs from

--- a/flag/doc.go
+++ b/flag/doc.go
@@ -3,9 +3,9 @@
 // This package is a small wrapper around the standard library `flag` package that standardizes a few
 // flag conventions used across go-service, especially configuration source selection.
 //
-// # Configuration input flag (-i)
+// # Configuration flag (-config / -c)
 //
-// Many go-service applications accept an "-i" flag that selects where configuration should be loaded from.
+// Many go-service applications accept "-config" and "-c" flags that select where configuration should be loaded from.
 // The conventional value format is:
 //
 //	"kind:location"
@@ -14,9 +14,9 @@
 //   - "file:/path/to/config.yaml" to read configuration from a file (decoder selected by extension)
 //   - "env:MY_CONFIG" to read configuration from an environment variable (typically "<ext>:<base64-content>")
 //
-// The `FlagSet` type in this package supports installing this convention via `(*FlagSet).AddInput` and
-// retrieving it via `(*FlagSet).GetInput`. The config subsystem (`config.NewDecoder`) consumes this value
+// The `FlagSet` type in this package supports installing this convention via `(*FlagSet).AddConfig` and
+// retrieving it via `(*FlagSet).GetConfig`. The config subsystem (`config.NewDecoder`) consumes this value
 // to route to the appropriate decoder.
 //
-// Start with `NewFlagSet`, `FlagSet.AddInput`, and `FlagSet.GetInput`.
+// Start with `NewFlagSet`, `FlagSet.AddConfig`, and `FlagSet.GetConfig`.
 package flag

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -17,17 +17,17 @@ func NewFlagSet(name string) *FlagSet {
 
 // FlagSet represents a set of defined flags.
 //
-// It wraps flag.FlagSet and provides optional support for the conventional go-service configuration input
-// flag ("-i") used by the config subsystem to route decoding.
+// It wraps flag.FlagSet and provides optional support for the conventional go-service configuration
+// flag ("-config" / "-c") used by the config subsystem to route decoding.
 //
 // This type is intentionally minimal: you can still use the embedded *flag.FlagSet to define and parse
 // arbitrary flags.
 type FlagSet struct {
-	input *string
+	config *string
 	*flag.FlagSet
 }
 
-// AddInput adds the conventional configuration input flag ("-i") to the flag set.
+// AddConfig adds the conventional configuration flag ("-config" / "-c") to the flag set.
 //
 // The value is treated as an opaque "kind:location" string that the config package interprets.
 // Common examples include:
@@ -35,17 +35,19 @@ type FlagSet struct {
 //   - "env:MY_CONFIG" (read config payload from environment variable MY_CONFIG)
 //
 // The provided value is used as the default.
-func (f *FlagSet) AddInput(value string) {
-	f.input = f.String("i", value, "input config location (format kind:location)")
+func (f *FlagSet) AddConfig(value string) {
+	f.config = &value
+	f.StringVar(f.config, "config", value, "config location (format kind:location)")
+	f.StringVar(f.config, "c", value, "config location (format kind:location)")
 }
 
-// GetInput returns the configured input flag ("-i") value.
+// GetConfig returns the configured config flag ("-config" / "-c") value.
 //
-// This method is nil-safe with respect to AddInput: if AddInput was not called, GetInput returns an empty
-// string. This allows callers to depend on GetInput unconditionally.
-func (f *FlagSet) GetInput() string {
-	if f.input != nil {
-		return *f.input
+// This method is nil-safe with respect to AddConfig: if AddConfig was not called, GetConfig returns an empty
+// string. This allows callers to depend on GetConfig unconditionally.
+func (f *FlagSet) GetConfig() string {
+	if f.config != nil {
+		return *f.config
 	}
 	return strings.Empty
 }

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -1,0 +1,36 @@
+package flag_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/flag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConfigWithoutAddConfig(t *testing.T) {
+	set := flag.NewFlagSet("test")
+
+	require.Empty(t, set.GetConfig())
+}
+
+func TestAddConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		args []string
+	}{
+		{name: "default", want: "file:config.yml"},
+		{name: "long flag", args: []string{"-config", "file:override.yml"}, want: "file:override.yml"},
+		{name: "short flag", args: []string{"-c", "env:CONFIG"}, want: "env:CONFIG"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set := flag.NewFlagSet("test")
+			set.AddConfig("file:config.yml")
+
+			require.NoError(t, set.Parse(tt.args))
+			require.Equal(t, tt.want, set.GetConfig())
+		})
+	}
+}

--- a/module/example_test.go
+++ b/module/example_test.go
@@ -8,7 +8,7 @@ import (
 func ExampleServer() {
 	app := cli.NewApplication(func(commander cli.Commander) {
 		server := commander.AddServer("serve", "Run the service", module.Server)
-		server.AddInput("file:./config.yml")
+		server.AddConfig("file:./config.yml")
 	})
 
 	_ = app
@@ -18,7 +18,7 @@ func ExampleServer() {
 func ExampleClient() {
 	app := cli.NewApplication(func(commander cli.Commander) {
 		client := commander.AddClient("migrate", "Run client tasks", module.Client)
-		client.AddInput("file:./config.yml")
+		client.AddConfig("file:./config.yml")
 	})
 
 	_ = app

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -24,9 +24,9 @@ func TestEnv(t *testing.T) {
 }
 
 func TestSanitizeArgs(t *testing.T) {
-	args := []string{"service", "-test.v", "server", "-i", "config.yml", "-test.run=TestName", "-test-mode"}
+	args := []string{"service", "-test.v", "server", "-config", "config.yml", "-test.run=TestName", "-test-mode"}
 	sanitized := os.SanitizeArgs(args)
 
-	require.Equal(t, []string{"service", "server", "-i", "config.yml", "-test-mode"}, sanitized)
-	require.Equal(t, []string{"service", "-test.v", "server", "-i", "config.yml", "-test.run=TestName", "-test-mode"}, args)
+	require.Equal(t, []string{"service", "server", "-config", "config.yml", "-test-mode"}, sanitized)
+	require.Equal(t, []string{"service", "-test.v", "server", "-config", "config.yml", "-test.run=TestName", "-test-mode"}, args)
 }


### PR DESCRIPTION
## What

- Rename the config source helper API from AddInput/GetInput to AddConfig/GetConfig.
- Register -config and -c as the supported config source flags.
- Update docs, examples, and tests for the new flag names.

## Why

- Make the CLI config source flag clearer than the previous -i naming.

## Testing

- go test -count=1 ./flag ./config ./cli ./module ./os - passed
- make lint - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
