### PR TITLE
test(transport): cover retry and breaker edge cases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ matching skill for the task.
   promise a complete standalone server bundle without `module.Server`. Report
   this only if a public API explicitly promises standalone `transport.Module`
   composition without the standard `module.Server` bundle.
+- Module-related behavior is tested through CLI/server application wiring. Do
+  not flag missing direct package tests for Fx module provider inventory,
+  module composition, or `transport.Module` lifecycle registration solely
+  because they are not asserted in the package that declares the module. Report
+  only concrete broken behavior through the CLI or supported `module.Server`
+  path, or an explicit public promise of lower-level standalone module use.
 - Server defaults that use `net.DefaultAddress`, including the debug server's
   `tcp://:6060` fallback, intentionally bind all interfaces so containerized
   workloads remain reachable through Kubernetes Services, probes, ingress

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -30,6 +30,13 @@ func AppendNotZero[T any](slice []T, elems ...T) []T {
 	return slice
 }
 
+// Backward returns an iterator over index-value pairs in slice, traversing it backward.
+//
+// It is a thin wrapper around the standard library slices.Backward.
+func Backward[S ~[]E, E any](slice S) iter.Seq2[int, E] {
+	return slices.Backward(slice)
+}
+
 // ElemFunc returns the first element in slice that matches f, along with a boolean
 // indicating whether a match was found.
 //

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -67,6 +67,15 @@ func TestAppendNotZero(t *testing.T) {
 	})
 }
 
+func TestBackward(t *testing.T) {
+	values := []string{}
+	for _, value := range slices.Backward([]string{"first", "second"}) {
+		values = append(values, value)
+	}
+
+	require.Equal(t, []string{"second", "first"}, values)
+}
+
 func TestElemFunc(t *testing.T) {
 	elems := []*string{ptr.Value("test")}
 

--- a/transport/breaker/breaker_test.go
+++ b/transport/breaker/breaker_test.go
@@ -15,8 +15,38 @@ func TestDefaultSettings(t *testing.T) {
 	require.Equal(t, uint32(3), settings.MaxRequests)
 	require.Equal(t, (30 * time.Second).Duration(), settings.Interval)
 	require.Equal(t, (10 * time.Second).Duration(), settings.Timeout)
-	require.False(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 4}))
-	require.True(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 5}))
+
+	tests := []struct {
+		name   string
+		counts breaker.Counts
+		want   bool
+	}{
+		{
+			name:   "below consecutive threshold",
+			counts: breaker.Counts{ConsecutiveFailures: 4},
+			want:   false,
+		},
+		{
+			name: "total failures below consecutive threshold",
+			counts: breaker.Counts{
+				Requests:            6,
+				TotalFailures:       5,
+				ConsecutiveFailures: 4,
+			},
+			want: false,
+		},
+		{
+			name:   "consecutive threshold",
+			counts: breaker.Counts{ConsecutiveFailures: 5},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, settings.ReadyToTrip(tt.counts))
+		})
+	}
 }
 
 func TestNewCircuitBreaker(t *testing.T) {

--- a/transport/grpc/breaker/breaker_test.go
+++ b/transport/grpc/breaker/breaker_test.go
@@ -78,6 +78,42 @@ func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
 	}
 }
 
+func TestUnaryClientInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
+	interceptor := breaker.UnaryClientInterceptor(
+		breaker.WithSettings(settings()),
+		breaker.WithFailureCodes(codes.Unavailable),
+	)
+
+	calls := make(map[string]int)
+	invoker := func(_ context.Context, fullMethod string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		calls[fullMethod]++
+		if fullMethod == "/test.Service/GetBook" {
+			return status.Error(codes.Unavailable, "unavailable")
+		}
+
+		return nil
+	}
+
+	t.Run("opens breaker for failing method", func(t *testing.T) {
+		err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+		require.Error(t, err)
+		require.Equal(t, codes.Unavailable, status.Code(err))
+	})
+
+	t.Run("allows different method", func(t *testing.T) {
+		err := interceptor(t.Context(), "/test.Service/ListBooks", nil, nil, nil, invoker)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects failing method without invoker call", func(t *testing.T) {
+		err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+		require.Error(t, err)
+		require.Equal(t, codes.ResourceExhausted, status.Code(err))
+		require.Equal(t, 1, calls["/test.Service/GetBook"])
+		require.Equal(t, 1, calls["/test.Service/ListBooks"])
+	})
+}
+
 func settings(isSuccessful ...func(error) bool) breaker.Settings {
 	settings := breaker.Settings{
 		ReadyToTrip: func(counts basebreaker.Counts) bool {

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -3,11 +3,21 @@ package grpc_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/slices"
+	"github.com/alexfalkowski/go-service/v2/time"
 	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	"github.com/alexfalkowski/go-service/v2/transport/grpc/retry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +42,76 @@ func TestClientEmptyTLSConfigUsesTLS(t *testing.T) {
 	client := v1.NewGreeterServiceClient(conn)
 	_, err = client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
 	require.Error(t, err)
+}
+
+func TestUnaryClientInterceptorsGenerateStableRequestIDBeforeRetry(t *testing.T) {
+	interceptors := transportgrpc.UnaryClientInterceptors(
+		transportgrpc.WithClientID(&test.IDSequenceGenerator{IDs: []string{"generated-id"}}),
+		transportgrpc.WithClientRetry(&retry.Config{
+			Attempts: 2,
+			Timeout:  time.Second,
+			Backoff:  time.Millisecond,
+		}),
+	)
+
+	calls := 0
+	requestIDs := []string{}
+	err := invokeUnaryClientMethod(t.Context(), "/test.Service/CreateBook", interceptors,
+		func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			calls++
+			requestIDs = append(requestIDs, meta.RequestID(ctx).Value())
+			if calls == 1 {
+				return status.Error(codes.Unavailable, "unavailable")
+			}
+
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []string{"generated-id", "generated-id"}, requestIDs)
+}
+
+func TestUnaryClientInterceptorsGenerateTokenPerRetryAttempt(t *testing.T) {
+	interceptors := transportgrpc.UnaryClientInterceptors(
+		transportgrpc.WithClientRetry(&retry.Config{
+			Attempts: 2,
+			Timeout:  time.Second,
+			Backoff:  time.Millisecond,
+		}),
+		transportgrpc.WithClientTokenGenerator(env.UserID("service-user"), &test.SequenceGenerator{}),
+	)
+
+	calls := 0
+	authorizations := []string{}
+	err := invokeUnaryClientMethod(t.Context(), "/test.Service/GetBook", interceptors,
+		func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			calls++
+			md, ok := grpcmeta.FromOutgoingContext(ctx)
+			require.True(t, ok)
+			authorizations = append(authorizations, md.Get("authorization")...)
+			if calls == 1 {
+				return status.Error(codes.Unavailable, "unavailable")
+			}
+
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, authorizations)
+}
+
+func invokeUnaryClientMethod(ctx context.Context, fullMethod string, interceptors []grpc.UnaryClientInterceptor, invoker grpc.UnaryInvoker) error {
+	chained := invoker
+	for _, interceptor := range slices.Backward(interceptors) {
+		next := chained
+		chained = func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return interceptor(ctx, fullMethod, req, resp, conn, next, opts...)
+		}
+	}
+
+	return chained(ctx, fullMethod, nil, nil, nil)
 }

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -193,24 +193,36 @@ func TestUnaryClientInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) 
 }
 
 func TestUnaryClientInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(&config.Config{
-		Attempts: 2,
-		Timeout:  time.Second,
-		Backoff:  time.Millisecond,
-	}, retry.StandardReadMethods)
+	tests := []struct {
+		name       string
+		fullMethod string
+	}{
+		{name: "get", fullMethod: "/test.Service/GetBook"},
+		{name: "list", fullMethod: "/test.Service/ListBooks"},
+	}
 
-	calls := 0
-	err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
-		calls++
-		if calls == 1 {
-			return status.Error(codes.Unavailable, "unavailable")
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := retry.UnaryClientInterceptor(&config.Config{
+				Attempts: 2,
+				Timeout:  time.Second,
+				Backoff:  time.Millisecond,
+			}, retry.StandardReadMethods)
 
-		return nil
-	})
+			calls := 0
+			err := interceptor(t.Context(), tt.fullMethod, nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				if calls == 1 {
+					return status.Error(codes.Unavailable, "unavailable")
+				}
 
-	require.NoError(t, err)
-	require.Equal(t, 2, calls)
+				return nil
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, 2, calls)
+		})
+	}
 }
 
 func TestUnaryClientInterceptorComposesMultiplePolicies(t *testing.T) {

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -81,6 +81,53 @@ func TestRoundTripperOpensOnFailureStatus(t *testing.T) {
 	require.ErrorIs(t, err, breaker.ErrOpenState)
 }
 
+func TestRoundTripperIsolatesBreakersByHost(t *testing.T) {
+	transportErr := errors.New("transport unavailable")
+	calls := make(map[string]int)
+	rt := breaker.NewRoundTripper(
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			calls[req.URL.Host]++
+			if req.URL.Host == "broken.example" {
+				return nil, transportErr
+			}
+
+			return test.ResponseWithStatus(http.StatusOK), nil
+		}),
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+	)
+
+	t.Run("opens breaker for failing host", func(t *testing.T) {
+		brokenReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://broken.example", http.NoBody)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(brokenReq)
+		require.Nil(t, res)
+		require.ErrorIs(t, err, transportErr)
+	})
+
+	t.Run("allows different host", func(t *testing.T) {
+		healthyReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://healthy.example", http.NoBody)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(healthyReq)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("rejects failing host without transport call", func(t *testing.T) {
+		openReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://broken.example", http.NoBody)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(openReq)
+		require.Nil(t, res)
+		require.ErrorIs(t, err, breaker.ErrOpenState)
+		require.Equal(t, 1, calls["broken.example"])
+		require.Equal(t, 1, calls["healthy.example"])
+	})
+}
+
 func TestRoundTripperCountsFailureStatusWithCustomIsSuccessful(t *testing.T) {
 	rt := breaker.NewRoundTripper(
 		&test.StatusRoundTripper{Status: http.StatusInternalServerError},

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -8,9 +8,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/time"
 	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
+	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
+	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +26,28 @@ func TestClient(t *testing.T) {
 
 	_, err = transporthttp.NewClient(transporthttp.WithClientTLS(&tls.Config{}))
 	require.NoError(t, err)
+}
+
+func TestClientRoundTripperBypassesTLSConfig(t *testing.T) {
+	transporthttp.Register(test.FS)
+
+	called := false
+	client, err := transporthttp.NewClient(
+		transporthttp.WithClientRoundTripper(test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+		})),
+		transporthttp.WithClientTLS(&tls.Config{Cert: "bob", Key: "bob"}),
+	)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.True(t, called)
 }
 
 func TestClientNegativeTimeoutUsesDefault(t *testing.T) {
@@ -93,4 +119,67 @@ func TestRoundTripperGeneratesTokenPerRetryAttempt(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, base.AuthValues)
 	require.Equal(t, []int{1, 1}, base.AuthCounts)
+}
+
+func TestRoundTripperLimiterDenialDoesNotOpenBreaker(t *testing.T) {
+	clientLimiter, err := httplimiter.NewClientLimiter(test.NoopLifecycle{}, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 1))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientLimiter.Close(t.Context())) })
+
+	calls := 0
+	rt, err := transporthttp.NewRoundTripper(
+		transporthttp.WithClientRoundTripper(test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+		})),
+		transporthttp.WithClientLimiter(clientLimiter),
+		transporthttp.WithClientBreaker(breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		})),
+	)
+	require.NoError(t, err)
+
+	t.Run("allows first request", func(t *testing.T) {
+		res, err := rt.RoundTrip(newUserAgentRequest(t, "first-agent"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("denies exhausted key", func(t *testing.T) {
+		res, err := rt.RoundTrip(newUserAgentRequest(t, "first-agent"))
+		require.Nil(t, res)
+		require.Error(t, err)
+		require.Equal(t, http.StatusTooManyRequests, status.Code(err))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("denial does not open breaker", func(t *testing.T) {
+		res, err := rt.RoundTrip(newUserAgentRequest(t, "first-agent"))
+		require.Nil(t, res)
+		require.Error(t, err)
+		require.Equal(t, http.StatusTooManyRequests, status.Code(err))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("allows different key", func(t *testing.T) {
+		res, err := rt.RoundTrip(newUserAgentRequest(t, "second-agent"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+		require.Equal(t, 2, calls)
+	})
+}
+
+func newUserAgentRequest(t *testing.T, userAgent string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", userAgent)
+
+	return req
 }

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -21,12 +21,17 @@ import (
 
 func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 	tests := []struct {
-		name  string
-		codes []int
-		calls int
+		name   string
+		method string
+		codes  []int
+		calls  int
 	}{
-		{name: "too many requests", codes: []int{http.StatusTooManyRequests, http.StatusOK}, calls: 2},
-		{name: "service unavailable", codes: []int{http.StatusServiceUnavailable, http.StatusOK}, calls: 2},
+		{name: "get too many requests", method: http.MethodGet, codes: []int{http.StatusTooManyRequests, http.StatusOK}, calls: 2},
+		{name: "get service unavailable", method: http.MethodGet, codes: []int{http.StatusServiceUnavailable, http.StatusOK}, calls: 2},
+		{name: "head too many requests", method: http.MethodHead, codes: []int{http.StatusTooManyRequests, http.StatusOK}, calls: 2},
+		{name: "head service unavailable", method: http.MethodHead, codes: []int{http.StatusServiceUnavailable, http.StatusOK}, calls: 2},
+		{name: "options too many requests", method: http.MethodOptions, codes: []int{http.StatusTooManyRequests, http.StatusOK}, calls: 2},
+		{name: "options service unavailable", method: http.MethodOptions, codes: []int{http.StatusServiceUnavailable, http.StatusOK}, calls: 2},
 	}
 
 	for _, tt := range tests {
@@ -38,7 +43,7 @@ func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 				Backoff:  time.Millisecond,
 			}, rt)
 
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+			req := httptest.NewRequestWithContext(t.Context(), tt.method, "http://example.com", http.NoBody)
 
 			res, err := retrying.RoundTrip(req)
 			require.NoError(t, err)

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -62,6 +62,83 @@ func TestTake(t *testing.T) {
 	require.Equal(t, "limit=1, remaining=0", header)
 }
 
+func TestTakeSupportsCustomKeyKind(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{
+		"tenant": meta.UserID,
+	}
+	config := &limiter.Config{Kind: "tenant", Tokens: 1, Interval: time.Second}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	first := meta.WithAttributes(t.Context(), meta.WithUserID(meta.String("first-tenant")))
+	second := meta.WithAttributes(t.Context(), meta.WithUserID(meta.String("second-tenant")))
+
+	t.Run("takes first tenant token", func(t *testing.T) {
+		ok, header, err := limiter.Take(first)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "limit=1, remaining=0", header)
+	})
+
+	t.Run("denies exhausted tenant", func(t *testing.T) {
+		ok, header, err := limiter.Take(first)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Equal(t, "limit=1, remaining=0", header)
+	})
+
+	t.Run("uses independent bucket for second tenant", func(t *testing.T) {
+		ok, header, err := limiter.Take(second)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "limit=1, remaining=0", header)
+	})
+}
+
+func TestTakeRefillsAfterConfiguredInterval(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: 25 * time.Millisecond}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+
+	t.Run("takes initial token", func(t *testing.T) {
+		ok, header, err := limiter.Take(ctx)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "limit=1, remaining=0", header)
+	})
+
+	t.Run("denies exhausted bucket", func(t *testing.T) {
+		ok, header, err := limiter.Take(ctx)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Equal(t, "limit=1, remaining=0", header)
+	})
+
+	t.Run("refills after interval", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			ok, _, err := limiter.Take(ctx)
+			require.NoError(t, err)
+
+			return ok
+		}, time.Second.Duration(), (10 * time.Millisecond).Duration())
+	})
+}
+
 func TestTakeUsesSingleBucketForEmptyKeys(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}


### PR DESCRIPTION
## What

- Added coverage for breaker thresholds, limiter bucket behavior, HTTP and gRPC retry eligibility, breaker isolation, and client retry-chain composition.
- Added a project-owned slices.Backward wrapper used by the gRPC client interceptor-chain helper.
- Documented that module-related coverage is exercised through the supported CLI/server application wiring path.

## Why

- Protect repository-owned limiter, breaker, retry, and client interceptor ordering contracts from regressions.
- Avoid resurfacing direct module DI inventory checks when the supported behavior is already covered through higher-level application wiring.

## Testing

- `make specs` - passed
- `make lint` - passed
- `go test ./slices ./transport/breaker ./transport/limiter ./transport/http ./transport/http/breaker ./transport/http/retry ./transport/grpc ./transport/grpc/breaker ./transport/grpc/retry` - passed
- `go test ./slices ./transport/grpc -run 'TestBackward|TestUnaryClientInterceptors'` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
