### PR TITLE
feat(retry): clarify wrapper docs

### DIFF
--- a/retry/doc.go
+++ b/retry/doc.go
@@ -1,6 +1,7 @@
 // Package retry provides shared retry helpers for go-service.
 //
-// It wraps the repository's retry/backoff implementation behind the go-service
-// import path so transport packages can share retry semantics without importing
-// third-party retry primitives directly.
+// It wraps retry/backoff helpers such as [Backoff], [NewConstant],
+// [WithMaxRetries], [Do], and [DoValue] behind the go-service import path so
+// transport packages can share retry semantics without importing third-party
+// retry primitives directly.
 package retry

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -16,8 +16,8 @@ type RetryFunc = retry.RetryFunc
 type RetryFuncValue[T any] = retry.RetryFuncValue[T]
 
 // NewConstant creates a constant backoff.
-func NewConstant(t time.Duration) Backoff {
-	return retry.NewConstant(t.Duration())
+func NewConstant(duration time.Duration) Backoff {
+	return retry.NewConstant(duration.Duration())
 }
 
 // RetryableError marks err as retryable.
@@ -25,7 +25,7 @@ func RetryableError(err error) error {
 	return retry.RetryableError(err)
 }
 
-// WithMaxRetries limits next to attempts retries after the initial attempt.
+// WithMaxRetries wraps next so it retries at most attempts times after the initial attempt.
 func WithMaxRetries(attempts uint64, next Backoff) Backoff {
 	return retry.WithMaxRetries(attempts, next)
 }


### PR DESCRIPTION
## What

- Link retry wrapper helpers from the package documentation.
- Rename the constant-backoff duration parameter and clarify the max-retries comment.

## Why

- Make rendered docs easier to navigate and keep wrapper comments easier to scan.

## Testing

- `go test ./retry` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
