### PR TITLE
feat(env): clarify identity docs and tests

### DIFF
--- a/env/agent.go
+++ b/env/agent.go
@@ -6,8 +6,8 @@ package env
 //
 //	"<name>/<version>"
 //
-// Where name and version are derived from the provided Name and Version values (including any
-// normalization performed by Version.String).
+// Name and version come from the provided [Name] and [Version] values, including any normalization
+// performed by [Version.String].
 //
 // This value is commonly used for outbound HTTP clients so requests can be attributed to a specific
 // service and version by upstreams.

--- a/env/doc.go
+++ b/env/doc.go
@@ -2,11 +2,11 @@
 //
 // This package defines small types and constructors for common identity fields that are used across
 // go-service for consistent naming/versioning and outbound metadata, such as:
-//   - service name (Name)
-//   - service version (Version)
-//   - service instance id (ID)
-//   - service user id (UserID)
-//   - HTTP User-Agent value (UserAgent)
+//   - service name ([Name])
+//   - service version ([Version])
+//   - service instance id ([ID])
+//   - service user id ([UserID])
+//   - HTTP User-Agent value ([UserAgent])
 //
 // # Environment variable overrides
 //
@@ -20,8 +20,8 @@
 //
 // # Conventions
 //
-// Identity values are represented as small string wrapper types with a `String()` method.
+// Identity values are represented as small string wrapper types with String methods.
 // These wrappers preserve the underlying semantics while keeping imports consistent across go-service.
 //
-// Start with `NewName`, `NewVersion`, `NewID`, `NewUserID`, and `NewUserAgent`.
+// Start with [NewName], [NewVersion], [NewID], [NewUserID], and [NewUserAgent].
 package env

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -22,10 +22,22 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestID(t *testing.T) {
-	generator := uuid.NewGenerator()
-	require.NotEmpty(t, env.NewID(generator).String())
+	t.Run("generated default", func(t *testing.T) {
+		generator := uuid.NewGenerator()
 
-	t.Setenv("SERVICE_ID", "new_id")
-	require.Equal(t, "new_id", env.NewID(generator).String())
-	require.Equal(t, "new_id", env.NewID(nil).String())
+		require.NotEmpty(t, env.NewID(generator).String())
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		generator := uuid.NewGenerator()
+		t.Setenv("SERVICE_ID", "new_id")
+
+		require.Equal(t, "new_id", env.NewID(generator).String())
+	})
+
+	t.Run("env override without generator", func(t *testing.T) {
+		t.Setenv("SERVICE_ID", "new_id")
+
+		require.Equal(t, "new_id", env.NewID(nil).String())
+	})
 }

--- a/env/module.go
+++ b/env/module.go
@@ -7,13 +7,13 @@ import "github.com/alexfalkowski/go-service/v2/di"
 // It provides constructors for commonly used identity primitives derived from environment variables
 // with sensible fallbacks:
 //
-//   - ID via NewID (SERVICE_ID or generated id)
-//   - UserAgent via NewUserAgent ("<name>/<version>")
-//   - UserID via NewUserID (SERVICE_USER_ID or service name)
+//   - [ID] via [NewID] (SERVICE_ID or generated id)
+//   - [UserAgent] via [NewUserAgent] ("<name>/<version>")
+//   - [UserID] via [NewUserID] (SERVICE_USER_ID or service name)
 //
-// Note: this module does not provide Name or Version directly; those are commonly constructed by
-// callers using NewName (requires *os.FS) and NewVersion (uses runtime metadata). Consumers that
-// depend on UserAgent typically wire Name and Version elsewhere in their module graph.
+// Note: this module does not provide [Name] or [Version] directly; those are commonly constructed by
+// callers using [NewName] (requires *os.FS) and [NewVersion] (uses runtime metadata). Consumers that
+// depend on [UserAgent] typically wire [Name] and [Version] elsewhere in their module graph.
 var Module = di.Module(
 	di.Constructor(NewID),
 	di.Constructor(NewUserAgent),

--- a/env/user.go
+++ b/env/user.go
@@ -21,6 +21,6 @@ func NewUserID(name Name) UserID {
 type UserID string
 
 // String returns the user id value as a string.
-func (i UserID) String() string {
-	return string(i)
+func (id UserID) String() string {
+	return string(id)
 }

--- a/env/version_test.go
+++ b/env/version_test.go
@@ -11,10 +11,23 @@ import (
 
 func TestVersion(t *testing.T) {
 	require.Equal(t, "(devel)", env.NewVersion().String())
-	require.Equal(t, "1.0.0", env.Version("v1.0.0").String())
-	require.Equal(t, "what", env.Version("what").String())
-	require.Empty(t, env.Version(strings.Empty).String())
 
 	t.Setenv("SERVICE_VERSION", test.Version.String())
 	require.Equal(t, "1.0.0", env.NewVersion().String())
+}
+
+func TestVersionString(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		version  env.Version
+		expected string
+	}{
+		{name: "semver prefix", version: "v1.0.0", expected: "1.0.0"},
+		{name: "plain value", version: "what", expected: "what"},
+		{name: "empty", version: env.Version(strings.Empty), expected: strings.Empty},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.version.String())
+		})
+	}
 }


### PR DESCRIPTION
## What

- Link env package docs to exported identity types and constructors.
- Clarify the User-Agent constructor comment and UserID receiver name.
- Split ID and version tests into clearer named scenarios.

## Why

- Make the env package documentation easier to navigate and the small identity tests easier to scan.

## Testing

- `go test ./env` - passed
- `git diff --check` - passed
- `make lint` - passed
