### PR TITLE
feat(limiter): separate operation quotas by transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,13 +179,14 @@ matching skill for the task.
   construction to be passed in a single call; repeated calls intentionally
   replace earlier values. Do not flag this as dropped configuration unless a
   public API starts promising accumulation across repeated option helpers.
-- Transport limiter keys are `"user-agent"`, `"ip"`, `"user-id"`, and
-  `"service-method"`; `"token"` is intentionally not a limiter key. Server
-  limiters run after metadata extraction and token verification, so `"user-id"`
-  is the verified principal (JWT/PASETO subject or SSH key name), and missing,
-  malformed, or invalid auth is rejected before the limiter by design. Do not
-  flag that bypass; use an external edge, gateway, ingress, load balancer, or
-  service mesh limiter when those attempts need quota enforcement.
+- Transport limiter keys are `"user-id"`, `"transport-service-method"`,
+  `"service-method"`, `"ip"`, and `"user-agent"`; `"token"` is
+  intentionally not a limiter key. Server limiters run after metadata
+  extraction and token verification, so `"user-id"` is the verified principal
+  (JWT/PASETO subject or SSH key name), and missing, malformed, or invalid auth
+  is rejected before the limiter by design. Do not flag that bypass; use an
+  external edge, gateway, ingress, load balancer, or service mesh limiter when
+  those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
 - HTTP telemetry logger service/method derivation may include request URL path
   segments for non-canonical HTTP routes. This is intentional for client and

--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ Limiter config is `transport/limiter.Config` and is typically applied at transpo
 Supported key kinds (built-in):
 
 - `user-id`
+- `transport-service-method`
 - `service-method`
 - `ip`
 - `user-agent`
@@ -670,8 +671,9 @@ transport:
 > [!NOTE]
 > - `interval` is parsed as a Go duration string. Invalid values can fail fast.
 > - The built-in limiter is an in-memory, per-process safeguard. Use it as a last resort and prefer an external edge, gateway, ingress, load balancer, or service-mesh limiter for production abuse protection.
-> - The `user-id` key uses the verified principal stored in metadata. For JWT/PASETO tokens this is the subject claim; for SSH tokens this is the verified key name.
-> - The `service-method` key uses HTTP route/path metadata or the gRPC full method name.
+> - The `user-id` key uses the verified principal stored in metadata. For JWT/PASETO tokens this is the subject claim; for SSH tokens this is the verified key name. Prefer it when authenticated identity is available.
+> - The `transport-service-method` key prefixes the service-method value with the transport name, such as `http:GET /users/{id}` or `grpc:/users.v1.Users/Get`, so HTTP and gRPC operations use separate buckets.
+> - The `service-method` key uses HTTP route/path metadata or the gRPC full method name. Prefer `transport-service-method` unless cross-transport operations intentionally share quota.
 > - Server-side HTTP and gRPC limiters run after metadata extraction and token verification, so missing, malformed, or invalid authorization is rejected before it reaches the limiter. This is intentional; enforce quotas for those attempts with an external edge, gateway, ingress, load balancer, or service-mesh limiter.
 
 ---

--- a/meta/attrs.go
+++ b/meta/attrs.go
@@ -1,6 +1,9 @@
 package meta
 
-import "github.com/alexfalkowski/go-service/v2/context"
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
 
 const (
 	// RequestIDKey is the attribute key used for request IDs.
@@ -22,6 +25,11 @@ const (
 	//
 	// For example: an HTTP method name, an RPC method name, or a logical operation name.
 	MethodKey = "method"
+
+	// TransportKey is the attribute key used for transport names.
+	//
+	// For example: "http" or "grpc".
+	TransportKey = "transport"
 
 	// ServiceMethodKey is the attribute key used for transport service-method names.
 	//
@@ -103,6 +111,20 @@ func WithMethod(value Value) Pair {
 	return NewPair(MethodKey, value)
 }
 
+// WithTransport creates a transport pair for [WithAttributes].
+//
+// The pair stores value under [TransportKey].
+func WithTransport(value Value) Pair {
+	return NewPair(TransportKey, value)
+}
+
+// Transport returns the stored transport attribute from ctx.
+//
+// If no value is present, this returns the zero-value [Value].
+func Transport(ctx context.Context) Value {
+	return Attribute(ctx, TransportKey)
+}
+
 // WithServiceMethod creates a service-method pair for [WithAttributes].
 //
 // The pair stores value under [ServiceMethodKey].
@@ -115,6 +137,13 @@ func WithServiceMethod(value Value) Pair {
 // If no value is present, this returns the zero-value [Value].
 func ServiceMethod(ctx context.Context) Value {
 	return Attribute(ctx, ServiceMethodKey)
+}
+
+// TransportServiceMethod returns the transport and service-method attributes as one value.
+//
+// The returned ignored value is formatted as "<transport>:<service-method>".
+func TransportServiceMethod(ctx context.Context) Value {
+	return Ignored(strings.Concat(Transport(ctx).Value(), ":", ServiceMethod(ctx).Value()))
 }
 
 // WithCode creates a status code pair for [WithAttributes].

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -59,6 +59,7 @@ func TestPairHelpers(t *testing.T) {
 		{name: "system", key: meta.SystemKey, value: "system", pair: meta.WithSystem},
 		{name: "service", key: meta.ServiceKey, value: "service", pair: meta.WithService},
 		{name: "method", key: meta.MethodKey, value: "method", pair: meta.WithMethod},
+		{name: "transport", key: meta.TransportKey, value: "transport", pair: meta.WithTransport},
 		{name: "service method", key: meta.ServiceMethodKey, value: "service-method", pair: meta.WithServiceMethod},
 		{name: "code", key: meta.CodeKey, value: "code", pair: meta.WithCode},
 		{name: "duration", key: meta.DurationKey, value: "duration", pair: meta.WithDuration},
@@ -109,6 +110,7 @@ func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
 func TestAccessors(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
 		meta.WithRequestID(meta.String("request-id")),
+		meta.WithTransport(meta.String("transport")),
 		meta.WithServiceMethod(meta.String("service-method")),
 		meta.WithUserAgent(meta.String("user-agent")),
 		meta.WithUserID(meta.String("user-id")),
@@ -123,7 +125,9 @@ func TestAccessors(t *testing.T) {
 		want meta.Value
 	}{
 		{name: "request id", got: meta.RequestID(ctx), want: meta.String("request-id")},
+		{name: "transport", got: meta.Transport(ctx), want: meta.String("transport")},
 		{name: "service method", got: meta.ServiceMethod(ctx), want: meta.String("service-method")},
+		{name: "transport service method", got: meta.TransportServiceMethod(ctx), want: meta.Ignored("transport:service-method")},
 		{name: "user agent", got: meta.UserAgent(ctx), want: meta.String("user-agent")},
 		{name: "user id", got: meta.UserID(ctx), want: meta.String("user-id")},
 		{name: "ip addr", got: meta.IPAddr(ctx), want: meta.String("ip-addr")},
@@ -136,6 +140,15 @@ func TestAccessors(t *testing.T) {
 			require.Equal(t, test.want, test.got)
 		})
 	}
+}
+
+func TestTransportServiceMethod(t *testing.T) {
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithTransport(meta.Ignored("http")),
+		meta.WithServiceMethod(meta.Ignored("GET /users/{id}")),
+	)
+
+	require.Equal(t, meta.Ignored("http:GET /users/{id}"), meta.TransportServiceMethod(ctx))
 }
 
 func assertStrings(t *testing.T, ctx context.Context, name string, want meta.Map, export func(context.Context) meta.Map) {

--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -15,7 +15,7 @@ import (
 //
 // It ensures "user-agent" and "request-id" are present in outgoing metadata,
 // preferring values already present in the context or outgoing metadata, and
-// stores the chosen values back into the context.
+// stores the chosen values plus transport metadata back into the context.
 //
 // Existing outgoing metadata values for these keys are replaced so repeated
 // interceptor invocation does not accumulate duplicates or preserve stale
@@ -25,6 +25,7 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 		md, ua, requestID := clientMetadata(ctx, userAgent, generator)
 
 		ctx = meta.WithAttributes(ctx,
+			meta.WithTransport(meta.Ignored("grpc")),
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(requestID),
 			meta.WithServiceMethod(meta.Ignored(fullMethod)),
@@ -38,7 +39,7 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 //
 // It ensures "user-agent" and "request-id" are present in outgoing metadata,
 // preferring values already present in the context or outgoing metadata, and
-// stores the chosen values back into the context.
+// stores the chosen values plus transport metadata back into the context.
 //
 // Existing outgoing metadata values for these keys are replaced so repeated
 // interceptor invocation does not accumulate duplicates or preserve stale
@@ -48,6 +49,7 @@ func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) gr
 		md, ua, requestID := clientMetadata(ctx, userAgent, generator)
 
 		ctx = meta.WithAttributes(ctx,
+			meta.WithTransport(meta.Ignored("grpc")),
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(requestID),
 			meta.WithServiceMethod(meta.Ignored(fullMethod)),

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -30,6 +30,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
+		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
 		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
@@ -52,6 +53,7 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
 		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
+		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
 		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
@@ -90,6 +92,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, []string{"current-agent"}, md.Get("user-agent"))
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
+		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
 		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
@@ -116,6 +119,7 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
 		require.Equal(t, grpcmeta.String("fallback-agent"), grpcmeta.UserAgent(ctx))
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
+		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
 		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
@@ -155,6 +159,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
 		require.Equal(t, grpcmeta.String("peer"), grpcmeta.Attribute(ctx, grpcmeta.IPAddrKindKey))
 		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
+		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
 		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -24,6 +24,7 @@ import (
 // For non-ignored methods, the interceptor:
 //
 //   - copies incoming metadata from the request context
+//   - stores "grpc" as the ignored transport attribute
 //   - resolves "user-agent" and "request-id", preferring existing context
 //     attributes and then incoming metadata values
 //   - stores the RPC full method name as the ignored service-method attribute
@@ -55,6 +56,7 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 			return nil, status.SafeError(codes.InvalidArgument, err)
 		}
 		ctx = meta.WithAttributes(ctx,
+			meta.WithTransport(meta.Ignored("grpc")),
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
 			meta.WithServiceMethod(meta.Ignored(info.FullMethod)),
@@ -76,7 +78,8 @@ func UnaryServerInterceptor(userAgent env.UserAgent, version env.Version, genera
 // visible to downstream stream interceptors that need request metadata for resource controls.
 //
 // The interceptor performs the same metadata-to-context projection as [UnaryServerInterceptor], but applies it to
-// the wrapped stream context and emits response headers through the stream API.
+// the wrapped stream context, stores "grpc" as the ignored transport attribute, and emits response headers
+// through the stream API.
 func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, generator id.Generator) grpc.StreamServerInterceptor {
 	serviceVersion := version.String()
 
@@ -102,6 +105,7 @@ func StreamServerInterceptor(userAgent env.UserAgent, version env.Version, gener
 			auth = a
 		}
 		ctx = meta.WithAttributes(ctx,
+			meta.WithTransport(meta.Ignored("grpc")),
 			meta.WithUserAgent(ua),
 			meta.WithRequestID(id),
 			meta.WithServiceMethod(meta.Ignored(info.FullMethod)),

--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -31,7 +31,7 @@ type RoundTripper struct {
 // RoundTrip injects request metadata into the outbound request.
 //
 // It sets the "User-Agent" and "Request-Id" headers, preferring values already present in the context or
-// request headers, and stores the chosen values back into the request context.
+// request headers, and stores the chosen values plus transport metadata back into the request context.
 //
 // Precedence rules:
 //   - If the context already contains a value ([meta.UserAgent]/[meta.RequestID]), that value is used.
@@ -44,6 +44,7 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	requestID := clientRequestID(ctx, r.generator, req)
 
 	ctx = meta.WithAttributes(ctx,
+		meta.WithTransport(meta.Ignored("http")),
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
 		meta.WithServiceMethod(meta.Ignored(req.URL.Path)),

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -82,6 +82,7 @@ func TestRoundTripperStoresServiceMethod(t *testing.T) {
 		env.UserAgent("agent"),
 		test.StaticIDGenerator("request-id"),
 		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 			require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
 			require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 
@@ -117,6 +118,7 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
 		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})
@@ -130,6 +132,7 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("GET /users/{id}"), meta.ServiceMethod(req.Context()))
 		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -24,8 +24,9 @@ func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, gen
 
 // Handler extracts request metadata and stores it in the request context.
 //
-// Extracted metadata includes user agent, request id, ignored service-method, client IP address (and its source
-// kind), ignored geolocation, and ignored Authorization token value (when present and parseable).
+// Extracted metadata includes transport, user agent, request id, ignored service-method, client IP address
+// (and its source kind), ignored geolocation, and ignored Authorization token value (when present and
+// parseable).
 type Handler struct {
 	generator      id.Generator
 	name           env.Name
@@ -44,6 +45,7 @@ type Handler struct {
 // Context population:
 //
 // The handler populates the request context with:
+//   - transport ("http", stored as ignored)
 //   - user agent (from context, request header, or default userAgent parameter)
 //   - request id (from context, request header, or generated via generator)
 //   - service-method (from the matched request pattern, or URL path before routing; stored as ignored)
@@ -76,6 +78,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		return
 	}
 	ctx = meta.WithAttributes(ctx,
+		meta.WithTransport(meta.Ignored("http")),
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
 		meta.WithServiceMethod(serverServiceMethod(req)),

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -31,7 +31,7 @@ func TestUnlimited(t *testing.T) {
 }
 
 func TestServerLimiter(t *testing.T) {
-	for _, f := range []string{"user-agent", "ip", "service-method"} {
+	for _, f := range []string{"user-agent", "ip", "service-method", "transport-service-method"} {
 		t.Run(f, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),
@@ -75,7 +75,7 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 }
 
 func TestClientLimiter(t *testing.T) {
-	for _, f := range []string{"user-agent", "ip", "service-method"} {
+	for _, f := range []string{"user-agent", "ip", "service-method", "transport-service-method"} {
 		t.Run(f, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),

--- a/transport/limiter/config.go
+++ b/transport/limiter/config.go
@@ -7,7 +7,8 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // The limiter is typically constructed by [NewLimiter], which interprets these fields as:
 //
 //   - Kind: selects how request keys are derived from context metadata (see NewKeyMap for default kinds).
-//     Examples: "user-agent", "ip", "user-id", "service-method".
+//     Prefer "user-id" when authenticated identity is available, or "transport-service-method" for
+//     per-operation quotas. Other examples include "service-method", "ip", and "user-agent".
 //
 //   - Interval: a typed duration encoded as a Go duration string (e.g. "1s", "1m")
 //     defining the refill/measurement window used by the underlying token bucket store.

--- a/transport/limiter/doc.go
+++ b/transport/limiter/doc.go
@@ -10,33 +10,41 @@
 // are provided by [NewKeyMap], mapping a configured kind to a function that extracts a value from context
 // metadata:
 //
-//   - "user-agent": [meta.UserAgent]
-//   - "ip": [meta.IPAddr]
 //   - "user-id": [meta.UserID]
+//   - "transport-service-method": [meta.TransportServiceMethod]
 //   - "service-method": [meta.ServiceMethod]
+//   - "ip": [meta.IPAddr]
+//   - "user-agent": [meta.UserAgent]
 //
 // The configured kind is typically provided via [Config.Kind]. If the kind is not present in the KeyMap,
 // limiter construction fails with ErrMissingKey.
+//
+// The "user-id" key uses the verified principal stored in metadata. For
+// JWT/PASETO tokens this is the subject claim; for SSH tokens this is the
+// verified key name returned by the token verifier. Prefer it for per-principal
+// quotas when authenticated identity is available.
+//
+// The "transport-service-method" key prefixes that service-method value with
+// the transport name, such as "http:GET /users/{id}" or
+// "grpc:/users.v1.Users/Get". Use it when HTTP and gRPC operations should have
+// independent limiter buckets even if their service-method values overlap.
+//
+// The "service-method" key uses transport metadata populated by the HTTP and
+// gRPC metadata layers. HTTP stores the matched request pattern when available
+// and otherwise the URL path; gRPC stores the full method name. Prefer
+// "transport-service-method" unless cross-transport operations intentionally
+// share quota.
 //
 // The "ip" key uses IP metadata populated by transport metadata middleware. That
 // middleware intentionally trusts common forwarding headers such as
 // X-Forwarded-For and CF-Connecting-IP. The limiter does not validate CDN or
 // proxy source ranges itself; it consumes the metadata provided by the transport
-// stack.
-//
-// Use the "ip" key when the service is only reachable through trusted edge
+// stack. Use it only when the service is reachable through trusted edge
 // infrastructure that strips or overwrites client-supplied forwarding headers.
-// If direct origin access is possible, prefer a verified identity key such as
-// "user-id" or add application-specific trusted proxy validation before relying
-// on IP-based limits.
 //
-// The "user-id" key uses the verified principal stored in metadata. For
-// JWT/PASETO tokens this is the subject claim; for SSH tokens this is the
-// verified key name returned by the token verifier.
-//
-// The "service-method" key uses transport metadata populated by the HTTP and
-// gRPC metadata layers. HTTP stores the matched request pattern when available
-// and otherwise the URL path; gRPC stores the full method name.
+// The "user-agent" key uses caller-supplied User-Agent metadata. Treat it as a
+// coarse development or service-to-service convenience key, not as a public-edge
+// abuse-control identity.
 //
 // # In-memory behavior and lifecycle
 //

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -19,6 +19,34 @@ import (
 // request metadata from being retained verbatim as in-memory bucket names.
 const maxKeySize = 256
 
+// ErrMissingKey is returned when the configured key kind is not present in the KeyMap.
+var ErrMissingKey = errors.New("limiter: missing key")
+
+// NewKeyMap returns the default KeyMap used by the limiter.
+//
+// Supported default kinds, in the usual order of preference, are:
+//   - "user-id": rate limit per verified user/principal identifier ([meta.UserID])
+//   - "transport-service-method": rate limit per transport-prefixed service method
+//     ([meta.TransportServiceMethod])
+//   - "service-method": rate limit per HTTP route/path or gRPC full method ([meta.ServiceMethod])
+//   - "ip": rate limit per client IP address ([meta.IPAddr])
+//   - "user-agent": rate limit per User-Agent header ([meta.UserAgent])
+//
+// These defaults are intended for controlled service-to-service traffic where user agents,
+// forwarded IP headers, and authorization metadata are supplied by trusted clients or platform
+// infrastructure. They are not sufficient as public-edge anti-abuse controls when clients can
+// freely spoof headers; use trusted ingress, gateway, service-mesh, or post-auth identity limits
+// for those boundaries.
+func NewKeyMap() KeyMap {
+	return KeyMap{
+		"user-id":                  meta.UserID,
+		"transport-service-method": meta.TransportServiceMethod,
+		"service-method":           meta.ServiceMethod,
+		"ip":                       meta.IPAddr,
+		"user-agent":               meta.UserAgent,
+	}
+}
+
 // KeyFunc derives the metadata value used to key rate limits for ctx.
 //
 // The returned [meta.Value] is expected to yield a stable string via Value() that can be used as a
@@ -30,31 +58,6 @@ type KeyFunc func(context.Context) meta.Value
 //
 // It is typically constructed via NewKeyMap and passed to NewLimiter along with [Config.Kind].
 type KeyMap map[string]KeyFunc
-
-// NewKeyMap returns the default KeyMap used by the limiter.
-//
-// Supported default kinds are:
-//   - "user-agent": rate limit per User-Agent header ([meta.UserAgent])
-//   - "ip": rate limit per client IP address ([meta.IPAddr])
-//   - "user-id": rate limit per verified user/principal identifier ([meta.UserID])
-//   - "service-method": rate limit per HTTP route/path or gRPC full method ([meta.ServiceMethod])
-//
-// These defaults are intended for controlled service-to-service traffic where user agents,
-// forwarded IP headers, and authorization metadata are supplied by trusted clients or platform
-// infrastructure. They are not sufficient as public-edge anti-abuse controls when clients can
-// freely spoof headers; use trusted ingress, gateway, service-mesh, or post-auth identity limits
-// for those boundaries.
-func NewKeyMap() KeyMap {
-	return KeyMap{
-		"user-agent":     meta.UserAgent,
-		"ip":             meta.IPAddr,
-		"service-method": meta.ServiceMethod,
-		"user-id":        meta.UserID,
-	}
-}
-
-// ErrMissingKey is returned when the configured key kind is not present in the KeyMap.
-var ErrMissingKey = errors.New("limiter: missing key")
 
 // NewLimiter constructs a Limiter using the configured key kind and interval/tokens settings.
 //

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -219,6 +219,14 @@ func TestNewKeyMap(t *testing.T) {
 			ctx:  meta.WithAttributes(t.Context(), meta.WithServiceMethod(meta.String("GET /users/{id}"))),
 			want: meta.String("GET /users/{id}"),
 		},
+		{
+			name: "transport-service-method",
+			ctx: meta.WithAttributes(t.Context(),
+				meta.WithTransport(meta.String("http")),
+				meta.WithServiceMethod(meta.String("GET /users/{id}")),
+			),
+			want: meta.Ignored("http:GET /users/{id}"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

- Add ignored transport metadata for HTTP and gRPC request contexts.
- Add a transport-service-method key that scopes operation buckets by transport.
- Update limiter key documentation, recommendations, and tests.

## Why

- Avoid accidental quota sharing between HTTP and gRPC operations with the same service-method value.
- Keep the existing service-method key available when cross-transport quota sharing is intentional.

## Testing

- `make specs` - passed
- `make lint` - passed
- `go test ./transport/limiter` - passed
- `git diff --check` - passed
