### PR TITLE
feat(token): cover jwt validation edges

### DIFF
--- a/token/jwt/errors.go
+++ b/token/jwt/errors.go
@@ -1,12 +1,12 @@
 package jwt
 
-import webtoken "github.com/golang-jwt/jwt/v4"
+import "github.com/golang-jwt/jwt/v4"
 
 // ValidationError aliases the upstream JWT validation error type.
-type ValidationError = webtoken.ValidationError
+type ValidationError = jwt.ValidationError
 
 // ErrTokenMalformed aliases the upstream malformed JWT error.
-var ErrTokenMalformed = webtoken.ErrTokenMalformed
+var ErrTokenMalformed = jwt.ErrTokenMalformed
 
 // ErrTokenSignatureInvalid aliases the upstream invalid JWT signature error.
-var ErrTokenSignatureInvalid = webtoken.ErrTokenSignatureInvalid
+var ErrTokenSignatureInvalid = jwt.ErrTokenSignatureInvalid

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -9,6 +9,24 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+// Claims aliases the upstream JWT claims interface.
+type Claims = jwt.Claims
+
+// NumericDate aliases the upstream JWT numeric date type.
+type NumericDate = jwt.NumericDate
+
+// RegisteredClaims aliases the upstream JWT registered claims type.
+type RegisteredClaims = jwt.RegisteredClaims
+
+// SigningMethod aliases the upstream JWT signing method interface.
+type SigningMethod = jwt.SigningMethod
+
+// NewWithClaims aliases the upstream JWT token constructor.
+var NewWithClaims = jwt.NewWithClaims
+
+// SigningMethodEdDSA aliases the upstream JWT EdDSA signing method.
+var SigningMethodEdDSA = jwt.SigningMethodEdDSA
+
 // NewToken constructs a Token that issues and validates JWTs according to cfg.
 //
 // The resulting Token uses Ed25519 keys for signing and verification and an id.Generator
@@ -58,16 +76,16 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 
 	key := t.signer.PrivateKey
 	now := time.Now()
-	claims := &jwt.RegisteredClaims{
-		ExpiresAt: &jwt.NumericDate{Time: now.Add(t.cfg.Expiration.Duration())},
+	claims := &RegisteredClaims{
+		ExpiresAt: &NumericDate{Time: now.Add(t.cfg.Expiration.Duration())},
 		ID:        t.generator.Generate(),
-		IssuedAt:  &jwt.NumericDate{Time: now},
+		IssuedAt:  &NumericDate{Time: now},
 		Issuer:    t.cfg.Issuer,
-		NotBefore: &jwt.NumericDate{Time: now},
+		NotBefore: &NumericDate{Time: now},
 		Audience:  []string{aud},
 		Subject:   sub,
 	}
-	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	token := NewWithClaims(SigningMethodEdDSA, claims)
 	token.Header["kid"] = t.cfg.KeyID
 
 	return token.SignedString(key)
@@ -95,7 +113,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
 
-	claims := &jwt.RegisteredClaims{}
+	claims := &RegisteredClaims{}
 
 	_, err := jwt.ParseWithClaims(token, claims, t.validate)
 	if err != nil {
@@ -125,7 +143,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 }
 
 func (j *Token) validate(token *jwt.Token) (any, error) {
-	if token.Method.Alg() != jwt.SigningMethodEdDSA.Alg() {
+	if token.Method.Alg() != SigningMethodEdDSA.Alg() {
 		return nil, errors.ErrInvalidAlgorithm
 	}
 
@@ -141,7 +159,7 @@ func (j *Token) validate(token *jwt.Token) (any, error) {
 	return j.verifier.PublicKey, nil
 }
 
-func validateRequiredClaims(claims *jwt.RegisteredClaims) error {
+func validateRequiredClaims(claims *RegisteredClaims) error {
 	if claims.ExpiresAt == nil || claims.IssuedAt == nil || claims.NotBefore == nil {
 		return errors.ErrInvalidTime
 	}
@@ -153,7 +171,7 @@ func validateRequiredClaims(claims *jwt.RegisteredClaims) error {
 	return nil
 }
 
-func validateLifetime(claims *jwt.RegisteredClaims, maxLifetime time.Duration) error {
+func validateLifetime(claims *RegisteredClaims, maxLifetime time.Duration) error {
 	if !claims.ExpiresAt.After(claims.IssuedAt.Time) || claims.ExpiresAt.Sub(claims.IssuedAt.Time) > maxLifetime.Duration() {
 		return errors.ErrInvalidTime
 	}

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -175,6 +175,78 @@ func TestInvalidKeyID(t *testing.T) {
 		require.Empty(t, sub)
 		require.ErrorIs(t, err, errors.ErrInvalidKeyID)
 	})
+
+	t.Run("missing key id", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, signer, func(header map[string]any) {
+			delete(header, "kid")
+		}, nil)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidKeyID)
+	})
+
+	t.Run("empty key id", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, signer, func(header map[string]any) {
+			header["kid"] = ""
+		}, nil)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidKeyID)
+	})
+
+	t.Run("non string key id", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, signer, func(header map[string]any) {
+			header["kid"] = 123
+		}, nil)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidKeyID)
+	})
+}
+
+func TestInvalidRequiredClaims(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	token := jwt.NewToken(cfg.JWT, signer, verifier, uuid.NewGenerator())
+
+	tests := []struct {
+		claims func(*jwt.RegisteredClaims)
+		name   string
+	}{
+		{
+			name: "missing expiration",
+			claims: func(claims *jwt.RegisteredClaims) {
+				claims.ExpiresAt = nil
+			},
+		},
+		{
+			name: "missing issued at",
+			claims: func(claims *jwt.RegisteredClaims) {
+				claims.IssuedAt = nil
+			},
+		},
+		{
+			name: "missing not before",
+			claims: func(claims *jwt.RegisteredClaims) {
+				claims.NotBefore = nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tkn := signedJWT(t, cfg.JWT, signer, nil, tt.claims)
+
+			sub, err := token.Verify(tkn, "hello")
+			require.Empty(t, sub)
+			require.ErrorIs(t, err, errors.ErrInvalidTime)
+		})
+	}
 }
 
 func TestInvalidLifetimeExceedsConfig(t *testing.T) {
@@ -276,4 +348,39 @@ func TestInvalidPrivateKeyDoesNotPanic(t *testing.T) {
 	tkn, err := token.Generate("hello", test.UserID.String())
 	require.Empty(t, tkn)
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
+}
+
+func signedJWT(
+	t *testing.T,
+	cfg *jwt.Config,
+	signer *ed25519.Signer,
+	header func(map[string]any),
+	claimsFunc func(*jwt.RegisteredClaims),
+) string {
+	t.Helper()
+
+	now := time.Now()
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: &jwt.NumericDate{Time: now.Add(cfg.Expiration.Duration())},
+		ID:        "test-id",
+		IssuedAt:  &jwt.NumericDate{Time: now},
+		Issuer:    cfg.Issuer,
+		NotBefore: &jwt.NumericDate{Time: now},
+		Audience:  []string{"hello"},
+		Subject:   test.UserID.String(),
+	}
+	if claimsFunc != nil {
+		claimsFunc(claims)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = cfg.KeyID
+	if header != nil {
+		header(token.Header)
+	}
+
+	tkn, err := token.SignedString(signer.PrivateKey)
+	require.NoError(t, err)
+
+	return tkn
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -140,6 +140,34 @@ func TestVerifyRejectsPasetoEmptySubject(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidSubject)
 }
 
+func TestVerifyRejectsJWTEmptySubject(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+	tkn := token.NewToken(test.Name, cfg, test.FS, signer, verifier, gen)
+
+	raw, err := tkn.Generate("hello", strings.Empty)
+	require.NoError(t, err)
+
+	sub, err := tkn.Verify(raw, "hello")
+	require.Equal(t, strings.Empty, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidSubject)
+}
+
+func TestSSHSubjectIsIgnored(t *testing.T) {
+	cfg := test.NewToken("ssh")
+	tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)
+
+	raw, err := tkn.Generate("hello", "ignored-subject")
+	require.NoError(t, err)
+
+	sub, err := tkn.Verify(raw, "hello")
+	require.NoError(t, err)
+	require.Equal(t, test.UserID.String(), sub)
+}
+
 func TestUnknownKindConfig(t *testing.T) {
 	cfg := test.NewToken("none")
 	tkn := token.NewToken(test.Name, cfg, test.FS, nil, nil, nil)


### PR DESCRIPTION
## What

- Add root token facade tests for JWT empty subjects and SSH subject handling.
- Cover JWT key-id validation for missing, empty, and non-string `kid` headers.
- Cover required JWT time-claim validation for missing `exp`, `iat`, and `nbf` claims.
- Expose the narrow upstream JWT surface through `token/jwt` so crafted token tests use the repository wrapper.

## Why

- Protect repository-owned token validation behavior at the package boundary.
- Keep tests from importing the upstream JWT package directly while still exercising wrapper-owned edge cases.

## Testing

- `git diff --check` - passed
- `go test ./token/... -count=1` - passed
- `gmake lint` - passed
