### PR TITLE
feat(feature): clarify provider docs and tests

### DIFF
--- a/feature/config.go
+++ b/feature/config.go
@@ -4,18 +4,19 @@ import "github.com/alexfalkowski/go-service/v2/config/client"
 
 // Config configures OpenFeature client behavior for go-service.
 //
-// It embeds `config/client.Config` to reuse common client-side configuration fields that may be
+// It embeds [client.Config] to reuse common client-side configuration fields that may be
 // shared across feature-related integrations (for example address, timeout, TLS, retry/limiter,
 // and key-value options).
 //
 // # Optional pointers and "enabled" semantics
 //
 // This config is intentionally optional. By convention across go-service configuration types, a nil
-// *Config is treated as "feature disabled". The embedded `*client.Config` is also optional; IsEnabled
-// returns true only when both the outer *Config and the embedded *client.Config are non-nil/enabled.
+// *[Config] is treated as "feature disabled". The embedded *[client.Config] is also optional;
+// [Config.IsEnabled] returns true only when both the outer *[Config] and the embedded
+// *[client.Config] are non-nil/enabled.
 //
 // Note: provider registration itself is controlled by the presence of an OpenFeature provider in the
-// DI graph (see Register in this package). A service may have feature config present without wiring
+// DI graph (see [Register]). A service may have feature config present without wiring
 // a provider, in which case OpenFeature behaves with its default provider semantics.
 type Config struct {
 	*client.Config `yaml:",inline" json:",inline" toml:",inline"`

--- a/feature/doc.go
+++ b/feature/doc.go
@@ -6,24 +6,24 @@
 //
 // # Provider registration and enablement
 //
-// Provider registration is intentionally optional. The `Register` function is wired via `Module` and
-// is a no-op when no `openfeature.FeatureProvider` is available in the DI graph (i.e. it is not
+// Provider registration is intentionally optional. The [Register] function is wired via [Module] and
+// is a no-op when no openfeature.FeatureProvider is available in the DI graph (i.e. it is not
 // provided by the consuming service).
 //
-// This repository does not construct or connect a built-in OpenFeature provider from `feature.Config`.
+// This repository does not construct or connect a built-in OpenFeature provider from [Config].
 // Consuming services that need a remote or custom provider should use that config in their own provider
-// constructor and provide the resulting `openfeature.FeatureProvider` to the DI graph.
+// constructor and provide the resulting openfeature.FeatureProvider to the DI graph.
 //
-// When a provider is present, `Register` appends lifecycle hooks that:
-//   - call `openfeature.SetProviderWithContextAndWait` during application start, and
-//   - call `openfeature.ShutdownWithContext` during application stop.
+// When a provider is present, [Register] appends lifecycle hooks that:
+//   - call openfeature.SetProviderWithContextAndWait during application start, and
+//   - call openfeature.ShutdownWithContext during application stop.
 //
 // Register uses OpenFeature's package-level SDK APIs, so provider registration, hooks, and shutdown are
 // process-global effects.
 //
 // # Telemetry hooks
 //
-// When a metrics provider is available, `Register` installs OpenTelemetry hooks for OpenFeature so
+// When a metrics provider is available, [Register] installs OpenTelemetry hooks for OpenFeature so
 // evaluations can emit metrics and traces.
 //
 // Trace event attributes are produced by the upstream OpenFeature OpenTelemetry hook. They may include
@@ -32,8 +32,8 @@
 //
 // # Clients
 //
-// `NewClient` constructs an OpenFeature client named after the service (via env.Name). Callers can
+// [NewClient] constructs an OpenFeature client named after the service. Callers can
 // use this client to evaluate feature flags.
 //
-// Start with `Module`, `Register`, and `NewClient`.
+// Start with [Module], [Register], and [NewClient].
 package feature

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -26,11 +26,11 @@ type ProviderParams struct {
 
 	// FeatureProvider is the OpenFeature provider to register.
 	//
-	// It is optional: if not present in the DI graph, Register is a no-op and OpenFeature uses its default
-	// provider semantics.
+	// It is optional: if not present in the DI graph, [Register] is a no-op and OpenFeature uses its
+	// default provider semantics.
 	FeatureProvider openfeature.FeatureProvider `optional:"true"`
 
-	// Name is the service name. It is typically used when constructing an OpenFeature client (see NewClient).
+	// Name is the service name. It is typically used when constructing an OpenFeature client (see [NewClient]).
 	Name env.Name
 }
 
@@ -41,9 +41,8 @@ type ProviderParams struct {
 // Enabled behavior:
 //   - If a MetricProvider is available, Register installs OpenTelemetry hooks so evaluations emit metrics
 //     and traces.
-//   - Register appends lifecycle hooks that:
-//   - set the OpenFeature provider during application start, and
-//   - shut down the OpenFeature SDK during application stop.
+//   - Register appends lifecycle hooks that set the OpenFeature provider during application start and
+//     shut down the OpenFeature SDK during application stop.
 //
 // Register uses OpenFeature's package-level SDK APIs, so provider registration, hooks, and shutdown are
 // process-global effects.

--- a/feature/feature_test.go
+++ b/feature/feature_test.go
@@ -10,48 +10,37 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestNoProvider(t *testing.T) {
-	lc := fxtest.NewLifecycle(t)
-	attrs := map[string]any{"favorite_color": "blue"}
-	provider, err := test.NewPrometheusMeterProvider(lc)
-	require.NoError(t, err)
+func TestRegister(t *testing.T) {
+	for _, tt := range []struct {
+		provider openfeature.FeatureProvider
+		name     string
+	}{
+		{name: "no provider"},
+		{provider: openfeature.NoopProvider{}, name: "provider"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := fxtest.NewLifecycle(t)
+			meterProvider, err := test.NewPrometheusMeterProvider(lc)
+			require.NoError(t, err)
 
-	feature.Register(feature.ProviderParams{
-		Lifecycle:      lc,
-		Name:           test.Name,
-		MetricProvider: provider,
-	})
+			feature.Register(feature.ProviderParams{
+				Lifecycle:       lc,
+				Name:            test.Name,
+				MetricProvider:  meterProvider,
+				FeatureProvider: tt.provider,
+			})
 
-	client := feature.NewClient(test.Name)
+			client := feature.NewClient(test.Name)
 
-	lc.RequireStart()
+			lc.RequireStart()
 
-	v, err := client.BooleanValue(t.Context(), "v2_enabled", false, openfeature.NewEvaluationContext("tim@apple.com", attrs))
-	require.NoError(t, err)
-	require.False(t, v)
+			attrs := map[string]any{"favorite_color": "blue"}
+			evalCtx := openfeature.NewEvaluationContext("tim@apple.com", attrs)
+			v, err := client.BooleanValue(t.Context(), "v2_enabled", false, evalCtx)
+			require.NoError(t, err)
+			require.False(t, v)
 
-	lc.RequireStop()
-}
-
-func TestProvider(t *testing.T) {
-	lc := fxtest.NewLifecycle(t)
-	attrs := map[string]any{"favorite_color": "blue"}
-	provider, err := test.NewPrometheusMeterProvider(lc)
-	require.NoError(t, err)
-	feature.Register(feature.ProviderParams{
-		Lifecycle:       lc,
-		Name:            test.Name,
-		MetricProvider:  provider,
-		FeatureProvider: openfeature.NoopProvider{},
-	})
-
-	client := feature.NewClient(test.Name)
-
-	lc.RequireStart()
-
-	v, err := client.BooleanValue(t.Context(), "v2_enabled", false, openfeature.NewEvaluationContext("tim@apple.com", attrs))
-	require.NoError(t, err)
-	require.False(t, v)
-
-	lc.RequireStop()
+			lc.RequireStop()
+		})
+	}
 }

--- a/feature/module.go
+++ b/feature/module.go
@@ -5,16 +5,16 @@ import "github.com/alexfalkowski/go-service/v2/di"
 // Module wires OpenFeature into Fx/Dig.
 //
 // It provides:
-//   - an OpenFeature client constructor (NewClient), and
-//   - lifecycle registration (Register) that optionally installs a FeatureProvider.
+//   - an OpenFeature client constructor ([NewClient]), and
+//   - lifecycle registration ([Register]) that optionally installs a FeatureProvider.
 //
 // # Optional provider behavior
 //
-// Register is designed to be safe to include even when no OpenFeature provider is supplied by the
+// [Register] is designed to be safe to include even when no OpenFeature provider is supplied by the
 // consuming service. The FeatureProvider dependency is optional; if it is not present in the DI graph,
-// Register becomes a no-op and OpenFeature uses its default provider semantics.
+// [Register] becomes a no-op and OpenFeature uses its default provider semantics.
 //
-// When a provider is present, Register appends lifecycle hooks to set the provider during startup and
+// When a provider is present, [Register] appends lifecycle hooks to set the provider during startup and
 // shut down the OpenFeature SDK during stop. If a metrics provider is available, it also installs
 // OpenTelemetry hooks for metrics and traces.
 var Module = di.Module(


### PR DESCRIPTION
## What

- Link feature package docs to exported config, module, and registration helpers.
- Flatten OpenFeature lifecycle hook documentation for clearer GoDoc rendering.
- Consolidate provider registration tests into a shared table-driven scenario.

## Why

- Make the feature package docs easier to navigate and reduce duplicated provider registration test setup.

## Testing

- `go test ./feature` - passed
- `git diff --check` - passed
- `make lint` - passed
