### PR TITLE
feat(token): reject invalid generation inputs

### DIFF
--- a/env/version.go
+++ b/env/version.go
@@ -13,8 +13,8 @@ import (
 // It prefers the SERVICE_VERSION environment variable when set; otherwise it falls back to
 // [runtime.Version]().
 //
-// The returned Version is not normalized at construction time; normalization (currently stripping a
-// leading "v") is applied when calling [Version.String].
+// The returned Version is not normalized at construction time; normalization
+// is applied when calling [Version.String].
 func NewVersion() Version {
 	return Version(cmp.Or(os.Getenv("SERVICE_VERSION"), runtime.Version()))
 }
@@ -30,9 +30,13 @@ type Version string
 // so callers get "1.2.3". Other values are returned unchanged.
 func (v Version) String() string {
 	s := string(v)
-	if strings.IsEmpty(s) || s[0] != 'v' {
+	if strings.IsEmpty(s) || s[0] != 'v' || len(s) == 1 || !isDigit(s[1]) {
 		return s
 	}
 
 	return s[1:]
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }

--- a/env/version_test.go
+++ b/env/version_test.go
@@ -24,6 +24,9 @@ func TestVersionString(t *testing.T) {
 	}{
 		{name: "semver prefix", version: "v1.0.0", expected: "1.0.0"},
 		{name: "plain value", version: "what", expected: "what"},
+		{name: "plain value starting with v", version: "version", expected: "version"},
+		{name: "plain value starting with v and dash", version: "ver-1", expected: "ver-1"},
+		{name: "only v", version: "v", expected: "v"},
 		{name: "empty", version: env.Version(strings.Empty), expected: strings.Empty},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -73,6 +73,9 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 	if t.signer == nil || len(t.signer.PrivateKey) != ed25519.PrivateKeySize || t.generator == nil {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
+	if strings.IsEmpty(t.cfg.Issuer) || strings.IsEmpty(t.cfg.KeyID) || t.cfg.Expiration <= 0 {
+		return strings.Empty, errors.ErrInvalidConfig
+	}
 
 	key := t.signer.PrivateKey
 	now := time.Now()

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -339,6 +339,57 @@ func TestInvalidConfigDoesNotPanic(t *testing.T) {
 	})
 }
 
+func TestInvalidGenerateConfigDoesNotPanic(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	ec := test.NewEd25519()
+	signer, _ := ed25519.NewSigner(test.PEM, ec)
+	verifier, _ := ed25519.NewVerifier(test.PEM, ec)
+	gen := uuid.NewGenerator()
+
+	for _, tt := range []struct {
+		config *jwt.Config
+		name   string
+	}{
+		{
+			name: "generate without issuer",
+			config: &jwt.Config{
+				KeyID:      cfg.JWT.KeyID,
+				Expiration: cfg.JWT.Expiration,
+			},
+		},
+		{
+			name: "generate without key id",
+			config: &jwt.Config{
+				Issuer:     cfg.JWT.Issuer,
+				Expiration: cfg.JWT.Expiration,
+			},
+		},
+		{
+			name: "generate without expiration",
+			config: &jwt.Config{
+				Issuer: cfg.JWT.Issuer,
+				KeyID:  cfg.JWT.KeyID,
+			},
+		},
+		{
+			name: "generate with negative expiration",
+			config: &jwt.Config{
+				Issuer:     cfg.JWT.Issuer,
+				KeyID:      cfg.JWT.KeyID,
+				Expiration: -time.Second,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			token := jwt.NewToken(tt.config, signer, verifier, gen)
+
+			tkn, err := token.Generate("hello", test.UserID.String())
+			require.Empty(t, tkn)
+			require.ErrorIs(t, err, errors.ErrInvalidConfig)
+		})
+	}
+}
+
 func TestInvalidPrivateKeyDoesNotPanic(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	ec := test.NewEd25519()


### PR DESCRIPTION
## What

- Reject JWT generation configs that would emit locally unverifiable credentials.
- Preserve non-semver service versions that happen to start with v while still normalizing v-prefixed numeric versions.

## Why

- Invalid JWT issuer, key id, or expiration should fail before signing instead of producing values verification rejects.
- Service metadata and user agents should not drop the first character from plain version strings such as version or ver-1.

## Testing

- `go test ./env ./token/jwt ./token` - passed
- `make lint` - passed
