### PR TITLE
feat(time): polish network docs and tests

### DIFF
--- a/time/doc.go
+++ b/time/doc.go
@@ -8,9 +8,10 @@
 //     go-service can consistently import go-service packages while still using the
 //     underlying time semantics.
 //
-//     Exported types include Time (an alias of time.Time), Timer and Ticker
-//     (aliases of time.Timer and time.Ticker), Duration (a named type over
-//     time.Duration), common duration constants (Second, Minute, Hour, etc.), and RFC3339.
+//     Exported types include [Time] (an alias of time.Time), [Timer] and [Ticker]
+//     (aliases of time.Timer and time.Ticker), [Duration] (a named type over
+//     time.Duration), common duration constants ([Second], [Minute], [Hour],
+//     etc.), and [RFC3339].
 //
 //  2. Optional network time sourcing.
 //     In environments where local wall-clock time may drift or needs stronger
@@ -22,51 +23,52 @@
 // The following identifiers are thin wrappers around the standard library and do not
 // materially change semantics:
 //
-//   - Time aliases time.Time.
-//   - Duration wraps time.Duration and adds Text/JSON marshaling helpers while preserving
-//     Go duration string semantics.
-//   - Now, Since, Sleep, NewTimer, NewTicker, and ParseDuration forward to
-//     time.Now, time.Since, time.Sleep, time.NewTimer, time.NewTicker, and
-//     time.ParseDuration respectively.
-//   - Constants such as Second, Minute, Hour, and RFC3339 mirror the standard library
-//     values.
+//   - [Time] aliases time.Time.
+//   - [Duration] wraps time.Duration and adds Text/JSON marshaling helpers while
+//     preserving Go duration string semantics.
+//   - [Now], [Since], [Sleep], [NewTimer], [NewTicker], and [ParseDuration]
+//     forward to time.Now, time.Since, time.Sleep, time.NewTimer,
+//     time.NewTicker, and time.ParseDuration respectively.
+//   - Constants such as [Second], [Minute], [Hour], and [RFC3339] mirror the
+//     standard library values.
 //
 // Use these when you want to keep dependencies within the go-service module while
 // remaining close to the standard library time types.
 //
 // # Strict helpers
 //
-// MustParseDuration parses a Go duration string (see time.ParseDuration) and panics
-// if parsing fails (via runtime.Must).
+// [MustParseDuration] parses a Go duration string (see time.ParseDuration) and
+// panics if parsing fails (via runtime.Must).
 //
 // This is intended for strict startup/configuration code paths where an invalid
 // duration is a programmer/configuration error and should fail fast. If you need
-// recoverable error handling, use ParseDuration directly.
+// recoverable error handling, use [ParseDuration] directly.
 //
 // # Network time providers
 //
-// The Network interface provides a single method:
+// The [Network] interface provides a single method:
 //
 //   - Now() (Time, error): returns the current time as reported by the provider.
 //
-// NewNetwork constructs a Network implementation based on *Config. Enablement is
-// modeled by presence: a nil *Config is treated as disabled and NewNetwork returns
-// (nil, nil).
+// [NewNetwork] constructs a Network implementation based on [Config].
+// Enablement is modeled by presence: a nil *Config is treated as disabled and
+// NewNetwork returns (nil, nil).
 //
-// Config.Kind selects the provider implementation. This package currently supports:
+// [Config.Kind] selects the provider implementation. This package currently
+// supports:
 //
 //   - "ntp": Network Time Protocol (NTP).
 //   - "nts": Network Time Security (NTS), which provides authenticated time as
 //     defined by RFC 8915.
 //
-// If Config.Kind is not recognized, NewNetwork returns ErrNotFound.
+// If Config.Kind is not recognized, [NewNetwork] returns [ErrNotFound].
 //
 // Provider implementations may wrap and prefix errors to provide clearer context
 // (for example "ntp: ..." or "nts: ...").
 //
 // # Dependency injection (Fx)
 //
-// Module wires NewNetwork into Fx as a constructor so applications can optionally
+// [Module] wires [NewNetwork] into Fx as a constructor so applications can optionally
 // depend on a Network provider when configured.
 //
 // # Notes

--- a/time/net.go
+++ b/time/net.go
@@ -2,24 +2,27 @@ package time
 
 import "github.com/alexfalkowski/go-service/v2/errors"
 
-// ErrNotFound is returned when Config.Kind does not match a supported network time provider.
+// ErrNotFound is returned when [Config.Kind] does not match a supported network
+// time provider.
 //
-// This error is returned by NewNetwork when cfg is enabled (non-nil) but Kind is not
-// recognized by this package.
+// This error is returned by [NewNetwork] when cfg is enabled (non-nil) but Kind
+// is not recognized by this package.
 var ErrNotFound = errors.New("time: network not found")
 
 // NewNetwork constructs a network time provider based on cfg.
 //
-// Enablement is modeled by presence: if cfg is nil (disabled), NewNetwork returns (nil, nil).
+// Enablement is modeled by presence: if cfg is nil (disabled), NewNetwork
+// returns (nil, nil).
 //
 // Supported kinds:
-//   - "ntp": constructs an NTP-backed provider (see NewNTPNetwork)
-//   - "nts": constructs an NTS-backed provider (see NewNTSNetwork)
+//   - "ntp": constructs an NTP-backed provider (see [NewNTPNetwork])
+//   - "nts": constructs an NTS-backed provider (see [NewNTSNetwork])
 //
 // If cfg.Kind is not recognized, NewNetwork returns (nil, ErrNotFound).
 //
-// Note: Address validation is provider-specific. NewNetwork does not validate cfg.Address;
-// providers typically return an error from Network.Now when the address is empty or invalid.
+// Note: Address validation is provider-specific. NewNetwork does not validate
+// cfg.Address; providers typically return an error from Network.Now when the
+// address is empty or invalid.
 func NewNetwork(cfg *Config) (Network, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil

--- a/time/net_test.go
+++ b/time/net_test.go
@@ -7,13 +7,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNil(t *testing.T) {
+func TestNewNetworkNilConfig(t *testing.T) {
 	net, err := time.NewNetwork(nil)
 	require.NoError(t, err)
 	require.Nil(t, net)
 }
 
-func TestInvalid(t *testing.T) {
+func TestNewNetworkInvalidKind(t *testing.T) {
 	_, err := time.NewNetwork(&time.Config{Kind: "invalid"})
+	require.Error(t, err)
+}
+
+func requireNetworkNow(t *testing.T, cfg *time.Config) {
+	t.Helper()
+
+	n, err := time.NewNetwork(cfg)
+	require.NoError(t, err)
+
+	_, err = n.Now()
+	require.NoError(t, err)
+}
+
+func requireNetworkNowError(t *testing.T, cfg *time.Config) {
+	t.Helper()
+
+	n, err := time.NewNetwork(cfg)
+	require.NoError(t, err)
+
+	_, err = n.Now()
 	require.Error(t, err)
 }

--- a/time/ntp_test.go
+++ b/time/ntp_test.go
@@ -4,25 +4,12 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidNTP(t *testing.T) {
-	c := &time.Config{Kind: "ntp", Address: "0.beevik-ntp.pool.ntp.org"}
-
-	n, err := time.NewNetwork(c)
-	require.NoError(t, err)
-
-	_, err = n.Now()
-	require.NoError(t, err)
+	requireNetworkNow(t, &time.Config{Kind: "ntp", Address: "0.beevik-ntp.pool.ntp.org"})
 }
 
 func TestInvalidNTP(t *testing.T) {
-	c := &time.Config{Kind: "ntp"}
-
-	n, err := time.NewNetwork(c)
-	require.NoError(t, err)
-
-	_, err = n.Now()
-	require.Error(t, err)
+	requireNetworkNowError(t, &time.Config{Kind: "ntp"})
 }

--- a/time/nts_test.go
+++ b/time/nts_test.go
@@ -4,25 +4,12 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidNTS(t *testing.T) {
-	c := &time.Config{Kind: "nts", Address: "time.cloudflare.com"}
-
-	n, err := time.NewNetwork(c)
-	require.NoError(t, err)
-
-	_, err = n.Now()
-	require.NoError(t, err)
+	requireNetworkNow(t, &time.Config{Kind: "nts", Address: "time.cloudflare.com"})
 }
 
 func TestInvalidNTS(t *testing.T) {
-	c := &time.Config{Kind: "nts"}
-
-	n, err := time.NewNetwork(c)
-	require.NoError(t, err)
-
-	_, err = n.Now()
-	require.Error(t, err)
+	requireNetworkNowError(t, &time.Config{Kind: "nts"})
 }

--- a/time/time.go
+++ b/time/time.go
@@ -33,14 +33,16 @@ func After(d Duration) <-chan Time {
 	return time.After(d.Duration())
 }
 
-// NewTimer returns a new [Timer] that will send the current time on its channel after at least duration d.
+// NewTimer returns a new [Timer] that will send the current time on its channel
+// after at least duration d.
 //
 // This is a thin wrapper around time.NewTimer and does not change semantics.
 func NewTimer(d Duration) *Timer {
 	return time.NewTimer(d.Duration())
 }
 
-// NewTicker returns a new [Ticker] containing a channel that will send the current time on the channel after each tick.
+// NewTicker returns a new [Ticker] containing a channel that will send the
+// current time on the channel after each tick.
 //
 // This is a thin wrapper around time.NewTicker and does not change semantics.
 func NewTicker(d Duration) *Ticker {


### PR DESCRIPTION
## What

- Add GoDoc links and reflow long comments in the time package documentation.
- Rename generic network tests and share the NTP/NTS test setup helpers.

## Why

- Address the style-review cleanup so generated docs are easier to navigate and provider tests read more consistently.

## Testing

- ok  	github.com/alexfalkowski/go-service/v2/time	(cached) - passed
-  - passed
- 0 issues. - passed
