### PR TITLE
feat(bytes): quote size json directly

### DIFF
--- a/bytes/size.go
+++ b/bytes/size.go
@@ -1,7 +1,6 @@
 package bytes
 
 import (
-	"encoding/json"
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/runtime"
@@ -85,16 +84,20 @@ func (s Size) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(string(text))
+	return []byte(strconv.Quote(string(text))), nil
 }
 
 // UnmarshalJSON decodes a quoted decimal size string into s.
 //
-// Non-string JSON values are rejected by the underlying JSON decoder before the
-// size parser runs.
+// Non-string JSON values are rejected before the size parser runs.
 func (s *Size) UnmarshalJSON(data []byte) error {
-	var text string
-	if err := json.Unmarshal(data, &text); err != nil {
+	data = TrimSpace(data)
+	if len(data) == 0 || data[0] != '"' {
+		return strconv.ErrSyntax
+	}
+
+	text, err := strconv.Unquote(string(data))
+	if err != nil {
 		return err
 	}
 

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -83,6 +83,7 @@ func TestSizeUnmarshalJSONInvalid(t *testing.T) {
 		{name: "object", input: "{}"},
 		{name: "invalid string value", input: `"bad"`},
 		{name: "malformed string", input: `"`},
+		{name: "go raw string", input: "`64B`"},
 	}
 
 	for _, tt := range tests {
@@ -93,6 +94,14 @@ func TestSizeUnmarshalJSONInvalid(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestSizeUnmarshalJSONWithWhitespace(t *testing.T) {
+	var size bytes.Size
+
+	err := json.Unmarshal([]byte(" \n\t\"64B\" \n\t"), &size)
+	require.NoError(t, err)
+	require.Equal(t, bytes.Size(64), size)
 }
 
 func TestSizeZeroValueEncoding(t *testing.T) {


### PR DESCRIPTION
## What

- Replace `encoding/json` usage in byte-size JSON encoding with direct `strconv` quoting and unquoting.
- Preserve JSON string behavior by trimming JSON whitespace, rejecting non-string values, and decoding escaped strings before size parsing.
- Add coverage for whitespace-wrapped JSON strings and rejecting Go raw-string syntax.

## Why

- Avoid routing a known string value through the full JSON encoder/decoder path while keeping the existing byte-size JSON contract intact.

## Testing

- `git diff --check` - passed
- `go test ./bytes -count=1` - passed
- `gmake lint` - passed
