### PR TITLE
test(config): cover non-integer size validation

### DIFF
--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -1,0 +1,18 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+type invalidConfigSize struct {
+	Size string `validate:"config_size"`
+}
+
+func TestValidatorRejectsConfigSizeWithNonInteger(t *testing.T) {
+	cfg := &invalidConfigSize{Size: "64B"}
+
+	require.Error(t, test.Validator.Struct(cfg))
+}


### PR DESCRIPTION
## What

- Add coverage for applying the `config_size` validator to a non-integer field.

## Why

- Exercise the validator branch that rejects fields which cannot be read as integers.

## Testing

- `go test ./config ./cache/config ./config/server` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
