### PR TITLE
test(grpc): stabilize stream status assertions

### DIFF
--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -116,10 +116,7 @@ func TestAuthStreamWithAppend(t *testing.T) {
 	stream, err := client.SayStreamHello(ctx)
 	require.NoError(t, err)
 
-	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
-	require.NoError(t, err)
-
-	_, err = stream.Recv()
+	_, err = sendStreamHello(t, stream, "test")
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
@@ -224,10 +221,7 @@ func TestValidAuthStream(t *testing.T) {
 	stream, err := client.SayStreamHello(t.Context())
 	require.NoError(t, err)
 
-	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
-	require.NoError(t, err)
-
-	resp, err := stream.Recv()
+	resp, err := sendStreamHello(t, stream, "test")
 	require.NoError(t, err)
 
 	require.Equal(t, "Hello test", resp.GetMessage())
@@ -248,10 +242,7 @@ func TestInvalidAuthStream(t *testing.T) {
 	stream, err := client.SayStreamHello(t.Context())
 	require.NoError(t, err)
 
-	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
-	require.NoError(t, err)
-
-	_, err = stream.Recv()
+	_, err = sendStreamHello(t, stream, "test")
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
@@ -286,10 +277,7 @@ func TestMissingClientAuthStream(t *testing.T) {
 	stream, err := client.SayStreamHello(t.Context())
 	require.NoError(t, err)
 
-	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
-	require.NoError(t, err)
-
-	_, err = stream.Recv()
+	_, err = sendStreamHello(t, stream, "test")
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -73,9 +73,7 @@ func TestStream(t *testing.T) {
 	stream, err := client.SayStreamHello(ctx)
 	require.NoError(t, err)
 
-	require.NoError(t, stream.Send(&v1.SayStreamHelloRequest{Name: "test"}))
-
-	resp, err := stream.Recv()
+	resp, err := sendStreamHello(t, stream, "test")
 	require.NoError(t, err)
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
@@ -101,11 +99,7 @@ func TestStreamMaxReceiveSize(t *testing.T) {
 	stream, err := client.SayStreamHello(t.Context())
 	require.NoError(t, err)
 
-	err = stream.Send(&v1.SayStreamHelloRequest{Name: strings.Repeat("a", 256)})
-	if err == nil {
-		_, err = stream.Recv()
-	}
-
+	_, err = sendStreamHello(t, stream, strings.Repeat("a", 256))
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
@@ -131,9 +125,7 @@ func TestStreamMaxSendSize(t *testing.T) {
 	stream, err := client.SayStreamHello(t.Context())
 	require.NoError(t, err)
 
-	require.NoError(t, stream.Send(&v1.SayStreamHelloRequest{Name: strings.Repeat("a", 256)}))
-
-	_, err = stream.Recv()
+	_, err = sendStreamHello(t, stream, strings.Repeat("a", 256))
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }

--- a/transport/grpc/helpers_test.go
+++ b/transport/grpc/helpers_test.go
@@ -3,7 +3,10 @@ package grpc_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/io"
 	servicegrpc "github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	"github.com/stretchr/testify/require"
@@ -16,4 +19,18 @@ func requireGRPCConn(tb testing.TB, world *test.World, opts ...breaker.Option) *
 	require.NoError(tb, err)
 
 	return conn
+}
+
+func sendStreamHello(tb testing.TB, stream v1.GreeterService_SayStreamHelloClient, name string) (*v1.SayStreamHelloResponse, error) {
+	tb.Helper()
+
+	if err := stream.Send(&v1.SayStreamHelloRequest{Name: name}); err != nil {
+		if errors.Is(err, io.EOF) {
+			return stream.Recv()
+		}
+
+		return nil, err
+	}
+
+	return stream.Recv()
 }

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
@@ -278,14 +276,6 @@ func sayStreamHello(t *testing.T, client v1.GreeterServiceClient) error {
 		return err
 	}
 
-	if err := stream.Send(&v1.SayStreamHelloRequest{Name: "test"}); err != nil {
-		if errors.Is(err, io.EOF) {
-			_, err = stream.Recv()
-		}
-
-		return err
-	}
-
-	_, err = stream.Recv()
+	_, err = sendStreamHello(t, stream, "test")
 	return err
 }


### PR DESCRIPTION
## What

- Add a shared gRPC stream test helper that handles EOF from early stream closure.
- Use the helper across auth, size-limit, and limiter stream tests.
- Keep negative stream assertions focused on the final gRPC status code.

## Why

- Prevent streaming tests from failing when the server closes the stream before the client send returns.

## Testing

- `go test ./transport/grpc -run 'Test(AuthStreamWithAppend|InvalidAuthStream|MissingClientAuthStream|StreamMaxReceiveSize|StreamMaxSendSize|ServerLimiterStream|ClientLimiterStream|ServerLimiterUsesVerifiedUserIDStream)$' -count=20` - passed
- `go test ./transport/grpc` - passed
- `git diff --check` - passed
- `make lint` - passed with the existing gomodguard deprecation warning

AI-assisted-by: [Codex](https://openai.com/codex/)
