### PR TITLE
feat(structs): polish pointer helper docs

### DIFF
--- a/structs/doc.go
+++ b/structs/doc.go
@@ -2,7 +2,7 @@
 // zero values.
 //
 // Despite the package name, these helpers are not limited to struct types. They
-// are intended to reduce boilerplate around common “is this value present?”
+// are intended to reduce boilerplate around common "is this value present?"
 // checks that appear throughout go-service configuration and wiring.
 //
 // # Concepts: nil, zero, and empty
@@ -11,22 +11,22 @@
 //
 //   - nil: the pointer itself is nil (no value is present).
 //
-//   - zero: a non-pointer value equals its type’s zero value (for example 0 for
+//   - zero: a non-pointer value equals its type's zero value (for example 0 for
 //     integers, "" for strings, false for bools, an empty struct value, etc.).
-//     In this package, “zero” is determined via == comparison against the zero
+//     In this package, "zero" is determined via == comparison against the zero
 //     value of the type.
 //
-//   - empty: a pointer is considered “empty” when either it is nil or it points
+//   - empty: a pointer is considered "empty" when either it is nil or it points
 //     to the zero value of its element type.
 //
 // # Functions
 //
-// IsNil reports whether a pointer is nil.
+// [IsNil] reports whether a pointer is nil.
 //
-// IsZero reports whether a value equals the zero value for its type. Because it
+// [IsZero] reports whether a value equals the zero value for its type. Because it
 // relies on ==, the type parameter must be comparable.
 //
-// IsEmpty reports whether a pointer is nil or points to a zero value.
+// [IsEmpty] reports whether a pointer is nil or points to a zero value.
 //
 // # Examples
 //
@@ -46,16 +46,14 @@
 //
 // # Notes and limitations
 //
-//   - IsZero and IsEmpty require comparable element types (T comparable). If you
-//     need “zero” semantics for non-comparable types (for example slices, maps,
-//     or structs containing non-comparable fields), you must define your own
-//     notion of emptiness or use reflection-based checks (with the usual
-//     tradeoffs).
+//   - [IsZero] and [IsEmpty] require comparable element types. For
+//     non-comparable types, define your own notion of emptiness or use
+//     reflection-based checks.
 //
-//   - For pointer types, IsEmpty treats “pointer to zero” as empty. This is
+//   - For pointer types, [IsEmpty] treats "pointer to zero" as empty. This is
 //     useful for optional configuration values where a pointer may be present
-//     but carry the default/zero value and you want to treat that as “unset”.
-//     If you need to distinguish “unset (nil)” from “explicitly set to zero”,
-//     do not use IsEmpty; check nil explicitly and handle the pointed-to value
+//     but carry the default/zero value and you want to treat that as "unset".
+//     If you need to distinguish "unset (nil)" from "explicitly set to zero",
+//     do not use [IsEmpty]; check nil explicitly and handle the pointed-to value
 //     separately.
 package structs

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -16,7 +16,7 @@ func IsNil[T any](value *T) bool {
 // IsZero reports whether value equals the zero value of T.
 //
 // Because it uses == comparison against the zero value, T must be comparable.
-// If you need “zero” semantics for non-comparable types (for example slices, maps,
+// If you need "zero" semantics for non-comparable types (for example slices, maps,
 // or structs containing non-comparable fields), define your own emptiness check.
 func IsZero[T comparable](value T) bool {
 	var zero T


### PR DESCRIPTION
## What

- Link helper names in package documentation.
- Replace smart punctuation with ASCII punctuation and tighten the repeated comparable-type note.

## Why

- Make generated documentation easier to navigate and keep the helper docs consistent with the repository style cleanup.

## Testing

- ?   	github.com/alexfalkowski/go-service/v2/structs	[no test files] - passed
-  - passed
- 0 issues. - passed
