### PR TITLE
feat(size): cap configurable byte limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,13 @@ matching skill for the task.
   passing absurd configured `bytes.Size` values directly to it; callers that
   compare configuration-sized limits, such as cache decode size guards, must
   guard those limits before calling it.
+- Configured byte-size limits that drive buffering paths are capped by
+  `bytes.MaxConfigSize` at the supported config validation boundary, including
+  cache value sizes and server receive sizes used by HTTP and gRPC transports.
+  Do not flag `MaxInt`, allocator, or `limit+1` overflow speculation from
+  absurd configured sizes unless a supported config/DI path bypasses that
+  validation or the public API starts promising safe arbitrary direct
+  constructor limits.
 - `bytes.ParseSize` intentionally delegates human-readable size parsing to
   `github.com/docker/go-units` for compatibility with existing configuration
   values. Do not flag upstream float-to-int range behavior from absurdly large

--- a/bytes/size.go
+++ b/bytes/size.go
@@ -19,6 +19,13 @@ const MB Size = Size(units.MB)
 // Its value is 4 megabytes.
 const DefaultSize Size = 4 * MB
 
+// MaxConfigSize is the largest byte size accepted by configuration surfaces.
+//
+// Configured sizes protect in-memory buffering paths such as cache values, HTTP request bodies,
+// HTTP client response bodies, and gRPC messages. Keep this comfortably below integer and allocator
+// edge cases while still allowing unusually large service payloads.
+const MaxConfigSize Size = 256 * MB
+
 // GB is the decimal gigabyte size constant: 1,000,000,000 bytes.
 const GB Size = Size(units.GB)
 

--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -26,8 +26,8 @@ type Config struct {
 	//
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//
-	// A zero value applies bytes.DefaultSize. Negative values are invalid.
-	MaxSize bytes.Size `yaml:"max_size,omitempty" json:"max_size,omitempty" toml:"max_size,omitempty" validate:"gte=0"`
+	// A zero value applies bytes.DefaultSize. Values must be between 0 and bytes.MaxConfigSize.
+	MaxSize bytes.Size `yaml:"max_size,omitempty" json:"max_size,omitempty" toml:"max_size,omitempty" validate:"config_size"`
 }
 
 // IsEnabled reports whether caching is enabled.

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -31,3 +31,15 @@ func TestConfigRejectsNegativeMaxSize(t *testing.T) {
 
 	require.Error(t, test.Validator.Struct(cfg))
 }
+
+func TestConfigAcceptsMaxSize(t *testing.T) {
+	cfg := &config.Config{MaxSize: bytes.MaxConfigSize}
+
+	require.NoError(t, test.Validator.Struct(cfg))
+}
+
+func TestConfigRejectsOversizedMaxSize(t *testing.T) {
+	cfg := &config.Config{MaxSize: bytes.MaxConfigSize + 1}
+
+	require.Error(t, test.Validator.Struct(cfg))
+}

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -43,8 +43,8 @@ type Config struct {
 	//
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//
-	// A zero value applies bytes.DefaultSize. Negative values are invalid.
-	MaxReceiveSize bytes.Size `yaml:"max_receive_size,omitempty" json:"max_receive_size,omitempty" toml:"max_receive_size,omitempty" validate:"gte=0"`
+	// A zero value applies bytes.DefaultSize. Values must be between 0 and bytes.MaxConfigSize.
+	MaxReceiveSize bytes.Size `yaml:"max_receive_size,omitempty" json:"max_receive_size,omitempty" toml:"max_receive_size,omitempty" validate:"config_size"`
 }
 
 // IsEnabled reports whether server configuration is present.

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -57,6 +57,16 @@ func TestConfigRejectsNegativeMaxReceiveSize(t *testing.T) {
 	require.Error(t, test.Validator.Struct(cfg))
 }
 
+func TestConfigAcceptsMaxReceiveSize(t *testing.T) {
+	cfg := &server.Config{MaxReceiveSize: bytes.MaxConfigSize}
+	require.NoError(t, test.Validator.Struct(cfg))
+}
+
+func TestConfigRejectsOversizedMaxReceiveSize(t *testing.T) {
+	cfg := &server.Config{MaxReceiveSize: bytes.MaxConfigSize + 1}
+	require.Error(t, test.Validator.Struct(cfg))
+}
+
 func TestConfigRejectsNegativeTimeout(t *testing.T) {
 	cfg := &server.Config{Timeout: -time.Second}
 	require.Error(t, test.Validator.Struct(cfg))

--- a/config/validator.go
+++ b/config/validator.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/go-playground/validator/v10"
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/runtime"
+	"github.com/go-playground/validator/v10"
+)
 
 // NewValidator constructs a Validator backed by go-playground/validator.
 //
@@ -10,7 +14,20 @@ import "github.com/go-playground/validator/v10"
 // This constructor is typically wired via `config.Module` and consumed by `NewConfig[T]` to validate
 // decoded configuration before returning it to the caller.
 func NewValidator() *Validator {
-	return &Validator{validator.New(validator.WithRequiredStructEnabled())}
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	runtime.Must(validate.RegisterValidation("config_size", validateConfigSize))
+
+	return &Validator{validate}
+}
+
+func validateConfigSize(fl validator.FieldLevel) bool {
+	field := fl.Field()
+	if !field.CanInt() {
+		return false
+	}
+
+	size := bytes.Size(field.Int())
+	return size >= 0 && size <= bytes.MaxConfigSize
 }
 
 // Validator wraps a go-playground validator instance.


### PR DESCRIPTION
## What

- Add a shared `bytes.MaxConfigSize` limit for configuration-driven byte sizes.
- Register a `config_size` validator that enforces the accepted range for cache value and server receive limits.
- Cover negative, maximum, and oversized cache/server configuration values.
- Document the config-boundary limit so future reviews do not flag impossible configured overflow paths.

## Why

- Keep in-memory buffering limits comfortably below integer and allocator edge cases while still allowing large service payloads.
- Make the supported configuration boundary explicit for HTTP, gRPC, and cache paths.

## Testing

- `git diff --check` - passed
- `go test ./bytes ./config ./cache/config ./config/server ./transport/http ./transport/grpc ./cache` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
