### PR TITLE
feat(cache): link package docs and simplify fallbacks

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -22,9 +22,9 @@ import (
 // maxBase64EncodedLenInput is the largest decoded-size limit whose padded base64 length fits in int.
 const maxBase64EncodedLenInput = math.MaxInt / 4 * 3
 
-// CacheParams defines dependencies for constructing a Cache.
+// CacheParams defines dependencies for constructing a [Cache].
 //
-// It is intended for dependency injection (Fx/Dig). The constructor will typically be wired via `Module`.
+// It is intended for dependency injection (Fx/Dig). The constructor will typically be wired via [Module].
 type CacheParams struct {
 	di.In
 	Config     *config.Config
@@ -34,9 +34,9 @@ type CacheParams struct {
 	Driver     driver.Driver
 }
 
-// NewCache constructs a Cache from configuration.
+// NewCache constructs a [Cache] from configuration.
 //
-// If caching is disabled (i.e. params.Config is nil), NewCache returns nil. Callers are expected to
+// If caching is disabled (i.e. params.Config is nil), [NewCache] returns nil. Callers are expected to
 // tolerate a nil cache instance.
 func NewCache(params CacheParams) *Cache {
 	if !params.Config.IsEnabled() {
@@ -58,9 +58,9 @@ func NewCache(params CacheParams) *Cache {
 // final bytes, and stores the resulting string via the configured driver.
 //
 // Encoding selection is operation-dependent:
-//   - Persist uses "plain" only for io.WriterTo values
-//   - Get uses "plain" only for io.ReaderFrom destinations
-//   - proto.Message uses "proto"
+//   - [Cache.Persist] uses "plain" only for [io.WriterTo] values
+//   - [Cache.Get] uses "plain" only for [io.ReaderFrom] destinations
+//   - [proto.Message] uses "proto"
 //   - otherwise the configured encoder is used, falling back to "json"
 //
 // Compression is selected from configuration, falling back to "none" when unknown/unavailable.
@@ -179,11 +179,7 @@ func (c *Cache) readEncoder(value any) encoding.Encoder {
 	case proto.Message:
 		return c.em.Get("proto")
 	default:
-		if enc := c.em.Get(c.cfg.Encoder); enc != nil {
-			return enc
-		}
-
-		return c.em.Get("json")
+		return c.configuredEncoder()
 	}
 }
 
@@ -194,10 +190,14 @@ func (c *Cache) writeEncoder(value any) encoding.Encoder {
 	case proto.Message:
 		return c.em.Get("proto")
 	default:
-		if enc := c.em.Get(c.cfg.Encoder); enc != nil {
-			return enc
-		}
-
-		return c.em.Get("json")
+		return c.configuredEncoder()
 	}
+}
+
+func (c *Cache) configuredEncoder() encoding.Encoder {
+	if enc := c.em.Get(c.cfg.Encoder); enc != nil {
+		return enc
+	}
+
+	return c.em.Get("json")
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -32,8 +32,8 @@ func TestValidCache(t *testing.T) {
 }
 
 func TestGenericValidCache(t *testing.T) {
-	config := test.NewCacheConfig("sync", "snappy", "json", "redis")
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())
+	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
 	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
@@ -155,8 +155,8 @@ func TestMaxSizeOnGetAllowsHugeConfiguredLimit(t *testing.T) {
 }
 
 func TestExpiredCache(t *testing.T) {
-	config := test.NewCacheConfig("sync", "snappy", "json", "redis")
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())
+	cfg := test.NewCacheConfig("sync", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Nanosecond))
 
 	// Simulate expiry.
@@ -208,14 +208,14 @@ func TestDisabledCache(t *testing.T) {
 
 func TestErroneousSave(t *testing.T) {
 	t.Run("invalid encoder", func(t *testing.T) {
-		config := test.NewCacheConfig("sync", "snappy", "error", "redis")
-		test.NewStartedWorld(t, test.WithWorldCacheConfig(config), test.WithWorldRegisterCache())
+		cfg := test.NewCacheConfig("sync", "snappy", "error", "redis")
+		test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 		require.Error(t, cache.Persist(t.Context(), "test", new("test"), time.Minute))
 	})
 
 	t.Run("read from only falls back to configured encoder", func(t *testing.T) {
-		config := test.NewCacheConfig("sync", "none", "json", "redis")
-		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config))
+		cfg := test.NewCacheConfig("sync", "none", "json", "redis")
+		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg))
 		require.NoError(t, world.Persist(t.Context(), "test", &test.ReadFromOnly{Name: "hello?"}, time.Minute))
 
 		var get test.Request
@@ -249,8 +249,8 @@ func TestErroneousGet(t *testing.T) {
 }
 
 func TestWriteToOnlyUsesConfiguredEncoderOnGet(t *testing.T) {
-	config := test.NewCacheConfig("sync", "none", "json", "redis")
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(config))
+	cfg := test.NewCacheConfig("sync", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg))
 	require.NoError(t, world.Persist(t.Context(), "test", &test.Request{Name: "hello?"}, time.Minute))
 
 	get := &test.WriteToOnly{}
@@ -276,19 +276,19 @@ func TestMissingCache(t *testing.T) {
 		Driver:     d,
 	}
 
-	kind := cache.NewCache(params)
+	c := cache.NewCache(params)
 	t.Cleanup(func() {
-		require.NoError(t, kind.Flush(context.Background()))
+		require.NoError(t, c.Flush(context.Background()))
 	})
 	value := "existing"
 
-	require.NoError(t, kind.Get(t.Context(), "missing", &value))
+	require.NoError(t, c.Get(t.Context(), "missing", &value))
 	require.Equal(t, "existing", value)
 }
 
 func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
 	cfg := &config.Config{Kind: "sync"}
-	kind := cache.NewCache(cache.CacheParams{
+	c := cache.NewCache(cache.CacheParams{
 		Config:     cfg,
 		Compressor: test.Compressor,
 		Encoder:    test.Encoder,
@@ -297,7 +297,7 @@ func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
 	})
 	value := "existing"
 
-	require.NoError(t, kind.Get(t.Context(), "expired", &value))
+	require.NoError(t, c.Get(t.Context(), "expired", &value))
 	require.Equal(t, "existing", value)
 }
 

--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	// Kind selects the cache backend implementation.
 	//
 	// The built-in driver kinds are "redis" and "sync". Unknown kinds cause
-	// cache/driver.NewDriver to return ErrNotFound.
+	// [github.com/alexfalkowski/go-service/v2/cache/driver.NewDriver] to return
+	// [github.com/alexfalkowski/go-service/v2/cache/driver.ErrNotFound].
 	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
 
 	// Compressor selects the compression algorithm used for cached values (if supported by the implementation).
@@ -26,7 +27,7 @@ type Config struct {
 	//
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//
-	// A zero value applies bytes.DefaultSize. Values must be between 0 and bytes.MaxConfigSize.
+	// A zero value applies [bytes.DefaultSize]. Values must be between 0 and [bytes.MaxConfigSize].
 	MaxSize bytes.Size `yaml:"max_size,omitempty" json:"max_size,omitempty" toml:"max_size,omitempty" validate:"config_size"`
 }
 
@@ -37,7 +38,7 @@ func (c *Config) IsEnabled() bool {
 
 // GetMaxSize returns the configured cache value limit.
 //
-// A nil receiver or a zero value falls back to bytes.DefaultSize.
+// A nil receiver or a zero value falls back to [bytes.DefaultSize].
 func (c *Config) GetMaxSize() bytes.Size {
 	if c == nil || c.MaxSize == 0 {
 		return bytes.DefaultSize

--- a/cache/config/doc.go
+++ b/cache/config/doc.go
@@ -1,7 +1,7 @@
 // Package config provides cache configuration types for go-service.
 //
 // This package contains configuration structs that are typically embedded into a larger
-// service configuration and then consumed by the cache wiring in `github.com/alexfalkowski/go-service/v2/cache`.
+// service configuration and then consumed by the cache wiring in [github.com/alexfalkowski/go-service/v2/cache].
 //
-// Start with `Config`.
+// Start with [Config].
 package config

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -1,25 +1,25 @@
 // Package cache provides cache abstractions, configuration, and drivers for go-service.
 //
-// The primary entrypoint is `NewCache`, which constructs a `*Cache` from configuration.
+// The primary entrypoint is [NewCache], which constructs a *[Cache] from configuration.
 //
 // # Disabled / nil behavior
 //
 // Caching is intentionally optional. When cache configuration is disabled/unset, constructors return nil
 // and callers are expected to tolerate a nil cache instance.
 //
-// In addition to the instance API on `*Cache`, this package exposes package-level generic helpers
-// (`Get` and `Persist`). Those helpers are nil-safe after `Register` has been called (via DI wiring in
-// `Module`), and they become no-ops / return zero values when caching is disabled. In the standard
+// In addition to the instance API on *[Cache], this package exposes package-level generic helpers
+// ([Get] and [Persist]). Those helpers are nil-safe after [Register] has been called (via DI wiring in
+// [Module]), and they become no-ops / return zero values when caching is disabled. In the standard
 // service composition this registration is performed for you by the module graph.
 //
 // # Value encoding
 //
-// `Cache` persists arbitrary values by encoding (and optionally compressing) them before passing them to
+// [Cache] persists arbitrary values by encoding (and optionally compressing) them before passing them to
 // the configured driver. The encoder/compressor used is selected by configuration with sensible defaults.
 //
 // # TTL resolution
 //
-// TTL handling depends on the selected driver. The built-in in-memory `sync`
+// TTL handling depends on the selected driver. The built-in in-memory "sync"
 // driver stores values in process memory and expires entries lazily when they
 // are read.
 package cache

--- a/cache/driver/doc.go
+++ b/cache/driver/doc.go
@@ -1,32 +1,33 @@
 // Package driver provides cache driver construction and related helpers for go-service.
 //
-// It contains the `NewDriver` constructor used by DI wiring to build a cache backend implementation
-// from `cache/config.Config`.
+// It contains the [NewDriver] constructor used by DI wiring to build a cache backend implementation
+// from [github.com/alexfalkowski/go-service/v2/cache/config.Config].
 //
 // # Disabled / nil behavior
 //
-// When caching is disabled (i.e. the cache config is nil), `NewDriver` returns a nil Driver and a nil error.
+// When caching is disabled (i.e. the cache config is nil), [NewDriver] returns a nil [Driver] and a nil error.
 //
 // # Supported kinds
 //
-// The driver kind is selected by `Config.Kind`. Supported values are implementation-dependent, but this
-// package currently includes built-in constructors for common backends (for example Redis and an in-memory
-// sync driver).
+// The driver kind is selected by [github.com/alexfalkowski/go-service/v2/cache/config.Config.Kind].
+// Supported values are implementation-dependent, but this package currently includes built-in constructors
+// for common backends (for example Redis and an in-memory sync driver).
 //
 // The built-in Redis backend resolves its URL from a go-service "source
 // string", constructs a go-redis client, and instruments that client via
-// `cache/telemetry` before exposing it through a context-aware driver.
-// Redis configuration is strict by design: `Config.Options["url"]` must exist
-// and be a string. The standard config fixtures provide that shape; callers that
-// build config manually should validate it before calling `NewDriver`.
+// [github.com/alexfalkowski/go-service/v2/cache/telemetry] before exposing it through a context-aware driver.
+// Redis configuration is strict by design: the
+// [github.com/alexfalkowski/go-service/v2/cache/config.Config.Options] map must contain a "url" string.
+// The standard config fixtures provide that shape; callers that build config manually should validate it
+// before calling [NewDriver].
 //
-// The built-in `sync` driver uses an in-process go-sync Map and lazily expires
+// The built-in "sync" driver uses an in-process go-sync Map and lazily expires
 // entries when they are read.
 //
-// If the configured kind is unknown, `NewDriver` returns `ErrNotFound`.
+// If the configured kind is unknown, [NewDriver] returns [ErrNotFound].
 //
 // # Errors
 //
-// This package provides `ErrExpired`, `ErrMissing`, and helper functions to
+// This package provides [ErrExpired], [ErrMissing], and helper functions to
 // classify backend-specific miss conditions in a backend-agnostic way.
 package driver

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -13,18 +13,18 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
-	redis "github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9"
 	notifications "github.com/redis/go-redis/v9/maintnotifications"
 )
 
 // ErrExpired is returned when a cache entry exists but is expired.
 //
-// Drivers may wrap this error; use IsExpiredError to classify this condition.
+// Drivers may wrap this error; use [IsExpiredError] to classify this condition.
 var ErrExpired = errors.New("cache: expired")
 
 // ErrMissing is returned when a cache entry does not exist.
 //
-// Drivers may wrap this error; use IsMissingError to classify this condition.
+// Drivers may wrap this error; use [IsMissingError] to classify this condition.
 var ErrMissing = errors.New("cache: missing")
 
 // ErrNotFound is returned when the configured cache driver kind is unknown.
@@ -33,7 +33,7 @@ var ErrNotFound = errors.New("cache: driver not found")
 // ErrInvalidURL is returned when a cache backend URL cannot be parsed.
 var ErrInvalidURL = errors.New("cache: invalid driver url")
 
-// DriverParams defines dependencies for constructing a Driver.
+// DriverParams defines dependencies for constructing a [Driver].
 type DriverParams struct {
 	di.In
 	Lifecycle di.Lifecycle
@@ -44,27 +44,27 @@ type DriverParams struct {
 	Logger *logger.Logger
 }
 
-// NewDriver constructs a cache Driver for the configured backend.
+// NewDriver constructs a cache [Driver] for the configured backend.
 //
 // # Disabled behavior
 //
-// If cfg is nil (caching disabled), NewDriver returns (nil, nil). Callers are expected to tolerate a nil Driver.
+// If cfg is nil (caching disabled), [NewDriver] returns (nil, nil). Callers are expected to tolerate a nil [Driver].
 //
 // # Configuration expectations
 //
-// NewDriver dispatches on cfg.Kind. Some backends expect specific keys to be present in cfg.Options.
+// NewDriver dispatches on [config.Config.Kind]. Some backends expect specific keys to be present in [config.Config.Options].
 // For example, the "redis" backend expects:
 //
 //   - options["url"] to be a string "source string" (e.g. "env:REDIS_URL" or "file:/path/to/url" or a literal URL)
 //
-// The URL is read via fs.ReadSource, parsed using redis/go-redis ParseURL, and
-// then the client is instrumented for tracing and metrics via `cache/telemetry`
+// The URL is read via [os.FS.ReadSource], parsed using [redis.ParseURL], and
+// then the client is instrumented for tracing and metrics via [telemetry]
 // when those telemetry providers are enabled.
 //
 // The Redis client is closed from the supplied lifecycle's OnStop hook.
 //
 // Instrumentation errors are treated as fatal configuration/runtime errors and
-// are converted into panics via runtime.Must, matching the existing repository
+// are converted into panics via [runtime.Must], matching the existing repository
 // convention for mandatory telemetry wiring in internal constructors.
 //
 // # Backends
@@ -73,9 +73,9 @@ type DriverParams struct {
 //   - "redis": Redis backend using github.com/redis/go-redis
 //   - "sync": in-memory backend using github.com/alexfalkowski/go-sync Map
 //
-// The built-in `sync` backend stores values in process memory and expires entries lazily on access.
+// The built-in "sync" backend stores values in process memory and expires entries lazily on access.
 //
-// If cfg.Kind is unknown, NewDriver returns ErrNotFound.
+// If [config.Config.Kind] is unknown, [NewDriver] returns [ErrNotFound].
 func NewDriver(params DriverParams) (Driver, error) {
 	cfg := params.Config
 	if !cfg.IsEnabled() {
@@ -162,7 +162,7 @@ func IsExpiredError(err error) bool {
 // IsMissingError reports whether err represents a missing cache entry.
 //
 // This helper normalizes the miss semantics of the backends currently supported by this package,
-// including Redis nil replies.
+// including Redis nil replies ([redis.Nil]).
 func IsMissingError(err error) bool {
 	if errors.Is(err, redis.Nil) {
 		return true

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/time"
-	redis "github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )

--- a/cache/driver/redis.go
+++ b/cache/driver/redis.go
@@ -4,7 +4,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/time"
-	redis "github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9"
 )
 
 type redisDriver struct {

--- a/cache/driver/sync.go
+++ b/cache/driver/sync.go
@@ -3,7 +3,7 @@ package driver
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/time"
-	sync "github.com/alexfalkowski/go-sync"
+	"github.com/alexfalkowski/go-sync"
 )
 
 type syncDriver struct {
@@ -30,18 +30,18 @@ func (d *syncDriver) Fetch(ctx context.Context, key string) (string, error) {
 		return "", err
 	}
 
-	value, ok := d.items.Load(key)
+	entry, ok := d.items.Load(key)
 	if !ok {
 		return "", ErrMissing
 	}
 
-	if !value.expiresAt.IsZero() && time.Now().After(value.expiresAt) {
-		d.items.CompareAndDelete(key, value)
+	if !entry.expiresAt.IsZero() && time.Now().After(entry.expiresAt) {
+		d.items.CompareAndDelete(key, entry)
 
 		return "", ErrExpired
 	}
 
-	return value.value, nil
+	return entry.value, nil
 }
 
 func (d *syncDriver) Flush(ctx context.Context) error {

--- a/cache/generic.go
+++ b/cache/generic.go
@@ -10,9 +10,9 @@ var cache *Cache
 
 // Register installs the package-level cache instance used by the generic helper functions.
 //
-// This function is primarily intended to be called by dependency injection wiring (see `Module`).
-// Once registered, package-level helpers like `Get` and `Persist` will delegate to the registered
-// `*Cache` instance.
+// This function is primarily intended to be called by dependency injection wiring (see [Module]).
+// Once registered, package-level helpers like [Get] and [Persist] will delegate to the registered
+// *[Cache] instance.
 //
 // If c is nil, the helpers behave as if caching is disabled (they return zero values / act as no-ops).
 func Register(c *Cache) {
@@ -22,9 +22,9 @@ func Register(c *Cache) {
 // Get loads a cached value for key into a newly allocated value of type T and returns it.
 //
 // Semantics:
-//   - If caching is disabled (no cache registered), Get returns a zero-value *T and a nil error.
-//   - If the cache driver reports a miss/expired entry, Get returns a zero-value *T and a nil error.
-//   - If a non-miss error occurs (for example decode failure or driver error), Get returns the
+//   - If caching is disabled (no cache registered), [Get] returns a zero-value *T and a nil error.
+//   - If the cache driver reports a miss/expired entry, [Get] returns a zero-value *T and a nil error.
+//   - If a non-miss error occurs (for example decode failure or driver error), [Get] returns the
 //     zero-value *T along with that error.
 //
 // The returned pointer is always non-nil.
@@ -39,8 +39,8 @@ func Get[T any](ctx context.Context, key string) (*T, error) {
 
 // Persist stores value under key with the provided TTL.
 //
-// If caching is disabled (no cache registered), Persist is a no-op and returns nil.
-// Otherwise it delegates to the registered `*Cache`.
+// If caching is disabled (no cache registered), [Persist] is a no-op and returns nil.
+// Otherwise it delegates to the registered *[Cache].
 func Persist[T any](ctx context.Context, key string, value *T, ttl time.Duration) error {
 	if cache == nil {
 		return nil

--- a/cache/module.go
+++ b/cache/module.go
@@ -8,14 +8,14 @@ import (
 // Module wires the cache subsystem into Fx.
 //
 // It provides, in order:
-//   - a cache Driver (see cache/driver.NewDriver)
-//   - a *Cache (see NewCache)
-//   - package-level registration (see Register) so generic helpers (Get/Persist) can be used
+//   - a cache [driver.Driver] (see [driver.NewDriver])
+//   - a *[Cache] (see [NewCache])
+//   - package-level registration (see [Register]) so generic helpers ([Get]/[Persist]) can be used
 //
 // # Disabled behavior
 //
-// When caching is disabled via configuration, driver.NewDriver returns a nil Driver and NewCache returns
-// a nil *Cache. Register is still invoked with nil, which makes the package-level helpers behave as if
+// When caching is disabled via configuration, [driver.NewDriver] returns a nil [driver.Driver] and [NewCache]
+// returns a nil *[Cache]. [Register] is still invoked with nil, which makes the package-level helpers behave as if
 // caching is disabled (no-ops / zero values) rather than failing.
 var Module = di.Module(
 	di.Constructor(driver.NewDriver),

--- a/cache/telemetry/doc.go
+++ b/cache/telemetry/doc.go
@@ -8,6 +8,6 @@
 //
 // Use this package when instrumenting go-redis clients that back the go-service
 // cache subsystem. Higher-level cache code should generally prefer
-// `cache/driver.NewDriver`, which applies this instrumentation automatically for
+// [github.com/alexfalkowski/go-service/v2/cache/driver.NewDriver], which applies this instrumentation automatically for
 // the built-in Redis backend.
 package telemetry

--- a/cache/telemetry/telemetry.go
+++ b/cache/telemetry/telemetry.go
@@ -2,28 +2,28 @@ package telemetry
 
 import (
 	"github.com/redis/go-redis/extra/redisotel/v9"
-	client "github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9"
 )
 
 // InstrumentTracing instruments a Redis client for OpenTelemetry tracing.
 //
-// This is a thin wrapper around redisotel.InstrumentTracing with raw command
+// This is a thin wrapper around [redisotel.InstrumentTracing] with raw command
 // statement capture disabled.
 //
 // The provided client is modified in place to emit tracing data for supported
 // Redis operations. The wrapper does not change upstream behavior or error
 // semantics.
-func InstrumentTracing(client client.UniversalClient) error {
+func InstrumentTracing(client redis.UniversalClient) error {
 	return redisotel.InstrumentTracing(client, redisotel.WithDBStatement(false))
 }
 
 // InstrumentMetrics instruments a Redis client for OpenTelemetry metrics.
 //
-// This is a thin wrapper around redisotel.InstrumentMetrics that unregisters
+// This is a thin wrapper around [redisotel.InstrumentMetrics] that unregisters
 // observable callbacks when closeChan is closed.
 //
 // The provided client is modified in place to emit Redis client metrics. The
 // wrapper does not change upstream behavior or error semantics.
-func InstrumentMetrics(client client.UniversalClient, closeChan chan struct{}) error {
+func InstrumentMetrics(client redis.UniversalClient, closeChan chan struct{}) error {
 	return redisotel.InstrumentMetrics(client, redisotel.WithCloseChan(closeChan))
 }


### PR DESCRIPTION
## What

- Added GoDoc links across the cache packages for exported APIs and package references.
- Simplified duplicate encoder fallback selection behind a shared helper.
- Cleaned up cache test locals and redundant import aliases for readability.

## Why

- Keeps package documentation easier to navigate in generated Go docs.
- Reduces small duplicated fallback logic and makes the style cleanup consistent across the package.

## Testing

- `make lint` - passed
- `GOCACHE=/private/tmp/go-build-cache go vet ./cache/...` - passed
- `GOCACHE=/private/tmp/go-build-cache go test ./cache/...` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
