### PR TITLE
feat(debug): polish diagnostics docs and tests

### DIFF
--- a/debug/doc.go
+++ b/debug/doc.go
@@ -7,29 +7,29 @@
 //
 // At a high level, the debug subsystem consists of:
 //
-//   - A debug HTTP server (`Server`) that runs independently from the main service server.
-//   - A debug router (`debug/http.ServeMux`) used to register endpoints.
-//   - Built-in endpoint registrations installed through `Register`.
+//   - A debug HTTP server ([Server]) that runs independently from the main service server.
+//   - A debug router (debug/http.ServeMux) used to register endpoints.
+//   - Built-in endpoint registrations installed through [Register].
 //
-// `Register` is the public front door for endpoint registration. The debug module wiring
+// [Register] is the public front door for endpoint registration. The debug module wiring
 // uses it to install the built-in handlers onto the debug mux, and callers that construct
 // a debug server manually should use it instead of depending on endpoint implementation packages.
 //
 // # Configuration and enablement
 //
-// Debug configuration is optional. By convention across go-service config types, a nil `*debug.Config`
-// (or nil embedded config) is treated as "disabled", and `NewServer` returns (nil, nil) when disabled.
+// Debug configuration is optional. By convention across go-service config types, a nil *[Config]
+// (or nil embedded config) is treated as "disabled", and [NewServer] returns (nil, nil) when disabled.
 //
-// When debug is enabled and no address is configured, the server binds to `tcp://:6060`. Production
+// When debug is enabled and no address is configured, the server binds to tcp://:6060. Production
 // deployments should set an explicit address, TLS/mTLS, and network or policy controls appropriate
 // for the environment.
 //
 // # TLS
 //
 // When TLS is enabled for the debug server, the package uses
-// `config/server.NewConfig` to resolve `crypto/tls/config.Config` source
-// strings and build the runtime `*crypto/tls.Config` assigned to the underlying
+// config/server.NewConfig to resolve crypto/tls/config.Config source
+// strings and build the runtime *crypto/tls.Config assigned to the underlying
 // HTTP server.
 //
-// Start with `Module`, `NewServer`, and `Register`.
+// Start with [Module], [NewServer], and [Register].
 package debug

--- a/debug/internal/psutil/mem.go
+++ b/debug/internal/psutil/mem.go
@@ -7,14 +7,14 @@ import (
 
 // NewMem collects memory and swap statistics for the debug endpoint.
 func NewMem(ctx context.Context) *Mem {
-	swapMem, _ := mem.SwapMemoryWithContext(ctx)
-	swapDev, _ := mem.SwapDevicesWithContext(ctx)
-	vms, _ := mem.VirtualMemoryWithContext(ctx)
+	swap, _ := mem.SwapMemoryWithContext(ctx)
+	devices, _ := mem.SwapDevicesWithContext(ctx)
+	virtual, _ := mem.VirtualMemoryWithContext(ctx)
 
 	return &Mem{
-		Swap:    swapMem,
-		Devices: swapDev,
-		Virtual: vms,
+		Swap:    swap,
+		Devices: devices,
+		Virtual: virtual,
 	}
 }
 

--- a/debug/internal/statsviz/statsviz.go
+++ b/debug/internal/statsviz/statsviz.go
@@ -23,9 +23,6 @@ func Register(lc di.Lifecycle, name env.Name, mux *http.ServeMux) error {
 
 	server.Register(mux.ServeMux)
 	lc.Append(di.Hook{
-		OnStart: func(context.Context) error {
-			return nil
-		},
 		OnStop: func(context.Context) error {
 			return server.Close()
 		},

--- a/debug/module.go
+++ b/debug/module.go
@@ -9,19 +9,12 @@ import (
 //
 // It provides:
 //
-//   - a debug router (`*debug/http.ServeMux`) via `http.NewServeMux`,
+//   - a debug router (*debug/http.ServeMux) via http.NewServeMux,
+//   - the debug server (*[Server]) via [NewServer] (returns nil when disabled), and
+//   - [Register], the front door for optional debug endpoint registration.
 //
-//   - the debug server (`*debug.Server`) via `NewServer` (returns nil when disabled), and
-//
-//   - `Register`, the front door for optional debug endpoint registration:
-//
-//   - statsviz under /debug/statsviz
-//
-//   - pprof under /debug/pprof
-//
-//   - fgprof under /debug/fgprof
-//
-//   - psutil under /debug/psutil
+// Register installs statsviz, pprof, fgprof, and psutil handlers under their
+// /debug/... routes.
 //
 // Register attaches handlers to the debug mux only when the debug server is enabled. The mux is then
 // used by the debug server when it is enabled via configuration.

--- a/debug/server.go
+++ b/debug/server.go
@@ -92,11 +92,11 @@ func (s *Server) GetService() *httpserver.Service {
 }
 
 func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
-	config := &config.Config{
+	serverConfig := &config.Config{
 		Address: cmp.Or(cfg.Address, net.DefaultAddress("6060")),
 	}
 	if !cfg.TLS.HasKeyMaterial() && !cfg.TLS.HasCA() {
-		return config, nil
+		return serverConfig, nil
 	}
 
 	tlsConfig, err := server.NewConfig(fs, cfg.TLS)
@@ -104,8 +104,8 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 		return nil, prefix(err)
 	}
 
-	config.TLS = tlsConfig
-	return config, nil
+	serverConfig.TLS = tlsConfig
+	return serverConfig, nil
 }
 
 func prefix(err error) error {

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var paths = []string{
+var debugPaths = []string{
 	"debug/statsviz",
 	"debug/pprof/",
 	"debug/pprof/cmdline",
@@ -21,33 +21,11 @@ var paths = []string{
 }
 
 func TestInsecureDebug(t *testing.T) {
-	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
-			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldDebug())
-
-			header := http.Header{}
-			url := world.NamedDebugURL("http", path)
-
-			res, err := world.ResponseWithNoBody(t.Context(), url, http.MethodGet, header)
-			require.NoError(t, err)
-			require.Equal(t, http.StatusOK, res.StatusCode)
-		})
-	}
+	requireDebugEndpoints(t, "http", test.WithWorldDebug())
 }
 
 func TestSecureDebug(t *testing.T) {
-	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
-			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldSecure(), test.WithWorldDebug())
-
-			header := http.Header{}
-			url := world.NamedDebugURL("https", path)
-
-			res, err := world.ResponseWithNoBody(t.Context(), url, http.MethodGet, header)
-			require.NoError(t, err)
-			require.Equal(t, http.StatusOK, res.StatusCode)
-		})
-	}
+	requireDebugEndpoints(t, "https", test.WithWorldSecure(), test.WithWorldDebug())
 }
 
 func TestInvalidServer(t *testing.T) {
@@ -65,4 +43,23 @@ func TestInvalidServer(t *testing.T) {
 
 	_, err := debug.NewServer(params)
 	require.Error(t, err)
+}
+
+func requireDebugEndpoints(t *testing.T, scheme string, options ...test.WorldOption) {
+	t.Helper()
+
+	options = append([]test.WorldOption{test.WithWorldTelemetry("otlp")}, options...)
+
+	for _, path := range debugPaths {
+		t.Run(path, func(t *testing.T) {
+			world := test.NewStartedWorld(t, options...)
+
+			header := http.Header{}
+			url := world.NamedDebugURL(scheme, path)
+
+			res, err := world.ResponseWithNoBody(t.Context(), url, http.MethodGet, header)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, res.StatusCode)
+		})
+	}
 }


### PR DESCRIPTION
## What

- Updated debug package docs and module comments with clearer GoDoc links and endpoint prose.
- Shared the secure and insecure debug endpoint test loop through a helper.
- Cleaned up local names in psutil memory collection and removed the empty statsviz lifecycle start hook.

## Why

- Keep debug wiring documentation and tests easier to scan after the style review.
- Remove small readability distractions without changing endpoint behavior.

## Testing

- `go test -count=1 ./debug/...` - passed
- `git diff --check` - passed
- `make lint` - passed
