### PR TITLE
feat(runtime): link docs and simplify recovery tests

### DIFF
--- a/runtime/doc.go
+++ b/runtime/doc.go
@@ -1,23 +1,24 @@
 // Package runtime provides small runtime-oriented helpers used by go-service.
 //
 // The package is intentionally small and focused. It contains:
-//   - strict helpers for startup/config paths (Must),
-//   - panic recovery conversion helpers (ConvertRecover and ErrRecovered),
-//   - build/runtime metadata helpers (Version),
-//   - optional runtime tuning integration (RegisterMemLimit), and
-//   - an Fx wiring module (Module) to register runtime integrations.
+//   - strict helpers for startup/config paths ([Must]),
+//   - panic recovery conversion helpers ([ConvertRecover] and [ErrRecovered]),
+//   - build/runtime metadata helpers ([Version]),
+//   - optional runtime tuning integration ([RegisterMemLimit]), and
+//   - an Fx wiring module ([Module]) to register runtime integrations.
 //
 // # Error handling helpers
 //
-// Must is intended for code paths where failure is not meaningfully recoverable
+// [Must] is intended for code paths where failure is not meaningfully recoverable
 // (for example, mandatory startup wiring). It panics when given a non-nil error
 // and is commonly paired with constructors that already return an error.
 //
-// ConvertRecover is intended to be used with `recover()` in deferred functions.
+// [ConvertRecover] is intended to be used with `recover()` in deferred functions.
 // It converts an arbitrary recovered value into an error, wrapping it with
-// ErrRecovered to provide a consistent sentinel that can be detected via errors.Is.
-// The original panic value is preserved in the returned error string and, when it
-// is already an error, is wrapped so it remains available via errors.As.
+// [ErrRecovered] to provide a consistent sentinel that can be detected via
+// errors.Is. The original panic value is preserved in the returned error string
+// and, when it is already an error, is wrapped so it remains available via
+// errors.As.
 //
 // Example:
 //
@@ -33,8 +34,8 @@
 //
 // # Version reporting
 //
-// Version returns the build version of the running binary by reading build info
-// via runtime/debug.ReadBuildInfo. When build info is unavailable, Version
+// [Version] returns the build version of the running binary by reading build info
+// via runtime/debug.ReadBuildInfo. When build info is unavailable, [Version]
 // returns "development".
 //
 // Note: the exact value depends on how the binary is built. For example, builds
@@ -43,19 +44,20 @@
 //
 // # Memory limit integration (GOMEMLIMIT)
 //
-// RegisterMemLimit integrates with the upstream automemlimit library to set
+// [RegisterMemLimit] integrates with the upstream automemlimit library to set
 // Go's memory limit (GOMEMLIMIT) based on container/cgroup constraints.
 // This is typically useful in containerized deployments where the Go runtime
 // otherwise cannot infer an appropriate heap limit.
 //
-// RegisterMemLimit is best-effort: it intentionally ignores returned values and
-// errors, because failing to set a memory limit should not typically prevent a
-// service from starting.
+// [RegisterMemLimit] is best-effort: it intentionally ignores returned values
+// and errors, because failing to set a memory limit should not typically prevent
+// a service from starting.
 //
 // # Dependency injection
 //
-// Module is an Fx module that registers RegisterMemLimit, allowing services that
-// include the runtime module to apply the optional runtime tuning automatically.
+// [Module] is an Fx module that registers [RegisterMemLimit], allowing services
+// that include the runtime module to apply the optional runtime tuning
+// automatically.
 //
-// Start with Must, ConvertRecover, Version, and Module.
+// Start with [Must], [ConvertRecover], [Version], and [Module].
 package runtime

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -55,12 +55,12 @@ func Must(err error) {
 //   - string: included as text
 //   - any other value: formatted with %v
 func ConvertRecover(value any) error {
-	switch kind := value.(type) {
+	switch recovered := value.(type) {
 	case error:
-		return fmt.Errorf("%w: %w", ErrRecovered, kind)
+		return fmt.Errorf("%w: %w", ErrRecovered, recovered)
 	case string:
-		return fmt.Errorf("%w: %s", ErrRecovered, kind)
+		return fmt.Errorf("%w: %s", ErrRecovered, recovered)
 	default:
-		return fmt.Errorf("%w: %v", ErrRecovered, kind)
+		return fmt.Errorf("%w: %v", ErrRecovered, recovered)
 	}
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8,65 +8,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPanic(t *testing.T) {
+func TestMustPanicsWithError(t *testing.T) {
 	require.Panics(t, func() { runtime.Must(test.ErrFailed) })
 }
 
 func TestRecover(t *testing.T) {
-	functions := []struct {
-		fun  func(t *testing.T) (err error)
-		name string
+	tests := []struct {
+		value   any
+		name    string
+		message string
 	}{
-		{
-			name: "error",
-			fun: func(t *testing.T) (err error) {
-				t.Helper()
-
-				defer func() {
-					if r := recover(); r != nil {
-						err = runtime.ConvertRecover(r)
-						require.Equal(t, "recovered: failed", err.Error())
-					}
-				}()
-
-				panic(test.ErrFailed)
-			},
-		},
-		{
-			name: "string",
-			fun: func(t *testing.T) (err error) {
-				t.Helper()
-
-				defer func() {
-					if r := recover(); r != nil {
-						err = runtime.ConvertRecover(r)
-						require.Equal(t, "recovered: test", err.Error())
-					}
-				}()
-
-				panic("test")
-			},
-		},
-		{
-			name: "int",
-			fun: func(t *testing.T) (err error) {
-				t.Helper()
-
-				defer func() {
-					if r := recover(); r != nil {
-						err = runtime.ConvertRecover(r)
-						require.Equal(t, "recovered: 1", err.Error())
-					}
-				}()
-
-				panic(1)
-			},
-		},
+		{name: "error", value: test.ErrFailed, message: "recovered: failed"},
+		{name: "string", value: "test", message: "recovered: test"},
+		{name: "int", value: 1, message: "recovered: 1"},
 	}
 
-	for _, tt := range functions {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Error(t, tt.fun(t))
+			err := recoverPanic(tt.value)
+
+			require.Error(t, err)
+			require.Equal(t, tt.message, err.Error())
 		})
 	}
+}
+
+func recoverPanic(value any) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = runtime.ConvertRecover(recovered)
+		}
+	}()
+
+	panic(value)
 }

--- a/runtime/version.go
+++ b/runtime/version.go
@@ -4,8 +4,9 @@ import "runtime/debug"
 
 // Version returns the build version of the running binary.
 //
-// It reads build info via debug.ReadBuildInfo and returns the main module version when available.
-// If build info is unavailable, it returns "development".
+// It reads build info via [debug.ReadBuildInfo] and returns the main module
+// version when available. If build info is unavailable, it returns
+// "development".
 func Version() string {
 	info, _ := debug.ReadBuildInfo()
 	if info != nil {


### PR DESCRIPTION
## What

- Link runtime helper references in package and version documentation.
- Rename the recovered value in panic conversion and simplify recovery tests with shared table setup.

## Why

- Make rendered docs easier to navigate and keep panic recovery test cases easier to scan.

## Testing

- `go test ./runtime` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
