### PR TITLE
feat(content): polish wrapper docs and tests

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -28,7 +28,7 @@ type Context = context.Context
 // Key is a typed helper for storing values in a context.
 //
 // Using a distinct key type reduces accidental collisions when multiple packages store values in the
-// same context. Prefer defining keys as unexported package variables, e.g.:
+// same context. Prefer defining keys as unexported package variables, for example:
 //
 //	var userIDKey context.Key = "user_id"
 //

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -16,7 +16,7 @@ func TestBackground(t *testing.T) {
 
 	deadline, ok := ctx.Deadline()
 	require.False(t, ok)
-	require.True(t, deadline.IsZero())
+	require.Zero(t, deadline)
 	require.Nil(t, ctx.Done())
 	require.NoError(t, ctx.Err())
 	require.NoError(t, context.Cause(ctx))
@@ -186,25 +186,28 @@ func TestCausePropagatesFromParent(t *testing.T) {
 func TestWithoutCancel(t *testing.T) {
 	t.Parallel()
 
-	parent, cancel := context.WithCancelCause(context.WithValue(context.Background(), context.Key("key"), "value"))
+	key := context.Key("key")
+	parent := context.WithValue(context.Background(), key, "value")
+	parent, cancel := context.WithCancelCause(parent)
 	child := context.WithoutCancel(parent)
 
 	cancel(errors.New("parent cause"))
 
 	deadline, ok := child.Deadline()
 	require.False(t, ok)
-	require.True(t, deadline.IsZero())
+	require.Zero(t, deadline)
 	require.Nil(t, child.Done())
 	require.NoError(t, child.Err())
 	require.NoError(t, context.Cause(child))
-	require.Equal(t, "value", child.Value(context.Key("key")))
+	require.Equal(t, "value", child.Value(key))
 }
 
 func TestWithValue(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.WithValue(context.Background(), context.Key("key"), "value")
+	key := context.Key("key")
+	ctx := context.WithValue(context.Background(), key, "value")
 
-	require.Equal(t, "value", ctx.Value(context.Key("key")))
+	require.Equal(t, "value", ctx.Value(key))
 	require.Nil(t, ctx.Value(context.Key("missing")))
 }

--- a/context/doc.go
+++ b/context/doc.go
@@ -1,17 +1,17 @@
 // Package context provides small wrappers and aliases around the standard library context package.
 //
 // The primary purpose of this package is to offer a stable go-service import path for commonly used
-// context primitives while preserving the exact semantics of the standard library `context` package.
+// context primitives while preserving the exact semantics of the standard library context package.
 //
-// Most identifiers are thin aliases/wrappers around `context` (for example `Context`, `CancelFunc`,
-// `CancelCauseFunc`, `Background`, `WithDeadline`, `WithTimeout`, `Cause`, and `WithValue`). They exist so
+// Most identifiers are thin aliases/wrappers around context (for example [Context], [CancelFunc],
+// [CancelCauseFunc], [Background], [WithDeadline], [WithTimeout], [Cause], and [WithValue]). They exist so
 // packages within go-service and downstream services can consistently import
-// `github.com/alexfalkowski/go-service/v2/context` without mixing direct stdlib imports across the codebase.
+// github.com/alexfalkowski/go-service/v2/context without mixing direct stdlib imports across the codebase.
 //
-// Cause-aware APIs mirror the standard library behavior: `Context.Err()` continues to report the standard
-// sentinels (`Canceled` or `DeadlineExceeded`), while `Cause(ctx)` can expose a richer diagnostic error when
+// Cause-aware APIs mirror the standard library behavior: Context.Err continues to report the standard
+// sentinels ([Canceled] or [DeadlineExceeded]), while [Cause] can expose a richer diagnostic error when
 // a cause-aware constructor was used.
 //
-// This package also defines `Key`, a typed helper for context value keys to reduce accidental collisions
+// This package also defines [Key], a typed helper for context value keys to reduce accidental collisions
 // when multiple packages store values in the same context.
 package context


### PR DESCRIPTION
## What

- Updated wrapper package docs to use GoDoc links and clearer prose.
- Replaced zero-deadline boolean assertions with direct zero assertions.
- Split value-key setup in tests into named locals for easier reading.

## Why

- Improve readability and local style consistency in the context wrapper package without changing behavior.
- No blocking code-review findings.

## Testing

- `go test ./context` - passed
- `make lint` - passed
- `git diff --check` - passed
