### PR TITLE
feat(health): polish server docs and checker tests

### DIFF
--- a/health/checker/db.go
+++ b/health/checker/db.go
@@ -69,8 +69,8 @@ func (c *DBChecker) dbs() []*sqlx.DB {
 	return dbs
 }
 
-func (o *DBChecker) ping(ctx context.Context, db *sqlx.DB) error {
-	ctx, cancel := context.WithTimeoutCause(ctx, o.timeout, ErrPingTimeout)
+func (c *DBChecker) ping(ctx context.Context, db *sqlx.DB) error {
+	ctx, cancel := context.WithTimeoutCause(ctx, c.timeout, ErrPingTimeout)
 	defer cancel()
 
 	return db.PingContext(ctx)

--- a/health/checker/db_test.go
+++ b/health/checker/db_test.go
@@ -39,12 +39,7 @@ func TestDBCheckerReturnsPingError(t *testing.T) {
 }
 
 func TestDBCheckerPingsMastersAndSlaves(t *testing.T) {
-	driverName := registerPingDriver(t)
-	db, errs := sql.ConnectMasterSlaves(driverName, []string{"master"}, []string{"slave"})
-	require.Empty(t, errs)
-	defer func() {
-		require.NoError(t, db.Destroy())
-	}()
+	db := newPingDB(t, []string{"master"}, []string{"slave"})
 
 	check := checker.NewDBChecker(db, time.Second)
 	err := check.Check(t.Context())
@@ -53,12 +48,7 @@ func TestDBCheckerPingsMastersAndSlaves(t *testing.T) {
 }
 
 func TestDBCheckerReturnsTimeoutCause(t *testing.T) {
-	driverName := registerPingDriver(t)
-	db, errs := sql.ConnectMasterSlaves(driverName, []string{"timeout"}, nil)
-	require.Empty(t, errs)
-	defer func() {
-		require.NoError(t, db.Destroy())
-	}()
+	db := newPingDB(t, []string{"timeout"}, nil)
 
 	check := checker.NewDBChecker(db, time.Millisecond)
 	require.ErrorIs(t, check.Check(t.Context()), checker.ErrPingTimeout)
@@ -69,6 +59,19 @@ var (
 	errSlavePing  = errors.New("slave ping")
 	pingDriverID  sync.Uint64
 )
+
+func newPingDB(t *testing.T, masters, slaves []string) *sql.DBs {
+	t.Helper()
+
+	driverName := registerPingDriver(t)
+	db, errs := sql.ConnectMasterSlaves(driverName, masters, slaves)
+	require.Empty(t, errs)
+	t.Cleanup(func() {
+		require.NoError(t, db.Destroy())
+	})
+
+	return db
+}
 
 func registerPingDriver(t *testing.T) string {
 	t.Helper()

--- a/health/checker/doc.go
+++ b/health/checker/doc.go
@@ -1,10 +1,10 @@
 // Package checker provides health check implementations used by go-service.
 //
-// This package contains `checker.Checker` implementations (from github.com/alexfalkowski/go-health/v2/checker)
+// This package contains checker.Checker implementations (from github.com/alexfalkowski/go-health/v2/checker)
 // that can be registered with a go-health server to expose liveness/readiness-style endpoints.
 //
 // The checkers in this package are intended to be composed by services depending on which subsystems they use
 // (database, caches, upstream dependencies, etc.).
 //
-// Start with the package-level constructors (for example `NewDBChecker`).
+// Start with [DBChecker] and [NewDBChecker].
 package checker

--- a/health/doc.go
+++ b/health/doc.go
@@ -7,10 +7,10 @@
 // # Registrations and checks
 //
 // The go-health server exposes health endpoints based on registrations and checkers managed by the
-// go-health package. This package provides the `Registrations` alias to make it easier to pass around
+// go-health package. This package provides the [Registrations] alias to make it easier to pass around
 // lists of health check registrations in go-service wiring.
 //
-// Health check implementations and constructors live under `health/checker`.
+// Health check implementations and constructors live under health/checker.
 //
-// Start with `Module` and `NewServer`.
+// Start with [Module] and [NewServer].
 package health

--- a/health/module.go
+++ b/health/module.go
@@ -5,10 +5,10 @@ import "github.com/alexfalkowski/go-service/v2/di"
 // Module wires the health server into Fx/Dig.
 //
 // It provides a constructor for `*server.Server` (from github.com/alexfalkowski/go-health/v2/server)
-// via `NewServer`, which is started/stopped automatically using Fx lifecycle hooks.
+// via [NewServer], which is started/stopped automatically using Fx lifecycle hooks.
 //
 // Additional health check registrations are typically provided by other packages (including
-// `health/checker`) and installed onto the returned server elsewhere in the application graph.
+// health/checker) and installed onto the returned server elsewhere in the application graph.
 var Module = di.Module(
 	di.Constructor(NewServer),
 )

--- a/health/server.go
+++ b/health/server.go
@@ -7,13 +7,10 @@ import (
 
 // NewServer constructs a go-health server and wires it into the application lifecycle.
 //
-// Lifecycle behavior:
-//   - OnStart: starts the underlying go-health server.
-//   - OnStop: stops the underlying go-health server.
-//
-// This makes the health server's lifetime match the Fx application lifetime, without requiring
-// callers to manually start/stop it. The returned server can then be configured by other wiring
-// (for example by registering health check registrations/endpoints provided by go-health).
+// It starts the underlying go-health server on application start and stops it on application stop.
+// This makes the health server's lifetime match the Fx application lifetime, without requiring callers
+// to manually start/stop it. The returned server can then be configured by other wiring (for example by
+// registering health check registrations/endpoints provided by go-health).
 func NewServer(lc di.Lifecycle) *health.Server {
 	server := health.NewServer()
 


### PR DESCRIPTION
## What

- Link health package docs to server and registration entrypoints.
- Simplify the health server lifecycle comment and align DBChecker receiver names.
- Extract repeated ping database setup into a test helper.

## Why

- Make the health package docs easier to navigate and keep checker test scenarios focused on assertions.

## Testing

- `go test ./health/...` - passed
- `git diff --check` - passed
- `make lint` - passed
