### PR TITLE
feat(telemetry): polish signal docs and helpers

### DIFF
--- a/sync/doc.go
+++ b/sync/doc.go
@@ -3,11 +3,11 @@
 // This package now has a narrow scope: it does not re-export mutexes, maps, or
 // buffer pool types. Code that needs synchronization primitives or
 // concurrency-safe containers should import the standard library sync package or
-// github.com/alexfalkowski/go-sync directly.
+// `github.com/alexfalkowski/go-sync` directly.
 //
 // # Dependency injection (Fx)
 //
-// Module registers github.com/alexfalkowski/go-sync.NewBufferPool with the Fx
+// Module registers `github.com/alexfalkowski/go-sync.NewBufferPool` with the Fx
 // graph so packages can share a single upstream buffer pool instance.
 //
 // This shared pool is consumed by allocation-sensitive helpers such as cache
@@ -19,5 +19,5 @@
 // standard buffer pool wiring.
 //
 // If you need the concrete pool type or other synchronization helpers, import
-// github.com/alexfalkowski/go-sync directly.
+// `github.com/alexfalkowski/go-sync` directly.
 package sync

--- a/sync/module.go
+++ b/sync/module.go
@@ -8,14 +8,15 @@ import (
 // Module wires the upstream go-sync buffer pool into Fx.
 //
 // Including this module in an Fx application provides a single shared buffer
-// pool instance constructed via github.com/alexfalkowski/go-sync.NewBufferPool.
+// pool instance constructed via
+// `github.com/alexfalkowski/go-sync.NewBufferPool`.
 //
 // This is commonly used to reduce allocations across components that build or
 // transform byte payloads, such as encoders, compressors, caches, and HTTP
 // helpers.
 //
 // The provided type and its lifecycle/usage contract are defined by the
-// upstream github.com/alexfalkowski/go-sync package.
+// upstream `github.com/alexfalkowski/go-sync` package.
 var Module = di.Module(
 	di.Constructor(sync.NewBufferPool),
 )

--- a/telemetry/attributes/doc.go
+++ b/telemetry/attributes/doc.go
@@ -13,10 +13,10 @@
 // service instance. This package exposes helper constructors for common resource
 // fields, such as:
 //
-//   - HostID
-//   - ServiceName
-//   - ServiceVersion
-//   - DeploymentEnvironmentName
+//   - [HostID]
+//   - [ServiceName]
+//   - [ServiceVersion]
+//   - [DeploymentEnvironmentName]
 //
 // These helpers return attribute.KeyValue values that can be passed to
 // resource.NewWithAttributes.

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -1,33 +1,39 @@
-// Package telemetry provides OpenTelemetry-based telemetry configuration and wiring for go-service.
+// Package telemetry provides OpenTelemetry-based telemetry configuration and
+// wiring for go-service.
 //
-// The telemetry subsystem in this repository is organized as a set of focused packages:
+// The telemetry subsystem in this repository is organized as a set of focused
+// packages:
 //
-//   - telemetry/logger: application/system logging (slog-based) with optional exporters (for example OTLP).
-//   - telemetry/metrics: metrics SDK wiring and exporters (for example OTLP or Prometheus), plus helpers
-//     for obtaining a Meter from a configured provider.
+//   - telemetry/logger: application/system logging (slog-based) with optional
+//     exporters (for example OTLP).
+//   - telemetry/metrics: metrics SDK wiring and exporters (for example OTLP or
+//     Prometheus), plus helpers for obtaining a Meter from a configured provider.
 //   - telemetry/tracer: tracing SDK wiring and OTLP exporter configuration.
-//   - telemetry/errors: OpenTelemetry error handler wiring so OTel SDK/internal errors are logged.
-//   - telemetry/header: helpers for exporter/request headers, including secret resolution via the
-//     go-service “source string” convention (env:/file:/literal).
+//   - telemetry/errors: OpenTelemetry error handler wiring so OTel SDK/internal
+//     errors are logged.
+//   - telemetry/header: helpers for exporter/request headers, including secret
+//     resolution via the go-service "source string" convention (env:/file:/literal).
 //   - telemetry/attributes: aliases/helpers for OpenTelemetry semantic convention attributes.
 //
 // This top-level package primarily provides:
 //
-//   - Config: a single configuration root that embeds logging/metrics/tracing configuration.
+//   - Config: a single configuration root that embeds logging/metrics/tracing
+//     configuration.
 //   - Register: a small initialization hook that configures global OpenTelemetry propagation.
 //   - Module: an Fx module that composes telemetry submodules and applies Register.
 //
 // # Configuration
 //
-// Config is a convenience root used by services to configure telemetry in one place. It contains pointers
-// to per-signal configs:
+// Config is a convenience root used by services to configure telemetry in one
+// place. It contains pointers to per-signal configs:
 //
 //   - Logger (*telemetry/logger.Config)
 //   - Metrics (*telemetry/metrics.Config)
 //   - Tracer (*telemetry/tracer.Config)
 //
-// A nil Config typically means “telemetry disabled” at the top level, while subpackages may also support
-// their own enable/disable semantics (for example nil config or empty kind).
+// A nil Config typically means "telemetry disabled" at the top level, while
+// subpackages may also support their own enable/disable semantics (for example
+// nil config or empty kind).
 //
 // # OTLP endpoint security
 //
@@ -39,28 +45,33 @@
 //
 // # Global propagation (Register)
 //
-// Register configures the global OpenTelemetry TextMapPropagator to a composite propagator containing:
+// Register configures the global OpenTelemetry TextMapPropagator to a composite
+// propagator containing:
 //
 //   - W3C Trace Context (propagation.TraceContext)
 //   - W3C Baggage (propagation.Baggage)
 //
-// This affects context extraction/injection for supported transports (HTTP/gRPC) when instrumentation uses
-// the global propagator.
+// This affects context extraction/injection for supported transports
+// (HTTP/gRPC) when instrumentation uses the global propagator.
 //
 // Register is intended to be called once during startup (for example via Module).
 //
 // # Dependency injection (Module)
 //
-// Module is an Fx module that wires the telemetry submodules into an application. In particular it
-// composes the logger/metrics/tracer/error-handler modules and registers Register so propagation is
-// configured as part of application startup.
+// Module is an Fx module that wires the telemetry submodules into an
+// application. In particular it composes the logger/metrics/tracer/error-handler
+// modules and registers Register so propagation is configured as part of
+// application startup.
 //
-// Module does not itself create spans/metrics/log records; it wires providers/exporters and global
-// configuration so instrumentation elsewhere in your service can emit telemetry.
+// Module does not itself create spans/metrics/log records; it wires
+// providers/exporters and global configuration so instrumentation elsewhere in
+// your service can emit telemetry.
 //
 // # Notes
 //
-// Many implementations in the telemetry subtree are thin adapters around upstream OpenTelemetry SDK and
-// exporter packages. For exact semantics (for example exporter behavior, supported options, and version-
-// specific details), consult the upstream documentation for the versions vendored by this repository.
+// Many implementations in the telemetry subtree are thin adapters around
+// upstream OpenTelemetry SDK and exporter packages. For exact semantics (for
+// example exporter behavior, supported options, and version-specific details),
+// consult the upstream documentation for the versions vendored by this
+// repository.
 package telemetry

--- a/telemetry/header/doc.go
+++ b/telemetry/header/doc.go
@@ -14,7 +14,7 @@
 // # Source string convention and secret resolution
 //
 // Header values are often sensitive and should not be committed to configuration
-// files. go-service supports a “source string” convention that allows a configured
+// files. go-service supports a "source string" convention that allows a configured
 // value to be read from an alternate source at runtime.
 //
 // Map.Secrets traverses the map and resolves each value using os.FS.ReadSource,

--- a/telemetry/header/header.go
+++ b/telemetry/header/header.go
@@ -12,12 +12,12 @@ import (
 //
 // The map keys are header names and the map values are header values.
 //
-// Values are often configured as go-service “source strings” so that secrets can be
+// Values are often configured as go-service "source strings" so that secrets can be
 // supplied at runtime rather than embedded directly in config files. See Secrets
 // for the supported forms and resolution behavior.
 type Map map[string]string
 
-// Secrets resolves configured header values using the go-service “source string” convention.
+// Secrets resolves configured header values using the go-service "source string" convention.
 //
 // It traverses m and resolves each value by reading it through fs.ReadSource.
 // fs.ReadSource supports these forms:

--- a/telemetry/logger/config.go
+++ b/telemetry/logger/config.go
@@ -6,7 +6,7 @@ import "github.com/alexfalkowski/go-service/v2/telemetry/header"
 //
 // This package is responsible for constructing the logger based on Config.
 // However, note that this type intentionally does not resolve header secrets by
-// itself. If Headers contains go-service “source strings” (for example "env:NAME"
+// itself. If Headers contains go-service "source strings" (for example "env:NAME"
 // or "file:/path"), callers are expected to resolve them before constructing
 // exporters/handlers (for example via header.Map.Secrets or header.Map.MustSecrets).
 //
@@ -17,7 +17,7 @@ type Config struct {
 	// These headers are primarily used by exporter-backed logger kinds (for example
 	// "otlp") to pass authentication and/or routing metadata to a collector.
 	//
-	// Values may be configured as go-service “source strings” (for example "env:NAME",
+	// Values may be configured as go-service "source strings" (for example "env:NAME",
 	// "file:/path", or a literal value). Resolution is performed by the consumer that
 	// prepares configuration for use by the logger/exporter.
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`

--- a/telemetry/logger/doc.go
+++ b/telemetry/logger/doc.go
@@ -43,7 +43,7 @@
 // Some kinds (notably "otlp") support outbound request headers for authentication or
 // routing. These are configured in Config.Headers.
 //
-// Header values may be configured using go-service “source strings” (for example
+// Header values may be configured using go-service "source strings" (for example
 // "env:NAME", "file:/path", or a literal value). Those values are resolved by
 // telemetry/header.Map.Secrets or telemetry/header.Map.MustSecrets by the consumer
 // that projects configuration before constructing exporters.

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -187,18 +187,6 @@ func (l *Logger) Info(msg string, args ...any) {
 	l.Logger.Info(msg, args...)
 }
 
-// Error logs at [LevelError].
-//
-// It forwards msg and args to the embedded [slog.Logger] unchanged. It is a
-// no-op when l is nil.
-func (l *Logger) Error(msg string, args ...any) {
-	if l == nil {
-		return
-	}
-
-	l.Logger.Error(msg, args...)
-}
-
 // Warn logs at [LevelWarn].
 //
 // It forwards msg and args to the embedded [slog.Logger] unchanged. It is a
@@ -209,6 +197,18 @@ func (l *Logger) Warn(msg string, args ...any) {
 	}
 
 	l.Logger.Warn(msg, args...)
+}
+
+// Error logs at [LevelError].
+//
+// It forwards msg and args to the embedded [slog.Logger] unchanged. It is a
+// no-op when l is nil.
+func (l *Logger) Error(msg string, args ...any) {
+	if l == nil {
+		return
+	}
+
+	l.Logger.Error(msg, args...)
 }
 
 // Log logs msg.Text at the level derived from [Message.Level].

--- a/telemetry/logger/meta.go
+++ b/telemetry/logger/meta.go
@@ -20,14 +20,12 @@ const maxMetaValueLength = 1024
 // The returned attributes are intended to be appended to log records to provide
 // consistent request/service context across log lines.
 func Meta(ctx context.Context) []slog.Attr {
-	strings := meta.CamelStrings(ctx, meta.NoPrefix)
-	fields := make([]slog.Attr, len(strings))
-	index := 0
-	for k, v := range strings {
-		fields[index] = slog.String(k, truncateMetaValue(v))
-		index++
+	metadata := meta.CamelStrings(ctx, meta.NoPrefix)
+	fields := make([]slog.Attr, 0, len(metadata))
+	for k, v := range metadata {
+		fields = append(fields, slog.String(k, truncateMetaValue(v)))
 	}
-	return fields[:index]
+	return fields
 }
 
 func truncateMetaValue(value string) string {

--- a/telemetry/logger/tint.go
+++ b/telemetry/logger/tint.go
@@ -10,7 +10,7 @@ import (
 func newTintLogger(params LoggerParams) *slog.Logger {
 	opts := &tint.Options{
 		Level: level(params.Config),
-		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
 			if attr.Value.Kind() == slog.KindAny {
 				if err, ok := attr.Value.Any().(error); ok {
 					err := tint.Err(err)

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	// These headers are primarily used by exporter-based kinds (for example "otlp") to pass
 	// authentication and/or routing metadata to a collector.
 	//
-	// Values may be configured as go-service “source strings” (for example "env:NAME",
+	// Values may be configured as go-service "source strings" (for example "env:NAME",
 	// "file:/path", or a literal value). Resolution is performed by the consumer that
 	// prepares configuration for use by the exporter (for example via header.Map.Secrets
 	// or header.Map.MustSecrets).
@@ -22,7 +22,7 @@ type Config struct {
 	//   - "otlp": export metrics via OpenTelemetry OTLP/HTTP using a periodic reader.
 	//   - "prometheus": expose metrics via the Prometheus exporter/reader.
 	//
-	// If Kind is unknown, reader construction will return an error (see the metrics package’s
+	// If Kind is unknown, reader construction will return an error (see the metrics package's
 	// ErrNotFound).
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
 

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -72,7 +72,6 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		return noopProvider
 	}
 
-	reader := params.Reader
 	attrs := resource.NewWithAttributes(
 		attributes.SchemaURL,
 		attributes.HostID(params.ID.String()),
@@ -80,7 +79,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		attributes.ServiceVersion(params.Version.String()),
 		attributes.DeploymentEnvironmentName(params.Environment.String()),
 	)
-	provider := sdk.NewMeterProvider(sdk.WithReader(reader), sdk.WithResource(attrs))
+	provider := sdk.NewMeterProvider(sdk.WithReader(params.Reader), sdk.WithResource(attrs))
 	SetMeterProvider(provider)
 	enabled.Store(true)
 

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	// These headers are primarily used by exporter-backed tracer kinds (for example
 	// "otlp") to pass authentication and/or routing metadata to a collector.
 	//
-	// Values may be configured using go-service “source strings” (for example "env:NAME",
+	// Values may be configured using go-service "source strings" (for example "env:NAME",
 	// "file:/path", or a literal value). This package does not resolve secrets itself;
 	// resolution is performed by the consumer that prepares configuration for use by the
 	// exporter (for example via header.Map.Secrets or header.Map.MustSecrets).

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -41,7 +41,7 @@
 // ErrNotFound.
 //
 // The exporter request headers are provided by Config.Headers. Header values may be
-// configured as go-service “source strings” (for example "env:NAME", "file:/path", or a
+// configured as go-service "source strings" (for example "env:NAME", "file:/path", or a
 // literal value) and are resolved by telemetry/header.Map.Secrets or
 // telemetry/header.Map.MustSecrets by the consumer that projects configuration before
 // constructing exporters.


### PR DESCRIPTION
## What

- Format sync upstream package references and refresh telemetry docs with ASCII punctuation, links, and lighter wrapping.
- Simplify logger metadata construction, tint callback parameters, severity helper order, and metrics provider reader usage.

## Why

- Address the style-review cleanup so documentation is easier to scan and small helper code reads more directly.

## Testing

- ?   	github.com/alexfalkowski/go-service/v2/sync	[no test files]
?   	github.com/alexfalkowski/go-service/v2/telemetry	[no test files]
ok  	github.com/alexfalkowski/go-service/v2/telemetry/attributes	(cached)
ok  	github.com/alexfalkowski/go-service/v2/telemetry/errors	(cached)
ok  	github.com/alexfalkowski/go-service/v2/telemetry/header	(cached)
ok  	github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp	(cached)
ok  	github.com/alexfalkowski/go-service/v2/telemetry/logger	(cached)
ok  	github.com/alexfalkowski/go-service/v2/telemetry/metrics	(cached)
ok  	github.com/alexfalkowski/go-service/v2/telemetry/tracer	(cached) - passed
-  - passed
- 0 issues. - passed
