### PR TITLE
feat(errors): polish safe message docs

### DIFF
--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,34 +1,35 @@
 // Package errors provides small error helpers used across go-service.
 //
 // This package is intentionally lightweight. It primarily re-exports a subset of the standard library
-// `errors` package APIs (As/AsType/Is/Join/New) behind a stable go-service import path, and provides a small
-// convenience helper (`Prefix`) for consistently attributing errors to a subsystem or component.
+// errors package APIs ([As], [AsType], [Is], [Join], [New]) behind a stable go-service import path,
+// and provides a small convenience helper ([Prefix]) for consistently attributing errors to a
+// subsystem or component.
 //
 // # Re-exports
 //
 // The following functions mirror the behavior and semantics of the standard library equivalents:
 //
-//   - As: type-assert (via error chain traversal) into a target
-//   - AsType: generic typed lookup in an error chain
-//   - Is: match a target error in an error chain
-//   - Join: combine multiple errors into one
-//   - New: construct a sentinel error value
+//   - [As]: type-assert (via error chain traversal) into a target
+//   - [AsType]: generic typed lookup in an error chain
+//   - [Is]: match a target error in an error chain
+//   - [Join]: combine multiple errors into one
+//   - [New]: construct a sentinel error value
 //
 // # Prefixing errors
 //
-// Prefix is commonly used at module/service boundaries to add a stable component prefix to an error
+// [Prefix] is commonly used at module/service boundaries to add a stable component prefix to an error
 // message while preserving the original error for unwrapping:
 //
 //	err := errors.Prefix("cache", underlyingErr)
 //
-// Prefix returns nil when the input error is nil, which makes it convenient to use in return
+// [Prefix] returns nil when the input error is nil, which makes it convenient to use in return
 // statements without additional nil checks.
 //
 // # Safe messages
 //
-// SafeMessenger lets error implementations expose a non-sensitive message for clients while retaining
-// diagnostic Error text for logs and wrapping. SafeMessage walks an error chain, returns the first
+// [SafeMessenger] lets error implementations expose a non-sensitive message for clients while retaining
+// diagnostic Error text for logs and wrapping. [SafeMessage] walks an error chain, returns the first
 // non-empty safe message it finds, and falls back to the caller-provided message when none is available.
 //
-// Start with `As`, `AsType`, `Is`, `Join`, `New`, `Prefix`, and `SafeMessage`.
+// Start with [As], [AsType], [Is], [Join], [New], [Prefix], and [SafeMessage].
 package errors

--- a/errors/safe.go
+++ b/errors/safe.go
@@ -36,8 +36,8 @@ func safeMessage(err error) string {
 	}
 
 	if unwrapper, ok := err.(interface{ Unwrap() []error }); ok {
-		for _, err := range unwrapper.Unwrap() {
-			if msg := safeMessage(err); msg != "" {
+		for _, wrapped := range unwrapper.Unwrap() {
+			if msg := safeMessage(wrapped); msg != "" {
 				return msg
 			}
 		}

--- a/errors/safe_test.go
+++ b/errors/safe_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestSafeMessage(t *testing.T) {
 	for _, tc := range []struct {
-		err  error
 		name string
+		err  error
 		want string
 	}{
 		{name: "nil", want: "fallback"},
 		{name: "plain", err: errors.New("internal"), want: "fallback"},
 		{name: "wrapped", err: fmt.Errorf("wrapped: %w", test.SafeMessageError{Message: "safe"}), want: "safe"},
-		{name: "empty", err: test.EmptySafeMessageError{Err: test.SafeMessageError{Message: "safe"}}, want: "safe"},
+		{name: "empty safe message", err: test.EmptySafeMessageError{Err: test.SafeMessageError{Message: "safe"}}, want: "safe"},
 		{name: "joined", err: errors.Join(errors.New("internal"), test.SafeMessageError{Message: "safe"}), want: "safe"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

- Link errors package docs to exported helpers and safe-message types.
- Rename the joined-error traversal variable to avoid shadowing.
- Reorder the safe-message test table fields and clarify the empty-message case name.

## Why

- Make the errors package documentation easier to navigate and the safe-message traversal tests easier to scan.

## Testing

- `go test ./errors` - passed
- `git diff --check` - passed
- `make lint` - passed
