### PR TITLE
feat(crypto): polish key helper readability

### DIFF
--- a/crypto/aes/aes.go
+++ b/crypto/aes/aes.go
@@ -80,12 +80,12 @@ func (c *Cipher) Encrypt(msg []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	bytes, err := c.gen.GenerateBytes(aead.NonceSize())
+	nonce, err := c.gen.GenerateBytes(aead.NonceSize())
 	if err != nil {
 		return nil, err
 	}
 
-	return aead.Seal(bytes, bytes, msg, nil), nil
+	return aead.Seal(nonce, nonce, msg, nil), nil
 }
 
 // Decrypt decrypts a value produced by Encrypt.

--- a/crypto/aes/aes_test.go
+++ b/crypto/aes/aes_test.go
@@ -26,9 +26,9 @@ func TestGenerator(t *testing.T) {
 }
 
 func TestValidCipher(t *testing.T) {
-	rand := rand.NewGenerator(rand.NewReader())
+	gen := rand.NewGenerator(rand.NewReader())
 
-	cipher, err := aes.NewCipher(rand, test.FS, test.NewAES())
+	cipher, err := aes.NewCipher(gen, test.FS, test.NewAES())
 	require.NoError(t, err)
 	require.NotNil(t, cipher)
 

--- a/crypto/aes/config.go
+++ b/crypto/aes/config.go
@@ -6,7 +6,7 @@ import "github.com/alexfalkowski/go-service/v2/os"
 type Config struct {
 	// Key is a "source string" that resolves to the raw AES key bytes.
 	//
-	// It supports the go-service source string pattern implemented by `os.FS.ReadSource`:
+	// It supports the go-service source string pattern implemented by [os.FS.ReadSource]:
 	//   - "env:NAME" to read from an environment variable,
 	//   - "file:/path/to/key" to read from a file, or
 	//   - any other value treated as a literal.
@@ -24,7 +24,7 @@ func (c *Config) IsEnabled() bool {
 
 // GetKey resolves and returns the AES key bytes using the configured Key source.
 //
-// It delegates to `fs.ReadSource(c.Key)` and returns any read/resolve error from that operation.
+// It delegates to fs.ReadSource(c.Key) and returns any read/resolve error from that operation.
 func (c *Config) GetKey(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.Key)
 }

--- a/crypto/bcrypt/bcrypt_test.go
+++ b/crypto/bcrypt/bcrypt_test.go
@@ -13,21 +13,21 @@ func TestSigner(t *testing.T) {
 	signer := bcrypt.NewSigner()
 
 	t.Run("sign and verify", func(t *testing.T) {
-		s, err := signer.Sign(strings.Bytes("test"))
+		hash, err := signer.Sign(strings.Bytes("test"))
 		require.NoError(t, err)
-		require.NotEmpty(t, s)
+		require.NotEmpty(t, hash)
 
-		cost, err := bcrypt.Cost(s)
+		cost, err := bcrypt.Cost(hash)
 		require.NoError(t, err)
 		require.Equal(t, bcrypt.DefaultCost, cost)
 
-		require.NoError(t, signer.Verify(s, strings.Bytes("test")))
+		require.NoError(t, signer.Verify(hash, strings.Bytes("test")))
 	})
 
 	t.Run("wrong password", func(t *testing.T) {
-		s, err := signer.Sign(strings.Bytes("steve"))
+		hash, err := signer.Sign(strings.Bytes("steve"))
 		require.NoError(t, err)
-		require.ErrorIs(t, signer.Verify(s, strings.Bytes("bob")), errors.ErrInvalidMatch)
+		require.ErrorIs(t, signer.Verify(hash, strings.Bytes("bob")), errors.ErrInvalidMatch)
 	})
 
 	t.Run("malformed hash", func(t *testing.T) {

--- a/crypto/bcrypt/doc.go
+++ b/crypto/bcrypt/doc.go
@@ -4,5 +4,5 @@
 //   - hashes passwords using bcrypt.GenerateFromPassword with bcrypt.DefaultCost, and
 //   - verifies password hashes using bcrypt.CompareHashAndPassword.
 //
-// Start with `Signer` and `NewSigner`.
+// Start with [Signer] and [NewSigner].
 package bcrypt

--- a/crypto/bcrypt/module.go
+++ b/crypto/bcrypt/module.go
@@ -4,7 +4,7 @@ import "github.com/alexfalkowski/go-service/v2/di"
 
 // Module wires the bcrypt subsystem into Fx/Dig.
 //
-// It provides a constructor for `*Signer` via `NewSigner`, which can be used for password hashing
+// It provides a constructor for [*Signer] via [NewSigner], which can be used for password hashing
 // and verification using bcrypt with the default cost.
 //
 // This module does not require configuration.

--- a/crypto/doc.go
+++ b/crypto/doc.go
@@ -1,21 +1,21 @@
 // Package crypto provides cryptographic configuration and DI wiring used by go-service.
 //
 // This package is primarily an entrypoint for wiring multiple cryptographic subpackages into a single
-// module (see `Module`) and for composing their configuration into `crypto.Config`.
+// module (see [Module]) and for composing their configuration into [Config].
 //
 // # Scope
 //
-// Most concrete cryptographic functionality lives in subpackages (for example `crypto/aes`,
-// `crypto/ed25519`, `crypto/hmac`, `crypto/rsa`, `crypto/ssh`, `crypto/tls`, `crypto/pem`, and
-// `crypto/rand`). Prefer importing those packages directly when you need specific primitives.
+// Most concrete cryptographic functionality lives in subpackages (for example crypto/aes,
+// crypto/ed25519, crypto/hmac, crypto/rsa, crypto/ssh, crypto/tls, crypto/pem, and
+// crypto/rand). Prefer importing those packages directly when you need specific primitives.
 //
 // The root package intentionally stays small:
-//   - it defines the top-level `Config` used to enable/configure crypto subsystems, and
+//   - it defines the top-level [Config] used to enable/configure crypto subsystems, and
 //   - it exports an Fx/Dig module that wires the supported crypto implementations.
 //
 // # Configuration conventions
 //
-// Sub-config fields on `crypto.Config` are pointers and are treated as optional. A nil sub-config is
-// generally interpreted as "disabled" by the corresponding subsystem (see each subpackage's `IsEnabled`
+// Sub-config fields on [Config] are pointers and are treated as optional. A nil sub-config is
+// generally interpreted as "disabled" by the corresponding subsystem (see each subpackage's IsEnabled
 // convention where applicable).
 package crypto

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -51,9 +51,9 @@ func TestValid(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, verifier.PublicKey)
 
-	e, err := signer.Sign(strings.Bytes("test"))
+	sig, err := signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
-	require.NoError(t, verifier.Verify(e, strings.Bytes("test")))
+	require.NoError(t, verifier.Verify(sig, strings.Bytes("test")))
 
 	signer, err = ed25519.NewSigner(nil, nil)
 	require.NoError(t, err)
@@ -123,9 +123,9 @@ func TestInvalidSignature(t *testing.T) {
 	sig = append(sig, byte('w'))
 	require.Error(t, verifier.Verify(sig, strings.Bytes("test")))
 
-	e, err := signer.Sign(strings.Bytes("test"))
+	sig, err = signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
-	require.ErrorIs(t, verifier.Verify(e, strings.Bytes("bob")), errors.ErrInvalidMatch)
+	require.ErrorIs(t, verifier.Verify(sig, strings.Bytes("bob")), errors.ErrInvalidMatch)
 }
 
 func TestInvalidSignerPrivateKey(t *testing.T) {

--- a/crypto/ed25519/generator.go
+++ b/crypto/ed25519/generator.go
@@ -25,7 +25,7 @@ type Generator struct {
 
 // Generate returns an Ed25519 public/private key pair encoded as PEM strings.
 //
-// The returned PEM blocks are compatible with the expectations of `crypto/ed25519.Config`:
+// The returned PEM blocks are compatible with the expectations of [Config]:
 //
 //   - public:  a PEM block with Type "PUBLIC KEY" containing PKIX-encoded bytes (x509.MarshalPKIXPublicKey)
 //   - private: a PEM block with Type "PRIVATE KEY" containing PKCS#8-encoded bytes (x509.MarshalPKCS8PrivateKey)
@@ -37,18 +37,18 @@ func (g *Generator) Generate() (string, string, error) {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	mpu, err := x509.MarshalPKIXPublicKey(public)
+	publicDER, err := x509.MarshalPKIXPublicKey(public)
 	if err != nil {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	mpr, err := x509.MarshalPKCS8PrivateKey(private)
+	privateDER, err := x509.MarshalPKCS8PrivateKey(private)
 	if err != nil {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	pub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: mpu})
-	pri := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: mpr})
+	pub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER})
+	pri := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})
 	return bytes.String(pub), bytes.String(pri), nil
 }
 

--- a/crypto/errors/doc.go
+++ b/crypto/errors/doc.go
@@ -2,7 +2,7 @@
 // crypto helpers.
 //
 // The package centralizes sentinel errors that callers can compare with
-// `errors.Is` regardless of which concrete crypto helper produced them.
+// errors.Is regardless of which concrete crypto helper produced them.
 //
 // Current sentinels include:
 //   - ErrInvalidMatch: a verification operation failed because the provided

--- a/crypto/hmac/config.go
+++ b/crypto/hmac/config.go
@@ -6,7 +6,7 @@ import "github.com/alexfalkowski/go-service/v2/os"
 type Config struct {
 	// Key is a "source string" that resolves to the raw HMAC key bytes.
 	//
-	// It supports the go-service source string pattern implemented by `os.FS.ReadSource`:
+	// It supports the go-service source string pattern implemented by [os.FS.ReadSource]:
 	//   - "env:NAME" to read from an environment variable,
 	//   - "file:/path/to/key" to read from a file, or
 	//   - any other value treated as a literal.
@@ -24,7 +24,7 @@ func (c *Config) IsEnabled() bool {
 
 // GetKey resolves and returns the HMAC key bytes using the configured Key source.
 //
-// It delegates to `fs.ReadSource(c.Key)` and returns any read/resolve error from that operation.
+// It delegates to fs.ReadSource(c.Key) and returns any read/resolve error from that operation.
 func (c *Config) GetKey(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.Key)
 }

--- a/crypto/hmac/hmac_test.go
+++ b/crypto/hmac/hmac_test.go
@@ -39,10 +39,10 @@ func TestValidSigner(t *testing.T) {
 	signer, err = hmac.NewSigner(test.FS, test.NewHMAC())
 	require.NoError(t, err)
 
-	e, err := signer.Sign(strings.Bytes("test"))
+	mac, err := signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
-	require.Len(t, e, hmac.Size)
-	require.NoError(t, signer.Verify(e, strings.Bytes("test")))
+	require.Len(t, mac, hmac.Size)
+	require.NoError(t, signer.Verify(mac, strings.Bytes("test")))
 
 	signer, err = hmac.NewSigner(nil, nil)
 	require.NoError(t, err)
@@ -77,19 +77,19 @@ func TestInvalidSigner(t *testing.T) {
 		signer, err := hmac.NewSigner(test.FS, test.NewHMAC())
 		require.NoError(t, err)
 
-		sign, err := signer.Sign(strings.Bytes("test"))
+		mac, err := signer.Sign(strings.Bytes("test"))
 		require.NoError(t, err)
 
-		sign = append(sign, byte('w'))
-		require.Error(t, signer.Verify(sign, strings.Bytes("test")))
+		mac = append(mac, byte('w'))
+		require.Error(t, signer.Verify(mac, strings.Bytes("test")))
 	})
 
 	t.Run("wrong message", func(t *testing.T) {
 		signer, err := hmac.NewSigner(test.FS, test.NewHMAC())
 		require.NoError(t, err)
 
-		e, err := signer.Sign(strings.Bytes("test"))
+		mac, err := signer.Sign(strings.Bytes("test"))
 		require.NoError(t, err)
-		require.ErrorIs(t, signer.Verify(e, strings.Bytes("bob")), errors.ErrInvalidMatch)
+		require.ErrorIs(t, signer.Verify(mac, strings.Bytes("bob")), errors.ErrInvalidMatch)
 	})
 }

--- a/crypto/module.go
+++ b/crypto/module.go
@@ -15,21 +15,21 @@ import (
 // Module wires cryptographic subpackages into Fx/Dig.
 //
 // It composes the modules from the crypto subpackages so services can include a single
-// `crypto.Module` to register the supported crypto primitives and helpers.
+// [Module] to register the supported crypto primitives and helpers.
 //
 // The included submodules currently wire:
 //
-//   - `crypto/pem`: PEM parsing helpers for keys/certificates.
-//   - `crypto/rand`: cryptographically secure randomness utilities.
-//   - `crypto/aes`: AES key generation and symmetric encryption helpers.
-//   - `crypto/bcrypt`: password hashing helpers.
-//   - `crypto/ed25519`: Ed25519 key generation, signing, and verification.
-//   - `crypto/hmac`: HMAC key generation and signing/verification helpers.
-//   - `crypto/rsa`: RSA key generation and encryption/decryption helpers.
-//   - `crypto/ssh`: SSH key generation, signing, and verification.
+//   - crypto/pem: PEM parsing helpers for keys/certificates.
+//   - crypto/rand: cryptographically secure randomness utilities.
+//   - crypto/aes: AES key generation and symmetric encryption helpers.
+//   - crypto/bcrypt: password hashing helpers.
+//   - crypto/ed25519: Ed25519 key generation, signing, and verification.
+//   - crypto/hmac: HMAC key generation and signing/verification helpers.
+//   - crypto/rsa: RSA key generation and encryption/decryption helpers.
+//   - crypto/ssh: SSH key generation, signing, and verification.
 //
 // Note: this module only wires constructors; feature enablement is typically controlled via
-// configuration in the consuming subsystems (e.g. nil/disabled sub-configs).
+// configuration in the consuming subsystems (for example nil/disabled sub-configs).
 var Module = di.Module(
 	pem.Module,
 	rand.Module,

--- a/crypto/pem/doc.go
+++ b/crypto/pem/doc.go
@@ -3,5 +3,5 @@
 // This package provides a Decoder that reads PEM-encoded data (typically via the go-service "source string"
 // pattern such as "env:NAME", "file:/path", or a literal value) and returns the raw bytes of a specific PEM block kind.
 //
-// Start with `Decoder` and `NewDecoder`.
+// Start with [Decoder] and [NewDecoder].
 package pem

--- a/crypto/pem/module.go
+++ b/crypto/pem/module.go
@@ -4,7 +4,7 @@ import "github.com/alexfalkowski/go-service/v2/di"
 
 // Module wires the PEM decoding subsystem into Fx/Dig.
 //
-// It provides a constructor for `*Decoder` via `NewDecoder`, which resolves PEM-encoded sources using the
+// It provides a constructor for [*Decoder] via [NewDecoder], which resolves PEM-encoded sources using the
 // go-service "source string" pattern and extracts raw bytes for a requested PEM block kind.
 //
 // This module does not require configuration.

--- a/crypto/pem/pem.go
+++ b/crypto/pem/pem.go
@@ -33,9 +33,9 @@ type Decoder struct {
 	fs *os.FS
 }
 
-// Decode resolves PEM data from path (a go-service "source string") and returns the raw bytes for a PEM block of kind.
+// Decode resolves PEM data from source (a go-service "source string") and returns the raw bytes for a PEM block of kind.
 //
-// The path parameter is resolved via os.FS.ReadSource, so it can be:
+// The source parameter is resolved via [os.FS.ReadSource], so it can be:
 //   - "env:NAME" (read from environment variable NAME)
 //   - "file:/path" (read from the filesystem)
 //   - or a literal PEM value.
@@ -47,12 +47,12 @@ type Decoder struct {
 //   - returns ErrInvalidBlock if no PEM block can be decoded.
 //   - returns ErrInvalidKind if a PEM block is decoded but its Type does not equal kind.
 //   - returns any error from fs.ReadSource if the input cannot be resolved/read.
-func (d *Decoder) Decode(path, kind string) ([]byte, error) {
-	if strings.IsEmpty(path) {
+func (d *Decoder) Decode(source, kind string) ([]byte, error) {
+	if strings.IsEmpty(source) {
 		return nil, crypto.ErrMissingKey
 	}
 
-	data, err := d.fs.ReadSource(path)
+	data, err := d.fs.ReadSource(source)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/rand/rand.go
+++ b/crypto/rand/rand.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
-const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const alphanumeric = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 // ErrInvalidSize is returned when a random value size is negative.
 var ErrInvalidSize = errors.New("rand: invalid size")
@@ -79,7 +79,7 @@ func (g *Generator) GenerateBytes(size int) ([]byte, error) {
 
 // GenerateText returns a cryptographically random string of length size.
 //
-// Characters are drawn from the package's letter set, making this helper
+// Characters are drawn from the package's alphanumeric set, making this helper
 // suitable for text tokens but not a substitute for GenerateBytes when binary
 // randomness is required.
 func (g *Generator) GenerateText(size int) (string, error) {
@@ -88,7 +88,7 @@ func (g *Generator) GenerateText(size int) (string, error) {
 	}
 
 	data := make([]byte, size)
-	length := int64(len(letters))
+	length := int64(len(alphanumeric))
 
 	for i := range size {
 		num, err := rand.Int(g.reader, big.NewInt(length))
@@ -96,7 +96,7 @@ func (g *Generator) GenerateText(size int) (string, error) {
 			return strings.Empty, err
 		}
 
-		data[i] = letters[num.Int64()]
+		data[i] = alphanumeric[num.Int64()]
 	}
 
 	return bytes.String(data), nil

--- a/crypto/rand/rand_test.go
+++ b/crypto/rand/rand_test.go
@@ -16,9 +16,9 @@ func TestValidRand(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, c, 5)
 
-	s, err := gen.GenerateText(32)
+	text, err := gen.GenerateText(32)
 	require.NoError(t, err)
-	require.Len(t, s, 32)
+	require.Len(t, text, 32)
 }
 
 func TestGenerateTextUsesAlphanumericAlphabet(t *testing.T) {

--- a/crypto/rsa/generator.go
+++ b/crypto/rsa/generator.go
@@ -31,20 +31,20 @@ type Generator struct {
 // With Go 1.26 and later, crypto/rsa.GenerateKey uses the standard library's
 // secure random source and ignores this Generator's injected reader by default.
 //
-// The returned PEM blocks are compatible with the expectations of `crypto/rsa.Config`:
+// The returned PEM blocks are compatible with the expectations of [Config]:
 //
 //   - public:  a PEM block with Type "RSA PUBLIC KEY" containing PKCS#1-encoded bytes (x509.MarshalPKCS1PublicKey)
 //   - private: a PEM block with Type "RSA PRIVATE KEY" containing PKCS#1-encoded bytes (x509.MarshalPKCS1PrivateKey)
 //
 // If key generation or encoding fails, the returned error is prefixed with "rsa".
 func (g *Generator) Generate() (string, string, error) {
-	public, err := rsa.GenerateKey(g.generator, KeySize)
+	privateKey, err := rsa.GenerateKey(g.generator, KeySize)
 	if err != nil {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	pub := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: x509.MarshalPKCS1PublicKey(&public.PublicKey)})
-	pri := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(public)})
+	pub := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: x509.MarshalPKCS1PublicKey(&privateKey.PublicKey)})
+	pri := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
 	return bytes.String(pub), bytes.String(pri), nil
 }
 

--- a/crypto/rsa/rsa_test.go
+++ b/crypto/rsa/rsa_test.go
@@ -31,53 +31,53 @@ func TestGenerator(t *testing.T) {
 }
 
 func TestValid(t *testing.T) {
-	rand := rand.NewGenerator(rand.NewReader())
+	gen := rand.NewGenerator(rand.NewReader())
 
-	enc, err := rsa.NewEncryptor(rand, test.PEM, test.NewRSA())
+	enc, err := rsa.NewEncryptor(gen, test.PEM, test.NewRSA())
 	require.NoError(t, err)
 	require.NotNil(t, enc)
 
-	dec, err := rsa.NewDecryptor(rand, test.PEM, test.NewRSA())
+	dec, err := rsa.NewDecryptor(gen, test.PEM, test.NewRSA())
 	require.NoError(t, err)
 	require.NotNil(t, dec)
 
 	cfg := test.NewRSA()
 
-	enc, err = rsa.NewEncryptor(rand, test.PEM, cfg)
+	enc, err = rsa.NewEncryptor(gen, test.PEM, cfg)
 	require.NoError(t, err)
 
-	dec, err = rsa.NewDecryptor(rand, test.PEM, cfg)
+	dec, err = rsa.NewDecryptor(gen, test.PEM, cfg)
 	require.NoError(t, err)
 
-	e, err := enc.Encrypt(strings.Bytes("test"))
+	ciphertext, err := enc.Encrypt(strings.Bytes("test"))
 	require.NoError(t, err)
 
-	d, err := dec.Decrypt(e)
+	plaintext, err := dec.Decrypt(ciphertext)
 	require.NoError(t, err)
-	require.Equal(t, "test", bytes.String(d))
+	require.Equal(t, "test", bytes.String(plaintext))
 
 	privateKey, err := cfg.PrivateKey(test.PEM)
 	require.NoError(t, err)
 
-	d, err = rsa.DecryptOAEP(rand, privateKey, e)
+	plaintext, err = rsa.DecryptOAEP(gen, privateKey, ciphertext)
 	require.NoError(t, err)
-	require.Equal(t, "test", bytes.String(d))
+	require.Equal(t, "test", bytes.String(plaintext))
 
 	publicKey, err := cfg.PublicKey(test.PEM)
 	require.NoError(t, err)
 
-	e, err = rsa.EncryptOAEP(rand, publicKey, strings.Bytes("test"))
+	ciphertext, err = rsa.EncryptOAEP(gen, publicKey, strings.Bytes("test"))
 	require.NoError(t, err)
 
-	d, err = dec.Decrypt(e)
+	plaintext, err = dec.Decrypt(ciphertext)
 	require.NoError(t, err)
-	require.Equal(t, "test", bytes.String(d))
+	require.Equal(t, "test", bytes.String(plaintext))
 
-	enc, err = rsa.NewEncryptor(rand, test.PEM, nil)
+	enc, err = rsa.NewEncryptor(gen, test.PEM, nil)
 	require.NoError(t, err)
 	require.Nil(t, enc)
 
-	dec, err = rsa.NewDecryptor(rand, test.PEM, nil)
+	dec, err = rsa.NewDecryptor(gen, test.PEM, nil)
 	require.NoError(t, err)
 	require.Nil(t, dec)
 }
@@ -129,11 +129,11 @@ func TestInvalid(t *testing.T) {
 		dec, err := rsa.NewDecryptor(gen, test.PEM, cfg)
 		require.NoError(t, err)
 
-		e, err := enc.Encrypt(strings.Bytes("test"))
+		ciphertext, err := enc.Encrypt(strings.Bytes("test"))
 		require.NoError(t, err)
 
-		e = append(e, byte('w'))
-		_, err = dec.Decrypt(e)
+		ciphertext = append(ciphertext, byte('w'))
+		_, err = dec.Decrypt(ciphertext)
 		require.Error(t, err)
 	})
 

--- a/crypto/ssh/generator.go
+++ b/crypto/ssh/generator.go
@@ -25,7 +25,7 @@ type Generator struct {
 
 // Generate returns an Ed25519 public/private key pair encoded in SSH formats.
 //
-// The returned values are compatible with the expectations of `crypto/ssh.Config`:
+// The returned values are compatible with the expectations of [Config]:
 //
 //   - public: SSH authorized_keys format (via x/crypto/ssh.MarshalAuthorizedKey)
 //   - private: PEM-encoded SSH private key (via x/crypto/ssh.MarshalPrivateKey and pem.EncodeToMemory)
@@ -37,18 +37,18 @@ func (g *Generator) Generate() (string, string, error) {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	mpu, err := ssh.NewPublicKey(public)
+	publicKey, err := ssh.NewPublicKey(public)
 	if err != nil {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	mpr, err := ssh.MarshalPrivateKey(private, strings.Empty)
+	privateBlock, err := ssh.MarshalPrivateKey(private, strings.Empty)
 	if err != nil {
 		return strings.Empty, strings.Empty, g.prefix(err)
 	}
 
-	pub := ssh.MarshalAuthorizedKey(mpu)
-	pri := pem.EncodeToMemory(mpr)
+	pub := ssh.MarshalAuthorizedKey(publicKey)
+	pri := pem.EncodeToMemory(privateBlock)
 	return bytes.String(pub), bytes.String(pri), nil
 }
 

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -47,9 +47,9 @@ func TestValid(t *testing.T) {
 	verifier, err := ssh.NewVerifier(test.FS, cfg)
 	require.NoError(t, err)
 
-	e, err := signer.Sign(strings.Bytes("test"))
+	sig, err := signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
-	require.NoError(t, verifier.Verify(e, strings.Bytes("test")))
+	require.NoError(t, verifier.Verify(sig, strings.Bytes("test")))
 
 	signer, err = ssh.NewSigner(nil, nil)
 	require.NoError(t, err)
@@ -148,9 +148,9 @@ func TestInvalidSignature(t *testing.T) {
 	sig = append(sig, byte('w'))
 	require.Error(t, verifier.Verify(sig, strings.Bytes("test")))
 
-	e, err := signer.Sign(strings.Bytes("test"))
+	sig, err = signer.Sign(strings.Bytes("test"))
 	require.NoError(t, err)
-	require.ErrorIs(t, verifier.Verify(e, strings.Bytes("bob")), errors.ErrInvalidMatch)
+	require.ErrorIs(t, verifier.Verify(sig, strings.Bytes("bob")), errors.ErrInvalidMatch)
 }
 
 func TestInvalidSignerPrivateKey(t *testing.T) {

--- a/crypto/tls/config/certificate_test.go
+++ b/crypto/tls/config/certificate_test.go
@@ -29,16 +29,16 @@ func TestNewKeyPair(t *testing.T) {
 	}
 
 	invalidTests := []struct {
-		config        *tls.Config
-		name          string
-		errMissingKey bool
+		config         *tls.Config
+		name           string
+		wantMissingKey bool
 	}{
-		{name: "nil config", errMissingKey: true},
-		{name: "empty config", config: &tls.Config{}, errMissingKey: true},
-		{name: "missing cert", config: &tls.Config{Key: test.FilePath("certs/key.pem")}, errMissingKey: true},
-		{name: "missing key", config: &tls.Config{Cert: test.FilePath("certs/cert.pem")}, errMissingKey: true},
-		{name: "empty cert source", config: &tls.Config{Cert: "env:TLS_EMPTY", Key: test.FilePath("certs/key.pem")}, errMissingKey: true},
-		{name: "empty key source", config: &tls.Config{Cert: test.FilePath("certs/cert.pem"), Key: "env:TLS_EMPTY"}, errMissingKey: true},
+		{name: "nil config", wantMissingKey: true},
+		{name: "empty config", config: &tls.Config{}, wantMissingKey: true},
+		{name: "missing cert", config: &tls.Config{Key: test.FilePath("certs/key.pem")}, wantMissingKey: true},
+		{name: "missing key", config: &tls.Config{Cert: test.FilePath("certs/cert.pem")}, wantMissingKey: true},
+		{name: "empty cert source", config: &tls.Config{Cert: "env:TLS_EMPTY", Key: test.FilePath("certs/key.pem")}, wantMissingKey: true},
+		{name: "empty key source", config: &tls.Config{Cert: test.FilePath("certs/cert.pem"), Key: "env:TLS_EMPTY"}, wantMissingKey: true},
 		{name: "invalid key", config: test.NewTLSConfig("certs/client-cert.pem", "secrets/none")},
 		{name: "invalid cert", config: test.NewTLSConfig("secrets/none", "certs/client-key.pem")},
 		{name: "invalid pair", config: test.NewTLSConfig("secrets/hooks", "certs/client-key.pem")},
@@ -49,7 +49,7 @@ func TestNewKeyPair(t *testing.T) {
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tls.NewKeyPair(test.FS, tt.config)
-			if tt.errMissingKey {
+			if tt.wantMissingKey {
 				require.ErrorIs(t, err, errors.ErrMissingKey)
 				return
 			}

--- a/crypto/tls/config/config.go
+++ b/crypto/tls/config/config.go
@@ -11,7 +11,7 @@ var ErrInvalidCA = errors.New("tls: invalid ca")
 
 // Config configures TLS key material loading from go-service source strings.
 //
-// Cert, Key, and CA are "source strings" resolved by `os.FS.ReadSource`.
+// Cert, Key, and CA are "source strings" resolved by [os.FS.ReadSource].
 // They may be:
 //   - "env:NAME" to read PEM bytes from environment variable NAME,
 //   - "file:/path/to/pem" to read PEM bytes from a file, or
@@ -20,7 +20,7 @@ var ErrInvalidCA = errors.New("tls: invalid ca")
 // This config is intentionally minimal: it models leaf certificate/private-key
 // material, an optional peer CA bundle, and an optional client-side server name.
 // It does not model cipher suites, ALPN, session tickets, or the many other
-// knobs on `crypto/tls.Config`.
+// knobs on crypto/tls.Config.
 type Config struct {
 	// Cert is a "source string" for the TLS certificate (PEM-encoded).
 	//
@@ -87,7 +87,7 @@ func (c *Config) HasServerName() bool {
 // GetCert resolves and returns the certificate bytes from the configured source
 // string.
 //
-// It delegates to `fs.ReadSource(c.Cert)` and returns any read/resolve error
+// It delegates to fs.ReadSource(c.Cert) and returns any read/resolve error
 // from that operation.
 func (c *Config) GetCert(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.Cert)
@@ -96,7 +96,7 @@ func (c *Config) GetCert(fs *os.FS) ([]byte, error) {
 // GetKey resolves and returns the private key bytes from the configured source
 // string.
 //
-// It delegates to `fs.ReadSource(c.Key)` and returns any read/resolve error
+// It delegates to fs.ReadSource(c.Key) and returns any read/resolve error
 // from that operation.
 func (c *Config) GetKey(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.Key)
@@ -105,7 +105,7 @@ func (c *Config) GetKey(fs *os.FS) ([]byte, error) {
 // GetCA resolves and returns the peer CA bytes from the configured source
 // string.
 //
-// It delegates to `fs.ReadSource(c.CA)` and returns any read/resolve error
+// It delegates to fs.ReadSource(c.CA) and returns any read/resolve error
 // from that operation.
 func (c *Config) GetCA(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(c.CA)

--- a/crypto/tls/config/doc.go
+++ b/crypto/tls/config/doc.go
@@ -1,15 +1,15 @@
 // Package config defines the go-service TLS configuration model and constructor
 // helpers.
 //
-// This package is the configuration-facing counterpart to `crypto/tls`.
+// This package is the configuration-facing counterpart to crypto/tls.
 // It contains:
-//   - the lightweight `Config` struct used to describe certificate, key, CA,
+//   - the lightweight [Config] struct used to describe certificate, key, CA,
 //     and server-name settings in decoded application config, and
 //   - helper functions that resolve those source strings into runtime TLS key
 //     material.
 //
-// Use `config/server.NewConfig` and `config/client.NewConfig` when code needs a
-// runtime `*crypto/tls.Config` for a specific TLS role. Use `crypto/tls`
+// Use config/server.NewConfig and config/client.NewConfig when code needs a
+// runtime crypto/tls.Config for a specific TLS role. Use crypto/tls
 // directly when code already has a runtime TLS config and only needs low-level
 // TLS types or helpers.
 package config

--- a/crypto/tls/config/pool_test.go
+++ b/crypto/tls/config/pool_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -42,8 +41,7 @@ func TestNewCertPoolInvalid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tls.NewCertPool(test.FS, tt.config)
-			require.Error(t, err)
-			require.True(t, errors.Is(err, tls.ErrInvalidCA))
+			require.ErrorIs(t, err, tls.ErrInvalidCA)
 		})
 	}
 }
@@ -51,5 +49,5 @@ func TestNewCertPoolInvalid(t *testing.T) {
 func TestNewCertPoolSourceError(t *testing.T) {
 	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: test.FilePath("certs/missing.pem")})
 	require.Error(t, err)
-	require.False(t, errors.Is(err, tls.ErrInvalidCA))
+	require.NotErrorIs(t, err, tls.ErrInvalidCA)
 }


### PR DESCRIPTION
## What

- Renamed crypto helper locals to clarify key formats, nonce data, source strings, and generated text alphabets.
- Tightened crypto tests with domain-specific names for ciphertext, plaintext, signatures, MACs, hashes, and TLS expectations.
- Polished GoDoc links and prose across the touched crypto docs.

## Why

- Improve readability and local style consistency in crypto helpers and tests without changing behavior.
- No blocking code-review findings.

## Testing

- `go test ./crypto/...` - passed
- `make lint` - passed
- `git diff --check` - passed
