### PR TITLE
feat(config): polish decoder and option helpers

### DIFF
--- a/config/client/config.go
+++ b/config/client/config.go
@@ -51,33 +51,33 @@ func (c *Config) IsEnabled() bool {
 // configured, it is copied into the runtime TLS config for server certificate
 // hostname verification.
 func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
-	config := &tls.Config{
+	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
 
 	if !cfg.IsEnabled() {
-		return config, nil
+		return tlsConfig, nil
 	}
 
 	if cfg.HasKeyMaterial() {
 		pair, err := tlsconfig.NewKeyPair(fs, cfg)
 		if err != nil {
-			return config, err
+			return tlsConfig, err
 		}
 
-		config.Certificates = []tls.Certificate{pair}
+		tlsConfig.Certificates = []tls.Certificate{pair}
 	}
 
 	if cfg.HasCA() {
 		pool, err := tlsconfig.NewCertPool(fs, cfg)
 		if err != nil {
-			return config, err
+			return tlsConfig, err
 		}
 
-		config.RootCAs = pool
+		tlsConfig.RootCAs = pool
 	}
 
-	config.ServerName = cfg.ServerName
+	tlsConfig.ServerName = cfg.ServerName
 
-	return config, nil
+	return tlsConfig, nil
 }

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/config/client"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -106,5 +105,5 @@ func TestNewConfigInvalidKeyPair(t *testing.T) {
 func TestNewConfigInvalidCA(t *testing.T) {
 	_, err := client.NewConfig(test.FS, &config.Config{CA: "invalid ca"})
 	require.Error(t, err)
-	require.True(t, errors.Is(err, config.ErrInvalidCA))
+	require.ErrorIs(t, err, config.ErrInvalidCA)
 }

--- a/config/client/doc.go
+++ b/config/client/doc.go
@@ -3,5 +3,5 @@
 // This package contains configuration types and helpers intended to be embedded into a
 // larger service configuration when wiring client dependencies.
 //
-// Start with `Config`.
+// Start with [Config].
 package client

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,9 +29,9 @@ func TestValidFileConfig(t *testing.T) {
 
 			decoder := test.NewDecoder(set)
 
-			config, err := config.NewConfig[config.Config](decoder, test.Validator)
+			cfg, err := config.NewConfig[config.Config](decoder, test.Validator)
 			require.NoError(t, err)
-			verifyConfig(t, config)
+			verifyConfig(t, cfg)
 		})
 	}
 }
@@ -49,9 +49,9 @@ func TestValidHomeFileConfig(t *testing.T) {
 
 	decoder := test.NewDecoder(set)
 
-	config, err := config.NewConfig[config.Config](decoder, test.Validator)
+	cfg, err := config.NewConfig[config.Config](decoder, test.Validator)
 	require.NoError(t, err)
-	verifyConfig(t, config)
+	verifyConfig(t, cfg)
 }
 
 func TestInvalidFileConfig(t *testing.T) {
@@ -101,9 +101,9 @@ func TestValidEnvConfig(t *testing.T) {
 
 			decoder := test.NewDecoder(set)
 
-			config, err := config.NewConfig[config.Config](decoder, test.Validator)
+			cfg, err := config.NewConfig[config.Config](decoder, test.Validator)
 			require.NoError(t, err)
-			verifyConfig(t, config)
+			verifyConfig(t, cfg)
 		})
 	}
 }
@@ -177,9 +177,9 @@ func TestValidCommonConfig(t *testing.T) {
 
 			decoder := test.NewDecoder(set)
 
-			config, err := config.NewConfig[config.Config](decoder, test.Validator)
+			cfg, err := config.NewConfig[config.Config](decoder, test.Validator)
 			require.NoError(t, err)
-			verifyConfig(t, config)
+			verifyConfig(t, cfg)
 
 			require.NoError(t, test.FS.RemoveAll(path))
 		})
@@ -214,70 +214,129 @@ func TestNewConfigRejectsEmptyDecodedConfig(t *testing.T) {
 	require.ErrorIs(t, err, config.ErrInvalidConfig)
 }
 
-//nolint:funlen,gosec
-func verifyConfig(t *testing.T, config *config.Config) {
+func verifyConfig(t *testing.T, cfg *config.Config) {
 	t.Helper()
 
-	require.Equal(t, "tcp://localhost:6060", config.Debug.Address)
-	require.False(t, config.Debug.TLS.IsEnabled())
-	require.True(t, config.Crypto.RSA.IsEnabled())
-	require.Equal(t, "redis", config.Cache.Kind)
-	require.Equal(t, "snappy", config.Cache.Compressor)
-	require.Equal(t, "proto", config.Cache.Encoder)
-	require.Equal(t, 4*bytes.MB, config.Cache.MaxSize)
-	require.Equal(t, "file:../test/secrets/redis", config.Cache.Options["url"])
-	require.True(t, config.Crypto.IsEnabled())
-	require.True(t, config.Crypto.AES.IsEnabled())
-	require.NotEmpty(t, config.Crypto.AES.Key)
-	require.True(t, config.Crypto.Ed25519.IsEnabled())
-	require.NotEmpty(t, config.Crypto.Ed25519.Public)
-	require.NotEmpty(t, config.Crypto.Ed25519.Private)
-	require.True(t, config.Crypto.HMAC.IsEnabled())
-	require.NotEmpty(t, config.Crypto.HMAC.Key)
-	require.True(t, config.Crypto.RSA.IsEnabled())
-	require.NotEmpty(t, config.Crypto.RSA.Public)
-	require.NotEmpty(t, config.Crypto.RSA.Private)
-	require.True(t, config.Crypto.SSH.IsEnabled())
-	require.NotEmpty(t, config.Crypto.SSH.Public)
-	require.NotEmpty(t, config.Crypto.SSH.Private)
-	require.True(t, config.Debug.IsEnabled())
-	require.Equal(t, "development", config.Environment.String())
-	require.True(t, config.Feature.IsEnabled())
-	require.Equal(t, "localhost:9000", config.Feature.Address)
-	require.Equal(t, 10*time.Second, config.Feature.Timeout)
-	require.Equal(t, 100*time.Millisecond, config.Feature.Retry.Backoff)
-	require.Equal(t, time.Second, config.Feature.Retry.Timeout)
-	require.Equal(t, uint64(3), config.Feature.Retry.Attempts)
-	require.Equal(t, "uuid", config.ID.Kind)
-	require.Equal(t, "file:../test/secrets/hooks", config.Hooks.Secret)
-	require.Len(t, config.SQL.PG.Masters, 1)
-	require.Equal(t, "file:../test/secrets/pg", config.SQL.PG.Masters[0].URL)
-	require.Len(t, config.SQL.PG.Slaves, 1)
-	require.Equal(t, "file:../test/secrets/pg", config.SQL.PG.Slaves[0].URL)
-	require.Equal(t, 5, config.SQL.PG.MaxIdleConns)
-	require.Equal(t, 5, config.SQL.PG.MaxOpenConns)
-	require.Equal(t, time.Hour, config.SQL.PG.ConnMaxLifetime)
-	require.Equal(t, "text", config.Telemetry.Logger.Kind)
-	require.Equal(t, "info", config.Telemetry.Logger.Level)
-	require.Equal(t, "prometheus", config.Telemetry.Metrics.Kind)
-	require.Equal(t, "nts", config.Time.Kind)
-	require.Equal(t, "time.cloudflare.com", config.Time.Address)
-	require.Equal(t, "http://localhost:4318/v1/traces", config.Telemetry.Tracer.URL)
-	require.Equal(t, "otlp", config.Telemetry.Tracer.Kind)
-	require.True(t, config.Transport.GRPC.Token.IsEnabled())
-	require.Equal(t, "file:../test/configs/rbac.conf", config.Transport.GRPC.Token.Access.Model)
-	require.Equal(t, "file:../test/configs/rbac.csv", config.Transport.GRPC.Token.Access.Policy)
-	require.Equal(t, "jwt", config.Transport.GRPC.Token.Kind)
-	require.Equal(t, time.Hour, config.Transport.GRPC.Token.JWT.Expiration)
-	require.Equal(t, "iss", config.Transport.GRPC.Token.JWT.Issuer)
-	require.Equal(t, "1234567890", config.Transport.GRPC.Token.JWT.KeyID)
-	require.True(t, config.Transport.GRPC.Config.IsEnabled())
-	require.Equal(t, "tcp://localhost:12000", config.Transport.GRPC.Address)
-	require.Equal(t, 10*time.Second, config.Transport.GRPC.Timeout)
-	require.Equal(t, 3*bytes.MB, config.Transport.GRPC.MaxReceiveSize)
-	require.Equal(t, "user-agent", config.Transport.GRPC.Limiter.Kind)
-	require.Equal(t, 10, int(config.Transport.GRPC.Limiter.Tokens))
-	require.Equal(t, time.Second, config.Transport.GRPC.Limiter.Interval)
+	verifyDebugConfig(t, cfg)
+	verifyCacheConfig(t, cfg)
+	verifyCryptoConfig(t, cfg)
+	verifyFeatureConfig(t, cfg)
+	verifyIDConfig(t, cfg)
+	verifyHooksConfig(t, cfg)
+	verifySQLConfig(t, cfg)
+	verifyTelemetryConfig(t, cfg)
+	verifyTimeConfig(t, cfg)
+	verifyGRPCConfig(t, cfg)
+	verifyHTTPConfig(t, cfg)
+}
+
+func verifyDebugConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.True(t, cfg.Debug.IsEnabled())
+	require.Equal(t, "tcp://localhost:6060", cfg.Debug.Address)
+	require.False(t, cfg.Debug.TLS.IsEnabled())
+}
+
+func verifyCacheConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Equal(t, "redis", cfg.Cache.Kind)
+	require.Equal(t, "snappy", cfg.Cache.Compressor)
+	require.Equal(t, "proto", cfg.Cache.Encoder)
+	require.Equal(t, 4*bytes.MB, cfg.Cache.MaxSize)
+	require.Equal(t, "file:../test/secrets/redis", cfg.Cache.Options["url"])
+}
+
+func verifyCryptoConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.True(t, cfg.Crypto.IsEnabled())
+	require.True(t, cfg.Crypto.AES.IsEnabled())
+	require.NotEmpty(t, cfg.Crypto.AES.Key)
+	require.True(t, cfg.Crypto.Ed25519.IsEnabled())
+	require.NotEmpty(t, cfg.Crypto.Ed25519.Public)
+	require.NotEmpty(t, cfg.Crypto.Ed25519.Private)
+	require.True(t, cfg.Crypto.HMAC.IsEnabled())
+	require.NotEmpty(t, cfg.Crypto.HMAC.Key)
+	require.True(t, cfg.Crypto.RSA.IsEnabled())
+	require.NotEmpty(t, cfg.Crypto.RSA.Public)
+	require.NotEmpty(t, cfg.Crypto.RSA.Private)
+	require.True(t, cfg.Crypto.SSH.IsEnabled())
+	require.NotEmpty(t, cfg.Crypto.SSH.Public)
+	require.NotEmpty(t, cfg.Crypto.SSH.Private)
+}
+
+func verifyFeatureConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Equal(t, "development", cfg.Environment.String())
+	require.True(t, cfg.Feature.IsEnabled())
+	require.Equal(t, "localhost:9000", cfg.Feature.Address)
+	require.Equal(t, 10*time.Second, cfg.Feature.Timeout)
+	require.Equal(t, 100*time.Millisecond, cfg.Feature.Retry.Backoff)
+	require.Equal(t, time.Second, cfg.Feature.Retry.Timeout)
+	require.Equal(t, uint64(3), cfg.Feature.Retry.Attempts)
+}
+
+func verifyIDConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Equal(t, "uuid", cfg.ID.Kind)
+}
+
+func verifyHooksConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Equal(t, "file:../test/secrets/hooks", cfg.Hooks.Secret)
+}
+
+func verifySQLConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Len(t, cfg.SQL.PG.Masters, 1)
+	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Masters[0].URL)
+	require.Len(t, cfg.SQL.PG.Slaves, 1)
+	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Slaves[0].URL)
+	require.Equal(t, 5, cfg.SQL.PG.MaxIdleConns)
+	require.Equal(t, 5, cfg.SQL.PG.MaxOpenConns)
+	require.Equal(t, time.Hour, cfg.SQL.PG.ConnMaxLifetime)
+}
+
+func verifyTelemetryConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Equal(t, "text", cfg.Telemetry.Logger.Kind)
+	require.Equal(t, "info", cfg.Telemetry.Logger.Level)
+	require.Equal(t, "prometheus", cfg.Telemetry.Metrics.Kind)
+	require.Equal(t, "http://localhost:4318/v1/traces", cfg.Telemetry.Tracer.URL)
+	require.Equal(t, "otlp", cfg.Telemetry.Tracer.Kind)
+}
+
+func verifyTimeConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.Equal(t, "nts", cfg.Time.Kind)
+	require.Equal(t, "time.cloudflare.com", cfg.Time.Address)
+}
+
+func verifyGRPCConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.True(t, cfg.Transport.GRPC.Token.IsEnabled())
+	require.Equal(t, "file:../test/configs/rbac.conf", cfg.Transport.GRPC.Token.Access.Model)
+	require.Equal(t, "file:../test/configs/rbac.csv", cfg.Transport.GRPC.Token.Access.Policy)
+	require.Equal(t, "jwt", cfg.Transport.GRPC.Token.Kind)
+	require.Equal(t, time.Hour, cfg.Transport.GRPC.Token.JWT.Expiration)
+	require.Equal(t, "iss", cfg.Transport.GRPC.Token.JWT.Issuer)
+	require.Equal(t, "1234567890", cfg.Transport.GRPC.Token.JWT.KeyID)
+	require.True(t, cfg.Transport.GRPC.Config.IsEnabled())
+	require.Equal(t, "tcp://localhost:12000", cfg.Transport.GRPC.Address)
+	require.Equal(t, 10*time.Second, cfg.Transport.GRPC.Timeout)
+	require.Equal(t, 3*bytes.MB, cfg.Transport.GRPC.MaxReceiveSize)
+	require.Equal(t, "user-agent", cfg.Transport.GRPC.Limiter.Kind)
+	require.Equal(t, uint64(10), cfg.Transport.GRPC.Limiter.Tokens)
+	require.Equal(t, time.Second, cfg.Transport.GRPC.Limiter.Interval)
 	require.Equal(t,
 		options.Map{
 			"keepalive_enforcement_policy_ping_min_time": "10s",
@@ -292,23 +351,28 @@ func verifyConfig(t *testing.T, config *config.Config) {
 			"initial_conn_window_size":                   "2MB",
 			"max_send_msg_size":                          "8MB",
 		},
-		config.Transport.GRPC.Options,
+		cfg.Transport.GRPC.Options,
 	)
-	require.False(t, config.Transport.GRPC.TLS.IsEnabled())
-	require.True(t, config.Transport.HTTP.Token.IsEnabled())
-	require.Equal(t, "file:../test/configs/rbac.conf", config.Transport.HTTP.Token.Access.Model)
-	require.Equal(t, "file:../test/configs/rbac.csv", config.Transport.HTTP.Token.Access.Policy)
-	require.Equal(t, "jwt", config.Transport.HTTP.Token.Kind)
-	require.Equal(t, time.Hour, config.Transport.HTTP.Token.JWT.Expiration)
-	require.Equal(t, "iss", config.Transport.HTTP.Token.JWT.Issuer)
-	require.Equal(t, "1234567890", config.Transport.HTTP.Token.JWT.KeyID)
-	require.True(t, config.Transport.HTTP.Config.IsEnabled())
-	require.Equal(t, "tcp://localhost:11000", config.Transport.HTTP.Address)
-	require.Equal(t, 10*time.Second, config.Transport.HTTP.Timeout)
-	require.Equal(t, 2*bytes.MB, config.Transport.HTTP.MaxReceiveSize)
-	require.Equal(t, "user-agent", config.Transport.HTTP.Limiter.Kind)
-	require.Equal(t, 10, int(config.Transport.HTTP.Limiter.Tokens))
-	require.Equal(t, time.Second, config.Transport.HTTP.Limiter.Interval)
+	require.False(t, cfg.Transport.GRPC.TLS.IsEnabled())
+}
+
+func verifyHTTPConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	require.True(t, cfg.Transport.HTTP.Token.IsEnabled())
+	require.Equal(t, "file:../test/configs/rbac.conf", cfg.Transport.HTTP.Token.Access.Model)
+	require.Equal(t, "file:../test/configs/rbac.csv", cfg.Transport.HTTP.Token.Access.Policy)
+	require.Equal(t, "jwt", cfg.Transport.HTTP.Token.Kind)
+	require.Equal(t, time.Hour, cfg.Transport.HTTP.Token.JWT.Expiration)
+	require.Equal(t, "iss", cfg.Transport.HTTP.Token.JWT.Issuer)
+	require.Equal(t, "1234567890", cfg.Transport.HTTP.Token.JWT.KeyID)
+	require.True(t, cfg.Transport.HTTP.Config.IsEnabled())
+	require.Equal(t, "tcp://localhost:11000", cfg.Transport.HTTP.Address)
+	require.Equal(t, 10*time.Second, cfg.Transport.HTTP.Timeout)
+	require.Equal(t, 2*bytes.MB, cfg.Transport.HTTP.MaxReceiveSize)
+	require.Equal(t, "user-agent", cfg.Transport.HTTP.Limiter.Kind)
+	require.Equal(t, uint64(10), cfg.Transport.HTTP.Limiter.Tokens)
+	require.Equal(t, time.Second, cfg.Transport.HTTP.Limiter.Interval)
 	require.Equal(t,
 		options.Map{
 			"read_timeout":        "10s",
@@ -317,9 +381,9 @@ func verifyConfig(t *testing.T, config *config.Config) {
 			"read_header_timeout": "10s",
 			"max_header_bytes":    "32KB",
 		},
-		config.Transport.HTTP.Options,
+		cfg.Transport.HTTP.Options,
 	)
-	require.False(t, config.Transport.HTTP.TLS.IsEnabled())
+	require.False(t, cfg.Transport.HTTP.TLS.IsEnabled())
 }
 
 type decoderFunc func(any) error

--- a/config/default.go
+++ b/config/default.go
@@ -64,25 +64,26 @@ func (c *Default) Decode(v any) error {
 }
 
 func (c *Default) find() (string, io.ReadCloser, error) {
+	name := c.name.String()
+	dirs := []string{
+		c.fs.ExecutableDir(),
+		c.fs.Join(os.UserConfigDir(), name),
+		"/etc/" + name,
+	}
 	extensions := []string{".yaml", ".yml", ".hjson", ".toml", ".json"}
+
 	for _, extension := range extensions {
-		n := c.name.String()
-		file := n + extension
-		dirs := []string{
-			c.fs.ExecutableDir(),
-			c.fs.Join(os.UserConfigDir(), n),
-			"/etc/" + n,
-		}
+		file := name + extension
 
 		for _, dir := range dirs {
-			name := c.fs.Join(dir, file)
-			if !c.fs.PathExists(name) {
+			path := c.fs.Join(dir, file)
+			if !c.fs.PathExists(path) {
 				continue
 			}
 
-			f, err := c.fs.Open(name)
+			f, err := c.fs.Open(path)
 
-			return c.fs.PathExtension(name), f, err
+			return c.fs.PathExtension(path), f, err
 		}
 	}
 

--- a/config/options/options.go
+++ b/config/options/options.go
@@ -14,19 +14,15 @@ import (
 //
 // It is commonly embedded into larger configuration structs to allow passing implementation-specific
 // knobs without expanding the strongly-typed schema.
+//
+// Option values are treated as trusted startup configuration. Helpers panic for invalid present values
+// so low-level knob mistakes fail fast during startup rather than surfacing on request paths.
 type Map map[string]string
 
 // Duration returns a duration option for key if present; otherwise it returns fallback.
 //
 // The stored value must be a Go duration string accepted by time.ParseDuration (for example "250ms",
 // "30s", or "5m").
-//
-// Failure mode: if key is present but the value cannot be parsed as a duration, Duration will panic
-// because it uses time.MustParseDuration. Use this helper only when the option values are validated
-// or come from trusted configuration.
-//
-// Design note: option values are treated as trusted startup configuration. Panics are intentional
-// fail-fast behavior for invalid low-level knobs, not request-path error handling.
 func (m Map) Duration(key string, fallback time.Duration) time.Duration {
 	if val, ok := m[key]; ok {
 		return time.MustParseDuration(val)
@@ -51,12 +47,6 @@ func (m Map) NonNegativeDuration(key string, fallback time.Duration) time.Durati
 // Uint32 returns an unsigned integer option for key if present; otherwise it returns fallback.
 //
 // The stored value must be a base-10 unsigned integer accepted by strconv.ParseUint for a 32-bit size.
-//
-// Failure mode: if key is present but the value cannot be parsed as a uint32, Uint32 will panic because
-// it treats invalid startup/configuration values as fatal.
-//
-// Design note: option values are treated as trusted startup configuration. Panics are intentional
-// fail-fast behavior for invalid low-level knobs, not request-path error handling.
 func (m Map) Uint32(key string, fallback uint32) uint32 {
 	if val, ok := m[key]; ok {
 		num, err := strconv.ParseUint(val, 10, 32)
@@ -72,13 +62,6 @@ func (m Map) Uint32(key string, fallback uint32) uint32 {
 //
 // The stored value must be a human-readable decimal size string accepted by bytes.ParseSize, such
 // as "64B", "2MB", or "4GB".
-//
-// Failure mode: if key is present but the value cannot be parsed as a size, Size will panic because
-// it uses bytes.MustParseSize. Use this helper only when the option values are validated or come from
-// trusted configuration.
-//
-// Design note: option values are treated as trusted startup configuration. Panics are intentional
-// fail-fast behavior for invalid low-level knobs, not request-path error handling.
 func (m Map) Size(key string, fallback bytes.Size) bytes.Size {
 	if val, ok := m[key]; ok {
 		return bytes.MustParseSize(val)

--- a/config/options/options_test.go
+++ b/config/options/options_test.go
@@ -13,7 +13,7 @@ import (
 func TestDuration(t *testing.T) {
 	require.Equal(t, 10*time.Minute, test.ConfigOptions.Duration("read_timeout", 5*time.Second))
 	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("timeout", 5*time.Second))
-	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("bob", 5*time.Second))
+	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("missing", 5*time.Second))
 }
 
 func TestNonNegativeDuration(t *testing.T) {

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -83,34 +83,34 @@ func (c *Config) GetTimeout() time.Duration {
 // Any configured TLS material requires a complete server certificate/key pair.
 // A CA-only configuration returns ErrMissingKeyPair.
 func NewConfig(fs *os.FS, cfg *tlsconfig.Config) (*tls.Config, error) {
-	config := &tls.Config{
+	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
 
 	if !cfg.HasKeyMaterial() && !cfg.HasCA() {
-		return config, nil
+		return tlsConfig, nil
 	}
 
 	if !cfg.HasKeyPair() {
-		return config, ErrMissingKeyPair
+		return tlsConfig, ErrMissingKeyPair
 	}
 
 	pair, err := tlsconfig.NewKeyPair(fs, cfg)
 	if err != nil {
-		return config, err
+		return tlsConfig, err
 	}
 
-	config.Certificates = []tls.Certificate{pair}
+	tlsConfig.Certificates = []tls.Certificate{pair}
 
 	if cfg.HasCA() {
 		pool, err := tlsconfig.NewCertPool(fs, cfg)
 		if err != nil {
-			return config, err
+			return tlsConfig, err
 		}
 
-		config.ClientCAs = pool
-		config.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.ClientCAs = pool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
-	return config, nil
+	return tlsConfig, nil
 }

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -176,5 +175,5 @@ func TestNewConfigInvalidCA(t *testing.T) {
 		CA:   "invalid ca",
 	})
 	require.Error(t, err)
-	require.True(t, errors.Is(err, config.ErrInvalidCA))
+	require.ErrorIs(t, err, config.ErrInvalidCA)
 }

--- a/config/server/doc.go
+++ b/config/server/doc.go
@@ -3,5 +3,5 @@
 // This package contains configuration types and helpers intended to be embedded into a
 // larger service configuration when wiring server dependencies.
 //
-// Start with `Config`.
+// Start with [Config].
 package server


### PR DESCRIPTION
## What

- Hoisted default decoder lookup setup and clarified runtime TLS local names.
- Simplified option helper documentation and linked client/server package docs to `Config`.
- Refactored root fixture assertions into domain helpers and tightened test names/assertions.

## Why

- Improve readability and local style consistency in configuration decoding, option helpers, and fixture verification.
- No blocking code-review findings.

## Testing

- `go test ./config/...` - passed
- `make lint` - passed
- `git diff --check` - passed
