### PR TITLE
feat(net): polish networking docs and names

### DIFF
--- a/net/doc.go
+++ b/net/doc.go
@@ -1,20 +1,20 @@
 // Package net provides small network helpers and wrappers used by go-service.
 //
-// This package is a lightweight convenience layer over the standard library `net` package.
+// This package is a lightweight convenience layer over the standard library net package.
 // It exists to provide a stable go-service import path for common networking primitives and
 // a few helpers that are used by higher-level server and transport wiring.
 //
 // # Re-exported types
 //
-// This package re-exports selected `net` types (Conn, Dialer, Listener) as aliases so callers can
+// This package re-exports selected net types ([Conn], [Dialer], [Listener]) as aliases so callers can
 // depend on go-service primitives while preserving the exact semantics of the standard library.
 //
 // # Helpers
 //
 // The helpers in this package focus on:
-//   - creating listeners that respect context cancellation (Listen), and
+//   - creating listeners that respect context cancellation ([Listen]), and
 //   - working with go-service address conventions, such as "tcp://host:port" style addresses
-//     (SplitNetworkAddress, Host, DefaultAddress).
+//     ([SplitNetworkAddress], [Host], [DefaultAddress]).
 //
-// Start with `Listen` and `DefaultAddress`.
+// Start with [Listen] and [DefaultAddress].
 package net

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -356,41 +356,41 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 // Any additional opts are appended after the keepalive options and may further
 // customize server behavior (for example interceptors, credentials, or stats handlers).
 func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption) *Server {
-	os := make([]ServerOption, 0, 8+len(opts))
-	os = append(os, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+	serverOptions := make([]ServerOption, 0, 8+len(opts))
+	serverOptions = append(serverOptions, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 		MinTime:             options.NonNegativeDuration("keepalive_enforcement_policy_ping_min_time", timeout).Duration(),
 		PermitWithoutStream: true,
 	}))
-	os = append(os, grpc.KeepaliveParams(keepalive.ServerParameters{
+	serverOptions = append(serverOptions, grpc.KeepaliveParams(keepalive.ServerParameters{
 		MaxConnectionIdle:     options.NonNegativeDuration("keepalive_max_connection_idle", timeout).Duration(),
 		MaxConnectionAge:      options.NonNegativeDuration("keepalive_max_connection_age", timeout).Duration(),
 		MaxConnectionAgeGrace: options.NonNegativeDuration("keepalive_max_connection_age_grace", timeout).Duration(),
 		Time:                  options.NonNegativeDuration("keepalive_ping_time", timeout).Duration(),
 		Timeout:               timeout.Duration(),
 	}))
-	os = append(os, grpc.ConnectionTimeout(options.NonNegativeDuration("connection_timeout", timeout).Duration()))
+	serverOptions = append(serverOptions, grpc.ConnectionTimeout(options.NonNegativeDuration("connection_timeout", timeout).Duration()))
 	if _, ok := options["max_concurrent_streams"]; ok {
-		os = append(os, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 0)))
+		serverOptions = append(serverOptions, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 0)))
 	}
 
 	if _, ok := options["max_header_list_size"]; ok {
-		os = append(os, grpc.MaxHeaderListSize(options.Uint32Size("max_header_list_size", 0)))
+		serverOptions = append(serverOptions, grpc.MaxHeaderListSize(options.Uint32Size("max_header_list_size", 0)))
 	}
 
 	if _, ok := options["initial_window_size"]; ok {
-		os = append(os, grpc.InitialWindowSize(options.Int32Size("initial_window_size", 0)))
+		serverOptions = append(serverOptions, grpc.InitialWindowSize(options.Int32Size("initial_window_size", 0)))
 	}
 
 	if _, ok := options["initial_conn_window_size"]; ok {
-		os = append(os, grpc.InitialConnWindowSize(options.Int32Size("initial_conn_window_size", 0)))
+		serverOptions = append(serverOptions, grpc.InitialConnWindowSize(options.Int32Size("initial_conn_window_size", 0)))
 	}
 
 	if _, ok := options["max_send_msg_size"]; ok {
-		os = append(os, grpc.MaxSendMsgSize(options.IntSize("max_send_msg_size", 0)))
+		serverOptions = append(serverOptions, grpc.MaxSendMsgSize(options.IntSize("max_send_msg_size", 0)))
 	}
-	os = append(os, opts...)
+	serverOptions = append(serverOptions, opts...)
 
-	server := grpc.NewServer(os...)
+	server := grpc.NewServer(serverOptions...)
 	// security: reflection is intentionally always enabled for go-service
 	// servers so internal tooling can discover registered services. Restrict
 	// public exposure at the network/auth boundary when needed.

--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -22,11 +22,11 @@ import (
 // values ahead of the resolved value.
 func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		md, ua, id := clientMetadata(ctx, userAgent, generator)
+		md, ua, requestID := clientMetadata(ctx, userAgent, generator)
 
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
-			meta.WithRequestID(id),
+			meta.WithRequestID(requestID),
 			meta.WithServiceMethod(meta.Ignored(fullMethod)),
 		)
 		ctx = NewOutgoingContext(ctx, md)
@@ -45,11 +45,11 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 // values ahead of the resolved value.
 func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		md, ua, id := clientMetadata(ctx, userAgent, generator)
+		md, ua, requestID := clientMetadata(ctx, userAgent, generator)
 
 		ctx = meta.WithAttributes(ctx,
 			meta.WithUserAgent(ua),
-			meta.WithRequestID(id),
+			meta.WithRequestID(requestID),
 			meta.WithServiceMethod(meta.Ignored(fullMethod)),
 		)
 		ctx = NewOutgoingContext(ctx, md)
@@ -60,14 +60,14 @@ func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) gr
 func clientMetadata(ctx context.Context, userAgent env.UserAgent, generator id.Generator) (Map, meta.Value, meta.Value) {
 	md, ok := FromOutgoingContext(ctx)
 	ua := clientUserAgent(ctx, md, userAgent)
-	id := clientRequestID(ctx, generator, md)
+	requestID := clientRequestID(ctx, generator, md)
 	if !ok {
-		return clientOutgoingHeaders(ua.Value(), id.Value()), ua, id
+		return clientOutgoingHeaders(ua.Value(), requestID.Value()), ua, requestID
 	}
 
-	setClientOutgoingHeaders(md, ua.Value(), id.Value())
+	setClientOutgoingHeaders(md, ua.Value(), requestID.Value())
 
-	return md, ua, id
+	return md, ua, requestID
 }
 
 func clientOutgoingHeaders(userAgent, requestID string) Map {
@@ -100,11 +100,11 @@ func clientUserAgent(ctx context.Context, md metadata.MD, userAgent env.UserAgen
 }
 
 func clientRequestID(ctx context.Context, generator id.Generator, md metadata.MD) meta.Value {
-	if id := meta.RequestID(ctx); !id.IsEmpty() {
-		return id
+	if requestID := meta.RequestID(ctx); !requestID.IsEmpty() {
+		return requestID
 	}
-	if id := md.Get("request-id"); len(id) > 0 && !strings.IsEmpty(id[0]) {
-		return meta.String(id[0])
+	if requestID := md.Get("request-id"); len(requestID) > 0 && !strings.IsEmpty(requestID[0]) {
+		return meta.String(requestID[0])
 	}
 
 	return meta.String(generator.Generate())

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -47,7 +47,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 		ua := serverUserAgent(ctx, userAgent)
 		id := serverRequestID(ctx, generator)
 
-		kind, ip := serverIPAddr(ctx)
+		ipKind, ipAddr := serverIPAddr(ctx)
 		geolocation := serverGeolocation(ctx)
 
 		auth, err := serverAuthorization(ctx)
@@ -58,8 +58,8 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
 			meta.WithServiceMethod(meta.Ignored(info.FullMethod)),
-			meta.WithIPAddr(ip),
-			meta.WithIPAddrKind(kind),
+			meta.WithIPAddr(ipAddr),
+			meta.WithIPAddrKind(ipKind),
 			meta.WithGeolocation(geolocation),
 			meta.WithAuthorization(auth),
 		)
@@ -86,7 +86,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 
 		id := serverRequestID(ctx, generator)
 
-		kind, ip := serverIPAddr(ctx)
+		ipKind, ipAddr := serverIPAddr(ctx)
 		geolocation := serverGeolocation(ctx)
 
 		// Operation streams still need metadata for limiting, but they keep the same auth bypass as unary
@@ -105,8 +105,8 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
 			meta.WithServiceMethod(meta.Ignored(info.FullMethod)),
-			meta.WithIPAddr(ip),
-			meta.WithIPAddrKind(kind),
+			meta.WithIPAddr(ipAddr),
+			meta.WithIPAddrKind(ipKind),
 			meta.WithGeolocation(geolocation),
 			meta.WithAuthorization(auth),
 		)

--- a/net/grpc/server/server.go
+++ b/net/grpc/server/server.go
@@ -27,7 +27,7 @@ type Service = server.Service
 //
 // Parameters:
 //   - name: a logical service name used for logging/identification.
-//   - grpc: the already-configured gRPC server instance (services registered,
+//   - grpcServer: the already-configured gRPC server instance (services registered,
 //     interceptors/credentials/stats handlers configured, etc.).
 //   - cfg: gRPC bind configuration; cfg.Address is expected to be in the
 //     go-service network address format (for example "tcp://:9090").
@@ -35,8 +35,8 @@ type Service = server.Service
 //   - sh: a shutdown coordinator used to signal application shutdown.
 //
 // Returns an error if the listener cannot be created.
-func NewService(name string, grpc *grpc.Server, cfg *config.Config, logger *logger.Logger, sh di.Shutdowner) (*Service, error) {
-	serv, err := NewServer(grpc, cfg)
+func NewService(name string, grpcServer *grpc.Server, cfg *config.Config, logger *logger.Logger, sh di.Shutdowner) (*Service, error) {
+	serv, err := NewServer(grpcServer, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -72,7 +72,7 @@ func TestSafeErrorf(t *testing.T) {
 	require.NotContains(t, s.Message(), "secret database failure")
 	require.ErrorIs(t, err, cause)
 
-	unwrapper, ok := err.(interface{ Unwrap() error })
+	unwrapper, ok := err.(unwrapper)
 	require.True(t, ok)
 	require.Contains(t, unwrapper.Unwrap().Error(), "load tenant tenant-1")
 }
@@ -85,7 +85,7 @@ func TestSafeErrorfWithoutCause(t *testing.T) {
 	require.Equal(t, codes.Internal, s.Code())
 	require.Equal(t, "grpc: internal", s.Message())
 
-	unwrapper, ok := err.(interface{ Unwrap() error })
+	unwrapper, ok := err.(unwrapper)
 	require.True(t, ok)
 	require.EqualError(t, unwrapper.Unwrap(), "load tenant tenant-1")
 }
@@ -100,7 +100,7 @@ func TestSafeErrorfWithoutFormat(t *testing.T) {
 	require.Equal(t, "grpc: internal", s.Message())
 	require.ErrorIs(t, err, cause)
 
-	unwrapper, ok := err.(interface{ Unwrap() error })
+	unwrapper, ok := err.(unwrapper)
 	require.True(t, ok)
 	require.Same(t, cause, unwrapper.Unwrap())
 }
@@ -128,4 +128,8 @@ func TestErrorIs(t *testing.T) {
 	target := status.Error(codes.NotFound, "missing")
 
 	require.ErrorIs(t, err, target)
+}
+
+type unwrapper interface {
+	Unwrap() error
 }

--- a/net/header/doc.go
+++ b/net/header/doc.go
@@ -7,5 +7,5 @@
 // extracted IPs for access logs, policy, or rate limiting should only receive traffic through trusted edge
 // infrastructure that strips or overwrites client-supplied forwarding headers.
 //
-// Start with `ParseBearer` and `ForwardedIPs`.
+// Start with [ParseBearer] and [ForwardedIPs].
 package header

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -26,14 +26,16 @@ type ClientOption interface {
 // Redirect configures how Client handles HTTP redirects.
 type Redirect int
 
-// RedirectFollow follows redirects using the standard library default policy.
-const RedirectFollow Redirect = iota
+const (
+	// RedirectFollow follows redirects using the standard library default policy.
+	RedirectFollow Redirect = iota
 
-// RedirectIgnore returns redirect responses without following them.
-const RedirectIgnore Redirect = 1
+	// RedirectIgnore returns redirect responses without following them.
+	RedirectIgnore
 
-// RedirectSameOrigin follows redirects only when scheme and host are unchanged.
-const RedirectSameOrigin Redirect = 2
+	// RedirectSameOrigin follows redirects only when scheme and host are unchanged.
+	RedirectSameOrigin
+)
 
 type clientOpts struct {
 	roundTripper    http.RoundTripper
@@ -102,17 +104,17 @@ func WithRedirect(redirect Redirect) ClientOption {
 //
 // Callers should treat the returned Client as safe for concurrent use.
 func NewClient(content *content.Content, pool *sync.BufferPool, opts ...ClientOption) *Client {
-	os := options(opts...)
-	client := http.NewClient(os.roundTripper, os.timeout)
+	clientOptions := options(opts...)
+	client := http.NewClient(clientOptions.roundTripper, clientOptions.timeout)
 
-	switch os.redirect {
+	switch clientOptions.redirect {
 	case RedirectIgnore:
 		client.CheckRedirect = http.IgnoreRedirect
 	case RedirectSameOrigin:
 		client.CheckRedirect = http.SameOriginRedirect
 	}
 
-	return &Client{client: client, content: content, pool: pool, maxResponseSize: os.maxResponseSize.Bytes()}
+	return &Client{client: client, content: content, pool: pool, maxResponseSize: clientOptions.maxResponseSize.Bytes()}
 }
 
 // Options describes the request/response payloads and content type for a single call.
@@ -211,17 +213,17 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 //     selected by the response Content-Type (falling back to opts.ContentType if absent).
 //
 // Notes:
-//   - callers may pass the zero Options value when no request/response bodies are needed.
+//   - Callers may pass the zero Options value when no request/response bodies are needed.
 //   - This method buffers response bodies in memory up to the configured limit.
 //
 //nolint:cyclop
 func (c *Client) Do(ctx context.Context, method, url string, opts Options) error {
-	mediaType := c.content.NewFromMedia(opts.ContentType)
+	requestMedia := c.content.NewFromMedia(opts.ContentType)
 
 	body := io.Reader(http.NoBody)
 	if opts.HasRequest() {
 		var requestBody bytes.Buffer
-		if err := mediaType.Encoder.Encode(&requestBody, opts.Request); err != nil {
+		if err := requestMedia.Encoder.Encode(&requestBody, opts.Request); err != nil {
 			return errors.Prefix("http: encode", err)
 		}
 
@@ -235,7 +237,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 		return errors.Prefix("http: new request", err)
 	}
 
-	request.Header.Set(content.TypeKey, mediaType.String())
+	request.Header.Set(content.TypeKey, requestMedia.String())
 
 	response, err := c.client.Do(request)
 	if err != nil {
@@ -255,8 +257,8 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	contentType := cmp.Or(response.Header.Get(content.TypeKey), opts.ContentType)
 
 	// The server handlers return text/error to indicate an error.
-	media := c.content.NewFromMedia(contentType)
-	if media.IsError() {
+	responseMedia := c.content.NewFromMedia(contentType)
+	if responseMedia.IsError() {
 		code := response.StatusCode
 		if !isErrorStatus(code) {
 			code = http.StatusInternalServerError
@@ -270,7 +272,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	}
 
 	if opts.HasResponse() {
-		if err := media.Encoder.Decode(responseBody, opts.Response); err != nil {
+		if err := responseMedia.Encoder.Decode(responseBody, opts.Response); err != nil {
 			return errors.Prefix("http: decode", err)
 		}
 	}
@@ -296,22 +298,22 @@ func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {
 }
 
 func options(opts ...ClientOption) *clientOpts {
-	os := &clientOpts{redirect: RedirectSameOrigin}
+	clientOptions := &clientOpts{redirect: RedirectSameOrigin}
 	for _, o := range opts {
-		o.apply(os)
+		o.apply(clientOptions)
 	}
 
-	if os.timeout <= 0 {
-		os.timeout = time.DefaultTimeout
+	if clientOptions.timeout <= 0 {
+		clientOptions.timeout = time.DefaultTimeout
 	}
 
-	if os.maxResponseSize <= 0 {
-		os.maxResponseSize = bytes.DefaultSize
+	if clientOptions.maxResponseSize <= 0 {
+		clientOptions.maxResponseSize = bytes.DefaultSize
 	}
 
-	if os.roundTripper == nil {
-		os.roundTripper = http.Transport(nil)
+	if clientOptions.roundTripper == nil {
+		clientOptions.roundTripper = http.Transport(nil)
 	}
 
-	return os
+	return clientOptions
 }

--- a/net/http/rest/doc.go
+++ b/net/http/rest/doc.go
@@ -27,6 +27,6 @@
 //
 // # Registration requirement
 //
-// Register must be called before using any server or client helpers in this package; otherwise globals will be nil and
-// handler/client construction will panic.
+// Register must be called before using any server or client helpers in this package.
+// Otherwise globals will be nil and handler/client construction will panic.
 package rest

--- a/net/http/rpc/doc.go
+++ b/net/http/rpc/doc.go
@@ -28,6 +28,6 @@
 //
 // # Registration requirement
 //
-// Register must be called before using any server or client helpers in this package; otherwise globals will be nil and
-// handler/client construction will panic.
+// Register must be called before using any server or client helpers in this package.
+// Otherwise globals will be nil and handler/client construction will panic.
 package rpc

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -40,7 +40,7 @@ func TestSplitAndJoinHostPort(t *testing.T) {
 	require.Equal(t, "localhost:9000", net.JoinHostPort(host, port))
 }
 
-func TestNetworkAddress(t *testing.T) {
+func TestSplitNetworkAddress(t *testing.T) {
 	network, address, ok := net.SplitNetworkAddress("tcp://localhost:9000")
 	require.True(t, ok)
 	require.Equal(t, "tcp", network)

--- a/net/server/doc.go
+++ b/net/server/doc.go
@@ -7,17 +7,17 @@
 //
 // The main abstractions are:
 //
-//   - Server: a minimal interface describing a runnable server that can be gracefully shut down.
+//   - [Server]: a minimal interface describing a runnable server that can be gracefully shut down.
 //
-//   - Service: a small lifecycle manager that starts a Server asynchronously,
+//   - [Service]: a small lifecycle manager that starts a [Server] asynchronously,
 //     logs start/stop events, and triggers application shutdown with
 //     os.ExitCodeServeFailure when the underlying Server.Serve returns an error.
 //
 // # Typical usage
 //
-// Transport-specific packages construct a concrete implementation of Server (wrapping a net/http.Server
-// or grpc.Server), then wrap it in a Service and call Service.Start during application startup.
-// On shutdown, the application stops the underlying server by calling Service.Stop with a context.
+// Transport-specific packages construct a concrete implementation of [Server] (wrapping a net/http.Server
+// or grpc.Server), then wrap it in a [Service] and call [Service.Start] during application startup.
+// On shutdown, the application stops the underlying server by calling [Service.Stop] with a context.
 //
-// Start with `Server`, `Service`, and `Register`.
+// Start with [Server], [Service], and [Register].
 package server

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -31,8 +31,8 @@ func TestRegisterStopErrors(t *testing.T) {
 	require.ErrorIs(t, err, secondErr)
 	require.ErrorContains(t, err, "first: failed")
 	require.ErrorContains(t, err, "second: other failed")
-	require.Equal(t, 1, first.Shutdowns)
-	require.Equal(t, 1, second.Shutdowns)
+	require.Equal(t, 1, first.Shutdowns, "first shutdowns")
+	require.Equal(t, 1, second.Shutdowns, "second shutdowns")
 }
 
 func TestRegisterStartsAllServices(t *testing.T) {
@@ -51,8 +51,8 @@ func TestRegisterStartsAllServices(t *testing.T) {
 	waitForRegisteredService(t, second.Done)
 
 	require.NoError(t, lc.Stop(t.Context()))
-	require.Equal(t, 1, first.Shutdowns)
-	require.Equal(t, 1, second.Shutdowns)
+	require.Equal(t, 1, first.Shutdowns, "first shutdowns")
+	require.Equal(t, 1, second.Shutdowns, "second shutdowns")
 }
 
 func TestRegisterSnapshotsServices(t *testing.T) {
@@ -68,15 +68,11 @@ func TestRegisterSnapshotsServices(t *testing.T) {
 	services[0] = server.NewService("replacement", replacement, nil, sh)
 
 	require.NoError(t, lc.Start(t.Context()))
-	select {
-	case <-original.Done:
-	case <-time.After(time.Second):
-		require.Fail(t, "registered service was not started")
-	}
+	waitForRegisteredService(t, original.Done)
 
 	require.NoError(t, lc.Stop(t.Context()))
-	require.Equal(t, 1, original.Shutdowns)
-	require.Equal(t, 0, replacement.Shutdowns)
+	require.Equal(t, 1, original.Shutdowns, "original shutdowns")
+	require.Equal(t, 0, replacement.Shutdowns, "replacement shutdowns")
 }
 
 func waitForRegisteredService(t *testing.T, done <-chan struct{}) {

--- a/net/server/service_test.go
+++ b/net/server/service_test.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestInvalidServer(t *testing.T) {
+func TestStartRequestsShutdownOnServeError(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	l, err := test.NewLogger(lc, test.NewJSONLoggerConfig())
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestInvalidServer(t *testing.T) {
 	require.True(t, sh.Called())
 }
 
-func TestValidServer(t *testing.T) {
+func TestStartDoesNotShutdownOnNilServeReturn(t *testing.T) {
 	sh := test.NewShutdowner()
 	srv := test.NewObservableServer(nil, nil)
 	svc := server.NewService("test", srv, nil, sh)

--- a/net/url/url_test.go
+++ b/net/url/url_test.go
@@ -25,12 +25,12 @@ func TestSplitPath(t *testing.T) {
 		{name: "empty", path: ""},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			first, rest, ok := url.SplitPath(test.path)
-			require.Equal(t, test.first, first)
-			require.Equal(t, test.rest, rest)
-			require.Equal(t, test.ok, ok)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first, rest, ok := url.SplitPath(tt.path)
+			require.Equal(t, tt.first, first)
+			require.Equal(t, tt.rest, rest)
+			require.Equal(t, tt.ok, ok)
 		})
 	}
 }


### PR DESCRIPTION
## What

- Add GoDoc links across networking package overviews and wrap long REST/RPC registration docs.
- Rename terse networking locals and group redirect constants for easier scanning.
- Clarify net, URL, server lifecycle, and gRPC status tests with better names and helper reuse.

## Why

- Improve generated documentation navigation and make networking helper code and tests easier to read.

## Testing

- `go test ./net/...` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
