### PR TITLE
feat(meta): suppress service method exports

### DIFF
--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -27,7 +27,7 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
-			meta.WithServiceMethod(meta.String(fullMethod)),
+			meta.WithServiceMethod(meta.Ignored(fullMethod)),
 		)
 		ctx = NewOutgoingContext(ctx, md)
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
@@ -50,7 +50,7 @@ func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) gr
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
-			meta.WithServiceMethod(meta.String(fullMethod)),
+			meta.WithServiceMethod(meta.Ignored(fullMethod)),
 		)
 		ctx = NewOutgoingContext(ctx, md)
 		return streamer(ctx, desc, conn, fullMethod, opts...)

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -30,7 +30,8 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
-		require.Equal(t, meta.String("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
+		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
+		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil
 	})
@@ -51,7 +52,8 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
 		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
-		require.Equal(t, meta.String("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
+		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
+		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil
 	})
@@ -88,7 +90,8 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
-		require.Equal(t, meta.String("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
+		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
+		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil, nil
 	}
@@ -113,7 +116,8 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
 		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
-		require.Equal(t, meta.String("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
+		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
+		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil, nil
 	}
@@ -151,7 +155,8 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
 		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
-		require.Equal(t, meta.String("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
+		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
+		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return "ok", nil
 	})
@@ -240,7 +245,8 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 	stream := &test.MetaServerStream{Ctx: ctx}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(_ any, stream grpc.ServerStream) error {
-		require.Equal(t, meta.String("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(stream.Context()))
+		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(stream.Context()))
+		require.NotContains(t, meta.CamelStrings(stream.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil
 	})

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -26,7 +26,7 @@ import (
 //   - copies incoming metadata from the request context
 //   - resolves "user-agent" and "request-id", preferring existing context
 //     attributes and then incoming metadata values
-//   - stores the RPC full method name as the service-method attribute
+//   - stores the RPC full method name as the ignored service-method attribute
 //   - derives IP address information from trusted forwarding headers or, if
 //     absent, from the gRPC peer address
 //   - parses the "authorization" header into the request attribute model
@@ -57,7 +57,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
-			meta.WithServiceMethod(meta.String(info.FullMethod)),
+			meta.WithServiceMethod(meta.Ignored(info.FullMethod)),
 			meta.WithIPAddr(ip),
 			meta.WithIPAddrKind(kind),
 			meta.WithGeolocation(geolocation),
@@ -104,7 +104,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
-			meta.WithServiceMethod(meta.String(info.FullMethod)),
+			meta.WithServiceMethod(meta.Ignored(info.FullMethod)),
 			meta.WithIPAddr(ip),
 			meta.WithIPAddrKind(kind),
 			meta.WithGeolocation(geolocation),

--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -46,7 +46,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx = meta.WithAttributes(ctx,
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
-		meta.WithServiceMethod(meta.String(req.URL.Path)),
+		meta.WithServiceMethod(meta.Ignored(req.URL.Path)),
 	)
 
 	cloned := req.Clone(ctx)

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -82,7 +82,8 @@ func TestRoundTripperStoresServiceMethod(t *testing.T) {
 		env.UserAgent("agent"),
 		test.StaticIDGenerator("request-id"),
 		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			require.Equal(t, meta.String("/users/123"), meta.ServiceMethod(req.Context()))
+			require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
+			require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 
 			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
 		}),
@@ -116,7 +117,8 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
-		require.Equal(t, meta.String("/users/123"), meta.ServiceMethod(req.Context()))
+		require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
+		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})
 }
 
@@ -128,7 +130,8 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
-		require.Equal(t, meta.String("GET /users/{id}"), meta.ServiceMethod(req.Context()))
+		require.Equal(t, meta.Ignored("GET /users/{id}"), meta.ServiceMethod(req.Context()))
+		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})
 }
 

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -24,8 +24,8 @@ func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, gen
 
 // Handler extracts request metadata and stores it in the request context.
 //
-// Extracted metadata includes user agent, request id, service-method, client IP address (and its source kind),
-// ignored geolocation, and ignored Authorization token value (when present and parseable).
+// Extracted metadata includes user agent, request id, ignored service-method, client IP address (and its source
+// kind), ignored geolocation, and ignored Authorization token value (when present and parseable).
 type Handler struct {
 	generator      id.Generator
 	name           env.Name
@@ -46,7 +46,7 @@ type Handler struct {
 // The handler populates the request context with:
 //   - user agent (from context, request header, or default userAgent parameter)
 //   - request id (from context, request header, or generated via generator)
-//   - service-method (from the matched request pattern, or URL path before routing)
+//   - service-method (from the matched request pattern, or URL path before routing; stored as ignored)
 //   - client IP address and IP address kind (derived from forwarded headers or RemoteAddr)
 //   - geolocation (from "Geolocation" header, stored as ignored)
 //   - authorization value (derived from the "Authorization" header, when present)
@@ -122,10 +122,10 @@ func serverRequestID(ctx context.Context, generator id.Generator, req *http.Requ
 
 func serverServiceMethod(req *http.Request) meta.Value {
 	if !strings.IsEmpty(req.Pattern) {
-		return meta.String(req.Pattern)
+		return meta.Ignored(req.Pattern)
 	}
 
-	return meta.String(req.URL.Path)
+	return meta.Ignored(req.URL.Path)
 }
 
 func serverIP(req *http.Request) (meta.Value, meta.Value) {


### PR DESCRIPTION
## What

- Store HTTP and gRPC service-method metadata as ignored values while preserving the underlying value for in-process consumers.
- Update HTTP and gRPC metadata tests to assert serviceMethod is not exported through camel-cased metadata maps.

## Why

- Prevent transport route and RPC method metadata from being echoed through exported metadata while keeping limiter key derivation and direct context access intact.

## Testing

- `go test ./net/http/meta ./net/grpc/meta ./transport/limiter` - passed
