### PR TITLE
feat(bytes): polish helper readability

### DIFF
--- a/bytes/benchmark_test.go
+++ b/bytes/benchmark_test.go
@@ -19,13 +19,13 @@ func BenchmarkBytes(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("copy", func(b *testing.B) {
-		for n := 0; b.Loop(); n++ {
+		for b.Loop() {
 			benchmarkStringSink = string(bs)
 		}
 	})
 
 	b.Run("convert", func(b *testing.B) {
-		for n := 0; b.Loop(); n++ {
+		for b.Loop() {
 			benchmarkStringSink = bytes.String(bs)
 		}
 	})

--- a/bytes/bytes.go
+++ b/bytes/bytes.go
@@ -53,10 +53,11 @@ func Clone(b []byte) []byte {
 //
 // # Safety and lifetime
 //
-// The returned string aliases the memory backing b. That means:
+// This function uses unsafe to create a string view over b's backing storage. As a result:
 //
-//   - You MUST NOT modify the contents of b after calling String(b).
-//   - The returned string is only valid while b remains alive (reachable) and its backing array is not reused.
+//   - The returned string aliases the same memory as b.
+//   - The contents of b must be treated as read-only after calling String(b).
+//   - Do not retain the returned string beyond the lifetime of b or after b's backing array may be reused.
 //
 // Violating these constraints can lead to surprising behavior, data races, or memory safety issues.
 // Use this helper only when you control the lifecycle of b and need to avoid an allocation.

--- a/bytes/bytes_test.go
+++ b/bytes/bytes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopy(t *testing.T) {
+func TestClone(t *testing.T) {
 	hello := strings.Bytes("hello")
 	require.Equal(t, hello, bytes.Clone(hello))
 }

--- a/bytes/doc.go
+++ b/bytes/doc.go
@@ -7,8 +7,9 @@
 //
 // # Aliases and wrappers
 //
-// `Buffer` is an alias for `bytes.Buffer`, and constructors like `NewBuffer`, `NewBufferString`,
-// and `NewReader` delegate directly to the standard library.
+// `Buffer` is an alias for `bytes.Buffer`, constructors like `NewBuffer`, `NewBufferString`, and
+// `NewReader` delegate directly to the standard library, and helpers like `Clone` and `TrimSpace`
+// mirror standard library behavior through the go-service import path.
 //
 // # Zero-copy conversions
 //
@@ -18,7 +19,7 @@
 //
 // # Human-readable sizes
 //
-// `Size` is a named byte-count type for typed configuration surfaces. `String` and `ParseSize`
+// `Size` is a named byte-count type for typed configuration surfaces. `Size.String` and `ParseSize`
 // use human-readable decimal size strings such as `64B`, `2MB`, and `4GB`.
 //
 // Text and JSON marshaling emit exact raw byte counts with a `B` suffix, such as `4000000B`.

--- a/bytes/size.go
+++ b/bytes/size.go
@@ -7,32 +7,36 @@ import (
 	units "github.com/docker/go-units"
 )
 
-// KB is the decimal kilobyte size constant: 1,000 bytes.
-const KB Size = Size(units.KB)
+const (
+	// KB is the decimal kilobyte size constant: 1,000 bytes.
+	KB Size = Size(units.KB)
 
-// MB is the decimal megabyte size constant: 1,000,000 bytes.
-const MB Size = Size(units.MB)
+	// MB is the decimal megabyte size constant: 1,000,000 bytes.
+	MB Size = Size(units.MB)
 
-// DefaultSize is the shared default size used by config surfaces that need a conservative byte limit.
-//
-// Its value is 4 megabytes.
-const DefaultSize Size = 4 * MB
+	// GB is the decimal gigabyte size constant: 1,000,000,000 bytes.
+	GB Size = Size(units.GB)
 
-// MaxConfigSize is the largest byte size accepted by configuration surfaces.
-//
-// Configured sizes protect in-memory buffering paths such as cache values, HTTP request bodies,
-// HTTP client response bodies, and gRPC messages. Keep this comfortably below integer and allocator
-// edge cases while still allowing unusually large service payloads.
-const MaxConfigSize Size = 256 * MB
+	// TB is the decimal terabyte size constant: 1,000,000,000,000 bytes.
+	TB Size = Size(units.TB)
 
-// GB is the decimal gigabyte size constant: 1,000,000,000 bytes.
-const GB Size = Size(units.GB)
+	// PB is the decimal petabyte size constant: 1,000,000,000,000,000 bytes.
+	PB Size = Size(units.PB)
+)
 
-// TB is the decimal terabyte size constant: 1,000,000,000,000 bytes.
-const TB Size = Size(units.TB)
+const (
+	// DefaultSize is the shared default size used by config surfaces that need a conservative byte limit.
+	//
+	// Its value is 4 megabytes.
+	DefaultSize Size = 4 * MB
 
-// PB is the decimal petabyte size constant: 1,000,000,000,000,000 bytes.
-const PB Size = Size(units.PB)
+	// MaxConfigSize is the largest byte size accepted by configuration surfaces.
+	//
+	// Configured sizes protect in-memory buffering paths such as cache values, HTTP request bodies,
+	// HTTP client response bodies, and gRPC messages. Keep this comfortably below integer and allocator
+	// edge cases while still allowing unusually large service payloads.
+	MaxConfigSize Size = 256 * MB
+)
 
 // Size is the go-service decimal byte-size type used across the repository.
 //

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -22,11 +22,11 @@ func TestSizeTextRoundTrip(t *testing.T) {
 		text string
 		size bytes.Size
 	}{
-		{name: "decimal boundary", size: bytes.MustParseSize("4MB"), text: "4000000B"},
-		{name: "above byte boundary", size: bytes.Size(1001), text: "1001B"},
-		{name: "binary megabyte", size: bytes.Size(1048576), text: "1048576B"},
-		{name: "below decimal megabyte", size: bytes.Size(999999), text: "999999B"},
-		{name: "above decimal megabyte", size: bytes.Size(1000001), text: "1000001B"},
+		{name: "decimal boundary", text: "4000000B", size: bytes.MustParseSize("4MB")},
+		{name: "above byte boundary", text: "1001B", size: bytes.Size(1001)},
+		{name: "binary megabyte", text: "1048576B", size: bytes.Size(1048576)},
+		{name: "below decimal megabyte", text: "999999B", size: bytes.Size(999999)},
+		{name: "above decimal megabyte", text: "1000001B", size: bytes.Size(1000001)},
 	}
 
 	for _, tt := range tests {
@@ -43,27 +43,26 @@ func TestSizeTextRoundTrip(t *testing.T) {
 }
 
 func TestSizeJSONRoundTrip(t *testing.T) {
-	size := bytes.MustParseSize("64B")
+	tests := []struct {
+		name string
+		text string
+		size bytes.Size
+	}{
+		{name: "byte size", text: `"64B"`, size: bytes.MustParseSize("64B")},
+		{name: "binary megabyte", text: `"1048576B"`, size: bytes.Size(1048576)},
+	}
 
-	data, err := json.Marshal(size)
-	require.NoError(t, err)
-	require.Equal(t, `"64B"`, string(data))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.size)
+			require.NoError(t, err)
+			require.Equal(t, tt.text, string(data))
 
-	var decoded bytes.Size
-	require.NoError(t, json.Unmarshal(data, &decoded))
-	require.Equal(t, size, decoded)
-}
-
-func TestSizeJSONRoundTripPreservesByteCount(t *testing.T) {
-	size := bytes.Size(1048576)
-
-	data, err := json.Marshal(size)
-	require.NoError(t, err)
-	require.Equal(t, `"1048576B"`, string(data))
-
-	var decoded bytes.Size
-	require.NoError(t, json.Unmarshal(data, &decoded))
-	require.Equal(t, size, decoded)
+			var decoded bytes.Size
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			require.Equal(t, tt.size, decoded)
+		})
+	}
 }
 
 func TestSizeUnmarshalTextInvalid(t *testing.T) {


### PR DESCRIPTION
## What

- Clarify byte helper docs and package overview wording.
- Group size unit constants separately from config defaults.
- Simplify bytes tests and benchmark loops.

## Why

- Keeps byte helper docs and tests easier to scan while preserving behavior.

## Testing

- `go test ./bytes` - passed
- `make lint` - passed
