### PR TITLE
feat(ptr): remove value helper

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -35,7 +35,7 @@ func TestGenericValidCache(t *testing.T) {
 	config := test.NewCacheConfig("sync", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())
 
-	require.NoError(t, cache.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute))
+	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
 	value, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestModuleRegistersGenericCache(t *testing.T) {
 		require.NoError(t, app.Stop(context.Background()))
 	})
 
-	require.NoError(t, cache.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute))
+	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
 	value, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestModuleRegistersGenericCache(t *testing.T) {
 func TestGenericDisabledCache(t *testing.T) {
 	cache.Register(nil)
 
-	require.NoError(t, cache.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute))
+	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
 	value, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestMaxSizeOnPersist(t *testing.T) {
 	cfg.MaxSize = 4
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
-	err := world.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute)
+	err := world.Persist(t.Context(), "test", new("hello?"), time.Minute)
 	require.ErrorIs(t, err, errors.ErrTooLarge)
 }
 
@@ -100,7 +100,7 @@ func TestMaxSizeOnPersistCompressedValue(t *testing.T) {
 	cfg.MaxSize = 4
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
-	err := world.Persist(t.Context(), "test", ptr.Value("a"), time.Minute)
+	err := world.Persist(t.Context(), "test", new("a"), time.Minute)
 	require.ErrorIs(t, err, errors.ErrTooLarge)
 }
 
@@ -108,7 +108,7 @@ func TestMaxSizeOnGet(t *testing.T) {
 	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
-	require.NoError(t, world.Persist(t.Context(), "test", ptr.Value("hello?"), time.Minute))
+	require.NoError(t, world.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
 	cfg.MaxSize = 4
 
@@ -157,7 +157,7 @@ func TestMaxSizeOnGetAllowsHugeConfiguredLimit(t *testing.T) {
 func TestExpiredCache(t *testing.T) {
 	config := test.NewCacheConfig("sync", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())
-	require.NoError(t, cache.Persist(t.Context(), "test", ptr.Value("hello?"), time.Nanosecond))
+	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Nanosecond))
 
 	// Simulate expiry.
 	time.Sleep(time.Second)
@@ -210,7 +210,7 @@ func TestErroneousSave(t *testing.T) {
 	t.Run("invalid encoder", func(t *testing.T) {
 		config := test.NewCacheConfig("sync", "snappy", "error", "redis")
 		test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())
-		require.Error(t, cache.Persist(t.Context(), "test", ptr.Value("test"), time.Minute))
+		require.Error(t, cache.Persist(t.Context(), "test", new("test"), time.Minute))
 	})
 
 	t.Run("read from only falls back to configured encoder", func(t *testing.T) {
@@ -314,7 +314,7 @@ func cacheRoundTripCases() []cacheRoundTripCase {
 		{
 			name:    "sync/default/string",
 			config:  test.NewCacheConfig("sync", strings.Empty, strings.Empty, "redis"),
-			persist: func() any { return ptr.Value("hello?") },
+			persist: func() any { return new("hello?") },
 			get:     func() any { return ptr.Zero[string]() },
 		},
 		{

--- a/ptr/doc.go
+++ b/ptr/doc.go
@@ -6,18 +6,14 @@
 //
 // # Helpers
 //
-// Zero returns a pointer to the zero value of T:
+// [Zero] returns a pointer to the zero value of T:
 //
 //	var p *int = ptr.Zero[int]() // points to 0
 //
-// Value returns a pointer to the provided value:
-//
-//	p := ptr.Value("hello") // *string
-//
 // # Semantics and pitfalls
 //
-// These helpers allocate storage for the pointed-to value and return a pointer to
-// that storage. Each call returns a distinct pointer.
+// This helper allocates storage for the pointed-to zero value and returns a
+// pointer to that storage. Each call returns a distinct pointer.
 //
 // For example, two calls produce two different pointers even if the values are equal:
 //
@@ -37,7 +33,6 @@
 //
 //	p := &MyStruct{Field: "x"}
 //
-// This package is best used when you need a pointer but don't have an addressable
-// value at the call site or you want a concise, generic helper in tests and
+// This package is best used when you need a pointer to a zero value in tests or
 // configuration wiring.
 package ptr

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -4,23 +4,7 @@ package ptr
 //
 // This helper allocates storage for a zero value of T and returns a pointer to it.
 // Each call returns a distinct pointer.
-//
-// Example:
-//
-//	p := ptr.Zero[int]() // points to 0
 func Zero[T any]() *T {
 	var t T
 	return &t
-}
-
-// Value returns a pointer to t.
-//
-// This helper allocates storage for the provided value and returns a pointer to it.
-// Each call returns a distinct pointer, even if the values are equal.
-//
-// Example:
-//
-//	p := ptr.Value("hello") // *string pointing to "hello"
-func Value[T any](t T) *T {
-	return new(t)
 }

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
-	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +76,7 @@ func TestBackward(t *testing.T) {
 }
 
 func TestElemFunc(t *testing.T) {
-	elems := []*string{ptr.Value("test")}
+	elems := []*string{new("test")}
 
 	elem, ok := slices.ElemFunc(elems, func(t *string) bool { return *t == "test" })
 	require.NotNil(t, elem)


### PR DESCRIPTION
## What

- Remove the generic Value helper from pointer helpers.
- Replace test call sites with built-in new expressions and update package docs for the remaining Zero helper.

## Why

- The built-in new expression covers pointer-to-value test setup and satisfies modernize lint without an extra wrapper API.

## Testing

- `go test ./ptr ./cache ./slices` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
