### PR TITLE
feat(encoding): polish codec docs and tests

### DIFF
--- a/encoding/doc.go
+++ b/encoding/doc.go
@@ -1,26 +1,26 @@
 // Package encoding provides value encoding/decoding helpers and DI wiring used by go-service.
 //
-// This package defines a small `Encoder` interface (encode to an `io.Writer`, decode from an `io.Reader`)
-// and a registry (`Map`) used to select an encoder by kind at runtime.
+// This package defines a small [Encoder] interface (encode to an io.Writer, decode from an io.Reader)
+// and a registry ([Map]) used to select an encoder by kind at runtime.
 //
 // # Registry
 //
-// `Map` is a kind→Encoder lookup. It is commonly used by configuration loading and transport layers to
+// Map is a kind-to-Encoder lookup. It is commonly used by configuration loading and transport layers to
 // choose a decoder/encoder based on either:
-//   - a file extension (e.g. "yaml", "yml", "toml", "json"), or
-//   - a content kind / media subtype (e.g. "proto", "plain", "octet-stream").
+//   - a file extension (for example "yaml", "yml", "toml", "json"), or
+//   - a content kind / media subtype (for example "proto", "plain", "octet-stream").
 //
-// Callers typically obtain a `*Map` via DI and then use `Get(kind)` to select an encoder, often
+// Callers typically obtain a *[Map] via DI and then use [Map.Get] to select an encoder, often
 // falling back to a default when the requested kind is not registered.
 //
 // # Wiring
 //
-// `Module` wires the default encoder implementations and provides a `*Map` pre-populated with common
+// Module wires the default encoder implementations and provides a *[Map] pre-populated with common
 // kinds used throughout go-service, including:
 //   - JSON, HJSON, YAML, TOML, MessagePack
 //   - protobuf binary/text/JSON variants
 //   - gob
 //   - "plain"/bytes passthrough for io.ReaderFrom/io.WriterTo payloads
 //
-// Start with `Encoder`, `Map`, `NewMap`, and `Module`.
+// Start with [Encoder], [Map], [NewMap], and [Module].
 package encoding

--- a/encoding/errors/doc.go
+++ b/encoding/errors/doc.go
@@ -1,2 +1,2 @@
-// Package errors provides encoding helpers and adapters used by go-service.
+// Package errors provides encoding error values and helpers used by go-service.
 package errors

--- a/encoding/gob/gob_test.go
+++ b/encoding/gob/gob_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncoder(t *testing.T) {
+func TestEncodeDecode(t *testing.T) {
 	encoder := gob.NewEncoder()
 
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
-	require.NoError(t, encoder.Encode(bytes, map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"test": "test"}))
 
 	var msg map[string]string
-	require.NoError(t, encoder.Decode(bytes, &msg))
+	require.NoError(t, encoder.Decode(buffer, &msg))
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
@@ -42,10 +42,10 @@ func TestMarshalReturnsError(t *testing.T) {
 func TestEncodeReturnsError(t *testing.T) {
 	encoder := gob.NewEncoder()
 
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
-	require.Error(t, encoder.Encode(bytes, func() {}))
+	require.Error(t, encoder.Encode(buffer, func() {}))
 }
 
 func TestDecodeReturnsError(t *testing.T) {
@@ -58,27 +58,27 @@ func TestDecodeReturnsError(t *testing.T) {
 func TestDecodeRejectsTrailingValue(t *testing.T) {
 	encoder := gob.NewEncoder()
 
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
-	require.NoError(t, encoder.Encode(bytes, map[string]string{"test": "test"}))
-	require.NoError(t, encoder.Encode(bytes, map[string]string{"extra": "value"}))
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Encode(buffer, map[string]string{"extra": "value"}))
 
 	var msg map[string]string
-	err := encoder.Decode(bytes, &msg)
+	err := encoder.Decode(buffer, &msg)
 
 	require.ErrorIs(t, err, errors.ErrTrailingData)
 }
 
 func TestUnmarshalRejectsTrailingValue(t *testing.T) {
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
-	require.NoError(t, gob.NewEncoder().Encode(bytes, map[string]string{"test": "test"}))
-	require.NoError(t, gob.NewEncoder().Encode(bytes, map[string]string{"extra": "value"}))
+	require.NoError(t, gob.NewEncoder().Encode(buffer, map[string]string{"test": "test"}))
+	require.NoError(t, gob.NewEncoder().Encode(buffer, map[string]string{"extra": "value"}))
 
 	var msg map[string]string
-	err := gob.Unmarshal(test.Pool.Copy(bytes), &msg)
+	err := gob.Unmarshal(test.Pool.Copy(buffer), &msg)
 
 	require.ErrorIs(t, err, errors.ErrTrailingData)
 }

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type message struct {
-	Test string `json:"test"`
-}
-
 func TestEncode(t *testing.T) {
 	encoder := hjson.NewEncoder()
 	buf := &bytes.Buffer{}
@@ -81,4 +77,8 @@ func TestUnmarshalRejectsDuplicateKeys(t *testing.T) {
 	err := hjson.Unmarshal([]byte("{\n  test: first\n  test: second\n}\n"), msg)
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(err.Error()), "duplicate")
+}
+
+type message struct {
+	Test string `json:"test"`
 }

--- a/encoding/module.go
+++ b/encoding/module.go
@@ -14,36 +14,14 @@ import (
 
 // Module wires the default encoder implementations and the encoder registry into Fx/Dig.
 //
-// Provided constructors:
+// It provides protobuf encoders (*proto.Binary, *proto.Text, *proto.JSON),
+// structured config encoders (*json.Encoder, *hjson.Encoder, *toml.Encoder,
+// *yaml.Encoder, *msgpack.Encoder), and passthrough/specialized encoders
+// (*gob.Encoder and *bytes.Encoder).
 //
-//   - Protobuf encoders:
-//
-//   - *proto.Binary (via proto.NewBinary)
-//
-//   - *proto.Text (via proto.NewText)
-//
-//   - *proto.JSON (via proto.NewJSON)
-//
-//   - Structured config encoders:
-//
-//   - *json.Encoder (via json.NewEncoder)
-//
-//   - *hjson.Encoder (via hjson.NewEncoder)
-//
-//   - *toml.Encoder (via toml.NewEncoder)
-//
-//   - *yaml.Encoder (via yaml.NewEncoder)
-//
-//   - *msgpack.Encoder (via msgpack.NewEncoder)
-//
-//   - Other encoders:
-//
-//   - *gob.Encoder (via gob.NewEncoder)
-//
-//   - *bytes.Encoder (via bytes.NewEncoder) for io.ReaderFrom/io.WriterTo passthrough
-//
-// Finally, it constructs an `*encoding.Map` via `NewMap`, pre-populated with common kind aliases
-// (e.g. "yaml"/"yml", protobuf kind synonyms, and "plain"/"octet-stream" passthrough kinds).
+// Finally, it constructs a *[Map] via [NewMap], pre-populated with common kind
+// aliases (for example "yaml"/"yml", protobuf kind synonyms, and
+// "plain"/"octet-stream" passthrough kinds).
 var Module = di.Module(
 	di.Constructor(proto.NewBinary),
 	di.Constructor(proto.NewText),

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -14,117 +14,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidBinaryEncoder(t *testing.T) {
-	encoder := proto.NewBinary()
+func TestEncodeDecode(t *testing.T) {
+	for _, tt := range protoEncoders() {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := test.Pool.Get()
+			defer test.Pool.Put(buffer)
 
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+			require.NoError(t, tt.encoder.Encode(buffer, &health.Response{Status: health.Serving}))
 
-	require.NoError(t, encoder.Encode(bytes, &health.Response{Status: health.Serving}))
-
-	var decode health.Response
-	require.NoError(t, encoder.Decode(bytes, &decode))
-	require.Equal(t, health.Serving, decode.GetStatus())
+			var decode health.Response
+			require.NoError(t, tt.encoder.Decode(buffer, &decode))
+			require.Equal(t, health.Serving, decode.GetStatus())
+		})
+	}
 }
 
-func TestInvalidBinaryEncode(t *testing.T) {
-	encoder := proto.NewBinary()
+func TestEncodeRejectsInvalidType(t *testing.T) {
+	for _, tt := range protoEncoders() {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := test.Pool.Get()
+			defer test.Pool.Put(buffer)
 
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	var msg string
-	require.ErrorIs(t, encoder.Encode(bytes, &msg), errors.ErrInvalidType)
+			var msg string
+			require.ErrorIs(t, tt.encoder.Encode(buffer, &msg), errors.ErrInvalidType)
+		})
+	}
 }
 
-func TestInvalidBinaryDecode(t *testing.T) {
-	encoder := proto.NewBinary()
+func TestDecodeRejectsInvalidType(t *testing.T) {
+	for _, tt := range protoEncoders() {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := test.Pool.Get()
+			defer test.Pool.Put(buffer)
 
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+			require.NoError(t, tt.encoder.Encode(buffer, &health.Response{Status: health.Serving}))
 
-	require.NoError(t, encoder.Encode(bytes, &health.Response{Status: health.Serving}))
-
-	var msg string
-	require.Error(t, encoder.Decode(bytes, &msg))
+			var msg string
+			require.ErrorIs(t, tt.encoder.Decode(buffer, &msg), errors.ErrInvalidType)
+		})
+	}
 }
 
-func TestInvalidBinaryDecodeDoesNotRead(t *testing.T) {
-	encoder := proto.NewBinary()
-	reader := &test.TrackingReader{Err: io.EOF}
+func TestDecodeRejectsInvalidTypeWithoutReading(t *testing.T) {
+	for _, tt := range protoEncoders() {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &test.TrackingReader{Err: io.EOF}
 
-	var msg string
-	err := encoder.Decode(reader, &msg)
-	require.ErrorIs(t, err, errors.ErrInvalidType)
-	require.Zero(t, reader.Reads)
-}
-
-func TestValidTextEncoder(t *testing.T) {
-	encoder := proto.NewText()
-
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	require.NoError(t, encoder.Encode(bytes, &health.Response{Status: health.Serving}))
-
-	var decode health.Response
-	require.NoError(t, encoder.Decode(bytes, &decode))
-	require.Equal(t, health.Serving, decode.GetStatus())
-}
-
-func TestInvalidTextEncode(t *testing.T) {
-	encoder := proto.NewText()
-
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	var msg string
-	require.ErrorIs(t, encoder.Encode(bytes, &msg), errors.ErrInvalidType)
-}
-
-func TestInvalidTextDecode(t *testing.T) {
-	encoder := proto.NewText()
-
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	require.NoError(t, encoder.Encode(bytes, &health.Response{Status: health.Serving}))
-
-	var msg string
-	require.Error(t, encoder.Decode(bytes, &msg))
-}
-
-func TestInvalidTextDecodeDoesNotRead(t *testing.T) {
-	encoder := proto.NewText()
-	reader := &test.TrackingReader{Err: io.EOF}
-
-	var msg string
-	err := encoder.Decode(reader, &msg)
-	require.ErrorIs(t, err, errors.ErrInvalidType)
-	require.Zero(t, reader.Reads)
-}
-
-func TestValidJSONEncoder(t *testing.T) {
-	encoder := proto.NewJSON()
-
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	require.NoError(t, encoder.Encode(bytes, &health.Response{Status: health.Serving}))
-
-	var decode health.Response
-	require.NoError(t, encoder.Decode(bytes, &decode))
-	require.Equal(t, health.Serving, decode.GetStatus())
-}
-
-func TestInvalidJSONEncode(t *testing.T) {
-	encoder := proto.NewJSON()
-
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	var msg string
-	require.ErrorIs(t, encoder.Encode(bytes, &msg), errors.ErrInvalidType)
+			var msg string
+			err := tt.encoder.Decode(reader, &msg)
+			require.ErrorIs(t, err, errors.ErrInvalidType)
+			require.Zero(t, reader.Reads)
+		})
+	}
 }
 
 func TestEncodersUseExpectedWireFormats(t *testing.T) {
@@ -168,74 +109,25 @@ func TestEncodersUseExpectedWireFormats(t *testing.T) {
 	})
 }
 
-func TestInvalidJSONDecode(t *testing.T) {
-	encoder := proto.NewJSON()
-
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
-
-	require.NoError(t, encoder.Encode(bytes, &health.Response{Status: health.Serving}))
-
-	var msg string
-	require.Error(t, encoder.Decode(bytes, &msg))
-}
-
-func TestInvalidJSONDecodeDoesNotRead(t *testing.T) {
-	encoder := proto.NewJSON()
-	reader := &test.TrackingReader{Err: io.EOF}
-
-	var msg string
-	err := encoder.Decode(reader, &msg)
-	require.ErrorIs(t, err, errors.ErrInvalidType)
-	require.Zero(t, reader.Reads)
-}
-
 func TestEncodeReturnsWriteError(t *testing.T) {
-	encoders := []struct {
-		encoder encoding.Encoder
-		name    string
-	}{
-		{encoder: proto.NewBinary(), name: "binary"},
-		{encoder: proto.NewJSON(), name: "json"},
-		{encoder: proto.NewText(), name: "text"},
-	}
-
-	for _, tt := range encoders {
+	for _, tt := range protoEncoders() {
 		t.Run(tt.name, func(t *testing.T) {
 			require.ErrorIs(t, tt.encoder.Encode(test.ErrWriter{}, &health.Response{Status: health.Serving}), test.ErrFailed)
 		})
 	}
 }
 
-func TestErrBinaryDecode(t *testing.T) {
-	encoder := proto.NewBinary()
-	var msg health.Response
-	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
-}
-
-func TestErrTextDecode(t *testing.T) {
-	encoder := proto.NewText()
-	var msg health.Response
-	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
-}
-
-func TestErrJSONDecode(t *testing.T) {
-	encoder := proto.NewJSON()
-	var msg health.Response
-	require.ErrorIs(t, encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
+func TestDecodeReturnsReadError(t *testing.T) {
+	for _, tt := range protoEncoders() {
+		t.Run(tt.name, func(t *testing.T) {
+			var msg health.Response
+			require.ErrorIs(t, tt.encoder.Decode(&test.ErrReaderCloser{}, &msg), test.ErrFailed)
+		})
+	}
 }
 
 func TestInvalidTypedNilEncode(t *testing.T) {
-	encoders := []struct {
-		encoder encoding.Encoder
-		name    string
-	}{
-		{encoder: proto.NewBinary(), name: "binary"},
-		{encoder: proto.NewJSON(), name: "json"},
-		{encoder: proto.NewText(), name: "text"},
-	}
-
-	for _, tt := range encoders {
+	for _, tt := range protoEncoders() {
 		t.Run(tt.name, func(t *testing.T) {
 			var msg *health.Response
 
@@ -246,16 +138,7 @@ func TestInvalidTypedNilEncode(t *testing.T) {
 }
 
 func TestInvalidTypedNilDecodeDoesNotRead(t *testing.T) {
-	encoders := []struct {
-		encoder encoding.Encoder
-		name    string
-	}{
-		{encoder: proto.NewBinary(), name: "binary"},
-		{encoder: proto.NewJSON(), name: "json"},
-		{encoder: proto.NewText(), name: "text"},
-	}
-
-	for _, tt := range encoders {
+	for _, tt := range protoEncoders() {
 		t.Run(tt.name, func(t *testing.T) {
 			reader := &test.TrackingReader{Err: io.EOF}
 			var msg *health.Response
@@ -264,5 +147,19 @@ func TestInvalidTypedNilDecodeDoesNotRead(t *testing.T) {
 			require.ErrorIs(t, err, errors.ErrInvalidType)
 			require.Zero(t, reader.Reads)
 		})
+	}
+}
+
+func protoEncoders() []struct {
+	encoder encoding.Encoder
+	name    string
+} {
+	return []struct {
+		encoder encoding.Encoder
+		name    string
+	}{
+		{encoder: proto.NewBinary(), name: "binary"},
+		{encoder: proto.NewJSON(), name: "json"},
+		{encoder: proto.NewText(), name: "text"},
 	}
 }

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func TestEncode(t *testing.T) {
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
 	encoder := toml.NewEncoder()
 	msg := map[string]string{"test": "test"}
 
-	require.NoError(t, encoder.Encode(bytes, msg))
-	require.Equal(t, `test = "test"`, strings.TrimSpace(bytes.String()))
+	require.NoError(t, encoder.Encode(buffer, msg))
+	require.Equal(t, `test = "test"`, strings.TrimSpace(buffer.String()))
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
@@ -40,12 +40,12 @@ func TestMarshalReturnsError(t *testing.T) {
 }
 
 func TestEncodeReturnsError(t *testing.T) {
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
 	encoder := toml.NewEncoder()
 
-	require.Error(t, encoder.Encode(bytes, func() {}))
+	require.Error(t, encoder.Encode(buffer, func() {}))
 }
 
 func TestDecode(t *testing.T) {

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestEncode(t *testing.T) {
-	bytes := test.Pool.Get()
-	defer test.Pool.Put(bytes)
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
 
 	encoder := yaml.NewEncoder()
 	msg := map[string]string{"test": "test"}
 
-	require.NoError(t, encoder.Encode(bytes, msg))
-	require.Equal(t, "test: test", strings.TrimSpace(bytes.String()))
+	require.NoError(t, encoder.Encode(buffer, msg))
+	require.Equal(t, "test: test", strings.TrimSpace(buffer.String()))
 }
 
 func TestMarshalUnmarshal(t *testing.T) {


### PR DESCRIPTION
## What

- Refresh package docs for the codec registry and module wiring.
- Consolidate protobuf encoder tests through shared table coverage.
- Rename pooled buffers and move helper types to make tests easier to scan.

## Why

- Keep GoDoc links readable and reduce repeated test scaffolding across codec variants.

## Testing

- `go test ./encoding/...` - passed
- `git diff --check` - passed
- `make lint` - passed
