### PR TITLE
feat(os): polish filesystem documentation links

### DIFF
--- a/os/doc.go
+++ b/os/doc.go
@@ -7,42 +7,42 @@
 //
 // # Filesystem wrapper
 //
-// The primary type in this package is FS, a thin wrapper around an avfs.VFS that
-// provides go-service-specific helpers:
+// The primary type in this package is [FS], a thin wrapper around an avfs.VFS
+// that provides go-service-specific helpers:
 //
 //   - Path normalization:
-//     FS.CleanPath expands a leading "~" (when present) and then cleans the path.
-//     FS.ReadFile and FS.WriteFile call CleanPath before accessing the filesystem.
+//     [FS.CleanPath] expands a leading "~" (when present) and then cleans the path.
+//     [FS.ReadFile] and [FS.WriteFile] call [FS.CleanPath] before accessing the filesystem.
 //
 //   - Trimming behavior:
-//     FS.ReadFile trims leading/trailing whitespace from the bytes it returns.
-//     FS.WriteFile trims leading/trailing whitespace from the bytes it writes.
+//     [FS.ReadFile] trims leading/trailing whitespace from the bytes it returns.
+//     [FS.WriteFile] trims leading/trailing whitespace from the bytes it writes.
 //     This is convenient for reading and writing configuration fragments and
 //     secrets where trailing newlines are common (for example when sourced from
 //     files created by tooling).
 //
 //   - Existence and errors:
-//     FS.PathExists reports whether a path exists.
-//     FS.IsNotExist reports whether an error represents a missing path.
+//     [FS.PathExists] reports whether a path exists.
+//     [FS.IsNotExist] reports whether an error represents a missing path.
 //
 //   - Path helpers:
-//     FS.PathExtension returns the file extension without the leading dot.
-//     FS.ExecutableName and FS.ExecutableDir derive values from the running
+//     [FS.PathExtension] returns the file extension without the leading dot.
+//     [FS.ExecutableName] and [FS.ExecutableDir] derive values from the running
 //     executable.
 //
-// NewFS constructs an FS backed by the real OS filesystem.
+// [NewFS] constructs an [FS] backed by the real OS filesystem.
 //
-// # “Source string” pattern
+// # "Source string" pattern
 //
-// FS.ReadSource implements the go-service “source string” convention, which
+// [FS.ReadSource] implements the go-service "source string" convention, which
 // allows configuration to reference values that may come from different sources.
 // Supported forms are:
 //
 //   - "env:NAME"    reads the value of environment variable NAME. If NAME is
-//     unset (or omitted entirely as "env:"), FS.ReadSource returns
-//     ErrEnvSourceMissing. If NAME is explicitly set to the empty string, it
+//     unset (or omitted entirely as "env:"), [FS.ReadSource] returns
+//     [ErrEnvSourceMissing]. If NAME is explicitly set to the empty string, it
 //     resolves to empty bytes.
-//   - "file:/path"  reads bytes from the file at /path (via FS.ReadFile,
+//   - "file:/path"  reads bytes from the file at /path (via [FS.ReadFile],
 //     including path cleaning and trimming).
 //   - otherwise     treats the string as the literal value.
 //
@@ -54,9 +54,9 @@
 // Some OS directory helpers are intentionally strict and will panic on unexpected
 // OS errors by using runtime.Must:
 //
-//   - Executable
-//   - UserHomeDir
-//   - UserConfigDir
+//   - [Executable]
+//   - [UserHomeDir]
+//   - [UserConfigDir]
 //
 // This design assumes that inability to determine these values is not a
 // recoverable runtime condition for typical service operation. If your use case
@@ -66,12 +66,13 @@
 // # Relationship to the standard library
 //
 // Several identifiers are thin wrappers or aliases of the standard library
-// package os (for example Getenv/LookupEnv/Setenv/Unsetenv, Exit, Args, Stdout).
-// They exist to keep go-service code depending on go-service packages
-// consistently, while still delegating to the underlying OS implementation.
+// package os (for example [Getenv], [LookupEnv], [Setenv], [Unsetenv], [Exit],
+// [Args], and [Stdout]). They exist to keep go-service code depending on
+// go-service packages consistently, while still delegating to the underlying OS
+// implementation.
 //
 // # Process exit codes
 //
-// ExitCodeSuccess, ExitCodeFailure, and ExitCodeServeFailure provide shared
+// [ExitCodeSuccess], [ExitCodeFailure], and [ExitCodeServeFailure] provide shared
 // process exit-code meanings for CLI and server lifecycle code.
 package os

--- a/os/fs.go
+++ b/os/fs.go
@@ -51,9 +51,10 @@ func NewFS() *FS {
 //
 // FS is intended to be used anywhere go-service needs filesystem access, while
 // also providing:
-//   - consistent path normalization (CleanPath / ExpandPath),
-//   - convenience helpers (ExecutableName / ExecutableDir / PathExtension),
-//   - and "source string" loading (ReadSource).
+//   - consistent path normalization ([FS.CleanPath] / [FS.ExpandPath]),
+//   - convenience helpers
+//     ([FS.ExecutableName] / [FS.ExecutableDir] / [FS.PathExtension]),
+//   - and "source string" loading ([FS.ReadSource]).
 //
 // The embedded avfs.VFS exposes a rich filesystem API; FS adds small, opinionated
 // behavior on top (notably whitespace trimming for ReadFile/WriteFile).

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -10,21 +10,19 @@ import (
 )
 
 func TestReadFile(t *testing.T) {
-	for _, path := range []string{"none"} {
-		t.Run(path, func(t *testing.T) {
-			_, err := test.FS.ReadFile(path)
-			require.Error(t, err)
+	path := "none"
 
-			require.True(t, test.FS.IsNotExist(err))
-			require.False(t, test.FS.PathExists(path))
-		})
-	}
+	_, err := test.FS.ReadFile(path)
+	require.Error(t, err)
+
+	require.True(t, test.FS.IsNotExist(err))
+	require.False(t, test.FS.PathExists(path))
 }
 
 func TestPathExtension(t *testing.T) {
-	for _, f := range []string{"file.yaml", "file.test.yaml", "test/.config/existing.client.yaml"} {
-		t.Run(f, func(t *testing.T) {
-			require.Equal(t, "yaml", test.FS.PathExtension(f))
+	for _, path := range []string{"file.yaml", "file.test.yaml", "test/.config/existing.client.yaml"} {
+		t.Run(path, func(t *testing.T) {
+			require.Equal(t, "yaml", test.FS.PathExtension(path))
 		})
 	}
 


### PR DESCRIPTION
## What

- Link filesystem helper references in package documentation and comments.
- Simplify the missing-file test shape and rename the path extension loop variable.

## Why

- Make rendered package docs easier to navigate and keep the tests a little easier to read.

## Testing

- `go test ./os` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
