### PR TITLE
feat(module): link bundle docs

### DIFF
--- a/module/doc.go
+++ b/module/doc.go
@@ -9,13 +9,11 @@
 //
 // The exported bundles are intended as defaults:
 //
-//   - `Library`: shared, transport-agnostic wiring (building block for both servers and clients).
+//   - [Library]: shared, transport-agnostic wiring.
 //
-//   - `Server`: a typical server composition (builds on Library and adds configuration decoding,
-//     server-side transports, telemetry, debugging, health checks, and common integrations).
+//   - [Server]: a typical server composition.
 //
-//   - `Client`: a typical client composition (builds on Library and adds configuration decoding,
-//     telemetry, and common client integrations/helpers). It does not wire transports by default.
+//   - [Client]: a typical client composition.
 //
 // # Enablement and configuration
 //
@@ -23,6 +21,6 @@
 // pointer sub-configs (nil meaning "disabled"). These bundles wire constructors and registrations;
 // whether a subsystem is active depends on the configuration supplied to the graph.
 //
-// Start with `Library`, `Server`, and `Client`. Drop down to lower-level package composition only when
+// Start with [Library], [Server], and [Client]. Drop down to lower-level package composition only when
 // you intentionally need custom wiring beyond what the standard bundles provide.
 package module

--- a/module/example_test.go
+++ b/module/example_test.go
@@ -6,21 +6,21 @@ import (
 )
 
 func ExampleServer() {
-	app := cli.NewApplication(func(commander cli.Commander) {
+	application := cli.NewApplication(func(commander cli.Commander) {
 		server := commander.AddServer("serve", "Run the service", module.Server)
 		server.AddConfig("file:./config.yml")
 	})
 
-	_ = app
+	_ = application
 	// Output:
 }
 
 func ExampleClient() {
-	app := cli.NewApplication(func(commander cli.Commander) {
+	application := cli.NewApplication(func(commander cli.Commander) {
 		client := commander.AddClient("migrate", "Run client tasks", module.Client)
 		client.AddConfig("file:./config.yml")
 	})
 
-	_ = app
+	_ = application
 	// Output:
 }

--- a/module/module.go
+++ b/module/module.go
@@ -21,85 +21,83 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
 
-var (
-	// Library provides a baseline Fx module intended for reuse by both servers and clients.
-	//
-	// It wires common, transport-agnostic dependencies that many subsystems build upon:
-	//   - env.Module (service identity values like name/version/id, user agent, etc.)
-	//   - compress.Module (compression registry and default codecs)
-	//   - encoding.Module (encoding registry and default encoders)
-	//   - crypto.Module (crypto primitives and helpers)
-	//   - time.Module (time providers/utilities)
-	//   - sync.Module (shared buffer pool wiring)
-	//   - id.Module (ID generator implementations and selection)
-	//
-	// Library does not wire transports, servers, or request handling; it is intended to be a common
-	// foundation that both the Server and Client bundles build upon.
-	Library = di.Module(
-		env.Module,
-		compress.Module,
-		encoding.Module,
-		crypto.Module,
-		time.Module,
-		sync.Module,
-		id.Module,
-	)
+// Library provides a baseline Fx module intended for reuse by both servers and clients.
+//
+// It wires common, transport-agnostic dependencies that many subsystems build upon:
+//   - [env.Module] (service identity values like name/version/id, user agent, etc.)
+//   - [compress.Module] (compression registry and default codecs)
+//   - [encoding.Module] (encoding registry and default encoders)
+//   - [crypto.Module] (crypto primitives and helpers)
+//   - [time.Module] (time providers/utilities)
+//   - [sync.Module] (shared buffer pool wiring)
+//   - [id.Module] (ID generator implementations and selection)
+//
+// Library does not wire transports, servers, or request handling; it is intended to be a common
+// foundation that both the [Server] and [Client] bundles build upon.
+var Library = di.Module(
+	env.Module,
+	compress.Module,
+	encoding.Module,
+	crypto.Module,
+	time.Module,
+	sync.Module,
+	id.Module,
+)
 
-	// Server provides the standard Fx module composition for a go-service server.
-	//
-	// It builds on Library and adds server-oriented wiring commonly needed by services:
-	//   - debug.Module (debug server + diagnostic endpoints)
-	//   - config.Module (config decoding + validation + common sub-config projections)
-	//   - telemetry.Module (logging/tracing/metrics wiring)
-	//   - cache.Module (cache drivers, cache facade, and package-level cache registration)
-	//   - feature.Module (OpenFeature client + optional provider registration)
-	//   - sql.Module (SQL database wiring; currently PostgreSQL)
-	//   - limiter.Module (rate limiter key map wiring; transport modules typically construct limiters)
-	//   - transport.Module (HTTP/gRPC transports and related client/server integrations)
-	//   - health.Module (health server wiring)
-	//
-	// Many of these subsystems are optional and are enabled/disabled by configuration (often via nil pointer
-	// sub-configs). This bundle wires constructors/registrations; runtime behavior depends on the config
-	// supplied to the graph.
-	//
-	// This is the primary entrypoint for server applications built from `go-service-template`.
-	Server = di.Module(
-		Library,
-		debug.Module,
-		config.Module,
-		telemetry.Module,
-		cache.Module,
-		feature.Module,
-		sql.Module,
-		limiter.Module,
-		transport.Module,
-		health.Module,
-	)
+// Server provides the standard Fx module composition for a go-service server.
+//
+// It builds on [Library] and adds server-oriented wiring commonly needed by services:
+//   - [debug.Module] (debug server + diagnostic endpoints)
+//   - [config.Module] (config decoding + validation + common sub-config projections)
+//   - [telemetry.Module] (logging/tracing/metrics wiring)
+//   - [cache.Module] (cache drivers, cache facade, and package-level cache registration)
+//   - [feature.Module] (OpenFeature client + optional provider registration)
+//   - [sql.Module] (SQL database wiring; currently PostgreSQL)
+//   - [limiter.Module] (rate limiter key map wiring; transport modules typically construct limiters)
+//   - [transport.Module] (HTTP/gRPC transports and related client/server integrations)
+//   - [health.Module] (health server wiring)
+//
+// Many of these subsystems are optional and are enabled/disabled by configuration (often via nil pointer
+// sub-configs). This bundle wires constructors/registrations; runtime behavior depends on the config
+// supplied to the graph.
+//
+// This is the primary entrypoint for server applications built from `go-service-template`.
+var Server = di.Module(
+	Library,
+	debug.Module,
+	config.Module,
+	telemetry.Module,
+	cache.Module,
+	feature.Module,
+	sql.Module,
+	limiter.Module,
+	transport.Module,
+	health.Module,
+)
 
-	// Client provides the standard Fx module composition for a go-service client.
-	//
-	// It builds on Library and adds client-oriented wiring commonly needed by client processes
-	// and batch jobs:
-	//   - config.Module (config decoding + validation + common sub-config projections)
-	//   - telemetry.Module (logging/tracing/metrics wiring)
-	//   - cache.Module (cache drivers/facade; optional by config)
-	//   - feature.Module (OpenFeature client + optional provider registration)
-	//   - hooks.Module (Standard Webhooks helpers; used by HTTP hook integrations)
-	//   - sql.Module (SQL database wiring; currently PostgreSQL)
-	//   - limiter.Module (rate limiter key map wiring)
-	//
-	// Unlike Server, Client does not wire debug endpoints, transports, or a health server by default.
-	// Those can be added explicitly by composing additional modules on top of Client if needed.
-	//
-	// This is the primary entrypoint for client-style applications built from `go-service-template`.
-	Client = di.Module(
-		Library,
-		config.Module,
-		telemetry.Module,
-		cache.Module,
-		feature.Module,
-		hooks.Module,
-		sql.Module,
-		limiter.Module,
-	)
+// Client provides the standard Fx module composition for a go-service client.
+//
+// It builds on [Library] and adds client-oriented wiring commonly needed by client processes
+// and batch jobs:
+//   - [config.Module] (config decoding + validation + common sub-config projections)
+//   - [telemetry.Module] (logging/tracing/metrics wiring)
+//   - [cache.Module] (cache drivers/facade; optional by config)
+//   - [feature.Module] (OpenFeature client + optional provider registration)
+//   - [hooks.Module] (Standard Webhooks helpers; used by HTTP hook integrations)
+//   - [sql.Module] (SQL database wiring; currently PostgreSQL)
+//   - [limiter.Module] (rate limiter key map wiring)
+//
+// Unlike [Server], Client does not wire debug endpoints, transports, or a health server by default.
+// Those can be added explicitly by composing additional modules on top of Client if needed.
+//
+// This is the primary entrypoint for client-style applications built from `go-service-template`.
+var Client = di.Module(
+	Library,
+	config.Module,
+	telemetry.Module,
+	cache.Module,
+	feature.Module,
+	hooks.Module,
+	sql.Module,
+	limiter.Module,
 )


### PR DESCRIPTION
## What

- Add GoDoc links for the top-level bundle documentation and lower-level module references.
- Split the bundle declarations so each exported module has its own source-level doc block.
- Rename example variables to make the wiring examples read more clearly.

## Why

- Improve generated documentation navigation and make the standard bundle wiring easier to scan.

## Testing

- `go test ./module` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
