### PR TITLE
feat(reflect): link helper docs and table tests

### DIFF
--- a/reflect/doc.go
+++ b/reflect/doc.go
@@ -1,6 +1,6 @@
 // Package reflect provides small reflection helpers for go-service.
 //
-// The helpers in this package are intended to wrap common reflection patterns
-// behind focused, documented APIs so call sites do not need to repeat subtle
+// The [IsNil] and [IsZero] helpers wrap common reflection patterns behind
+// focused, documented APIs so call sites do not need to repeat subtle
 // interface/value checks.
 package reflect

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -9,33 +9,42 @@ import (
 )
 
 func TestIsNil(t *testing.T) {
-	require.True(t, reflect.IsNil(nil))
-}
-
-func TestIsNilWithTypedNil(t *testing.T) {
 	var err error = (*test.NilError)(nil)
 
-	require.True(t, reflect.IsNil(err))
-}
+	tests := []struct {
+		value any
+		name  string
+		want  bool
+	}{
+		{name: "nil", value: nil, want: true},
+		{name: "typed nil", value: err, want: true},
+		{name: "value", value: "value"},
+		{name: "kind that cannot be nil", value: 42},
+	}
 
-func TestIsNilWithValue(t *testing.T) {
-	require.False(t, reflect.IsNil("value"))
-}
-
-func TestIsNilWithNonNillableKind(t *testing.T) {
-	require.False(t, reflect.IsNil(42))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, reflect.IsNil(tt.value))
+		})
+	}
 }
 
 func TestIsZero(t *testing.T) {
-	require.True(t, reflect.IsZero(nil))
-}
-
-func TestIsZeroWithTypedNil(t *testing.T) {
 	var err error = (*test.NilError)(nil)
 
-	require.True(t, reflect.IsZero(err))
-}
+	tests := []struct {
+		value any
+		name  string
+		want  bool
+	}{
+		{name: "nil", value: nil, want: true},
+		{name: "typed nil", value: err, want: true},
+		{name: "value", value: "value"},
+	}
 
-func TestIsZeroWithValue(t *testing.T) {
-	require.False(t, reflect.IsZero("value"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, reflect.IsZero(tt.value))
+		})
+	}
 }


### PR DESCRIPTION
## What

- Link the reflection helper names from the package documentation.
- Convert the helper tests to table-driven subtests with clearer case names.

## Why

- Make rendered docs easier to navigate and keep the supported nil/zero scenarios easier to scan.

## Testing

- `go test ./reflect` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
