### PR TITLE
feat(http): honor disabled webhook signing pass-through

### DIFF
--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -200,13 +200,13 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
-	if http.IsCrossOriginRedirect(req) {
-		return nil, http.ErrUseLastResponse, true
-	}
-
 	if r.hook == nil {
 		res, err := r.RoundTripper.RoundTrip(req)
 		return res, err, false
+	}
+
+	if http.IsCrossOriginRedirect(req) {
+		return nil, http.ErrUseLastResponse, true
 	}
 
 	cloned := req.Clone(req.Context())

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -151,6 +151,25 @@ func TestRoundTripperDoesNotSignCrossOriginRedirect(t *testing.T) {
 	require.True(t, body.Closed)
 }
 
+func TestRoundTripperWithNilHookDelegatesCrossOriginRedirect(t *testing.T) {
+	called := false
+	rt := hooks.NewRoundTripper(nil, test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	}))
+
+	prev := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://example.com/events", http.NoBody)
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://attacker.example.com/events", body)
+	req.Response = &http.Response{Request: prev}
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.True(t, called)
+	require.False(t, body.Closed)
+}
+
 func TestRoundTripperClosesBodyOnSignError(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)


### PR DESCRIPTION
## What

- Let disabled webhook signing round trippers delegate cross-origin redirected requests without forcing `ErrUseLastResponse`.
- Add regression coverage for nil-hook pass-through redirect behavior.

## Why

- `NewRoundTripper(nil, rt)` is documented as pass-through, so redirect blocking should only apply when webhook signing is enabled.

## Testing

- `go test ./transport/http/hooks -count=1` - passed
- `go test -race ./transport/http/hooks -count=1` - passed
