### PR TITLE
feat(token): polish docs and validation tests

### DIFF
--- a/token/access/doc.go
+++ b/token/access/doc.go
@@ -1,6 +1,6 @@
 // Package access provides authorization (access control) helpers used by go-service.
 //
-// This package is focused on answering the question “is subject X allowed to do Y?”
+// This package is focused on answering the question "is subject X allowed to do Y?"
 // based on an authorization policy. It currently provides:
 //
 //   - Controller: an interface for permission checks.
@@ -28,9 +28,10 @@
 //
 // # Enablement
 //
-// Enablement is modeled by presence: if *Config is nil, NewController returns (nil, nil).
-// Callers should handle a nil Controller as “authorization disabled/unconfigured” and
-// decide on an appropriate default behavior at a higher layer.
+// Enablement is modeled by presence: if *Config is nil, NewController returns
+// (nil, nil). Callers should handle a nil Controller as "authorization
+// disabled/unconfigured" and decide on an appropriate default behavior at a
+// higher layer.
 //
 // Start with Config and NewController.
 package access

--- a/token/config.go
+++ b/token/config.go
@@ -10,7 +10,7 @@ import (
 // Config configures token generation and verification for a go-service application.
 //
 // This type is typically embedded into a larger service configuration and consumed
-// by the top-level token facade (see token.NewToken), which delegates to the
+// by the top-level token facade (see [NewToken]), which delegates to the
 // configured token implementation.
 //
 // # Enablement model
@@ -28,17 +28,18 @@ import (
 //   - "paseto": PASETO v4 public tokens (see package token/paseto)
 //   - "ssh": SSH-style signed tokens (see package token/ssh)
 //
-// The selected implementation’s nested configuration should typically be provided
+// The selected implementation's nested configuration should typically be provided
 // in the corresponding field (JWT/Paseto/SSH).
 //
 // If Kind is unknown, the token facade treats the configuration as invalid and
-// Generate/Verify return token/errors.ErrInvalidConfig.
+// [Token.Generate]/[Token.Verify] return token/errors.ErrInvalidConfig.
 //
 // # Access control (Access)
 //
-// Access configures optional access-control policy wiring (see package token/access).
-// It is orthogonal to the token kind: some services may use token verification to
-// establish identity (subject) and then evaluate permissions via Access.
+// Access configures optional access-control policy wiring (see package
+// token/access). It is orthogonal to the token kind: some services may use token
+// verification to establish identity (subject) and then evaluate permissions via
+// Access.
 type Config struct {
 	// Access configures access control policy used by token/access.
 	//

--- a/token/doc.go
+++ b/token/doc.go
@@ -3,13 +3,14 @@
 // This package defines common token concepts and shared helpers used by concrete
 // token implementations (for example JWT, PASETO, and SSH).
 //
-// It also provides a small facade type (Token) that delegates token generation and
-// verification to the configured implementation so callers can depend on a single
-// entry point when the token kind is selected by configuration.
+// It also provides a small facade type ([Token]) that delegates token generation
+// and verification to the configured implementation so callers can depend on a
+// single entry point when the token kind is selected by configuration.
 //
 // # Supported token kinds
 //
-// The top-level Token facade supports the following kinds, selected by Config.Kind:
+// The top-level [Token] facade supports the following kinds, selected by
+// [Config.Kind]:
 //
 //   - "jwt": JSON Web Tokens signed using Ed25519 (see the token/jwt package).
 //   - "paseto": PASETO v4 public tokens (see the token/paseto package).
@@ -37,13 +38,14 @@
 //
 // # Facade behavior and unknown kinds
 //
-// The Token facade is intentionally conservative when Config.Kind is unknown:
+// The [Token] facade is intentionally conservative when [Config.Kind] is
+// unknown:
 //
-//   - Generate returns (nil, token/errors.ErrInvalidConfig).
-//   - Verify returns (strings.Empty, token/errors.ErrInvalidConfig).
+//   - [Token.Generate] returns (nil, token/errors.ErrInvalidConfig).
+//   - [Token.Verify] returns (strings.Empty, token/errors.ErrInvalidConfig).
 //
-// This makes “unknown token kind” fail closed instead of behaving like “feature
-// disabled” in wiring scenarios. Callers should treat ErrInvalidConfig as a
+// This makes "unknown token kind" fail closed instead of behaving like "feature
+// disabled" in wiring scenarios. Callers should treat ErrInvalidConfig as a
 // startup or deployment configuration issue.
 //
 // # Configuration and enablement

--- a/token/generator.go
+++ b/token/generator.go
@@ -2,9 +2,9 @@ package token
 
 // Generator generates authentication tokens for a given audience and subject.
 //
-// This interface represents the “issuance” side of a token system. Concrete implementations
-// may generate different token formats depending on configuration (for example JWT, PASETO,
-// or other schemes).
+// This interface represents the "issuance" side of a token system. Concrete
+// implementations may generate different token formats depending on
+// configuration (for example JWT, PASETO, or other schemes).
 //
 // # Parameters
 //
@@ -13,26 +13,27 @@ package token
 //   - aud: the intended audience for the token (who the token is meant for).
 //   - sub: the subject identifier (who/what the token represents).
 //
-// In claim-based token formats (for example JWT/PASETO), aud and sub are typically encoded
-// into standard claims.
+// In claim-based token formats (for example JWT/PASETO), aud and sub are
+// typically encoded into standard claims.
 //
-// Some token kinds may ignore one or both parameters (for example formats that do not
-// carry claims or that encode identity differently). Callers should consult the
-// concrete implementation’s documentation for exact semantics.
+// Some token kinds may ignore one or both parameters (for example formats that
+// do not carry claims or that encode identity differently). Callers should
+// consult the concrete implementation's documentation for exact semantics.
 //
 // # Return value
 //
-// Generate returns the serialized token bytes. For text-based token formats, these bytes
-// are typically UTF-8 encoded.
+// Generate returns the serialized token bytes. For text-based token formats,
+// these bytes are typically UTF-8 encoded.
 //
 // # Errors
 //
-// Generate returns an error when token issuance fails (for example invalid configuration,
-// missing key material, signing failures, or serialization errors).
+// Generate returns an error when token issuance fails (for example invalid
+// configuration, missing key material, signing failures, or serialization
+// errors).
 type Generator interface {
 	// Generate creates a new token for the given audience and subject.
 	//
-	// Implementations should treat aud/sub as logical identity inputs and produce a token
-	// suitable for later validation by a corresponding Verifier.
+	// Implementations should treat aud/sub as logical identity inputs and produce
+	// a token suitable for later validation by a corresponding Verifier.
 	Generate(aud, sub string) ([]byte, error)
 }

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -142,7 +142,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 	return claims.Subject, nil
 }
 
-func (j *Token) validate(token *jwt.Token) (any, error) {
+func (t *Token) validate(token *jwt.Token) (any, error) {
 	if token.Method.Alg() != SigningMethodEdDSA.Alg() {
 		return nil, errors.ErrInvalidAlgorithm
 	}
@@ -152,11 +152,11 @@ func (j *Token) validate(token *jwt.Token) (any, error) {
 		return nil, errors.ErrInvalidKeyID
 	}
 
-	if kid != j.cfg.KeyID {
+	if kid != t.cfg.KeyID {
 		return nil, errors.ErrInvalidKeyID
 	}
 
-	return j.verifier.PublicKey, nil
+	return t.verifier.PublicKey, nil
 }
 
 func validateRequiredClaims(claims *RegisteredClaims) error {

--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -18,7 +18,7 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // is not consumed directly by that implementation.
 //
 // If you want to source Ed25519 key material from configuration, resolve Secret using the
-// go-service “source string” convention (for example via os.FS.ReadSource) and build the
+// go-service "source string" convention (for example via os.FS.ReadSource) and build the
 // Ed25519 signer/verifier in your wiring layer.
 //
 // # Expiration parsing and panics
@@ -34,7 +34,7 @@ import "github.com/alexfalkowski/go-service/v2/time"
 type Config struct {
 	// Secret is a "source string" intended to provide PASETO key material.
 	//
-	// It supports the go-service “source string” pattern:
+	// It supports the go-service "source string" pattern:
 	// - "env:NAME" to read from an environment variable
 	// - "file:/path" to read from a file
 	// - otherwise treated as the literal value

--- a/token/paseto/doc.go
+++ b/token/paseto/doc.go
@@ -67,11 +67,11 @@
 // # Secret field note
 //
 // Config contains a Secret field described as PASETO key material using the
-// go-service “source string” convention (env:/file:/literal). However, the
+// go-service "source string" convention (env:/file:/literal). However, the
 // current implementation constructs PASETO v4 public tokens using Ed25519 key
 // material supplied via crypto/ed25519.Signer and crypto/ed25519.Verifier passed
 // to NewToken. The Secret field is therefore not consumed directly by this
-// package’s Token implementation.
+// package's Token implementation.
 //
 // If your service wants to source key material from config, resolve Config.Secret
 // (using os.FS.ReadSource) and construct the Ed25519 signer/verifier accordingly

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -107,16 +107,16 @@ func (t *Token) Verify(token, aud string) (string, error) {
 		return strings.Empty, err
 	}
 
-	to, err := parser.ParseV4Public(s, token, nil)
+	parsed, err := parser.ParseV4Public(s, token, nil)
 	if err != nil {
 		return strings.Empty, err
 	}
 
-	if err := validateLifetime(to, t.cfg.Expiration); err != nil {
+	if err := validateLifetime(parsed, t.cfg.Expiration); err != nil {
 		return strings.Empty, err
 	}
 
-	return subject(to)
+	return subject(parsed)
 }
 
 func subject(token *paseto.Token) (string, error) {

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -47,13 +47,13 @@ func TestValid(t *testing.T) {
 	ec := test.NewEd25519()
 	signer, _ := ed25519.NewSigner(test.PEM, ec)
 	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
-	paseto := paseto.NewToken(cfg.Paseto, signer, verifier, uuid.NewGenerator())
+	token := paseto.NewToken(cfg.Paseto, signer, verifier, uuid.NewGenerator())
 
-	token, err := paseto.Generate("hello", test.UserID.String())
+	tkn, err := token.Generate("hello", test.UserID.String())
 	require.NoError(t, err)
-	require.NotEmpty(t, token)
+	require.NotEmpty(t, tkn)
 
-	sub, err := paseto.Verify(token, "hello")
+	sub, err := token.Verify(tkn, "hello")
 	require.NoError(t, err)
 	require.Equal(t, test.UserID.String(), sub)
 }
@@ -143,47 +143,57 @@ func TestInvalid(t *testing.T) {
 	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
 	gen := uuid.NewGenerator()
 
-	cfg := test.NewToken("paseto")
-	token := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+	t.Run("audience mismatch", func(t *testing.T) {
+		cfg := test.NewToken("paseto")
+		token := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
 
-	tkn, err := token.Generate("hello", test.UserID.String())
-	require.NoError(t, err)
-	require.NotEmpty(t, tkn)
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
 
-	_, err = token.Verify(tkn, "test")
-	require.Error(t, err)
+		_, err = token.Verify(tkn, "test")
+		require.Error(t, err)
+	})
 
-	token = paseto.NewToken(&paseto.Config{Issuer: "test", Expiration: time.Hour}, signer, verifier, gen)
+	t.Run("matching issuer and audience", func(t *testing.T) {
+		token := paseto.NewToken(&paseto.Config{Issuer: "test", Expiration: time.Hour}, signer, verifier, gen)
 
-	tkn, err = token.Generate("hello", test.UserID.String())
-	require.NoError(t, err)
-	require.NotEmpty(t, tkn)
+		tkn, err := token.Generate("hello", test.UserID.String())
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
 
-	_, err = token.Verify(tkn, "hello")
-	require.NoError(t, err)
+		_, err = token.Verify(tkn, "hello")
+		require.NoError(t, err)
+	})
 
-	for _, tkn := range []string{"invalid"} {
-		t.Run(tkn, func(t *testing.T) {
-			cfg := test.NewToken("paseto")
-			token := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
+	t.Run("malformed token", func(t *testing.T) {
+		cfg := test.NewToken("paseto")
+		token := paseto.NewToken(cfg.Paseto, signer, verifier, gen)
 
-			_, err := token.Verify(tkn, "aud")
-			require.Error(t, err)
-		})
-	}
+		_, err := token.Verify("invalid", "aud")
+		require.Error(t, err)
+	})
 
-	cfg = test.NewToken("paseto")
+	t.Run("generate with malformed private key", func(t *testing.T) {
+		cfg := test.NewToken("paseto")
+		token := paseto.NewToken(cfg.Paseto, &ed25519.Signer{}, verifier, gen)
 
-	token = paseto.NewToken(cfg.Paseto, &ed25519.Signer{}, verifier, gen)
-	_, err = token.Generate("hello", test.UserID.String())
-	require.Error(t, err)
+		_, err := token.Generate("hello", test.UserID.String())
+		require.Error(t, err)
+	})
 
-	token = paseto.NewToken(cfg.Paseto, signer, &ed25519.Verifier{}, gen)
-	_, err = token.Verify(strings.Empty, "aud")
-	require.Error(t, err)
+	t.Run("verify with malformed public key", func(t *testing.T) {
+		cfg := test.NewToken("paseto")
+		token := paseto.NewToken(cfg.Paseto, signer, &ed25519.Verifier{}, gen)
 
-	token = paseto.NewToken(nil, signer, verifier, gen)
-	require.Nil(t, token)
+		_, err := token.Verify(strings.Empty, "aud")
+		require.Error(t, err)
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		token := paseto.NewToken(nil, signer, verifier, gen)
+		require.Nil(t, token)
+	})
 }
 
 func TestInvalidConfigDoesNotPanic(t *testing.T) {

--- a/token/ssh/claims.go
+++ b/token/ssh/claims.go
@@ -47,7 +47,9 @@ func validateClaims(c *claims, aud string, now int64, maxLifetime time.Duration)
 	if c.Version != tokenVersion {
 		return crypto.ErrInvalidMatch
 	}
-	if c.IssuedAt <= 0 || c.IssuedAt > now || c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt {
+	invalidIssuedAt := c.IssuedAt <= 0 || c.IssuedAt > now
+	invalidExpiration := c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt
+	if invalidIssuedAt || invalidExpiration {
 		return token.ErrInvalidTime
 	}
 	if c.ExpiresAt-c.IssuedAt > maxLifetime.Duration().Nanoseconds() {

--- a/token/ssh/doc.go
+++ b/token/ssh/doc.go
@@ -29,7 +29,7 @@
 //   - Config.Keys is a set of named public keys used for Verify.
 //   - Config.Expiration controls how long generated tokens remain valid.
 //
-// Verification is “name-based”: Verify extracts kid from the signed claims and
+// Verification is "name-based": Verify extracts kid from the signed claims and
 // then looks up a matching public key configuration in Config.Keys (via
 // Keys.Get(kid)). If no key with that name exists, verification fails.
 //
@@ -37,14 +37,15 @@
 // with the active signing key name while allowing verification against multiple
 // historical/active public keys by including them in Config.Keys.
 //
-// # Key material loading and “source strings”
+// # Key material loading and "source strings"
 //
 // The Token constructor accepts an *os.FS and uses go-service crypto/ssh helpers to
 // load key material based on the embedded crypto/ssh.Config in Key.
 //
-// Those configs commonly support go-service “source strings” for key sources
-// (for example env:/file:/literal). Resolution and filesystem behavior depend on
-// the go-service os.FS and crypto/ssh packages used by your wiring.
+// Those configs commonly support go-service "source strings" for key sources
+// (for example "env:SSH_KEY", "file:/path/to/key", or a literal value).
+// Resolution and filesystem behavior depend on the go-service os.FS and
+// crypto/ssh packages used by your wiring.
 //
 // # Error handling expectations
 //
@@ -59,7 +60,7 @@
 //   - signature verification fails,
 //   - key material cannot be loaded.
 //
-// Some invalid-token cases are intentionally collapsed into a generic “invalid match”
+// Some invalid-token cases are intentionally collapsed into a generic "invalid match"
 // class so callers do not learn whether a name exists or which specific check failed.
 // Callers that need fine-grained diagnostics should add logging/metrics at the call
 // site rather than relying on error text.

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -150,12 +150,12 @@ func (t *Token) Verify(tkn, aud string) (string, error) {
 		return strings.Empty, token.ErrInvalidConfig
 	}
 
-	data, encoded, key, err := parseClaims(tkn)
+	claims, claimsJSON, rawSignature, err := parseClaims(tkn)
 	if err != nil {
 		return strings.Empty, err
 	}
 
-	cfg := t.cfg.Keys.Get(data.KeyID)
+	cfg := t.cfg.Keys.Get(claims.KeyID)
 	if cfg == nil {
 		return strings.Empty, crypto.ErrInvalidMatch
 	}
@@ -169,18 +169,18 @@ func (t *Token) Verify(tkn, aud string) (string, error) {
 		return strings.Empty, err
 	}
 
-	sig, err := base64.Decode(key)
+	sig, err := base64.Decode(rawSignature)
 	if err != nil {
 		return strings.Empty, err
 	}
 
-	if err := verifier.Verify(sig, encoded); err != nil {
+	if err := verifier.Verify(sig, claimsJSON); err != nil {
 		return strings.Empty, err
 	}
 
-	if err := validateClaims(data, aud, time.Now().UnixNano(), t.cfg.Expiration); err != nil {
+	if err := validateClaims(claims, aud, time.Now().UnixNano(), t.cfg.Expiration); err != nil {
 		return strings.Empty, err
 	}
 
-	return data.KeyID, nil
+	return claims.KeyID, nil
 }

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -247,26 +247,32 @@ func TestValidNameWithDash(t *testing.T) {
 	require.Equal(t, "test-user", sub)
 }
 
-func TestInvalid(t *testing.T) {
+func TestInvalidPrivateKey(t *testing.T) {
 	token := ssh.NewToken(&ssh.Config{
 		Key: &ssh.Key{
 			Name:   "test",
 			Config: test.NewSSH("secrets/ssh_public", "secrets/none"),
 		},
 	}, test.FS)
+
 	_, err := token.Generate(strings.Empty, strings.Empty)
 	require.Error(t, err)
+}
 
+func TestInvalidTokenShapes(t *testing.T) {
 	for _, tkn := range []string{strings.Empty, "none-", "test-", "test-bob"} {
 		t.Run(tkn, func(t *testing.T) {
 			token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
+
 			sub, err := token.Verify(tkn, strings.Empty)
 			require.Error(t, err)
 			require.Empty(t, sub)
 		})
 	}
+}
 
-	token = ssh.NewToken(&ssh.Config{
+func TestInvalidPublicKey(t *testing.T) {
+	token := ssh.NewToken(&ssh.Config{
 		Keys: ssh.Keys{
 			&ssh.Key{
 				Name:   "test",
@@ -274,15 +280,18 @@ func TestInvalid(t *testing.T) {
 			},
 		},
 	}, test.FS)
+
 	sub, err := token.Verify("test-bob", strings.Empty)
 	require.Error(t, err)
 	require.Empty(t, sub)
+}
 
+func TestInvalidUnknownKey(t *testing.T) {
 	valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 	tkn, err := valid.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
 
-	token = ssh.NewToken(&ssh.Config{
+	token := ssh.NewToken(&ssh.Config{
 		Expiration: time.Hour,
 		Keys: ssh.Keys{
 			&ssh.Key{
@@ -291,18 +300,27 @@ func TestInvalid(t *testing.T) {
 			},
 		},
 	}, test.FS)
-	sub, err = token.Verify(tkn, strings.Empty)
+
+	sub, err := token.Verify(tkn, strings.Empty)
 	require.Empty(t, sub)
 	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
+}
+
+func TestInvalidSignature(t *testing.T) {
+	valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
+	tkn, err := valid.Generate(strings.Empty, strings.Empty)
+	require.NoError(t, err)
 
 	encoded, _, ok := strings.Cut(tkn, ".")
 	require.True(t, ok)
 
-	sub, err = valid.Verify(encoded+"."+base64.Encode([]byte("bad")), "other")
+	sub, err := valid.Verify(encoded+"."+base64.Encode([]byte("bad")), "other")
 	require.Empty(t, sub)
 	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
+}
 
-	token = ssh.NewToken(nil, test.FS)
+func TestInvalidConfig(t *testing.T) {
+	token := ssh.NewToken(nil, test.FS)
 	require.Nil(t, token)
 }
 

--- a/token/verifier.go
+++ b/token/verifier.go
@@ -1,10 +1,12 @@
 package token
 
-// Verifier verifies authentication tokens for an expected audience and returns the subject identifier.
+// Verifier verifies authentication tokens for an expected audience and returns
+// the subject identifier.
 //
-// This interface represents the “verification” side of a token system. Concrete implementations may
-// verify different token formats (for example JWT, PASETO, or other schemes) and may impose additional
-// checks such as issuer matching, algorithm constraints, key ID matching, or time validity.
+// This interface represents the "verification" side of a token system. Concrete
+// implementations may verify different token formats (for example JWT, PASETO,
+// or other schemes) and may impose additional checks such as issuer matching,
+// algorithm constraints, key ID matching, or time validity.
 //
 // # Parameters
 //
@@ -12,20 +14,23 @@ package token
 //   - token: the serialized token bytes to verify.
 //   - aud: the expected audience value for which the token must be valid.
 //
-// In claim-based token formats (for example JWT/PASETO), aud is typically validated against an "aud"
-// claim. Some token kinds may ignore aud entirely (for example formats without claims). Callers should
-// consult the concrete implementation’s documentation for exact semantics.
+// In claim-based token formats (for example JWT/PASETO), aud is typically
+// validated against an "aud" claim. Some token kinds may ignore aud entirely
+// (for example formats without claims). Callers should consult the concrete
+// implementation's documentation for exact semantics.
 //
 // # Return value
 //
-// On success, Verify returns the subject identifier represented by the token (commonly the "sub" claim).
-// If the token kind does not carry a subject claim, the implementation may return an alternate identifier.
+// On success, Verify returns the subject identifier represented by the token
+// (commonly the "sub" claim). If the token kind does not carry a subject claim,
+// the implementation may return an alternate identifier.
 //
 // # Errors
 //
-// Verify returns an error when validation fails (for example malformed token, signature mismatch, wrong
-// issuer/audience, expired/not-yet-valid token, key mismatch, or missing key material). When an error is
-// returned, the subject return value should not be trusted.
+// Verify returns an error when validation fails (for example malformed token,
+// signature mismatch, wrong issuer/audience, expired/not-yet-valid token, key
+// mismatch, or missing key material). When an error is returned, the subject
+// return value should not be trusted.
 type Verifier interface {
 	// Verify validates token for the given audience and returns the subject identifier.
 	Verify(token []byte, aud string) (string, error)


### PR DESCRIPTION
## What

- Clarify package and interface GoDoc links, ASCII punctuation, and source string examples.
- Rename short locals and receivers in JWT, PASETO, and SSH verification paths for readability.
- Split invalid PASETO and SSH test coverage into focused cases.

## Why

- Make authentication docs and tests easier to scan without changing behavior.

## Testing

- `go test ./token/...` - passed
- `git diff --check` - passed
- `make lint` - passed with the existing gomodguard deprecation warning

AI-assisted-by: [Codex](https://openai.com/codex/)
