### PR TITLE
feat(sql): polish connection helpers and tests

### DIFF
--- a/database/sql/doc.go
+++ b/database/sql/doc.go
@@ -1,12 +1,12 @@
 // Package sql provides SQL database wiring and helpers for go-service.
 //
 // This package is the entrypoint for wiring SQL database support into Fx/Dig. It composes
-// driver-specific modules (for example PostgreSQL via `database/sql/pg`) and exposes a small,
-// consistent configuration shape for services (`sql.Config`).
+// driver-specific modules (for example PostgreSQL via database/sql/pg) and exposes a small,
+// consistent configuration shape for services ([Config]).
 //
 // # Configuration and enablement
 //
-// SQL configuration is optional. By convention across go-service config types, a nil `*sql.Config`
+// SQL configuration is optional. By convention across go-service config types, a nil *[Config]
 // is treated as "disabled". Driver-specific configs typically follow the same convention, and
 // constructors that depend on config often return (nil, nil) when disabled.
 //
@@ -14,19 +14,19 @@
 //
 // This package also exposes the shared master/slave pool abstraction used by
 // repository code:
-//   - `DBs`, the go-service wrapper for the upstream pool collection type, and
-//   - `ConnectMasterSlaves`, the go-service wrapper for opening those pools.
+//   - [DBs], the go-service wrapper for the upstream pool collection type, and
+//   - [ConnectMasterSlaves], the go-service wrapper for opening those pools.
 //
 // This keeps internal code on a go-service import path instead of importing the
 // upstream helper package directly where the package graph allows it. The
 // wrapper embeds the upstream type so existing query/ping/pool helper methods
 // are still available, while go-service-owned cleanup remains attached to
-// `Destroy`.
+// [DBs.Destroy].
 //
 // # Master/slave pools and telemetry
 //
 // Driver integrations typically open master/slave connection pools, configure pool limits/lifetimes,
-// and register OpenTelemetry instrumentation/metrics for `database/sql` connections.
+// and register OpenTelemetry instrumentation/metrics for database/sql connections.
 //
-// Start with `Module` and `Config`.
+// Start with [Module] and [Config].
 package sql

--- a/database/sql/driver/driver.go
+++ b/database/sql/driver/driver.go
@@ -147,32 +147,14 @@ func ConnectMasterSlaves(name string, masterDSNs, slaveDSNs []string) (*DBs, []e
 }
 
 func connect(name string, fs *os.FS, cfg *config.Config, opts ...telemetry.Option) (*DBs, error) {
-	masters := make([]string, len(cfg.Masters))
-
-	for i, m := range cfg.Masters {
-		u, err := m.GetURL(fs)
-		if err != nil {
-			return nil, err
-		}
-		if len(u) == 0 {
-			return nil, ErrEmptyDSN
-		}
-
-		masters[i] = bytes.String(u)
+	masters, err := resolveDSNs(fs, cfg.Masters)
+	if err != nil {
+		return nil, err
 	}
 
-	slaves := make([]string, len(cfg.Slaves))
-
-	for i, s := range cfg.Slaves {
-		u, err := s.GetURL(fs)
-		if err != nil {
-			return nil, err
-		}
-		if len(u) == 0 {
-			return nil, ErrEmptyDSN
-		}
-
-		slaves[i] = bytes.String(u)
+	slaves, err := resolveDSNs(fs, cfg.Slaves)
+	if err != nil {
+		return nil, err
 	}
 
 	db, err := connectDBs(name, masters, slaves, opts...)
@@ -185,6 +167,24 @@ func connect(name string, fs *os.FS, cfg *config.Config, opts ...telemetry.Optio
 	db.SetMaxOpenConns(cfg.MaxOpenConns)
 
 	return db, nil
+}
+
+func resolveDSNs(fs *os.FS, dsns []config.DSN) ([]string, error) {
+	resolved := make([]string, len(dsns))
+
+	for i, dsn := range dsns {
+		url, err := dsn.GetURL(fs)
+		if err != nil {
+			return nil, err
+		}
+		if len(url) == 0 {
+			return nil, ErrEmptyDSN
+		}
+
+		resolved[i] = bytes.String(url)
+	}
+
+	return resolved, nil
 }
 
 func connectDBs(name string, masterDSNs, slaveDSNs []string, opts ...telemetry.Option) (*DBs, error) {

--- a/database/sql/driver/driver_test.go
+++ b/database/sql/driver/driver_test.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
+const dbStatsMetricCount = 7
+
 func TestOpenUnregistersDBStatsMetrics(t *testing.T) {
 	reader := test.EnableMetricsReader(t)
 	driverName := registerDriver(t)
@@ -171,7 +173,7 @@ func requireDBStatsMetrics(t *testing.T, reader metrics.Reader) {
 	got := &metrics.ResourceMetrics{}
 	require.NoError(t, reader.Collect(t.Context(), got))
 	require.Len(t, got.ScopeMetrics, 1)
-	require.Len(t, got.ScopeMetrics[0].Metrics, 7)
+	require.Len(t, got.ScopeMetrics[0].Metrics, dbStatsMetricCount)
 }
 
 func requireNoDBStatsMetrics(t *testing.T, reader metrics.Reader) {

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -125,7 +125,7 @@ func TestInvalidOpen(t *testing.T) {
 	}
 }
 
-func TestSQL(t *testing.T) {
+func TestConfiguredSQLPings(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil), test.WithWorldLoggerConfig("otlp"))
 
 	require.NoError(t, errors.Join(world.DB.Ping()...))
@@ -167,12 +167,9 @@ func TestOpenClosesDBsOnStop(t *testing.T) {
 func TestDBQuery(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
 	rows, err := world.DB.QueryContext(ctx, "SELECT table_name FROM information_schema.tables WHERE table_schema='public'")
 	require.NoError(t, err)
 
@@ -183,19 +180,13 @@ func TestDBQuery(t *testing.T) {
 	require.Positive(t, count)
 	require.NoError(t, rows.Err())
 	require.NoError(t, rows.Close())
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestDBExec(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	result, err := world.DB.ExecContext(ctx, "INSERT INTO accounts(created_at) VALUES($1)", time.Now())
 	require.NoError(t, err)
@@ -203,19 +194,13 @@ func TestDBExec(t *testing.T) {
 	num, err := result.RowsAffected()
 	require.NoError(t, err)
 	require.Positive(t, num)
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestDBCommitTransExec(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	tx, err := world.DB.BeginTx(ctx, nil)
 	require.NoError(t, err)
@@ -235,19 +220,13 @@ func TestDBCommitTransExec(t *testing.T) {
 	num, err := result.RowsAffected()
 	require.NoError(t, err)
 	require.Positive(t, num)
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestDBRollbackTransExec(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	tx, err := world.DB.BeginTx(ctx, nil)
 	require.NoError(t, err)
@@ -264,19 +243,13 @@ func TestDBRollbackTransExec(t *testing.T) {
 	num, err := result.RowsAffected()
 	require.NoError(t, err)
 	require.Positive(t, num)
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestStatementQuery(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	_, stmt, err := world.DB.PrepareContext(ctx, "SELECT table_name FROM information_schema.tables WHERE table_schema = $1")
 	require.NoError(t, err)
@@ -293,19 +266,13 @@ func TestStatementQuery(t *testing.T) {
 	require.Positive(t, count)
 	require.NoError(t, rows.Err())
 	require.NoError(t, rows.Close())
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestStatementExec(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	_, stmt, err := world.DB.PrepareContext(ctx, "INSERT INTO accounts(created_at) VALUES($1)")
 	require.NoError(t, err)
@@ -321,19 +288,13 @@ func TestStatementExec(t *testing.T) {
 	num, err := result.RowsAffected()
 	require.NoError(t, err)
 	require.Positive(t, num)
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestTransStatementExec(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	tx, err := world.DB.Begin()
 	require.NoError(t, err)
@@ -358,19 +319,13 @@ func TestTransStatementExec(t *testing.T) {
 	num, err := result.RowsAffected()
 	require.NoError(t, err)
 	require.Positive(t, num)
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestInvalidStatementQuery(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil), test.WithWorldLoggerConfig("tint"))
 
-	require.NoError(t, up(t.Context(), world.DB))
-
-	ctx, cancel := test.Timeout(t.Context())
-	defer cancel()
-
-	ctx = meta.WithAttributes(ctx, test.WithTest(meta.String("test")))
+	ctx, cleanup := setupAccounts(t, world.DB)
+	defer cleanup()
 
 	_, stmt, err := world.DB.PrepareContext(ctx, "SELECT table_name FROM information_schema.tables WHERE table_schema = $1")
 	require.NoError(t, err)
@@ -379,8 +334,6 @@ func TestInvalidStatementQuery(t *testing.T) {
 
 	_, err = stmt.QueryContext(ctx, 1)
 	require.Error(t, err)
-
-	require.NoError(t, down(t.Context(), world.DB))
 }
 
 func TestInvalidSQLPort(t *testing.T) {
@@ -406,6 +359,19 @@ func TestInvalidSQLPort(t *testing.T) {
 	lc.RequireStart()
 	require.Error(t, errors.Join(db.Ping()...))
 	lc.RequireStop()
+}
+
+func setupAccounts(t *testing.T, db *sql.DBs) (context.Context, func()) {
+	t.Helper()
+
+	require.NoError(t, up(t.Context(), db))
+
+	ctx, cancel := test.Timeout(t.Context())
+
+	return meta.WithAttributes(ctx, test.WithTest(meta.String("test"))), func() {
+		require.NoError(t, down(t.Context(), db))
+		cancel()
+	}
 }
 
 func up(ctx context.Context, db *sql.DBs) error {

--- a/database/sql/telemetry/telemetry.go
+++ b/database/sql/telemetry/telemetry.go
@@ -24,8 +24,8 @@ type SpanOptions = otelsql.SpanOptions
 //
 // Raw SQL query text capture is disabled by default. Callers that need raw
 // statements in spans may opt in with WithSpanOptions.
-func Open(driverName, dataSourceName string, options ...Option) (*sql.DB, error) {
-	return otelsql.Open(driverName, dataSourceName, optionsWithDefaults(options)...)
+func Open(driverName, dataSourceName string, opts ...Option) (*sql.DB, error) {
+	return otelsql.Open(driverName, dataSourceName, optionsWithDefaults(opts)...)
 }
 
 // WrapDriver wraps a `database/sql/driver.Driver` with OpenTelemetry
@@ -58,10 +58,10 @@ func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) (metrics.Registration, e
 	return otelsql.RegisterDBStatsMetrics(db, opts...)
 }
 
-func optionsWithDefaults(options []Option) []Option {
-	opts := make([]Option, 0, len(options)+1)
-	opts = append(opts, WithSpanOptions(SpanOptions{DisableQuery: true}))
-	opts = append(opts, options...)
+func optionsWithDefaults(opts []Option) []Option {
+	options := make([]Option, 0, len(opts)+1)
+	options = append(options, WithSpanOptions(SpanOptions{DisableQuery: true}))
+	options = append(options, opts...)
 
-	return opts
+	return options
 }


### PR DESCRIPTION
## What

- Added GoDoc links in the root database package docs.
- Extracted shared DSN source resolution for master and slave config.
- Cleaned up telemetry option naming and PostgreSQL test setup readability, including a named DB stats metric count.

## Why

- Keep the database docs and tests easier to scan after the style review.
- Reduce duplicated DSN handling while preserving existing error behavior.

## Testing

- `go test -count=1 ./database/sql/...` - passed
- `git diff --check` - passed
- `make lint` - passed
