### PR TITLE
feat(id): link generator docs and simplify tests

### DIFF
--- a/id/benchmark_test.go
+++ b/id/benchmark_test.go
@@ -9,20 +9,17 @@ import (
 )
 
 func BenchmarkGenerators(b *testing.B) {
-	benchmarks := []struct {
-		name string
-		kind string
-	}{
-		{name: "ksuid", kind: "ksuid"},
-		{name: "nanoid", kind: "nanoid"},
-		{name: "ulid", kind: "ulid"},
-		{name: "uuid", kind: "uuid"},
-		{name: "xid", kind: "xid"},
+	kinds := []string{
+		"ksuid",
+		"nanoid",
+		"ulid",
+		"uuid",
+		"xid",
 	}
 
-	for _, benchmark := range benchmarks {
-		b.Run(benchmark.name, func(b *testing.B) {
-			gen, err := id.NewGenerator(&id.Config{Kind: benchmark.kind}, test.Generators)
+	for _, kind := range kinds {
+		b.Run(kind, func(b *testing.B) {
+			gen, err := id.NewGenerator(&id.Config{Kind: kind}, test.Generators)
 			require.NoError(b, err)
 
 			b.ReportAllocs()

--- a/id/config.go
+++ b/id/config.go
@@ -13,14 +13,14 @@ package id
 type Config struct {
 	// Kind selects the ID generator implementation.
 	//
-	// The set of supported kinds depends on what has been wired into the application (see the id module
-	// wiring). If Kind is set to an unknown value, generator selection typically returns ErrNotFound.
+	// The set of supported kinds depends on what has been wired into the application (see [Module]).
+	// If Kind is set to an unknown value, generator selection typically returns [ErrNotFound].
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
 }
 
 // IsEnabled reports whether ID configuration is present.
 //
-// By convention, a nil *Config is treated as "disabled".
+// By convention, a nil *[Config] is treated as "disabled".
 func (c *Config) IsEnabled() bool {
 	return c != nil
 }

--- a/id/doc.go
+++ b/id/doc.go
@@ -1,14 +1,14 @@
 // Package id provides ID generation abstractions, registries, and wiring used by go-service.
 //
-// This package defines a small `Generator` interface and provides a registry (`Map`) of generators
+// This package defines a small [Generator] interface and provides a registry ([Map]) of generators
 // keyed by kind (e.g. "uuid", "ksuid", etc.). A concrete generator can be selected at runtime via
-// `NewGenerator` using `Config.Kind`.
+// [NewGenerator] using [Config.Kind].
 //
 // # Kinds and implementations
 //
 // Concrete generator implementations live in subpackages under `id/*` (for example `id/uuid`,
-// `id/ksuid`, `id/ulid`, `id/nanoid`, and `id/xid`). The `id.Module` wiring constructs these
-// generators and registers them into a `*Map`.
+// `id/ksuid`, `id/ulid`, `id/nanoid`, and `id/xid`). The [Module] wiring constructs these
+// generators and registers them into a *[Map].
 //
 // Generator kinds are selected for different operational properties. The "uuid" generator is the
 // default and is optimized for the request metadata hot path. The "xid" generator is intentionally
@@ -17,8 +17,8 @@
 //
 // # Configuration and enablement
 //
-// ID generation configuration is optional. A nil `*id.Config` selects the default "uuid" generator.
-// If configuration is present but the configured kind is unknown, `NewGenerator` returns ErrNotFound.
+// ID generation configuration is optional. A nil *[Config] selects the default "uuid" generator.
+// If configuration is present but the configured kind is unknown, [NewGenerator] returns [ErrNotFound].
 //
-// Start with `Generator`, `Config`, `NewGenerator`, `Map`, and `Module`.
+// Start with [Generator], [Config], [NewGenerator], [Map], and [Module].
 package id

--- a/id/id.go
+++ b/id/id.go
@@ -12,12 +12,12 @@ import (
 
 // ErrNotFound is returned when generator selection fails because the configured kind is unknown.
 //
-// It is returned by NewGenerator when Config.Kind does not match any generator registered in the Map.
+// It is returned by [NewGenerator] when [Config.Kind] does not match any generator registered in the [Map].
 var ErrNotFound = errors.New("id: generator not found")
 
 // MapParams defines dependencies used to construct a generator Map.
 //
-// It is intended for dependency injection (Fx/Dig). The default wiring is provided by id.Module.
+// It is intended for dependency injection (Fx/Dig). The default wiring is provided by [Module].
 type MapParams struct {
 	di.In
 
@@ -47,7 +47,7 @@ type MapParams struct {
 //   - "xid"
 //
 // The map is fixed by standard wiring. Services that need custom generator kinds should provide
-// custom DI wiring for Map or Generator selection.
+// custom DI wiring for [Map] or [Generator] selection.
 func NewMap(params MapParams) *Map {
 	return &Map{
 		generators: map[string]Generator{
@@ -71,16 +71,16 @@ type Map struct {
 // Get returns the generator registered for kind.
 //
 // If no generator is registered for kind, Get returns nil.
-func (f *Map) Get(kind string) Generator {
-	return f.generators[kind]
+func (m *Map) Get(kind string) Generator {
+	return m.generators[kind]
 }
 
-// NewGenerator selects a Generator based on config.Kind from the provided registry.
+// NewGenerator selects a [Generator] based on [Config.Kind] from the provided registry.
 //
-// Default behavior: if config is nil/disabled, NewGenerator returns the "uuid" generator.
+// Default behavior: if config is nil/disabled, [NewGenerator] returns the "uuid" generator.
 //
-// Enabled behavior: if config is enabled, NewGenerator looks up the generator for config.Kind in m.
-// If the kind is registered, it returns that generator. If the kind is not registered, it returns ErrNotFound.
+// Enabled behavior: if config is enabled, [NewGenerator] looks up the generator for [Config.Kind] in m.
+// If the kind is registered, it returns that generator. If the kind is not registered, it returns [ErrNotFound].
 func NewGenerator(config *Config, m *Map) (Generator, error) {
 	if !config.IsEnabled() {
 		return m.Get("uuid"), nil

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestValidID(t *testing.T) {
-	configs := []*id.Config{
-		{Kind: "uuid"},
-		{Kind: "ksuid"},
-		{Kind: "nanoid"},
-		{Kind: "ulid"},
-		{Kind: "xid"},
+	kinds := []string{
+		"uuid",
+		"ksuid",
+		"nanoid",
+		"ulid",
+		"xid",
 	}
 
-	for _, config := range configs {
-		t.Run(config.Kind, func(t *testing.T) {
-			gen, err := id.NewGenerator(config, test.Generators)
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			gen, err := id.NewGenerator(&id.Config{Kind: kind}, test.Generators)
 			require.NoError(t, err)
 
 			require.NotEmpty(t, gen.Generate())
@@ -36,5 +36,5 @@ func TestDefaultID(t *testing.T) {
 
 func TestInvalidID(t *testing.T) {
 	_, err := id.NewGenerator(&id.Config{Kind: "invalid"}, test.Generators)
-	require.Error(t, err)
+	require.ErrorIs(t, err, id.ErrNotFound)
 }

--- a/id/module.go
+++ b/id/module.go
@@ -12,16 +12,16 @@ import (
 // Module wires ID generation into Fx/Dig.
 //
 // It provides constructors for the built-in generator implementations:
-//   - *ksuid.Generator via ksuid.NewGenerator (kind "ksuid")
-//   - *nanoid.Generator via nanoid.NewGenerator (kind "nanoid")
-//   - *ulid.Generator via ulid.NewGenerator (kind "ulid")
-//   - *uuid.Generator via uuid.NewGenerator (kind "uuid")
-//   - *xid.Generator via xid.NewGenerator (kind "xid")
+//   - *[ksuid.Generator] via [ksuid.NewGenerator] (kind "ksuid")
+//   - *[nanoid.Generator] via [nanoid.NewGenerator] (kind "nanoid")
+//   - *[ulid.Generator] via [ulid.NewGenerator] (kind "ulid")
+//   - *[uuid.Generator] via [uuid.NewGenerator] (kind "uuid")
+//   - *[xid.Generator] via [xid.NewGenerator] (kind "xid")
 //
-// It then constructs a generator registry (*id.Map) via NewMap and finally selects a concrete
-// Generator via NewGenerator using Config.Kind.
+// It then constructs a generator registry (*[Map]) via [NewMap] and finally selects a concrete
+// [Generator] via [NewGenerator] using [Config.Kind].
 //
-// Default behavior: when *id.Config is nil/disabled, NewGenerator returns the "uuid" generator so
+// Default behavior: when *[Config] is nil/disabled, [NewGenerator] returns the "uuid" generator so
 // downstream consumers always have a usable ID source.
 var Module = di.Module(
 	di.Constructor(ksuid.NewGenerator),

--- a/id/ulid/ulid.go
+++ b/id/ulid/ulid.go
@@ -28,8 +28,8 @@ type Generator struct {
 // injected cryptographically secure reader.
 //
 // If ULID generation fails (for example due to reader errors), this method panics via runtime.Must.
-func (k *Generator) Generate() string {
-	id, err := ulid.New(ulid.Timestamp(time.Now()), k.reader)
+func (g *Generator) Generate() string {
+	id, err := ulid.New(ulid.Timestamp(time.Now()), g.reader)
 	runtime.Must(err)
 	return id.String()
 }


### PR DESCRIPTION
## What

- Add GoDoc links across generator configuration, registry, and module documentation.
- Simplify generator tests and benchmarks to use kind lists.
- Rename unclear receiver variables in registry and ULID generation code.

## Why

- Improve generated documentation navigation and make test and benchmark setup easier to scan.

## Testing

- `go test ./id/...` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
