### PR TITLE
feat(compress): polish codec readability

### DIFF
--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -17,18 +17,20 @@ import (
 	"go.uber.org/fx"
 )
 
+var compressorKinds = []string{"zstd", "s2", "snappy", "none"}
+
 func TestMap(t *testing.T) {
-	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			cmp := test.Compressor.Get(kind)
 
 			data := strings.Bytes("hello")
-			d, err := cmp.Compress(data, bytes.KB)
+			compressed, err := cmp.Compress(data, bytes.KB)
 			require.NoError(t, err)
 
-			ns, err := cmp.Decompress(d, bytes.KB)
+			decompressed, err := cmp.Decompress(compressed, bytes.KB)
 			require.NoError(t, err)
-			require.Equal(t, data, ns)
+			require.Equal(t, data, decompressed)
 		})
 	}
 
@@ -53,10 +55,18 @@ func TestNewMapRegistersDefaultCompressors(t *testing.T) {
 		None:   noneCompressor,
 	})
 
-	require.Same(t, zstdCompressor, compressors.Get("zstd"))
-	require.Same(t, s2Compressor, compressors.Get("s2"))
-	require.Same(t, snappyCompressor, compressors.Get("snappy"))
-	require.Same(t, noneCompressor, compressors.Get("none"))
+	expected := map[string]compress.Compressor{
+		"zstd":   zstdCompressor,
+		"s2":     s2Compressor,
+		"snappy": snappyCompressor,
+		"none":   noneCompressor,
+	}
+
+	for kind, expectedCompressor := range expected {
+		t.Run(kind, func(t *testing.T) {
+			require.Same(t, expectedCompressor, compressors.Get(kind))
+		})
+	}
 }
 
 func TestMapRegister(t *testing.T) {
@@ -81,7 +91,7 @@ func TestModuleProvidesDefaultCompressors(t *testing.T) {
 	)
 
 	require.NoError(t, app.Err())
-	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			require.NotNil(t, compressors.Get(kind))
 		})
@@ -102,7 +112,7 @@ func TestNoneCompressorReturnsDataUnchanged(t *testing.T) {
 }
 
 func TestExactSizeLimits(t *testing.T) {
-	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			cmp := test.Compressor.Get(kind)
 			data := strings.Bytes("hello")
@@ -119,7 +129,7 @@ func TestExactSizeLimits(t *testing.T) {
 }
 
 func TestCompressRejectsTooLarge(t *testing.T) {
-	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			cmp := test.Compressor.Get(kind)
 
@@ -130,15 +140,15 @@ func TestCompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsTooLarge(t *testing.T) {
-	for _, kind := range []string{"zstd", "s2", "snappy", "none"} {
+	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			cmp := test.Compressor.Get(kind)
 
 			data := strings.Bytes("hello")
-			d, err := cmp.Compress(data, bytes.KB)
+			compressed, err := cmp.Compress(data, bytes.KB)
 			require.NoError(t, err)
 
-			_, err = cmp.Decompress(d, bytes.Size(len(data)-1))
+			_, err = cmp.Decompress(compressed, bytes.Size(len(data)-1))
 			require.ErrorIs(t, err, errors.ErrTooLarge)
 		})
 	}

--- a/compress/doc.go
+++ b/compress/doc.go
@@ -5,7 +5,7 @@
 //
 // # Registry
 //
-// `Map` is a simple kind→Compressor lookup (e.g. "zstd", "s2", "snappy", "none"). Callers typically
+// `Map` is a simple kind-to-Compressor lookup (e.g. "zstd", "s2", "snappy", "none"). Callers typically
 // obtain a `*Map` via DI and then use `Get` to select the configured algorithm, falling back to "none"
 // when the configured kind is not present.
 //

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -39,13 +39,13 @@ func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 		return nil, compress.ErrTooLarge
 	}
 
-	e, err := zstd.NewWriter(nil)
+	encoder, err := zstd.NewWriter(nil)
 	if err != nil {
 		return nil, err
 	}
-	defer e.Close()
+	defer encoder.Close()
 
-	return e.EncodeAll(data, nil), nil
+	return encoder.EncodeAll(data, nil), nil
 }
 
 // Decompress returns the decompressed representation of data.
@@ -58,16 +58,16 @@ func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 	}
 
 	maxMemory := uint64(max(limit, int64(MinWindowSize)))
-	d, err := zstd.NewReader(
+	decoder, err := zstd.NewReader(
 		bytes.NewReader(data),
 		zstd.WithDecoderMaxMemory(maxMemory),
 	)
 	if err != nil {
 		return nil, err
 	}
-	defer d.Close()
+	defer decoder.Close()
 
-	decoded, _, err := io.ReadAll(io.LimitReader(d, limit+1))
+	decoded, _, err := io.ReadAll(io.LimitReader(decoder, limit+1))
 	if err != nil {
 		if errors.Is(err, ErrDecoderSizeExceeded) {
 			return nil, fmt.Errorf("%w: %w", compress.ErrTooLarge, err)


### PR DESCRIPTION
## What

- Reuse a shared default-kind list in compressor tests.
- Use clearer local names in compression round-trip tests and zstd setup.
- Replace symbolic package-doc wording with plain text.

## Why

- Keeps the style cleanup readable and consistent with nearby registry test patterns.

## Testing

- `go test ./compress/...` - passed
- `make lint` - passed
