### PR TITLE
docs(net): clarify request body negotiation

### DIFF
--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -20,8 +20,8 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 //   - the selected encoder.
 //
 // Content negotiation:
-// The encoder is selected based on the request Content-Type, falling back to Accept when Content-Type is absent.
-// The response Content-Type header is set to the negotiated media type.
+// Request-body decoding uses the request Content-Type, falling back to JSON when Content-Type is absent or
+// unknown. The response Content-Type header is set to the negotiated media type.
 //
 // Errors:
 // If request decoding fails, NewRequestHandler converts the decode error into a 400 Bad Request using

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -56,8 +56,7 @@ func Patch[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 // RouteRequest registers a handler under pattern that decodes a request and encodes a response.
 //
 // The handler is built using net/http/content.NewRequestHandler, which:
-//   - selects an encoder based on the request Content-Type, falling back to the first Accept media type when
-//     Content-Type is absent,
+//   - decodes the request body using Content-Type, falling back to JSON when Content-Type is absent or unknown,
 //   - decodes the request body into a newly allocated request model, and
 //   - encodes the returned response model using the negotiated media type.
 //

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -17,8 +17,7 @@ import (
 //	Route("/greet.v1.Greeter/SayHello", handler) // registers "POST /greet.v1.Greeter/SayHello"
 //
 // The handler is constructed using net/http/content.NewRequestHandler, which:
-//   - selects an encoder based on the request Content-Type, falling back to the first Accept media type when
-//     Content-Type is absent,
+//   - decodes the request body using Content-Type, falling back to JSON when Content-Type is absent or unknown,
 //   - decodes the request body into a newly allocated request model, and
 //   - encodes the returned response model using the negotiated media type.
 //


### PR DESCRIPTION
## What

- Clarify request-body handler documentation around media selection.
- Document that request decoding uses Content-Type and falls back to JSON when Content-Type is absent or unknown.
- Align REST and RPC route comments with the content handler behavior.

## Why

- Avoid implying that Accept is used to decode request bodies; Accept describes preferred response formats, not the request body format.

## Testing

- `go test ./net/http/content ./net/http/rest ./net/http/rpc` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
