### PR TITLE
feat(flag): clarify config flag docs

### DIFF
--- a/flag/doc.go
+++ b/flag/doc.go
@@ -14,9 +14,9 @@
 //   - "file:/path/to/config.yaml" to read configuration from a file (decoder selected by extension)
 //   - "env:MY_CONFIG" to read configuration from an environment variable (typically "<ext>:<base64-content>")
 //
-// The `FlagSet` type in this package supports installing this convention via `(*FlagSet).AddConfig` and
-// retrieving it via `(*FlagSet).GetConfig`. The config subsystem (`config.NewDecoder`) consumes this value
+// The [FlagSet] type in this package supports installing this convention via [FlagSet.AddConfig] and
+// retrieving it via [FlagSet.GetConfig]. The config subsystem (config.NewDecoder) consumes this value
 // to route to the appropriate decoder.
 //
-// Start with `NewFlagSet`, `FlagSet.AddConfig`, and `FlagSet.GetConfig`.
+// Start with [NewFlagSet], [FlagSet.AddConfig], and [FlagSet.GetConfig].
 package flag

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -43,8 +43,7 @@ func (f *FlagSet) AddConfig(value string) {
 
 // GetConfig returns the configured config flag ("-config" / "-c") value.
 //
-// This method is nil-safe with respect to AddConfig: if AddConfig was not called, GetConfig returns an empty
-// string. This allows callers to depend on GetConfig unconditionally.
+// GetConfig is safe to call before [FlagSet.AddConfig]; in that case it returns an empty string.
 func (f *FlagSet) GetConfig() string {
 	if f.config != nil {
 		return *f.config

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -14,7 +14,7 @@ func TestGetConfigWithoutAddConfig(t *testing.T) {
 }
 
 func TestAddConfig(t *testing.T) {
-	tests := []struct {
+	cases := []struct {
 		name string
 		want string
 		args []string
@@ -24,7 +24,7 @@ func TestAddConfig(t *testing.T) {
 		{name: "short flag", args: []string{"-c", "env:CONFIG"}, want: "env:CONFIG"},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			set := flag.NewFlagSet("test")
 			set.AddConfig("file:config.yml")


### PR DESCRIPTION
## What

- Link flag package docs to the FlagSet config helpers.
- Simplify GetConfig documentation for pre-AddConfig calls.
- Rename the AddConfig test table to cases.

## Why

- Make the flag package docs easier to navigate and keep the test table naming consistent.

## Testing

- `go test ./flag` - passed
- `git diff --check` - passed
- `make lint` - passed
