### PR TITLE
feat(cli): polish command application tests

### DIFF
--- a/cli/application.go
+++ b/cli/application.go
@@ -12,7 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
-	cmd "github.com/cristalhq/acmd"
+	"github.com/cristalhq/acmd"
 )
 
 // ErrCommandRegistered indicates a subcommand name has already been registered on an Application.
@@ -40,7 +40,7 @@ func NewApplication(register RegisterFunc) *Application {
 // An Application maintains a set of commands and delegates parsing/execution to the underlying command
 // framework (github.com/cristalhq/acmd).
 type Application struct {
-	cmds    map[string]cmd.Command
+	cmds    map[string]acmd.Command
 	name    env.Name
 	version env.Version
 }
@@ -63,7 +63,7 @@ type Application struct {
 func (a *Application) AddServer(name, description string, opts ...Option) *Command {
 	opts = slices.Clone(opts)
 	server := NewCommand(name)
-	cmd := cmd.Command{
+	command := acmd.Command{
 		Name:        name,
 		Description: description,
 		ExecFunc: func(ctx context.Context, args []string) error {
@@ -85,14 +85,10 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 			case <-ctx.Done():
 			}
 
-			if err := a.shutdownError(name, app.Stop(a.stopContext(ctx)), code); err != nil {
-				return err
-			}
-
-			return nil
+			return a.shutdownError(name, app.Stop(a.stopContext(ctx)), code)
 		},
 	}
-	runtime.Must(a.register(cmd))
+	runtime.Must(a.register(command))
 
 	return server
 }
@@ -114,7 +110,7 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 func (a *Application) AddClient(name, description string, opts ...Option) *Command {
 	opts = slices.Clone(opts)
 	client := NewCommand(name)
-	cmd := cmd.Command{
+	command := acmd.Command{
 		Name:        name,
 		Description: description,
 		ExecFunc: func(ctx context.Context, args []string) error {
@@ -136,14 +132,10 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 			default:
 			}
 
-			if err := a.shutdownError(name, app.Stop(a.stopContext(ctx)), code); err != nil {
-				return err
-			}
-
-			return nil
+			return a.shutdownError(name, app.Stop(a.stopContext(ctx)), code)
 		},
 	}
-	runtime.Must(a.register(cmd))
+	runtime.Must(a.register(command))
 
 	return client
 }
@@ -159,7 +151,7 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 // It returns any execution error from the underlying runner or command ExecFunc.
 func (a *Application) Run(ctx context.Context) error {
 	name := a.name.String()
-	runner := cmd.RunnerOf(slices.Collect(maps.Values(a.cmds)), cmd.Config{
+	runner := acmd.RunnerOf(slices.Collect(maps.Values(a.cmds)), acmd.Config{
 		AppName:        name,
 		AppDescription: name,
 		Version:        a.version.String(),
@@ -185,9 +177,9 @@ func (a *Application) RunCode(ctx context.Context) int {
 	return os.ExitCodeSuccess
 }
 
-func (a *Application) register(command cmd.Command) error {
+func (a *Application) register(command acmd.Command) error {
 	if a.cmds == nil {
-		a.cmds = make(map[string]cmd.Command)
+		a.cmds = make(map[string]acmd.Command)
 	}
 
 	if _, ok := a.cmds[command.Name]; ok {
@@ -199,8 +191,8 @@ func (a *Application) register(command cmd.Command) error {
 	return nil
 }
 
-func (a *Application) prefix(prefix string, err error) error {
-	return errors.Prefix(prefix+": failed to run", di.RootCause(err))
+func (a *Application) prefix(name string, err error) error {
+	return errors.Prefix(name+": failed to run", di.RootCause(err))
 }
 
 func (a *Application) shutdownError(name string, err error, code int) error {

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -17,10 +17,7 @@ import (
 
 func TestApplicationRun(t *testing.T) {
 	config := test.FilePath("configs/config.yml")
-
-	os.Args = []string{test.Name.String(), "server", "-config", config}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server", "-config", config)
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -33,8 +30,7 @@ func TestApplicationRun(t *testing.T) {
 
 func TestApplicationRunCodeWithError(t *testing.T) {
 	config := test.FilePath("configs/invalid_http.config.yml")
-
-	os.Args = []string{test.Name.String(), "server", "-config", config}
+	setupCLI("server", "-config", config)
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -47,9 +43,7 @@ func TestApplicationRunCodeWithError(t *testing.T) {
 }
 
 func TestApplicationRunCodeOnSuccess(t *testing.T) {
-	os.Args = []string{test.Name.String(), "client"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("client")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -61,29 +55,29 @@ func TestApplicationRunCodeOnSuccess(t *testing.T) {
 }
 
 func TestApplicationRunWithInvalidFlag(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server", "--invalid-flag"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	t.Run("server", func(t *testing.T) {
+		setupCLI("server", "--invalid-flag")
 
-	app := cli.NewApplication(
-		func(c cli.Commander) {
-			cmd := c.AddServer("server", "Start the server.", test.Options()...)
-			cmd.AddConfig(strings.Empty)
-		},
-	)
-	require.Error(t, app.Run(t.Context()))
+		app := cli.NewApplication(
+			func(c cli.Commander) {
+				cmd := c.AddServer("server", "Start the server.", test.Options()...)
+				cmd.AddConfig(strings.Empty)
+			},
+		)
+		require.Error(t, app.Run(t.Context()))
+	})
 
-	os.Args = []string{test.Name.String(), "client", "--invalid-flag"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	t.Run("client", func(t *testing.T) {
+		setupCLI("client", "--invalid-flag")
 
-	app = cli.NewApplication(
-		func(c cli.Commander) {
-			cmd := c.AddClient("client", "Start the client.", test.Options()...)
-			cmd.AddConfig(strings.Empty)
-		},
-	)
-	require.Error(t, app.Run(t.Context()))
+		app := cli.NewApplication(
+			func(c cli.Commander) {
+				cmd := c.AddClient("client", "Start the client.", test.Options()...)
+				cmd.AddConfig(strings.Empty)
+			},
+		)
+		require.Error(t, app.Run(t.Context()))
+	})
 }
 
 func TestApplicationDuplicateCommand(t *testing.T) {
@@ -106,12 +100,9 @@ func TestApplicationDuplicateCommand(t *testing.T) {
 	require.ErrorContains(t, err, "server")
 }
 
-func TestApplicationRunWithInvalidParams(t *testing.T) {
+func TestApplicationRunWithConfigFlag(t *testing.T) {
 	config := test.FilePath("configs/config.yml")
-
-	os.Args = []string{test.Name.String(), "server", "-config", config}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server", "-config", config)
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -131,9 +122,7 @@ func TestApplicationInvalid(t *testing.T) {
 
 	for _, config := range configs {
 		t.Run(config, func(t *testing.T) {
-			os.Args = []string{test.Name.String(), "server", "-config", config}
-			cli.Name = test.Name
-			cli.Version = test.Version
+			setupCLI("server", "-config", config)
 
 			app := cli.NewApplication(
 				func(c cli.Commander) {
@@ -144,15 +133,13 @@ func TestApplicationInvalid(t *testing.T) {
 
 			err := app.Run(t.Context())
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "unknown port")
+			require.ErrorContains(t, err, "unknown port")
 		})
 	}
 }
 
 func TestApplicationDisabled(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server", "-config", test.FilePath("configs/disabled.config.yml")}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server", "-config", test.FilePath("configs/disabled.config.yml"))
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -164,9 +151,7 @@ func TestApplicationDisabled(t *testing.T) {
 }
 
 func TestApplicationClient(t *testing.T) {
-	os.Args = []string{test.Name.String(), "client"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("client")
 
 	opts := []di.Option{di.NoLogger}
 	app := cli.NewApplication(
@@ -179,9 +164,7 @@ func TestApplicationClient(t *testing.T) {
 }
 
 func TestApplicationClientCanRunTwice(t *testing.T) {
-	os.Args = []string{test.Name.String(), "client"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("client")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -194,9 +177,7 @@ func TestApplicationClientCanRunTwice(t *testing.T) {
 }
 
 func TestApplicationClientRecoversFromPanic(t *testing.T) {
-	os.Args = []string{test.Name.String(), "client"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("client")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -213,13 +194,11 @@ func TestApplicationClientRecoversFromPanic(t *testing.T) {
 
 	err := app.Run(t.Context())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), `panic: "bad client"`)
+	require.ErrorContains(t, err, `panic: "bad client"`)
 }
 
 func TestApplicationServerHonorsContextCancellation(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server")
 
 	started := make(chan struct{})
 	stopped := make(chan error, 1)
@@ -261,9 +240,7 @@ func TestApplicationServerHonorsContextCancellation(t *testing.T) {
 }
 
 func TestApplicationServerShutdownExitCodeIsReturned(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -275,9 +252,7 @@ func TestApplicationServerShutdownExitCodeIsReturned(t *testing.T) {
 }
 
 func TestApplicationServerShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -291,9 +266,7 @@ func TestApplicationServerShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) 
 }
 
 func TestApplicationClientShutdownExitCodeIsReturned(t *testing.T) {
-	os.Args = []string{test.Name.String(), "client"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("client")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -315,9 +288,7 @@ func TestApplicationClientShutdownExitCodeIsReturned(t *testing.T) {
 }
 
 func TestApplicationClientShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) {
-	os.Args = []string{test.Name.String(), "client"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("client")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -331,9 +302,7 @@ func TestApplicationClientShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) 
 }
 
 func TestApplicationServerServeFailureReturnsServeFailureExitCode(t *testing.T) {
-	os.Args = []string{test.Name.String(), "server"}
-	cli.Name = test.Name
-	cli.Version = test.Version
+	setupCLI("server")
 
 	app := cli.NewApplication(
 		func(c cli.Commander) {
@@ -352,9 +321,7 @@ func TestApplicationInvalidClient(t *testing.T) {
 
 	for _, config := range configs {
 		t.Run(config, func(t *testing.T) {
-			os.Args = []string{test.Name.String(), "client", "-config", config}
-			cli.Name = test.Name
-			cli.Version = test.Version
+			setupCLI("client", "-config", config)
 
 			app := cli.NewApplication(
 				func(c cli.Commander) {
@@ -365,9 +332,15 @@ func TestApplicationInvalidClient(t *testing.T) {
 
 			err := app.Run(t.Context())
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "unknown port")
+			require.ErrorContains(t, err, "unknown port")
 		})
 	}
+}
+
+func setupCLI(args ...string) {
+	os.Args = append([]string{test.Name.String()}, args...)
+	cli.Name = test.Name
+	cli.Version = test.Version
 }
 
 func shutdownExitCodeAndStopErrorOption(code int) di.Option {

--- a/cli/command.go
+++ b/cli/command.go
@@ -11,8 +11,7 @@ import (
 // Application subcommands call `(*flag.FlagSet).Parse` before starting DI, and the Command's
 // `module` wires the parsed FlagSet into the DI container so constructors can read flag values.
 func NewCommand(name string) *Command {
-	set := flag.NewFlagSet(name)
-	return &Command{FlagSet: set}
+	return &Command{FlagSet: flag.NewFlagSet(name)}
 }
 
 // Command wraps a `*flag.FlagSet` and provides DI wiring for CLI subcommands.


### PR DESCRIPTION
## What

- Removed the unnecessary `acmd` import alias and simplified command shutdown returns.
- Inlined command flag-set construction.
- Centralized application test setup, split invalid flag assertions into subtests, renamed the config flag test, and used `require.ErrorContains`.

## Why

- Keep command code aligned with Go import and naming idioms while reducing repeated setup in application tests.
- No blocking code-review findings.

## Testing

- `go test ./cli` - passed
- `make lint` - passed
- `git diff --check` - passed
