### PR TITLE
feat(strings): polish helper docs and tables

### DIFF
--- a/strings/benchmark_test.go
+++ b/strings/benchmark_test.go
@@ -23,13 +23,13 @@ func BenchmarkStrings(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("copy", func(b *testing.B) {
-		for n := 0; b.Loop(); n++ {
+		for b.Loop() {
 			benchmarkBytesSink = cp(s)
 		}
 	})
 
 	b.Run("convert", func(b *testing.B) {
-		for n := 0; b.Loop(); n++ {
+		for b.Loop() {
 			benchmarkBytesSink = strings.Bytes(s)
 		}
 	})

--- a/strings/doc.go
+++ b/strings/doc.go
@@ -7,38 +7,39 @@
 //     still delegating to the standard library for core string operations.
 //   - Provide a few convenience helpers that are frequently needed across the
 //     repository (for example emptiness checks and small splitting helpers).
-//   - Expose carefully documented unsafe utilities (see Bytes) for performance-
+//   - Expose carefully documented unsafe utilities (see [Bytes]) for performance-
 //     sensitive paths where avoiding allocations is important.
 //
 // Most functions in this package are thin wrappers around the corresponding
-// functions in the standard library strings package (for example Contains,
-// HasPrefix, ReplaceAll, TrimSpace) or the strcase package (for example
-// ToSnake, ToLowerCamel, ToDelimited). These wrappers do not change semantics.
+// functions in the standard library strings package (for example [Contains],
+// [HasPrefix], [ReplaceAll], [TrimSpace]) or the strcase package (for example
+// [ToSnake], [ToLowerCamel], [ToDelimited]). These wrappers do not change
+// semantics.
 //
 // # Convenience helpers
 //
 // This package also provides helpers not present in the standard library:
 //
-//   - IsEmpty / IsAnyEmpty: common emptiness checks.
+//   - [IsEmpty] / [IsAnyEmpty]: common emptiness checks.
 //
-//   - Join and Concat: Join accepts variadic strings so callers can avoid
+//   - [Join] and [Concat]: Join accepts variadic strings so callers can avoid
 //     allocating a slice at the callsite. Concat concatenates without a
 //     separator.
 //
-//   - CutColon: a small helper that splits on the first ":" using strings.Cut,
+//   - [CutColon]: a small helper that splits on the first ":" using strings.Cut,
 //     returning the part before and after. If ":" is not present, the "after"
 //     return value is empty.
 //
-//   - ToSnake / ToLowerCamel / ToDelimited: common string case conversion
+//   - [ToSnake] / [ToLowerCamel] / [ToDelimited]: common string case conversion
 //     helpers delegated to strcase.
 //
 // # Constants
 //
-// Empty and Space are provided as named constants for readability and reuse.
+// [Empty] and [Space] are provided as named constants for readability and reuse.
 //
 // # Unsafe conversions
 //
-// Bytes converts a string to a byte slice without allocation by using unsafe.
+// [Bytes] converts a string to a byte slice without allocation by using unsafe.
 //
 // Important: the returned []byte aliases the same memory as the input string.
 //

--- a/strings/strcase_test.go
+++ b/strings/strcase_test.go
@@ -7,14 +7,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestToDelimited(t *testing.T) {
-	require.Equal(t, "invalid argument", strings.ToDelimited("InvalidArgument", ' '))
-}
+func TestCaseConversion(t *testing.T) {
+	tests := []struct {
+		convert func() string
+		name    string
+		want    string
+	}{
+		{name: "delimited", convert: func() string { return strings.ToDelimited("InvalidArgument", ' ') }, want: "invalid argument"},
+		{name: "lower camel", convert: func() string { return strings.ToLowerCamel("request_id") }, want: "requestId"},
+		{name: "snake", convert: func() string { return strings.ToSnake("requestID") }, want: "request_id"},
+	}
 
-func TestToLowerCamel(t *testing.T) {
-	require.Equal(t, "requestId", strings.ToLowerCamel("request_id"))
-}
-
-func TestToSnake(t *testing.T) {
-	require.Equal(t, "request_id", strings.ToSnake("requestID"))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.convert())
+		})
+	}
 }

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -18,8 +18,8 @@ const Space = " "
 
 // Reader is an alias of strings.Reader.
 //
-// It is provided so go-service code can depend on a consistent import path while preserving
-// standard library semantics.
+// It is provided so go-service code can depend on a consistent import path while
+// preserving standard library semantics.
 type Reader = strings.Reader
 
 // Contains reports whether substr is within s.
@@ -36,14 +36,16 @@ func Count(s, substr string) int {
 	return strings.Count(s, substr)
 }
 
-// LastIndex returns the index of the last instance of substr in s, or -1 if substr is not present in s.
+// LastIndex returns the index of the last instance of substr in s, or -1 if
+// substr is not present in s.
 //
 // This is a thin wrapper around strings.LastIndex and does not change semantics.
 func LastIndex(s, substr string) int {
 	return strings.LastIndex(s, substr)
 }
 
-// Cut slices s around the first instance of sep, returning the text before and after sep.
+// Cut slices s around the first instance of sep, returning the text before and
+// after sep.
 //
 // The returned boolean reports whether sep was found.
 //
@@ -87,7 +89,8 @@ func ToLower(s string) string {
 	return strings.ToLower(s)
 }
 
-// Trim returns a slice of s with all leading and trailing Unicode code points contained in cutset removed.
+// Trim returns a slice of s with all leading and trailing Unicode code points
+// contained in cutset removed.
 //
 // This is a thin wrapper around strings.Trim and does not change semantics.
 func Trim(s, cutset string) string {


### PR DESCRIPTION
## What

- Link helper names in package documentation and reflow long wrapper comments.
- Simplify benchmark loops and table-drive the case-conversion wrapper tests.

## Why

- Make generated documentation easier to navigate and keep tests and benchmarks aligned with the local style-review cleanup.

## Testing

- ok  	github.com/alexfalkowski/go-service/v2/strings	(cached) - passed
-  - passed
- 0 issues. - passed
