### PR TITLE
feat(transport): expose circuit breaker state aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,11 @@ matching skill for the task.
 - Manual server lifecycle wiring should use `net/server.Register(...)`.
 - `transport.Module` is normally consumed through `module.Server`, which also
   wires `debug.Module`; do not flag `transport.NewServers` requiring
-  `*debug.Server` unless a public API starts promising standalone
-  `transport.Module` composition without the standard `module.Server` bundle.
+  `*debug.Server`. Mentions that `transport.Module` handles transport
+  registration, TLS filesystem registration, or lifecycle registration do not
+  promise a complete standalone server bundle without `module.Server`. Report
+  this only if a public API explicitly promises standalone `transport.Module`
+  composition without the standard `module.Server` bundle.
 - Server defaults that use `net.DefaultAddress`, including the debug server's
   `tcp://:6060` fallback, intentionally bind all interfaces so containerized
   workloads remain reachable through Kubernetes Services, probes, ingress

--- a/transport/breaker/breaker.go
+++ b/transport/breaker/breaker.go
@@ -5,34 +5,14 @@ import (
 	breaker "github.com/sony/gobreaker"
 )
 
-// NewCircuitBreaker constructs a new circuit breaker using the provided Settings.
-//
-// This is a thin wrapper around github.com/sony/gobreaker.NewCircuitBreaker that exists so
-// go-service can:
-//   - re-export gobreaker types behind a stable package path, and
-//   - centralize shared defaults via DefaultSettings.
-//
-// Callers typically customize Settings (e.g. Name, ReadyToTrip, IsSuccessful) and then pass it here.
-func NewCircuitBreaker(st Settings) *CircuitBreaker {
-	return breaker.NewCircuitBreaker(st)
-}
+// StateClosed is an alias for github.com/sony/gobreaker.StateClosed.
+const StateClosed = breaker.StateClosed
 
-// CircuitBreaker is an alias for github.com/sony/gobreaker.CircuitBreaker.
-//
-// It is a generic circuit breaker implementation used by go-service transports. Prefer importing
-// this package's alias when interacting with breakers created by NewCircuitBreaker.
-type CircuitBreaker = breaker.CircuitBreaker
+// StateHalfOpen is an alias for github.com/sony/gobreaker.StateHalfOpen.
+const StateHalfOpen = breaker.StateHalfOpen
 
-// Counts is an alias for github.com/sony/gobreaker.Counts.
-//
-// Counts is used by Settings.ReadyToTrip to decide whether the breaker should open.
-type Counts = breaker.Counts
-
-// Settings is an alias for github.com/sony/gobreaker.Settings.
-//
-// Settings controls breaker behavior (half-open behavior, rolling interval, open timeout, and
-// success/failure classification via IsSuccessful).
-type Settings = breaker.Settings
+// StateOpen is an alias for github.com/sony/gobreaker.StateOpen.
+const StateOpen = breaker.StateOpen
 
 // DefaultSettings provides a conservative default circuit breaker configuration.
 //
@@ -64,3 +44,37 @@ var ErrOpenState = breaker.ErrOpenState
 // It is returned by CircuitBreaker.Execute when the breaker is half-open and MaxRequests
 // would be exceeded.
 var ErrTooManyRequests = breaker.ErrTooManyRequests
+
+// NewCircuitBreaker constructs a new circuit breaker using the provided Settings.
+//
+// This is a thin wrapper around github.com/sony/gobreaker.NewCircuitBreaker that exists so
+// go-service can:
+//   - re-export gobreaker types behind a stable package path, and
+//   - centralize shared defaults via DefaultSettings.
+//
+// Callers typically customize Settings (e.g. Name, ReadyToTrip, IsSuccessful) and then pass it here.
+func NewCircuitBreaker(st Settings) *CircuitBreaker {
+	return breaker.NewCircuitBreaker(st)
+}
+
+// CircuitBreaker is an alias for github.com/sony/gobreaker.CircuitBreaker.
+//
+// It is a generic circuit breaker implementation used by go-service transports. Prefer importing
+// this package's alias when interacting with breakers created by NewCircuitBreaker.
+type CircuitBreaker = breaker.CircuitBreaker
+
+// Counts is an alias for github.com/sony/gobreaker.Counts.
+//
+// Counts is used by Settings.ReadyToTrip to decide whether the breaker should open.
+type Counts = breaker.Counts
+
+// State is an alias for github.com/sony/gobreaker.State.
+//
+// State represents the current state of a CircuitBreaker and is used by Settings.OnStateChange.
+type State = breaker.State
+
+// Settings is an alias for github.com/sony/gobreaker.Settings.
+//
+// Settings controls breaker behavior (half-open behavior, rolling interval, open timeout, and
+// success/failure classification via IsSuccessful).
+type Settings = breaker.Settings

--- a/transport/breaker/breaker_test.go
+++ b/transport/breaker/breaker_test.go
@@ -37,3 +37,26 @@ func TestNewCircuitBreaker(t *testing.T) {
 	})
 	require.ErrorIs(t, err, breaker.ErrOpenState)
 }
+
+func TestStateChangeUsesStableTypes(t *testing.T) {
+	errFailed := errors.New("failed")
+	var from, to breaker.State
+	cb := breaker.NewCircuitBreaker(breaker.Settings{
+		ReadyToTrip: func(counts breaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+		OnStateChange: func(_ string, f breaker.State, t breaker.State) {
+			from = f
+			to = t
+		},
+	})
+
+	_, err := cb.Execute(func() (any, error) {
+		return nil, errFailed
+	})
+
+	require.ErrorIs(t, err, errFailed)
+	require.Equal(t, breaker.StateClosed, from, "state change should start from closed")
+	require.Equal(t, breaker.StateOpen, to, "state change should transition to open")
+	require.Equal(t, "open", breaker.StateOpen.String(), "state alias should preserve upstream methods")
+}


### PR DESCRIPTION
## What

- Re-exported gobreaker state type/constants from `transport/breaker`.
- Added external-package coverage for `Settings.OnStateChange` using the stable wrapper API.
- Clarified review guidance around `transport.Module` and `debug.Module` wiring.

## Why

- Consumers should not need to import `github.com/sony/gobreaker` for breaker state callbacks.
- Future review passes should not flag the supported `module.Server` wiring as an incomplete DI graph.

## Testing

- `go test ./transport/breaker` - passed
- `make package=transport/breaker lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
