### PR TITLE
feat(di): polish wrapper docs

### DIFF
--- a/di/di.go
+++ b/di/di.go
@@ -12,8 +12,13 @@ type Hook = fx.Hook
 
 // Lifecycle is an alias for fx.Lifecycle.
 //
-// It is used to manage application start/stop hooks (e.g. via Lifecycle.Append).
+// It is used to manage application start/stop hooks, for example via [Lifecycle.Append].
 type Lifecycle = fx.Lifecycle
+
+// App is an alias for fx.App.
+//
+// It represents an Fx application built from Options.
+type App = fx.App
 
 // In is an alias for fx.In.
 //
@@ -66,7 +71,7 @@ func Decorate(decorators ...any) Option {
 // New constructs a new Fx application from the provided options.
 //
 // This is a thin wrapper around fx.New.
-func New(opts ...Option) *fx.App {
+func New(opts ...Option) *App {
 	return fx.New(opts...)
 }
 

--- a/di/doc.go
+++ b/di/doc.go
@@ -10,13 +10,13 @@
 //
 // # Common patterns
 //
-//   - Define parameter structs embedding `di.In` to declare injected dependencies.
-//   - Use `di.Module` to compose multiple `di.Option` values into a single module.
-//   - Use `di.Constructor` to provide constructors (Fx Provide).
-//   - Use `di.Decorate` to wrap/modify provided values (Fx Decorate).
-//   - Use `di.Register` to run registration/invocation hooks at startup (Fx Invoke).
-//   - Use `di.Recover` to recover constructor, decorator, and invocation panics.
-//   - Use `di.RootCause` to unwrap Fx/Dig errors to the underlying cause for reporting.
+//   - Define parameter structs embedding [In] to declare injected dependencies.
+//   - Use [Module] to compose multiple [Option] values into a single module.
+//   - Use [Constructor] to provide constructors (Fx Provide).
+//   - Use [Decorate] to wrap/modify provided values (Fx Decorate).
+//   - Use [Register] to run registration/invocation hooks at startup (Fx Invoke).
+//   - Use [Recover] to recover constructor, decorator, and invocation panics.
+//   - Use [RootCause] to unwrap Fx/Dig errors to the underlying cause for reporting.
 //
-// Start with `Module`, `Constructor`, `Register`, `Decorate`, `Recover`, and `RootCause`.
+// Start with [Module], [Constructor], [Register], [Decorate], [Recover], and [RootCause].
 package di


### PR DESCRIPTION
## What

- Added GoDoc links for the dependency injection wrapper common-pattern docs.
- Added a local App alias for the Fx application type and returned it from New.
- Clarified the Lifecycle comment with a GoDoc link to Append.

## Why

- Keep the wrapper documentation easier to navigate in rendered Go docs.
- Keep the public wrapper API consistent while preserving existing behavior.

## Testing

- `go test -count=1 ./di ./cli ./cache ./internal/test` - passed
- `git diff --check` - passed
- `make lint` - passed
