### PR TITLE
feat(meta): link attribute docs and simplify exports

### DIFF
--- a/meta/attrs.go
+++ b/meta/attrs.go
@@ -60,7 +60,7 @@ const (
 
 	// AuthorizationKey is the attribute key used for authorization values.
 	//
-	// Security note: authorization values often contain secrets. Prefer storing them as Redacted or Ignored
+	// Security note: authorization values often contain secrets. Prefer storing them as [Redacted] or [Ignored]
 	// values if there is any chance they will be exported to logs or headers.
 	AuthorizationKey = "authorization"
 
@@ -68,143 +68,143 @@ const (
 	GeolocationKey = "geoLocation"
 )
 
-// WithRequestID creates a request ID pair for WithAttributes.
+// WithRequestID creates a request ID pair for [WithAttributes].
 //
-// The pair stores value under RequestIDKey.
+// The pair stores value under [RequestIDKey].
 func WithRequestID(value Value) Pair {
 	return NewPair(RequestIDKey, value)
 }
 
 // RequestID returns the stored request ID attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func RequestID(ctx context.Context) Value {
 	return Attribute(ctx, RequestIDKey)
 }
 
-// WithSystem creates a system pair for WithAttributes.
+// WithSystem creates a system pair for [WithAttributes].
 //
-// The pair stores value under SystemKey.
+// The pair stores value under [SystemKey].
 func WithSystem(value Value) Pair {
 	return NewPair(SystemKey, value)
 }
 
-// WithService creates a service pair for WithAttributes.
+// WithService creates a service pair for [WithAttributes].
 //
-// The pair stores value under ServiceKey.
+// The pair stores value under [ServiceKey].
 func WithService(value Value) Pair {
 	return NewPair(ServiceKey, value)
 }
 
-// WithMethod creates a method pair for WithAttributes.
+// WithMethod creates a method pair for [WithAttributes].
 //
-// The pair stores value under MethodKey.
+// The pair stores value under [MethodKey].
 func WithMethod(value Value) Pair {
 	return NewPair(MethodKey, value)
 }
 
-// WithServiceMethod creates a service-method pair for WithAttributes.
+// WithServiceMethod creates a service-method pair for [WithAttributes].
 //
-// The pair stores value under ServiceMethodKey.
+// The pair stores value under [ServiceMethodKey].
 func WithServiceMethod(value Value) Pair {
 	return NewPair(ServiceMethodKey, value)
 }
 
 // ServiceMethod returns the stored service-method attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func ServiceMethod(ctx context.Context) Value {
 	return Attribute(ctx, ServiceMethodKey)
 }
 
-// WithCode creates a status code pair for WithAttributes.
+// WithCode creates a status code pair for [WithAttributes].
 //
-// The pair stores value under CodeKey.
+// The pair stores value under [CodeKey].
 func WithCode(value Value) Pair {
 	return NewPair(CodeKey, value)
 }
 
-// WithDuration creates a duration pair for WithAttributes.
+// WithDuration creates a duration pair for [WithAttributes].
 //
-// The pair stores value under DurationKey.
+// The pair stores value under [DurationKey].
 func WithDuration(value Value) Pair {
 	return NewPair(DurationKey, value)
 }
 
-// WithUserAgent creates a user agent pair for WithAttributes.
+// WithUserAgent creates a user agent pair for [WithAttributes].
 //
-// The pair stores value under UserAgentKey.
+// The pair stores value under [UserAgentKey].
 func WithUserAgent(value Value) Pair {
 	return NewPair(UserAgentKey, value)
 }
 
 // UserAgent returns the stored user agent attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func UserAgent(ctx context.Context) Value {
 	return Attribute(ctx, UserAgentKey)
 }
 
-// WithUserID creates a user ID pair for WithAttributes.
+// WithUserID creates a user ID pair for [WithAttributes].
 //
-// The pair stores value under UserIDKey.
+// The pair stores value under [UserIDKey].
 func WithUserID(value Value) Pair {
 	return NewPair(UserIDKey, value)
 }
 
 // UserID returns the stored user ID attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func UserID(ctx context.Context) Value {
 	return Attribute(ctx, UserIDKey)
 }
 
-// WithIPAddr creates an IP address pair for WithAttributes.
+// WithIPAddr creates an IP address pair for [WithAttributes].
 //
-// The pair stores value under IPAddrKey.
+// The pair stores value under [IPAddrKey].
 func WithIPAddr(value Value) Pair {
 	return NewPair(IPAddrKey, value)
 }
 
 // IPAddr returns the stored IP address attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func IPAddr(ctx context.Context) Value {
 	return Attribute(ctx, IPAddrKey)
 }
 
-// WithIPAddrKind creates an IP address kind pair for WithAttributes.
+// WithIPAddrKind creates an IP address kind pair for [WithAttributes].
 //
-// The pair stores value under IPAddrKindKey.
+// The pair stores value under [IPAddrKindKey].
 func WithIPAddrKind(value Value) Pair {
 	return NewPair(IPAddrKindKey, value)
 }
 
-// WithAuthorization creates an authorization pair for WithAttributes.
+// WithAuthorization creates an authorization pair for [WithAttributes].
 //
-// The pair stores value under AuthorizationKey. Authorization values often
-// contain secrets; prefer Ignored or Redacted values if they might be exported.
+// The pair stores value under [AuthorizationKey]. Authorization values often
+// contain secrets; prefer [Ignored] or [Redacted] values if they might be exported.
 func WithAuthorization(value Value) Pair {
 	return NewPair(AuthorizationKey, value)
 }
 
 // Authorization returns the stored authorization attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func Authorization(ctx context.Context) Value {
 	return Attribute(ctx, AuthorizationKey)
 }
 
-// WithGeolocation creates a geolocation pair for WithAttributes.
+// WithGeolocation creates a geolocation pair for [WithAttributes].
 //
-// The pair stores value under GeolocationKey.
+// The pair stores value under [GeolocationKey].
 func WithGeolocation(value Value) Pair {
 	return NewPair(GeolocationKey, value)
 }
 
 // Geolocation returns the stored geolocation attribute from ctx.
 //
-// If no value is present, this returns the zero-value Value.
+// If no value is present, this returns the zero-value [Value].
 func Geolocation(ctx context.Context) Value {
 	return Attribute(ctx, GeolocationKey)
 }

--- a/meta/doc.go
+++ b/meta/doc.go
@@ -1,19 +1,19 @@
 // Package meta provides context-scoped metadata storage and helpers for go-service.
 //
 // This package implements a small attribute store backed by context.Context. Attributes are stored as
-// key→meta.Value pairs, where Value carries both the underlying string and rendering semantics.
+// key→[Value] pairs, where Value carries both the underlying string and rendering semantics.
 //
 // # Storage model
 //
-// Attributes are stored on the context under a single internal key as a map-like Storage. WithAttributes
+// Attributes are stored on the context under a single internal key as a map-like [Storage]. [WithAttributes]
 // updates that storage using copy-on-write semantics so derived contexts do not mutate parent or sibling
-// context metadata. Callers provide updates as Pair values so multiple attributes can be stored with one
-// storage clone. Use NewPair for arbitrary keys, or the typed With* helpers such as WithRequestID and
-// WithUserID for standard metadata keys.
+// context metadata. Callers provide updates as [Pair] values so multiple attributes can be stored with one
+// storage clone. Use [NewPair] for arbitrary keys, or the typed With* helpers such as [WithRequestID] and
+// [WithUserID] for standard metadata keys.
 //
 // # Value rendering semantics
 //
-// Values are stored as meta.Value so callers can control how attributes are rendered when exporting them:
+// Values are stored as [Value] so callers can control how attributes are rendered when exporting them:
 //   - normal: renders the underlying value as-is
 //   - blank: represents "no value" and renders as empty
 //   - ignored: stores the underlying value but renders as empty (useful to keep the value in-context while
@@ -23,13 +23,13 @@
 // # Export helpers
 //
 // Stored attributes can be exported to plain string maps for logging and transport propagation using:
-//   - Strings: keys unchanged
-//   - SnakeStrings: keys converted to snake_case
-//   - CamelStrings: keys converted to lowerCamelCase
+//   - [Strings]: keys unchanged
+//   - [SnakeStrings]: keys converted to snake_case
+//   - [CamelStrings]: keys converted to lowerCamelCase
 //
 // Export helpers skip attributes whose rendered string is empty. A prefix may be prepended to each exported key.
 //
-// Start with `WithAttributes`, `NewPair`, the typed With* pair helpers, and `Attribute` for arbitrary
-// attributes. Use `Value` constructors (String/Blank/Ignored/Redacted) for controlling rendering, and
-// `Strings` / `SnakeStrings` / `CamelStrings` for exporting attributes.
+// Start with [WithAttributes], [NewPair], the typed With* pair helpers, and [Attribute] for arbitrary
+// attributes. Use [Value] constructors ([String], [Blank], [Ignored], [Redacted]) for controlling rendering,
+// and [Strings], [SnakeStrings], or [CamelStrings] for exporting attributes.
 package meta

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -29,15 +29,15 @@ func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
 
 // Attribute returns the stored attribute value for key.
 //
-// If no attribute is present for key, Attribute returns the zero-value Value. Callers can use
-// Value.IsEmpty to distinguish empty values.
+// If no attribute is present for key, Attribute returns the zero-value [Value]. Callers can use
+// [Value.IsEmpty] to distinguish empty values.
 func Attribute(ctx context.Context, key string) Value {
 	return attributes(ctx).Get(key)
 }
 
 // Map is a string key-value map of exported attributes.
 //
-// Export helpers return this type after rendering Values and applying key conversion and prefixing.
+// Export helpers return this type after rendering [Value] entries and applying key conversion and prefixing.
 type Map map[string]string
 
 // SnakeStrings returns all stored attributes as a string map with snake_cased keys.
@@ -61,5 +61,9 @@ func CamelStrings(ctx context.Context, prefix string) Map {
 // The prefix parameter is prepended to each exported key (if non-empty).
 // Attributes whose rendered value is empty are skipped.
 func Strings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix, func(s string) string { return s })
+	return attributes(ctx).Strings(prefix, identity)
+}
+
+func identity(s string) string {
+	return s
 }

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -8,48 +8,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSnakeCase(t *testing.T) {
-	ctx := t.Context()
-	ctx = meta.WithAttributes(ctx,
+func TestStrings(t *testing.T) {
+	ctx := meta.WithAttributes(t.Context(),
 		meta.NewPair("testId", meta.String("1")),
 		meta.NewPair("see", meta.Ignored("secret")),
 		meta.NewPair("redacted", meta.Redacted("2")),
 	)
 
-	require.Equal(t, meta.Map{"test_id": "1", "redacted": "*"}, meta.SnakeStrings(ctx, meta.NoPrefix))
-}
-
-func TestCamelCase(t *testing.T) {
-	ctx := t.Context()
-	ctx = meta.WithAttributes(ctx,
-		meta.NewPair("testId", meta.String("1")),
-		meta.NewPair("see", meta.Ignored("secret")),
-		meta.NewPair("redacted", meta.Redacted("2")),
-	)
-
-	require.Equal(t, meta.Map{"testId": "1", "redacted": "*"}, meta.CamelStrings(ctx, meta.NoPrefix))
-}
-
-func TestNoneCase(t *testing.T) {
-	ctx := t.Context()
-	ctx = meta.WithAttributes(ctx,
-		meta.NewPair("testId", meta.String("1")),
-		meta.NewPair("see", meta.Ignored("secret")),
-		meta.NewPair("redacted", meta.Redacted("2")),
-	)
-
-	require.Equal(t, meta.Map{"testId": "1", "redacted": "*"}, meta.Strings(ctx, meta.NoPrefix))
-}
-
-func TestPrefix(t *testing.T) {
-	ctx := t.Context()
-	ctx = meta.WithAttributes(ctx,
-		meta.NewPair("testId", meta.String("1")),
-		meta.NewPair("see", meta.Ignored("secret")),
-		meta.NewPair("redacted", meta.Redacted("2")),
-	)
-
-	require.Equal(t, meta.Map{"test.testId": "1", "test.redacted": "*"}, meta.Strings(ctx, "test."))
+	assertStrings(t, ctx, "snake", meta.Map{"test_id": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
+		return meta.SnakeStrings(ctx, meta.NoPrefix)
+	})
+	assertStrings(t, ctx, "camel", meta.Map{"testId": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
+		return meta.CamelStrings(ctx, meta.NoPrefix)
+	})
+	assertStrings(t, ctx, "none", meta.Map{"testId": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
+		return meta.Strings(ctx, meta.NoPrefix)
+	})
+	assertStrings(t, ctx, "prefix", meta.Map{"test.testId": "1", "test.redacted": "*"}, func(ctx context.Context) meta.Map {
+		return meta.Strings(ctx, "test.")
+	})
 }
 
 func TestWithAttributesReturnsSameContextWithoutPairs(t *testing.T) {
@@ -101,7 +78,7 @@ func TestPairHelpers(t *testing.T) {
 	}
 }
 
-func TestWithAttributesKeepsParentContextIsolatedWithSinglePairs(t *testing.T) {
+func TestWithAttributesKeepsParentContextIsolatedWithSinglePair(t *testing.T) {
 	parent := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("parent")))
 	child := meta.WithAttributes(parent, meta.WithUserID(meta.String("child")))
 
@@ -159,4 +136,12 @@ func TestAccessors(t *testing.T) {
 			require.Equal(t, test.want, test.got)
 		})
 	}
+}
+
+func assertStrings(t *testing.T, ctx context.Context, name string, want meta.Map, export func(context.Context) meta.Map) {
+	t.Helper()
+
+	t.Run(name, func(t *testing.T) {
+		require.Equal(t, want, export(ctx))
+	})
 }

--- a/meta/storage.go
+++ b/meta/storage.go
@@ -15,7 +15,7 @@ type Converter func(string) string
 // Storage stores meta values keyed by attribute name.
 //
 // Storage is the internal backing map used by this package to hold context-scoped attributes.
-// It is typically treated as immutable by callers. WithAttributes uses copy-on-write updates so
+// It is typically treated as immutable by callers. [WithAttributes] uses copy-on-write updates so
 // derived contexts do not mutate parent storage.
 type Storage map[string]Value
 
@@ -44,17 +44,17 @@ func (s Storage) Get(key string) Value {
 // Strings exports stored attributes as a string map.
 //
 // Each key is transformed using converter and then prefixed with prefix (if non-empty).
-// Each value is rendered using Value.String().
+// Each value is rendered using [Value.String].
 //
 // Export behavior:
 //   - Attributes whose rendered value is an empty string are skipped.
-//     (This includes Blank and Ignored values, and any Value whose rendered String() is empty.)
+//     (This includes [Blank] and [Ignored] values, and any [Value] whose rendered [Value.String] is empty.)
 //   - Keys are included only if they have a non-empty rendered value.
 func (s Storage) Strings(prefix string, converter Converter) Map {
 	attributes := make(Map, len(s))
-	for k, v := range s {
-		if v := v.String(); !strings.IsEmpty(v) {
-			attributes[s.key(prefix, converter(k))] = v
+	for key, value := range s {
+		if rendered := value.String(); !strings.IsEmpty(rendered) {
+			attributes[s.key(prefix, converter(key))] = rendered
 		}
 	}
 	return attributes
@@ -62,7 +62,7 @@ func (s Storage) Strings(prefix string, converter Converter) Map {
 
 // Clone returns a shallow copy of the storage.
 //
-// Values are copied by assignment, which is sufficient because Value is immutable.
+// Values are copied by assignment, which is sufficient because [Value] is immutable.
 func (s Storage) Clone() Storage {
 	cloned := make(Storage, len(s))
 	maps.Copy(cloned, s)

--- a/meta/value.go
+++ b/meta/value.go
@@ -20,10 +20,10 @@ const (
 // Ignored constructs a Value that preserves the underlying value in-context but renders as an empty string.
 //
 // This is useful when you want to keep the raw value available for in-process logic, but you do not want it
-// to be exported via `meta.Strings` / `meta.SnakeStrings` / `meta.CamelStrings` (for example into logs or
+// to be exported via [Strings], [SnakeStrings], or [CamelStrings] (for example into logs or
 // transport headers).
 //
-// Note: export helpers skip attributes whose rendered string is empty, so Ignored values will not appear
+// Note: export helpers skip attributes whose rendered string is empty, so [Ignored] values will not appear
 // in exported maps.
 func Ignored(value string) Value {
 	return Value{kind: ignored, value: value}
@@ -34,7 +34,7 @@ func Ignored(value string) Value {
 // The rendered value uses one '*' per UTF-8 rune in the underlying value, which can be useful to
 // preserve the shape of data without revealing the contents.
 //
-// Note: the underlying value is still stored in-context and can be retrieved via Value.Value(). Use this
+// Note: the underlying value is still stored in-context and can be retrieved via [Value.Value]. Use this
 // only when it is acceptable for in-process code to access the raw value.
 func Redacted(value string) Value {
 	return Value{kind: redacted, value: value}
@@ -44,7 +44,7 @@ func Redacted(value string) Value {
 //
 // Blank values render as empty strings and are skipped by export helpers.
 //
-// Use Blank when you want to explicitly represent "no value" rather than "an ignored value that still exists".
+// Use [Blank] when you want to explicitly represent "no value" rather than "an ignored value that still exists".
 func Blank() Value {
 	return Value{kind: blank, value: strings.Empty}
 }
@@ -56,7 +56,7 @@ func String(value string) Value {
 
 // Error converts err to a normal Value using err.Error().
 //
-// If err is nil, Error returns Blank.
+// If err is nil, Error returns [Blank].
 func Error(err error) Value {
 	if reflect.IsNil(err) {
 		return Blank()
@@ -67,7 +67,7 @@ func Error(err error) Value {
 
 // ToString converts st to a normal Value using st.String().
 //
-// If st is nil, ToString returns Blank.
+// If st is nil, ToString returns [Blank].
 func ToString(st fmt.Stringer) Value {
 	if reflect.IsNil(st) {
 		return Blank()
@@ -78,8 +78,8 @@ func ToString(st fmt.Stringer) Value {
 
 // ToRedacted converts st to a redacted Value using st.String().
 //
-// If st is nil, ToRedacted returns Blank.
-// The underlying (unredacted) string is still stored in-context and can be retrieved via Value.Value().
+// If st is nil, ToRedacted returns [Blank].
+// The underlying (unredacted) string is still stored in-context and can be retrieved via [Value.Value].
 func ToRedacted(st fmt.Stringer) Value {
 	if reflect.IsNil(st) {
 		return Blank()
@@ -90,8 +90,8 @@ func ToRedacted(st fmt.Stringer) Value {
 
 // ToIgnored converts st to an ignored Value using st.String().
 //
-// If st is nil, ToIgnored returns Blank.
-// The underlying string is still stored in-context and can be retrieved via Value.Value().
+// If st is nil, ToIgnored returns [Blank].
+// The underlying string is still stored in-context and can be retrieved via [Value.Value].
 func ToIgnored(st fmt.Stringer) Value {
 	if reflect.IsNil(st) {
 		return Blank()
@@ -104,8 +104,8 @@ func ToIgnored(st fmt.Stringer) Value {
 //
 // Value is designed to support two related use-cases:
 //
-//  1. In-process access: retrieve the underlying value with Value.Value() for business logic.
-//  2. Export: render the value with Value.String() when exporting metadata (logs/headers/etc.).
+//  1. In-process access: retrieve the underlying value with [Value.Value] for business logic.
+//  2. Export: render the value with [Value.String] when exporting metadata (logs/headers/etc.).
 //
 // Rendering is controlled by kind:
 //   - normal: renders the underlying value as-is
@@ -113,7 +113,7 @@ func ToIgnored(st fmt.Stringer) Value {
 //   - ignored: renders as empty (while still retaining the underlying value in-context)
 //   - redacted: renders as asterisks with one '*' per UTF-8 rune in the underlying value
 //
-// Note: Value.String intentionally does not distinguish between blank and ignored during rendering; both
+// Note: [Value.String] intentionally does not distinguish between blank and ignored during rendering; both
 // render as empty. The difference is semantic at construction time.
 type Value struct {
 	value string

--- a/meta/value_test.go
+++ b/meta/value_test.go
@@ -95,6 +95,18 @@ func TestToIgnoredWithTypedNil(t *testing.T) {
 }
 
 func TestRedactedWithMultiByteValue(t *testing.T) {
-	require.Equal(t, "*", meta.Redacted("é").String())
-	require.Equal(t, "**", meta.Redacted("éa").String())
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "single rune", value: "é", want: "*"},
+		{name: "multiple runes", value: "éa", want: "**"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, meta.Redacted(test.value).String())
+		})
+	}
 }


### PR DESCRIPTION
## What

- Add GoDoc links across metadata storage, attribute, value, and export documentation.
- Clarify storage string rendering by avoiding shadowed variables and using a named identity converter.
- Consolidate export helper tests and table the multibyte redaction cases.

## Why

- Improve generated documentation navigation and make metadata export test setup easier to scan.

## Testing

- `go test ./meta` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
