### PR TITLE
feat(encoding): standardize marshal helpers

### DIFF
--- a/bytes/size.go
+++ b/bytes/size.go
@@ -1,9 +1,9 @@
 package bytes
 
 import (
+	"encoding/json"
 	"strconv"
 
-	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	units "github.com/docker/go-units"
 )

--- a/encoding/gob/gob.go
+++ b/encoding/gob/gob.go
@@ -3,16 +3,19 @@ package gob
 import (
 	"encoding/gob"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
+
+var defaultEncoder = &Encoder{}
 
 // NewEncoder constructs a gob encoder.
 //
 // This encoder is a thin adapter around the standard library `encoding/gob` package that satisfies
 // `github.com/alexfalkowski/go-service/v2/encoding.Encoder`.
 func NewEncoder() *Encoder {
-	return &Encoder{}
+	return defaultEncoder
 }
 
 // Encoder implements gob encoding and decoding.
@@ -39,4 +42,21 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 
 	var extra any
 	return errors.TrailingData(decoder.Decode(&extra))
+}
+
+// Marshal encodes v as gob.
+func Marshal(v any) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := defaultEncoder.Encode(&buffer, v); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// Unmarshal decodes one gob value from data into v.
+//
+// It uses Decode, so it rejects trailing encoded values or malformed trailing data.
+func Unmarshal(data []byte, v any) error {
+	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }

--- a/encoding/gob/gob_test.go
+++ b/encoding/gob/gob_test.go
@@ -22,6 +22,23 @@ func TestEncoder(t *testing.T) {
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
+func TestMarshalUnmarshal(t *testing.T) {
+	msg := map[string]string{"test": "test"}
+
+	data, err := gob.Marshal(msg)
+	require.NoError(t, err)
+
+	var actual map[string]string
+	require.NoError(t, gob.Unmarshal(data, &actual))
+	require.Equal(t, msg, actual)
+}
+
+func TestMarshalReturnsError(t *testing.T) {
+	_, err := gob.Marshal(func() {})
+
+	require.Error(t, err)
+}
+
 func TestEncodeReturnsError(t *testing.T) {
 	encoder := gob.NewEncoder()
 
@@ -49,6 +66,19 @@ func TestDecodeRejectsTrailingValue(t *testing.T) {
 
 	var msg map[string]string
 	err := encoder.Decode(bytes, &msg)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+func TestUnmarshalRejectsTrailingValue(t *testing.T) {
+	bytes := test.Pool.Get()
+	defer test.Pool.Put(bytes)
+
+	require.NoError(t, gob.NewEncoder().Encode(bytes, map[string]string{"test": "test"}))
+	require.NoError(t, gob.NewEncoder().Encode(bytes, map[string]string{"extra": "value"}))
+
+	var msg map[string]string
+	err := gob.Unmarshal(test.Pool.Copy(bytes), &msg)
 
 	require.ErrorIs(t, err, errors.ErrTrailingData)
 }

--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -1,16 +1,19 @@
 package hjson
 
 import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/io"
 	hjson "github.com/hjson/hjson-go/v4"
 )
+
+var defaultEncoder = &Encoder{}
 
 // NewEncoder constructs an HJSON encoder.
 //
 // This encoder is a thin adapter around `github.com/hjson/hjson-go` that satisfies
 // `github.com/alexfalkowski/go-service/v2/encoding.Encoder`.
 func NewEncoder() *Encoder {
-	return &Encoder{}
+	return defaultEncoder
 }
 
 // Encoder implements HJSON encoding and decoding.
@@ -41,4 +44,21 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 	options.DisallowDuplicateKeys = true
 
 	return hjson.UnmarshalWithOptions(data, v, options)
+}
+
+// Marshal encodes v as HJSON.
+func Marshal(v any) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := defaultEncoder.Encode(&buffer, v); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// Unmarshal decodes HJSON data into v.
+//
+// It uses Decode, so it rejects duplicate object keys.
+func Unmarshal(data []byte, v any) error {
+	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -22,6 +22,22 @@ func TestEncode(t *testing.T) {
 	require.Contains(t, buf.String(), "test")
 }
 
+func TestMarshalUnmarshal(t *testing.T) {
+	data, err := hjson.Marshal(&message{Test: "test"})
+	require.NoError(t, err)
+	require.Contains(t, string(data), "test")
+
+	msg := &message{}
+	require.NoError(t, hjson.Unmarshal(data, msg))
+	require.Equal(t, "test", msg.Test)
+}
+
+func TestMarshalReturnsError(t *testing.T) {
+	_, err := hjson.Marshal(func() {})
+
+	require.Error(t, err)
+}
+
 func TestEncodeReturnsError(t *testing.T) {
 	encoder := hjson.NewEncoder()
 	buf := &bytes.Buffer{}
@@ -55,6 +71,14 @@ func TestDecodeRejectsDuplicateKeys(t *testing.T) {
 	msg := &message{}
 
 	err := encoder.Decode(bytes.NewBufferString("{\n  test: first\n  test: second\n}\n"), msg)
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "duplicate")
+}
+
+func TestUnmarshalRejectsDuplicateKeys(t *testing.T) {
+	msg := &message{}
+
+	err := hjson.Unmarshal([]byte("{\n  test: first\n  test: second\n}\n"), msg)
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(err.Error()), "duplicate")
 }

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -3,19 +3,11 @@ package json
 import (
 	"encoding/json"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
-
-// NewEncoder constructs a JSON encoder.
-//
-// NewEncoder returns an [Encoder] that satisfies
-// `github.com/alexfalkowski/go-service/v2/encoding.Encoder` while delegating to
-// the standard library's `encoding/json` implementation with its default
-// settings.
-func NewEncoder() *Encoder {
-	return &Encoder{}
-}
 
 // Marshaler aliases the standard library JSON marshaler interface.
 //
@@ -40,6 +32,18 @@ type RawMessage = json.RawMessage
 // It is primarily useful with decoders configured to preserve numeric values as
 // strings until the caller decides how to interpret them.
 type Number = json.Number
+
+var defaultEncoder = &Encoder{}
+
+// NewEncoder constructs a JSON encoder.
+//
+// NewEncoder returns an [Encoder] that satisfies
+// `github.com/alexfalkowski/go-service/v2/encoding.Encoder` while delegating to
+// the standard library's `encoding/json` implementation with its default
+// settings.
+func NewEncoder() *Encoder {
+	return defaultEncoder
+}
 
 // Encoder implements JSON encoding and decoding.
 //
@@ -73,28 +77,18 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 	return errors.TrailingData(decoder.Decode(&extra))
 }
 
-// Marshal encodes v as JSON using the standard library implementation.
+// Marshal encodes v as readable indented JSON.
 //
-// It exists so repository packages can use a single go-service JSON import path
-// without changing standard library marshaling behavior.
+// It exists so repository packages can use a single go-service JSON import path.
 func Marshal(v any) ([]byte, error) {
-	return json.Marshal(v)
+	return json.MarshalIndent(v, strings.Empty, "  ")
 }
 
-// MarshalIndent encodes v as indented JSON using the standard library
-// implementation.
+// Unmarshal decodes one JSON value from data into v.
 //
-// It behaves exactly like `encoding/json.MarshalIndent`.
-func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
-	return json.MarshalIndent(v, prefix, indent)
-}
-
-// Unmarshal decodes JSON data into v using the standard library implementation.
-//
-// In most cases v should be a pointer to the destination value. The decoding
-// rules and error behavior are identical to `encoding/json.Unmarshal`.
+// It uses Decode, so it rejects additional JSON values after the first payload.
 func Unmarshal(data []byte, v any) error {
-	return json.Unmarshal(data, v)
+	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }
 
 // Valid reports whether data is syntactically valid JSON.

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -68,6 +68,13 @@ func TestMarshal(t *testing.T) {
 	data, err := json.Marshal(msg)
 	require.NoError(t, err)
 	require.JSONEq(t, "{\"test\":\"test\"}", string(data))
+	require.Contains(t, string(data), "\n  \"test\": \"test\"\n")
+}
+
+func TestMarshalReturnsError(t *testing.T) {
+	_, err := json.Marshal(func() {})
+
+	require.Error(t, err)
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -75,4 +82,12 @@ func TestUnmarshal(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte("{\"test\":\"test\"}"), &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
+}
+
+func TestUnmarshalRejectsTrailingData(t *testing.T) {
+	var msg map[string]string
+
+	err := json.Unmarshal([]byte("{\"test\":\"test\"}{\"extra\":\"value\"}"), &msg)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
 }

--- a/encoding/msgpack/msgpack.go
+++ b/encoding/msgpack/msgpack.go
@@ -7,9 +7,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
+var defaultEncoder = &Encoder{}
+
 // NewEncoder constructs a MessagePack encoder.
 func NewEncoder() *Encoder {
-	return &Encoder{}
+	return defaultEncoder
 }
 
 // Encoder implements MessagePack encoding and decoding.
@@ -35,12 +37,17 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 
 // Marshal encodes v as MessagePack.
 func Marshal(v any) ([]byte, error) {
-	return msgpack.Marshal(v)
+	var buffer bytes.Buffer
+	if err := defaultEncoder.Encode(&buffer, v); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
 }
 
 // Unmarshal decodes one MessagePack value from data into v.
 //
 // It uses Decode, so it rejects trailing encoded values or malformed trailing data.
 func Unmarshal(data []byte, v any) error {
-	return NewEncoder().Decode(bytes.NewReader(data), v)
+	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }

--- a/encoding/msgpack/msgpack_test.go
+++ b/encoding/msgpack/msgpack_test.go
@@ -50,6 +50,12 @@ func TestMarshalUnmarshal(t *testing.T) {
 	require.Equal(t, msg, actual)
 }
 
+func TestMarshalReturnsError(t *testing.T) {
+	_, err := msgpack.Marshal(func() {})
+
+	require.Error(t, err)
+}
+
 func TestDecodeRejectsTrailingValue(t *testing.T) {
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)

--- a/encoding/toml/toml.go
+++ b/encoding/toml/toml.go
@@ -2,15 +2,18 @@ package toml
 
 import (
 	"github.com/BurntSushi/toml"
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
+
+var defaultEncoder = &Encoder{}
 
 // NewEncoder constructs a TOML encoder.
 //
 // This encoder is a thin adapter around github.com/BurntSushi/toml that satisfies
 // `github.com/alexfalkowski/go-service/v2/encoding.Encoder`.
 func NewEncoder() *Encoder {
-	return &Encoder{}
+	return defaultEncoder
 }
 
 // Encoder implements TOML encoding and decoding.
@@ -34,4 +37,19 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	_, err := toml.NewDecoder(r).Decode(v)
 	return err
+}
+
+// Marshal encodes v as TOML.
+func Marshal(v any) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := defaultEncoder.Encode(&buffer, v); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// Unmarshal decodes TOML data into v.
+func Unmarshal(data []byte, v any) error {
+	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -21,6 +21,24 @@ func TestEncode(t *testing.T) {
 	require.Equal(t, `test = "test"`, strings.TrimSpace(bytes.String()))
 }
 
+func TestMarshalUnmarshal(t *testing.T) {
+	msg := map[string]string{"test": "test"}
+
+	data, err := toml.Marshal(msg)
+	require.NoError(t, err)
+	require.Equal(t, `test = "test"`, strings.TrimSpace(string(data)))
+
+	var actual map[string]string
+	require.NoError(t, toml.Unmarshal(data, &actual))
+	require.Equal(t, msg, actual)
+}
+
+func TestMarshalReturnsError(t *testing.T) {
+	_, err := toml.Marshal(func() {})
+
+	require.Error(t, err)
+}
+
 func TestEncodeReturnsError(t *testing.T) {
 	bytes := test.Pool.Get()
 	defer test.Pool.Put(bytes)

--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -1,17 +1,20 @@
 package yaml
 
 import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	yaml "go.yaml.in/yaml/v3"
 )
+
+var defaultEncoder = &Encoder{}
 
 // NewEncoder constructs a YAML encoder.
 //
 // This encoder is a thin adapter around go-yaml v3 (imported as go.yaml.in/yaml/v3) that satisfies
 // `github.com/alexfalkowski/go-service/v2/encoding.Encoder`.
 func NewEncoder() *Encoder {
-	return &Encoder{}
+	return defaultEncoder
 }
 
 // Encoder implements YAML encoding and decoding.
@@ -44,4 +47,21 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 
 	var extra any
 	return errors.TrailingData(decoder.Decode(&extra))
+}
+
+// Marshal encodes v as YAML.
+func Marshal(v any) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := defaultEncoder.Encode(&buffer, v); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// Unmarshal decodes one YAML document from data into v.
+//
+// It uses Decode, so it rejects additional YAML documents after the first payload.
+func Unmarshal(data []byte, v any) error {
+	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -22,6 +22,24 @@ func TestEncode(t *testing.T) {
 	require.Equal(t, "test: test", strings.TrimSpace(bytes.String()))
 }
 
+func TestMarshalUnmarshal(t *testing.T) {
+	msg := map[string]string{"test": "test"}
+
+	data, err := yaml.Marshal(msg)
+	require.NoError(t, err)
+	require.Equal(t, "test: test", strings.TrimSpace(string(data)))
+
+	var actual map[string]string
+	require.NoError(t, yaml.Unmarshal(data, &actual))
+	require.Equal(t, msg, actual)
+}
+
+func TestMarshalReturnsError(t *testing.T) {
+	_, err := yaml.Marshal(marshalError{})
+
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
 func TestEncodeReturnsError(t *testing.T) {
 	encoder := yaml.NewEncoder()
 
@@ -50,4 +68,18 @@ func TestDecodeRejectsTrailingDocument(t *testing.T) {
 			require.ErrorIs(t, err, errors.ErrTrailingData)
 		})
 	}
+}
+
+func TestUnmarshalRejectsTrailingDocument(t *testing.T) {
+	var msg map[string]string
+
+	err := yaml.Unmarshal([]byte("test: test\n---\ntest: other"), &msg)
+
+	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+type marshalError struct{}
+
+func (m marshalError) MarshalYAML() (any, error) {
+	return nil, test.ErrFailed
 }


### PR DESCRIPTION
## What

- Add package-level Marshal and Unmarshal helpers across gob, hjson, toml, and yaml.
- Route package-level helpers through shared encoder instances so top-level decode behavior matches each package encoder.
- Make JSON Marshal produce readable indented output, keep JSON Unmarshal on the decoder path, and remove the separate MarshalIndent helper.
- Use the standard library JSON package inside bytes to avoid a dependency cycle while preserving public wrapper coverage in tests.

## Why

- Keep serializer packages consistent around Marshal and Unmarshal entrypoints.
- Preserve repository-owned decode checks such as trailing-data rejection and HJSON duplicate-key rejection from top-level helpers.
- Avoid coupling bytes back to the go-service JSON wrapper while still testing byte-size JSON behavior through the public wrapper path.

## Testing

- `go test ./...` - passed
- `make package=encoding lint` - passed
