### PR TITLE
feat(transport): polish client and limiter readability

### DIFF
--- a/transport/grpc/breaker/doc.go
+++ b/transport/grpc/breaker/doc.go
@@ -12,7 +12,7 @@
 //
 // The interceptor classifies whether an invocation is successful based on the gRPC status code
 // of the returned error. The set of status codes treated as failures is configurable via options
-// (see `WithFailureCodes` and the package defaults in `defaultOpts`).
+// (see `WithFailureCodes` and the package defaults).
 //
 // # Rejections
 //

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -31,24 +31,24 @@ type ClientOption interface {
 }
 
 type clientOpts struct {
-	gen               token.Generator
-	generator         id.Generator
-	security          *tls.Config
-	logger            *logger.Logger
-	retry             *retry.Config
-	retryPolicies     []retry.Policy
-	limiter           *limiter.Client
-	userAgent         env.UserAgent
-	id                env.UserID
-	opts              []grpc.DialOption
-	unary             []grpc.UnaryClientInterceptor
-	stream            []grpc.StreamClientInterceptor
-	breakerOptions    []breaker.Option
-	keepalive_ping    time.Duration
-	keepalive_timeout time.Duration
-	timeout           time.Duration
-	breaker           bool
-	compression       bool
+	gen              token.Generator
+	generator        id.Generator
+	security         *tls.Config
+	logger           *logger.Logger
+	retry            *retry.Config
+	retryPolicies    []retry.Policy
+	limiter          *limiter.Client
+	userAgent        env.UserAgent
+	id               env.UserID
+	opts             []grpc.DialOption
+	unary            []grpc.UnaryClientInterceptor
+	stream           []grpc.StreamClientInterceptor
+	breakerOptions   []breaker.Option
+	keepalivePing    time.Duration
+	keepaliveTimeout time.Duration
+	timeout          time.Duration
+	breaker          bool
+	compression      bool
 }
 
 type clientOptionFunc func(*clientOpts)
@@ -99,8 +99,8 @@ func WithClientTimeout(timeout time.Duration) ClientOption {
 // If either value is unset (0), it defaults to the resolved client timeout (see `NewDialOptions`).
 func WithClientKeepalive(ping, timeout time.Duration) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
-		o.keepalive_ping = ping
-		o.keepalive_timeout = timeout
+		o.keepalivePing = ping
+		o.keepaliveTimeout = timeout
 	})
 }
 
@@ -243,19 +243,19 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //     This default is intended for local and in-cluster/container traffic where transport security is provided
 //     at the platform boundary; use WithClientTLS for calls outside that trusted boundary.
 func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
-	os := options(opts...)
+	resolved := options(opts...)
 
-	if os.keepalive_ping == 0 {
-		os.keepalive_ping = os.timeout
+	if resolved.keepalivePing == 0 {
+		resolved.keepalivePing = resolved.timeout
 	}
 
-	if os.keepalive_timeout == 0 {
-		os.keepalive_timeout = os.timeout
+	if resolved.keepaliveTimeout == 0 {
+		resolved.keepaliveTimeout = resolved.timeout
 	}
 
 	var security grpc.DialOption
-	if os.security != nil {
-		conf, err := client.NewConfig(fs, os.security)
+	if resolved.security != nil {
+		conf, err := client.NewConfig(fs, resolved.security)
 		if err != nil {
 			return nil, err
 		}
@@ -266,18 +266,18 @@ func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
 	}
 
 	cis := UnaryClientInterceptors(opts...)
-	sto := streamDialOption(os)
+	sto := streamDialOption(resolved)
 	ops := []grpc.DialOption{
-		grpc.WithUserAgent(os.userAgent.String()),
-		grpc.WithKeepaliveParams(os.keepalive_ping, os.keepalive_timeout),
+		grpc.WithUserAgent(resolved.userAgent.String()),
+		grpc.WithKeepaliveParams(resolved.keepalivePing, resolved.keepaliveTimeout),
 		grpc.WithChainUnaryInterceptor(cis...), sto, security,
 	}
 
-	if os.compression {
+	if resolved.compression {
 		ops = append(ops, grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))
 	}
 
-	ops = append(ops, os.opts...)
+	ops = append(ops, resolved.opts...)
 
 	return ops, nil
 }
@@ -295,16 +295,16 @@ type ClientConn = grpc.ClientConn
 //
 // The returned connection should be closed by the caller when no longer needed.
 func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
-	os, err := NewDialOptions(opts...)
+	dialOptions, err := NewDialOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	if metrics.IsEnabled() || tracer.IsEnabled() {
-		os = append(os, grpc.WithStatsHandler(telemetry.NewClientHandler()))
+		dialOptions = append(dialOptions, grpc.WithStatsHandler(telemetry.NewClientHandler()))
 	}
 
-	return grpc.NewClient(target, os...)
+	return grpc.NewClient(target, dialOptions...)
 }
 
 // UnaryClientInterceptors builds the unary client interceptor chain derived from opts.
@@ -321,31 +321,31 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 //
 // The limiter stays before the breaker so local quota denials are not counted as upstream failures.
 func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor {
-	os := options(opts...)
+	resolved := options(opts...)
 	unary := []grpc.UnaryClientInterceptor{}
 
-	unary = append(unary, meta.UnaryClientInterceptor(os.userAgent, os.generator))
-	unary = append(unary, os.unary...)
-	unary = append(unary, grpc.TimeoutUnaryClientInterceptor(os.timeout))
+	unary = append(unary, meta.UnaryClientInterceptor(resolved.userAgent, resolved.generator))
+	unary = append(unary, resolved.unary...)
+	unary = append(unary, grpc.TimeoutUnaryClientInterceptor(resolved.timeout))
 
-	if os.limiter != nil {
-		unary = append(unary, limiter.UnaryClientInterceptor(os.limiter))
+	if resolved.limiter != nil {
+		unary = append(unary, limiter.UnaryClientInterceptor(resolved.limiter))
 	}
 
-	if os.breaker {
-		unary = append(unary, breaker.UnaryClientInterceptor(os.breakerOptions...))
+	if resolved.breaker {
+		unary = append(unary, breaker.UnaryClientInterceptor(resolved.breakerOptions...))
 	}
 
-	if os.retry != nil {
-		unary = append(unary, retry.UnaryClientInterceptor(os.retry, os.retryPolicies...))
+	if resolved.retry != nil {
+		unary = append(unary, retry.UnaryClientInterceptor(resolved.retry, resolved.retryPolicies...))
 	}
 
-	if os.logger != nil {
-		unary = append(unary, logger.UnaryClientInterceptor(os.logger))
+	if resolved.logger != nil {
+		unary = append(unary, logger.UnaryClientInterceptor(resolved.logger))
 	}
 
-	if os.gen != nil {
-		unary = append(unary, token.UnaryClientInterceptor(os.id, os.gen))
+	if resolved.gen != nil {
+		unary = append(unary, token.UnaryClientInterceptor(resolved.id, resolved.gen))
 	}
 
 	return unary
@@ -372,16 +372,16 @@ func streamDialOption(opts *clientOpts) grpc.DialOption {
 }
 
 func options(opts ...ClientOption) *clientOpts {
-	os := &clientOpts{}
+	resolved := &clientOpts{}
 	for _, o := range opts {
-		o.apply(os)
+		o.apply(resolved)
 	}
-	if os.timeout <= 0 {
-		os.timeout = time.DefaultTimeout
+	if resolved.timeout <= 0 {
+		resolved.timeout = time.DefaultTimeout
 	}
-	if os.generator == nil {
-		os.generator = uuid.NewGenerator()
+	if resolved.generator == nil {
+		resolved.generator = uuid.NewGenerator()
 	}
 
-	return os
+	return resolved
 }

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -203,7 +203,7 @@ func TestWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, health.Serving, resp.GetStatus())
-	requireWatchStaysOpen(t, cancel, wc)
+	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
 func TestWatchServerLimiter(t *testing.T) {
@@ -258,7 +258,7 @@ func TestInvalidWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, health.NotServing, resp.GetStatus())
-	requireWatchStaysOpen(t, cancel, wc)
+	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
 func TestOverallWatch(t *testing.T) {
@@ -279,7 +279,7 @@ func TestOverallWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, health.Serving, resp.GetStatus())
-	requireWatchStaysOpen(t, cancel, wc)
+	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
 func TestInvalidOverallWatch(t *testing.T) {
@@ -301,7 +301,7 @@ func TestInvalidOverallWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, health.NotServing, resp.GetStatus())
-	requireWatchStaysOpen(t, cancel, wc)
+	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
 func TestNotFoundWatch(t *testing.T) {
@@ -323,7 +323,7 @@ func TestNotFoundWatch(t *testing.T) {
 	resp, err := wc.Recv()
 	require.NoError(t, err)
 	require.Equal(t, health.ServiceUnknown, resp.GetStatus())
-	requireWatchStaysOpen(t, cancel, wc)
+	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
 func TestIgnoreAuthWatch(t *testing.T) {
@@ -349,7 +349,7 @@ func TestIgnoreAuthWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, health.Serving, resp.GetStatus())
-	requireWatchStaysOpen(t, cancel, wc)
+	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
 func TestWatchStatusChanges(t *testing.T) {
@@ -401,7 +401,7 @@ func TestWatchStatusChanges(t *testing.T) {
 	}
 }
 
-func requireWatchStaysOpen(t *testing.T, cancel context.CancelFunc, wc health.WatchClient) {
+func requireWatchStaysOpenUntilCancel(t *testing.T, cancel context.CancelFunc, wc health.WatchClient) {
 	t.Helper()
 
 	errCh := make(chan error, 1)

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -70,7 +70,7 @@ func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response
 //
 // It enumerates all observers registered for the "grpc" transport kind and returns their current serving
 // statuses.
-func (s *Server) List(_ context.Context, req *health.ListRequest) (*health.ListResponse, error) {
+func (s *Server) List(_ context.Context, _ *health.ListRequest) (*health.ListResponse, error) {
 	res := &health.ListResponse{Statuses: map[string]*health.Response{}}
 	for name, observer := range s.server.Observers("grpc") {
 		res.Statuses[name] = &health.Response{Status: s.status(observer)}

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -28,12 +28,12 @@ func NewServerLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Serve
 		return nil, nil
 	}
 
-	limiter, err := limiter.NewLimiter(lc, keys, cfg)
+	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Server{limiter}, nil
+	return &Server{rateLimiter}, nil
 }
 
 // Server wraps `*limiter.Limiter` for gRPC server integration.
@@ -121,12 +121,12 @@ func NewClientLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Clien
 		return nil, nil
 	}
 
-	limiter, err := limiter.NewLimiter(lc, keys, cfg)
+	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{limiter}, nil
+	return &Client{rateLimiter}, nil
 }
 
 // Client wraps `*limiter.Limiter` for gRPC client integration.

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -79,7 +79,7 @@ type ServerParams struct {
 //   - OpenTelemetry stats handling when tracing or metrics are enabled.
 //   - A unary interceptor chain that performs metadata extraction/injection, and optionally logging,
 //     token verification, and rate limiting, followed by any user-provided interceptors.
-//   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging
+//   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging,
 //     token verification, and rate limiting, followed by any user-provided interceptors.
 //
 // TLS:

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -89,7 +89,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
 	cb := r.get(req)
-	v, err := cb.Execute(func() (any, error) {
+	result, err := cb.Execute(func() (any, error) {
 		resp, err := r.RoundTripper.RoundTrip(req)
 		if err != nil {
 			return nil, err
@@ -109,7 +109,7 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 		return nil, err, errors.Is(err, breaker.ErrOpenState) || errors.Is(err, breaker.ErrTooManyRequests)
 	}
 
-	return v.(*http.Response), nil, false
+	return result.(*http.Response), nil, false
 }
 
 func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
@@ -118,10 +118,10 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 		return cb
 	}
 
-	s := r.opts.settings
-	s.Name = key
-	isSuccessful := s.IsSuccessful
-	s.IsSuccessful = func(err error) bool {
+	settings := r.opts.settings
+	settings.Name = key
+	isSuccessful := settings.IsSuccessful
+	settings.IsSuccessful = func(err error) bool {
 		if err == nil {
 			return true
 		}
@@ -135,7 +135,7 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 		return false
 	}
 
-	cb := breaker.NewCircuitBreaker(s)
+	cb := breaker.NewCircuitBreaker(settings)
 	actual, _ := r.breakers.LoadOrStore(key, cb)
 	return actual
 }

--- a/transport/http/breaker/error.go
+++ b/transport/http/breaker/error.go
@@ -9,7 +9,7 @@ type responseError struct {
 	resp *http.Response
 }
 
-// Error is just used to satisfy the error interface. We don't want to expose the response details.
+// Error satisfies the error interface without exposing response details.
 func (e responseError) Error() string {
 	return strings.Empty
 }

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -212,38 +212,38 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //   - Token injection remains inside retry so a fresh token is generated for each retry attempt.
 //   - The limiter stays outside the breaker so local quota denials are not counted as upstream failures.
 func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
-	os := options(opts...)
+	resolved := options(opts...)
 
-	hrt, err := roundTripper(os)
+	hrt, err := roundTripper(resolved)
 	if err != nil {
 		return nil, err
 	}
 
-	if os.compression {
+	if resolved.compression {
 		hrt = gzhttp.Transport(hrt, gzhttp.TransportEnableGzip(true))
 	}
 
-	if os.gen != nil {
-		hrt = token.NewRoundTripper(os.id, os.gen, hrt)
+	if resolved.gen != nil {
+		hrt = token.NewRoundTripper(resolved.id, resolved.gen, hrt)
 	}
 
-	if os.retry != nil {
-		hrt = retry.NewRoundTripper(os.retry, hrt, os.retryPolicies...)
+	if resolved.retry != nil {
+		hrt = retry.NewRoundTripper(resolved.retry, hrt, resolved.retryPolicies...)
 	}
 
-	if os.breaker {
-		hrt = breaker.NewRoundTripper(hrt, os.breakerOptions...)
+	if resolved.breaker {
+		hrt = breaker.NewRoundTripper(hrt, resolved.breakerOptions...)
 	}
 
-	if os.limiter != nil {
-		hrt = limiter.NewRoundTripper(os.limiter, hrt)
+	if resolved.limiter != nil {
+		hrt = limiter.NewRoundTripper(resolved.limiter, hrt)
 	}
 
-	if os.logger != nil {
-		hrt = logger.NewRoundTripper(os.logger, hrt)
+	if resolved.logger != nil {
+		hrt = logger.NewRoundTripper(resolved.logger, hrt)
 	}
 
-	hrt = meta.NewRoundTripper(os.userAgent, os.generator, hrt)
+	hrt = meta.NewRoundTripper(resolved.userAgent, resolved.generator, hrt)
 
 	return hrt, nil
 }
@@ -257,32 +257,32 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 // Note: `http.NewClient` wraps the provided transport with OpenTelemetry instrumentation when tracing
 // or metrics are enabled.
 func NewClient(opts ...ClientOption) (*http.Client, error) {
-	os := options(opts...)
+	resolved := options(opts...)
 
 	transport, err := NewRoundTripper(opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	client := http.NewClient(transport, os.timeout)
-	if os.gen != nil {
+	client := http.NewClient(transport, resolved.timeout)
+	if resolved.gen != nil {
 		client.CheckRedirect = http.SameOriginRedirect
 	}
 
 	return client, nil
 }
 
-func roundTripper(os *clientOpts) (http.RoundTripper, error) {
-	hrt := os.roundTripper
+func roundTripper(resolved *clientOpts) (http.RoundTripper, error) {
+	hrt := resolved.roundTripper
 	if hrt != nil {
 		return hrt, nil
 	}
 
-	if !os.tls.IsEnabled() {
+	if !resolved.tls.IsEnabled() {
 		return http.Transport(nil), nil
 	}
 
-	conf, err := client.NewConfig(fs, os.tls)
+	conf, err := client.NewConfig(fs, resolved.tls)
 	if err != nil {
 		return nil, err
 	}
@@ -291,18 +291,18 @@ func roundTripper(os *clientOpts) (http.RoundTripper, error) {
 }
 
 func options(opts ...ClientOption) *clientOpts {
-	os := &clientOpts{}
+	resolved := &clientOpts{}
 	for _, o := range opts {
-		o.apply(os)
+		o.apply(resolved)
 	}
 
-	if os.timeout <= 0 {
-		os.timeout = time.DefaultTimeout
+	if resolved.timeout <= 0 {
+		resolved.timeout = time.DefaultTimeout
 	}
 
-	if os.generator == nil {
-		os.generator = uuid.NewGenerator()
+	if resolved.generator == nil {
+		resolved.generator = uuid.NewGenerator()
 	}
 
-	return os
+	return resolved
 }

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -32,7 +32,7 @@ func TestSendReceiveWithRoundTripper(t *testing.T) {
 	require.NoError(t, e.SetData(events.TextPlain, "test"))
 
 	result := world.Sender.Send(ctx, e)
-	require.True(t, protocol.IsACK(result))
+	requireACK(t, result)
 	require.NotNil(t, world.Event)
 	require.Equal(t, "test", bytes.String(e.Data()))
 }
@@ -50,7 +50,7 @@ func TestSendReceiveWithoutRoundTripper(t *testing.T) {
 	require.NoError(t, e.SetData(events.TextPlain, "test"))
 
 	result := world.Sender.Send(ctx, e)
-	require.True(t, protocol.IsACK(result))
+	requireACK(t, result)
 	require.NotNil(t, world.Event)
 	require.Equal(t, "test", bytes.String(e.Data()))
 }
@@ -75,7 +75,7 @@ func TestSendNotReceive(t *testing.T) {
 	require.NoError(t, e.SetData(events.TextPlain, "test"))
 
 	result := world.Sender.Send(ctx, e)
-	require.True(t, protocol.IsNACK(result))
+	requireNACK(t, result)
 	require.Nil(t, world.Event)
 }
 
@@ -105,7 +105,7 @@ func TestSenderWithWebhookDoesNotFollowCrossOriginRedirect(t *testing.T) {
 	require.NoError(t, e.SetData(events.TextPlain, "test"))
 
 	result := sender.Send(events.ContextWithTarget(t.Context(), trusted.URL+"/events"), e)
-	require.True(t, protocol.IsNACK(result))
+	requireNACK(t, result)
 	require.NotEmpty(t, trustedSignature)
 	require.Empty(t, attackerSignature)
 }
@@ -137,7 +137,7 @@ func TestSenderUsesStructuredEncoding(t *testing.T) {
 
 	result := sender.Send(events.ContextWithTarget(t.Context(), server.URL+"/events"), e)
 	require.NoError(t, <-readErrors)
-	require.True(t, protocol.IsACK(result))
+	requireACK(t, result)
 	require.Equal(t, "application/cloudevents+json", <-contentTypes)
 	require.Empty(t, <-specVersions)
 	body := <-bodies
@@ -168,4 +168,16 @@ func TestReceiveUsesServerMaxReceiveSizeBeforeWebhookVerification(t *testing.T) 
 
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 	require.Nil(t, world.Event)
+}
+
+func requireACK(t *testing.T, result protocol.Result) {
+	t.Helper()
+
+	require.True(t, protocol.IsACK(result), "expected CloudEvents ACK: %v", result)
+}
+
+func requireNACK(t *testing.T, result protocol.Result) {
+	t.Helper()
+
+	require.True(t, protocol.IsNACK(result), "expected CloudEvents NACK: %v", result)
 }

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -51,8 +51,8 @@ func WithSenderRoundTripper(rt http.RoundTripper) SenderOption {
 // Note: the provided hook must be configured appropriately (for example with the expected secret) for
 // signing to succeed.
 func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {
-	os := options(opts...)
-	rt := hooks.NewRoundTripper(hook, os.roundTripper)
+	resolved := options(opts...)
+	rt := hooks.NewRoundTripper(hook, resolved.roundTripper)
 	httpClient := http.Client{Transport: rt, CheckRedirect: http.SameOriginRedirect}
 
 	sender, _ := events.NewClientHTTP(transport.WithClient(httpClient))
@@ -70,12 +70,12 @@ func (s *Sender) Send(ctx context.Context, event events.Event) protocol.Result {
 }
 
 func options(opts ...SenderOption) *senderOptions {
-	os := &senderOptions{}
+	resolved := &senderOptions{}
 	for _, o := range opts {
-		o.apply(os)
+		o.apply(resolved)
 	}
-	if os.roundTripper == nil {
-		os.roundTripper = http.Transport(nil)
+	if resolved.roundTripper == nil {
+		resolved.roundTripper = http.Transport(nil)
 	}
-	return os
+	return resolved
 }

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -26,12 +26,12 @@ func NewServerLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Serve
 		return nil, nil
 	}
 
-	limiter, err := limiter.NewLimiter(lc, keys, cfg)
+	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Server{limiter}, nil
+	return &Server{rateLimiter}, nil
 }
 
 // Server wraps `*limiter.Limiter` for HTTP server integration.
@@ -96,12 +96,12 @@ func NewClientLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Clien
 		return nil, nil
 	}
 
-	limiter, err := limiter.NewLimiter(lc, keys, cfg)
+	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{limiter}, nil
+	return &Client{rateLimiter}, nil
 }
 
 // Client wraps `*limiter.Limiter` for HTTP client integration.

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -165,7 +165,7 @@ func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *
 	attemptCtx, cancel := r.withAttemptTimeout(ctx)
 	defer cancel()
 
-	attemptReq, err := attempt.request(req, attemptCtx)
+	attemptReq, err := request(req, attemptCtx, attempt.attempt)
 	if err != nil {
 		return nil, err
 	}
@@ -203,15 +203,6 @@ func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Requ
 
 type roundTripAttempt struct {
 	attempt uint64
-}
-
-func (a *roundTripAttempt) request(req *http.Request, ctx context.Context) (*http.Request, error) {
-	attemptReq, err := request(req, ctx, a.attempt)
-	if err != nil {
-		return nil, err
-	}
-
-	return attemptReq, nil
 }
 
 func (a *roundTripAttempt) retry(ctx, attemptCtx context.Context, req *http.Request, res *http.Response, err error, maxRetries uint64) error {

--- a/transport/http/telemetry/logger/logger.go
+++ b/transport/http/telemetry/logger/logger.go
@@ -60,7 +60,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 
 	m := snoop.CaptureMetricsFn(res, func(res http.ResponseWriter) { next(res, req.WithContext(ctx)) })
 	attrs = append(attrs, logger.String(meta.DurationKey, m.Duration.String()), logger.Int(meta.CodeKey, m.Code))
-	message := logger.NewText(message(strings.Join(strings.Space, method, service)))
+	message := logger.NewText(httpMessage(strings.Join(strings.Space, method, service)))
 
 	h.logger.LogAttrs(ctx, codeToLevel(m.Code), message, attrs...)
 }
@@ -110,7 +110,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		attrs = append(attrs, logger.Int(meta.CodeKey, resp.StatusCode))
 	}
 
-	message := logger.NewMessage(message(strings.Join(strings.Space, method, service)), err)
+	message := logger.NewMessage(httpMessage(strings.Join(strings.Space, method, service)), err)
 
 	r.logger.LogAttrs(ctx, respToLevel(resp), message, attrs...)
 	return resp, err
@@ -139,6 +139,6 @@ func codeToLevel(code int) logger.Level {
 	return logger.LevelInfo
 }
 
-func message(msg string) string {
+func httpMessage(msg string) string {
 	return "http: " + msg
 }

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -146,14 +146,14 @@ func (l *Limiter) Close(ctx context.Context) error {
 }
 
 func key(value meta.Value) string {
-	key := value.Value()
-	if strings.IsEmpty(key) {
+	rawKey := value.Value()
+	if strings.IsEmpty(rawKey) {
 		return "<empty>"
 	}
-	if len(key) <= maxKeySize {
-		return key
+	if len(rawKey) <= maxKeySize {
+		return rawKey
 	}
 
-	sum := sha256.Sum256([]byte(key))
+	sum := sha256.Sum256([]byte(rawKey))
 	return strings.Concat("sha256:", hex.EncodeToString(sum[:]))
 }


### PR DESCRIPTION
## What

- Rename transport option locals and gRPC keepalive fields for clearer Go-style reading.
- Clarify limiter, breaker, logger, and health helper names without changing behavior.
- Add CloudEvents ACK/NACK assertion helpers and small package-doc/comment polish.

## Why

- Make transport wiring and tests easier to scan after the style-review pass.

## Testing

- `go test ./transport/...` - passed
- `git diff --check` - passed
- `make lint` - passed with the existing gomodguard deprecation warning

AI-assisted-by: [Codex](https://openai.com/codex/)
