### PR TITLE
feat(telemetry): harden exporter endpoint and metadata handling

### DIFF
--- a/telemetry/internal/otlp/endpoint.go
+++ b/telemetry/internal/otlp/endpoint.go
@@ -11,22 +11,16 @@ import (
 // ErrMissingEndpoint is returned when an OTLP exporter is enabled without an explicit endpoint.
 var ErrMissingEndpoint = errors.New("otlp: missing endpoint")
 
+// ErrInvalidEndpoint is returned when an OTLP exporter endpoint is not an HTTP URL.
+var ErrInvalidEndpoint = errors.New("otlp: invalid endpoint")
+
 // ErrInsecureEndpoint is returned when secret headers would be sent over a non-local HTTP endpoint.
 var ErrInsecureEndpoint = errors.New("otlp: insecure endpoint")
 
-// ValidateRequiredEndpoint validates an explicitly configured OTLP endpoint.
-func ValidateRequiredEndpoint(rawURL string, headers map[string]string) error {
+// ValidateEndpoint validates an explicitly configured OTLP endpoint.
+func ValidateEndpoint(rawURL string, headers map[string]string) error {
 	if strings.IsEmpty(rawURL) {
 		return ErrMissingEndpoint
-	}
-
-	return ValidateEndpoint(rawURL, headers)
-}
-
-// ValidateEndpoint rejects accidental cleartext OTLP endpoints when exporter headers are configured.
-func ValidateEndpoint(rawURL string, headers map[string]string) error {
-	if strings.IsEmpty(rawURL) || len(headers) == 0 {
-		return nil
 	}
 
 	u, err := url.Parse(rawURL)
@@ -34,7 +28,11 @@ func ValidateEndpoint(rawURL string, headers map[string]string) error {
 		return err
 	}
 
-	if u.Scheme != "http" || isLoopback(u.Hostname()) {
+	if (u.Scheme != "http" && u.Scheme != "https") || strings.IsEmpty(u.Host) {
+		return ErrInvalidEndpoint
+	}
+
+	if u.Scheme != "http" || len(headers) == 0 || isLoopback(u.Hostname()) {
 		return nil
 	}
 

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -10,7 +10,6 @@ import (
 func TestValidateEndpoint(t *testing.T) {
 	headers := map[string]string{"Authorization": "Bearer token"}
 
-	require.NoError(t, otlp.ValidateEndpoint("", headers))
 	require.NoError(t, otlp.ValidateEndpoint("https://collector.example.com/v1/traces", headers))
 	require.NoError(t, otlp.ValidateEndpoint("http://localhost:4318/v1/traces", headers))
 	require.NoError(t, otlp.ValidateEndpoint("http://127.0.0.1:4318/v1/traces", headers))
@@ -27,20 +26,33 @@ func TestValidateEndpointInvalidURL(t *testing.T) {
 	require.NotErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestValidateRequiredEndpoint(t *testing.T) {
+func TestValidateEndpointRejectsInvalidEndpoint(t *testing.T) {
+	for _, rawURL := range []string{
+		"htps://collector.example.com/v1/traces",
+		"https:///v1/traces",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			err := otlp.ValidateEndpoint(rawURL, nil)
+
+			require.ErrorIs(t, err, otlp.ErrInvalidEndpoint)
+		})
+	}
+}
+
+func TestValidateEndpointRequiresEndpoint(t *testing.T) {
 	headers := map[string]string{"Authorization": "Bearer token"}
 
-	require.ErrorIs(t, otlp.ValidateRequiredEndpoint("", headers), otlp.ErrMissingEndpoint)
-	require.NoError(t, otlp.ValidateRequiredEndpoint("https://collector.example.com/v1/traces", headers))
+	require.ErrorIs(t, otlp.ValidateEndpoint("", headers), otlp.ErrMissingEndpoint)
+	require.NoError(t, otlp.ValidateEndpoint("https://collector.example.com/v1/traces", headers))
 
-	err := otlp.ValidateRequiredEndpoint("http://collector.example.com/v1/traces", headers)
+	err := otlp.ValidateEndpoint("http://collector.example.com/v1/traces", headers)
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestValidateRequiredEndpointIgnoresEnv(t *testing.T) {
+func TestValidateEndpointIgnoresEnv(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector.example.com/v1/traces")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
 
-	err := otlp.ValidateRequiredEndpoint("", map[string]string{"Authorization": "Bearer token"})
+	err := otlp.ValidateEndpoint("", map[string]string{"Authorization": "Bearer token"})
 	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
 }

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -56,18 +56,30 @@ func TestMetaTruncatesLongValues(t *testing.T) {
 }
 
 func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
-	value := strings.Repeat("a", 1023) + "é" + "z"
-	ctx := meta.WithAttributes(
-		t.Context(),
-		meta.WithRequestID(meta.String(value)),
-	)
+	maxLength := metaValueLength(t, strings.Repeat("a", 2048))
+	prefix := strings.Repeat("a", maxLength-1)
 
-	attrs := logger.Meta(ctx)
-	truncated := attrs[0].Value.String()
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{name: "followed by another rune", value: prefix + "é" + "z"},
+		{name: "terminal rune", value: prefix + "é"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := meta.WithAttributes(
+				t.Context(),
+				meta.WithRequestID(meta.String(tt.value)),
+			)
 
-	require.Len(t, attrs, 1)
-	require.True(t, utf8.ValidString(truncated))
-	require.Equal(t, strings.Repeat("a", 1023), truncated)
+			attrs := logger.Meta(ctx)
+			truncated := attrs[0].Value.String()
+
+			require.Len(t, attrs, 1)
+			require.True(t, utf8.ValidString(truncated))
+			require.Equal(t, prefix, truncated)
+		})
+	}
 }
 
 func TestInvalidLogger(t *testing.T) {
@@ -224,4 +236,17 @@ func TestOTLPLoggerUsesConfiguredLevel(t *testing.T) {
 	require.NotPanics(t, func() {
 		child.ErrorContext(ctx, "exported")
 	})
+}
+
+func metaValueLength(t *testing.T, value string) int {
+	t.Helper()
+
+	ctx := meta.WithAttributes(
+		t.Context(),
+		meta.WithRequestID(meta.String(value)),
+	)
+	attrs := logger.Meta(ctx)
+
+	require.Len(t, attrs, 1)
+	return len(attrs[0].Value.String())
 }

--- a/telemetry/logger/meta.go
+++ b/telemetry/logger/meta.go
@@ -8,6 +8,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/meta"
 )
 
+// maxMetaValueLength keeps context metadata useful in logs without allowing one
+// value to dominate every record.
 const maxMetaValueLength = 1024
 
 // Meta extracts context metadata and returns it as slog attributes.
@@ -33,12 +35,11 @@ func truncateMetaValue(value string) string {
 		return value
 	}
 
-	for index := range value {
-		if index > maxMetaValueLength {
-			_, size := utf8.DecodeLastRuneInString(value[:index])
-			return value[:index-size]
-		}
+	truncated := value[:maxMetaValueLength]
+	for !utf8.ValidString(truncated) {
+		_, size := utf8.DecodeLastRuneInString(truncated)
+		truncated = truncated[:len(truncated)-size]
 	}
 
-	return value[:maxMetaValueLength]
+	return truncated
 }

--- a/telemetry/logger/otlp.go
+++ b/telemetry/logger/otlp.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
-	if err := otlp.ValidateRequiredEndpoint(params.Config.URL, params.Config.Headers); err != nil {
+	if err := otlp.ValidateEndpoint(params.Config.URL, params.Config.Headers); err != nil {
 		return nil, err
 	}
 

--- a/telemetry/metrics/reader.go
+++ b/telemetry/metrics/reader.go
@@ -49,7 +49,7 @@ func NewReader(lc di.Lifecycle, name env.Name, cfg *Config) (metric.Reader, erro
 func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
 	switch cfg.Kind {
 	case "otlp":
-		if err := otlp.ValidateRequiredEndpoint(cfg.URL, cfg.Headers); err != nil {
+		if err := otlp.ValidateEndpoint(cfg.URL, cfg.Headers); err != nil {
 			return nil, prefix(err)
 		}
 

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -101,7 +101,7 @@ func Register(params TracerParams) error {
 
 	switch params.Config.Kind {
 	case "otlp":
-		if err := otlp.ValidateRequiredEndpoint(params.Config.URL, params.Config.Headers); err != nil {
+		if err := otlp.ValidateEndpoint(params.Config.URL, params.Config.Headers); err != nil {
 			return prefix(err)
 		}
 


### PR DESCRIPTION
## What

- Validate configured OTLP exporter endpoints even when no headers are present.
- Reject missing hosts and non-HTTP endpoint schemes through the shared OTLP validator.
- Keep log metadata truncation on valid UTF-8 boundaries.

## Why

- Headerless OTLP URLs could previously bypass local validation and pass malformed or non-HTTP endpoints into upstream exporters.
- Metadata values ending with a multibyte rune at the byte limit could be truncated into invalid UTF-8.

## Testing

- `go test ./telemetry/internal/otlp ./telemetry/logger ./telemetry/metrics ./telemetry/tracer` - passed
- `go test ./telemetry/...` - passed
- `make lint` - passed
