### PR TITLE
feat(encoding): format streamed json output

### DIFF
--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -3,8 +3,8 @@
 // The package serves two related purposes:
 //
 //   - it exposes [Encoder], a thin adapter that satisfies the repository's
-//     generic encoding abstraction while preserving the default behavior of the
-//     standard library encoder and decoder
+//     generic encoding abstraction while using readable indented encoding and
+//     standard library decoding
 //   - it re-exports common JSON helpers and types from the standard library so
 //     packages in this repository can depend on a single go-service JSON import
 //     path instead of importing encoding/json directly

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -39,24 +39,28 @@ var defaultEncoder = &Encoder{}
 //
 // NewEncoder returns an [Encoder] that satisfies
 // `github.com/alexfalkowski/go-service/v2/encoding.Encoder` while delegating to
-// the standard library's `encoding/json` implementation with its default
-// settings.
+// the standard library's `encoding/json` implementation with readable indented
+// encoding and default decoding.
 func NewEncoder() *Encoder {
 	return defaultEncoder
 }
 
 // Encoder implements JSON encoding and decoding.
 //
-// It preserves the default behavior of the standard library `encoding/json`
-// encoder and decoder and does not add repository-specific options.
+// It writes readable indented JSON and uses the standard library
+// `encoding/json` decoder.
 type Encoder struct{}
 
 // Encode writes v to w as JSON.
 //
-// Encode is equivalent to calling `json.NewEncoder(w).Encode(v)`. As with the
-// standard library, the encoded output is terminated with a trailing newline.
+// Encode is equivalent to calling `json.NewEncoder(w).SetIndent("", "  ")`
+// before encoding v. As with the standard library, the encoded output is
+// terminated with a trailing newline.
 func (e *Encoder) Encode(w io.Writer, v any) error {
-	return json.NewEncoder(w).Encode(v)
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent(strings.Empty, "  ")
+
+	return encoder.Encode(v)
 }
 
 // Decode reads JSON from r and decodes it into v.


### PR DESCRIPTION
## What

- Configure the JSON encoder to write indented output with the same empty prefix and two-space indent used by Marshal.

## Why

- Keep streaming JSON output readable and aligned with the package marshaling helper.
- Non-blocking review note: the current GoDoc for Encoder and Encode still describes default standard-library behavior even though Encode now enables indentation.

## Testing

- `go test ./encoding/json` - passed
