### PR TITLE
feat(transport): bound in-memory limiter bucket keys

### DIFF
--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -1,6 +1,8 @@
 package limiter
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -12,6 +14,10 @@ import (
 	"github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/memorystore"
 )
+
+// maxKeySize keeps normal limiter keys readable while preventing oversized
+// request metadata from being retained verbatim as in-memory bucket names.
+const maxKeySize = 256
 
 // KeyFunc derives the metadata value used to key rate limits for ctx.
 //
@@ -118,7 +124,7 @@ type Limiter struct {
 //
 // Note: callers are responsible for deciding how to surface the header value (e.g. in HTTP response headers).
 func (l *Limiter) Take(ctx context.Context) (bool, string, error) {
-	tokens, remaining, _, ok, err := l.store.Take(ctx, l.key(ctx).Value())
+	tokens, remaining, _, ok, err := l.store.Take(ctx, key(l.key(ctx)))
 	if err != nil {
 		return false, strings.Empty, err
 	}
@@ -137,4 +143,17 @@ func (l *Limiter) Take(ctx context.Context) (bool, string, error) {
 // This is typically invoked automatically via the lifecycle hook installed by NewLimiter.
 func (l *Limiter) Close(ctx context.Context) error {
 	return l.store.Close(ctx)
+}
+
+func key(value meta.Value) string {
+	key := value.Value()
+	if strings.IsEmpty(key) {
+		return "<empty>"
+	}
+	if len(key) <= maxKeySize {
+		return key
+	}
+
+	sum := sha256.Sum256([]byte(key))
+	return strings.Concat("sha256:", hex.EncodeToString(sum[:]))
 }

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,60 @@ func TestTake(t *testing.T) {
 
 	ok, header, err := limiter.Take(first)
 
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(first)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(second)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+}
+
+func TestTakeUsesSingleBucketForEmptyKeys(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Second}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	ok, header, err := limiter.Take(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.Blank())))
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+}
+
+func TestTakeSupportsOversizedKeys(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Second}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	first := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String(strings.Repeat("a", 1024))))
+	second := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String(strings.Repeat("b", 1024))))
+
+	ok, header, err := limiter.Take(first)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "limit=1, remaining=0", header)


### PR DESCRIPTION
## What

- Normalize limiter keys before they reach the in-memory bucket store.
- Collapse empty keys into one bounded bucket and hash oversized keys to fixed-size bucket names.
- Add limiter coverage for empty and oversized metadata-derived keys.

## Why

- Prevent oversized request metadata from being retained verbatim as limiter bucket names while preserving normal key behavior.

## Testing

- `go test ./transport/...` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
