### PR TITLE
feat(cache): polish driver readability

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -52,7 +52,7 @@ func NewCache(params CacheParams) *Cache {
 	}
 }
 
-// Cache provides a typed-ish cache facade on top of a cache driver.
+// Cache provides a typed cache facade on top of a cache driver.
 //
 // It serializes values using an encoder, optionally compresses the serialized bytes, base64-encodes the
 // final bytes, and stores the resulting string via the configured driver.
@@ -156,7 +156,7 @@ func (c *Cache) decode(value string, field any) error {
 	}
 
 	// Enforce the read-side limit on decompressed payloads, not on the stored base64 wrapper.
-	decompressed, err := c.compressor().Decompress(decoded, c.cfg.GetMaxSize())
+	decompressed, err := c.compressor().Decompress(decoded, maxSize)
 	if err != nil {
 		return err
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -225,7 +225,7 @@ func TestErroneousSave(t *testing.T) {
 }
 
 func TestErroneousGet(t *testing.T) {
-	values := []struct {
+	tests := []struct {
 		driver driver.Driver
 		config *config.Config
 		name   string
@@ -236,11 +236,11 @@ func TestErroneousGet(t *testing.T) {
 		{name: "driver error", config: test.NewCacheConfig("sync", "snappy", "json", "redis"), driver: &test.ErrCache{}},
 	}
 
-	for _, value := range values {
-		t.Run(value.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
-				test.WithWorldCacheConfig(value.config),
-				test.WithWorldCacheDriver(value.driver),
+				test.WithWorldCacheConfig(tt.config),
+				test.WithWorldCacheDriver(tt.driver),
 			)
 
 			require.Error(t, world.Get(t.Context(), "test", ptr.Zero[string]()))
@@ -304,39 +304,41 @@ func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
 func cacheRoundTripCases() []cacheRoundTripCase {
 	compressors := []string{"none", "snappy", "s2", "zstd"}
 	encoders := []string{"json", "hjson", "yaml", "yml", "toml", "gob", "msgpack"}
-	tests := make([]cacheRoundTripCase, 0, 4+len(compressors)*len(encoders))
-	tests = append(tests,
-		cacheRoundTripCase{
+	cases := []cacheRoundTripCase{
+		{
 			name:    "redis/default/request",
 			config:  test.NewCacheConfig("redis", "snappy", strings.Empty, "redis"),
 			persist: func() any { return &test.Request{Name: "hello?"} },
 			get:     func() any { return &test.Request{} },
 		},
-		cacheRoundTripCase{
+		{
 			name:    "sync/default/string",
 			config:  test.NewCacheConfig("sync", strings.Empty, strings.Empty, "redis"),
 			persist: func() any { return ptr.Value("hello?") },
 			get:     func() any { return ptr.Zero[string]() },
 		},
-		cacheRoundTripCase{
+		{
 			name:    "sync/default/buffer",
 			config:  test.NewCacheConfig("sync", strings.Empty, strings.Empty, "redis"),
 			persist: func() any { return bytes.NewBufferString("hello?") },
 			get:     func() any { return &bytes.Buffer{} },
 		},
-		cacheRoundTripCase{
+		{
 			name:    "sync/default/protobuf",
 			config:  test.NewCacheConfig("sync", strings.Empty, strings.Empty, "redis"),
 			persist: func() any { return &v1.SayHelloRequest{Name: "hello?"} },
 			get:     func() any { return &v1.SayHelloRequest{} },
 		},
-		cacheRoundTripCase{
+		{
 			name:    "sync/unknown/unknown/request",
 			config:  test.NewCacheConfig("sync", "unknown", "unknown", "redis"),
 			persist: func() any { return &test.Request{Name: "hello?"} },
 			get:     func() any { return &test.Request{} },
 		},
-	)
+	}
+
+	tests := make([]cacheRoundTripCase, 0, len(cases)+len(compressors)*len(encoders))
+	tests = append(tests, cases...)
 
 	for _, compressor := range compressors {
 		for _, encoder := range encoders {

--- a/cache/driver/benchmark_test.go
+++ b/cache/driver/benchmark_test.go
@@ -31,13 +31,13 @@ func BenchmarkRedisTelemetry(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				cache, err := driver.NewDriver(driver.DriverParams{
+				drv, err := driver.NewDriver(driver.DriverParams{
 					Lifecycle: lc,
 					FS:        test.FS,
 					Config:    cfg,
 				})
 				require.NoError(b, err)
-				driverSink = cache
+				driverSink = drv
 			}
 		})
 	}

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -2,7 +2,7 @@ package driver
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	cache "github.com/alexfalkowski/go-service/v2/cache/config"
+	"github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/telemetry"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
@@ -13,7 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
-	client "github.com/redis/go-redis/v9"
+	redis "github.com/redis/go-redis/v9"
 	notifications "github.com/redis/go-redis/v9/maintnotifications"
 )
 
@@ -38,7 +38,7 @@ type DriverParams struct {
 	di.In
 	Lifecycle di.Lifecycle
 	FS        *os.FS
-	Config    *cache.Config
+	Config    *config.Config
 
 	// Logger routes Redis client logs through the go-service logger when configured.
 	Logger *logger.Logger
@@ -98,7 +98,7 @@ func newRedisDriver(params DriverParams) (Driver, error) {
 		return nil, err
 	}
 
-	opts, err := client.ParseURL(bytes.String(data))
+	opts, err := redis.ParseURL(bytes.String(data))
 	if err != nil {
 		return nil, ErrInvalidURL
 	}
@@ -107,10 +107,10 @@ func newRedisDriver(params DriverParams) (Driver, error) {
 		Mode: notifications.ModeDisabled,
 	}
 	if params.Logger != nil {
-		client.SetLogger(redisLogger{logger: params.Logger})
+		redis.SetLogger(redisLogger{logger: params.Logger})
 	}
 
-	redisClient := client.NewClient(opts)
+	redisClient := redis.NewClient(opts)
 	if tracer.IsEnabled() {
 		runtime.Must(telemetry.InstrumentTracing(redisClient))
 	}
@@ -164,7 +164,7 @@ func IsExpiredError(err error) bool {
 // This helper normalizes the miss semantics of the backends currently supported by this package,
 // including Redis nil replies.
 func IsMissingError(err error) bool {
-	if errors.Is(err, client.Nil) {
+	if errors.Is(err, redis.Nil) {
 		return true
 	}
 

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -18,21 +18,21 @@ import (
 
 func TestNewDriver(t *testing.T) {
 	tests := []struct {
-		config *config.Config
-		err    error
-		name   string
-		nil    bool
+		config  *config.Config
+		err     error
+		name    string
+		wantNil bool
 	}{
-		{name: "disabled", nil: true},
+		{name: "disabled", wantNil: true},
 		{name: "sync", config: &config.Config{Kind: "sync"}},
-		{name: "unknown", config: &config.Config{Kind: "unknown"}, err: driver.ErrNotFound, nil: true},
+		{name: "unknown", config: &config.Config{Kind: "unknown"}, err: driver.ErrNotFound, wantNil: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d, err := driver.NewDriver(driver.DriverParams{Config: tt.config})
 			require.ErrorIs(t, err, tt.err)
-			if tt.nil {
+			if tt.wantNil {
 				require.Nil(t, d)
 				return
 			}

--- a/cache/driver/redis.go
+++ b/cache/driver/redis.go
@@ -4,11 +4,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/time"
-	client "github.com/redis/go-redis/v9"
+	redis "github.com/redis/go-redis/v9"
 )
 
 type redisDriver struct {
-	client *client.Client
+	client *redis.Client
 }
 
 func (d *redisDriver) Delete(ctx context.Context, key string) error {
@@ -17,7 +17,7 @@ func (d *redisDriver) Delete(ctx context.Context, key string) error {
 
 func (d *redisDriver) Fetch(ctx context.Context, key string) (string, error) {
 	value, err := d.client.Get(ctx, key).Result()
-	if errors.Is(err, client.Nil) {
+	if errors.Is(err, redis.Nil) {
 		return "", ErrMissing
 	}
 


### PR DESCRIPTION
## What

- Clarify cache facade wording and reuse the decoded max-size value.
- Align cache driver import aliases with package names.
- Polish cache test table names, capacity setup, and benchmark locals.

## Why

- Keeps cache docs and tests easier to scan without changing behavior.

## Testing

- `go test ./cache/...` - passed
- `make lint` - passed
