### PR TITLE
feat(grpc): meter streaming messages in limiter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,11 @@ matching skill for the task.
   external edge, gateway, ingress, load balancer, or service mesh limiter when
   those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
+- gRPC stream limiters intentionally consume one token when a stream opens and
+  one token for each `RecvMsg` and `SendMsg` operation. Do not flag this as
+  accidental double-counting; report only concrete bugs such as missing message
+  limiting, ignored explicit limiter config, or incorrect status/header
+  behavior.
 - HTTP telemetry logger service/method derivation may include request URL path
   segments for non-canonical HTTP routes. This is intentional for client and
   server debugging because HTTP clients can call arbitrary paths and route

--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ transport:
 > - The `transport-service-method` key prefixes the service-method value with the transport name, such as `http:GET /users/{id}` or `grpc:/users.v1.Users/Get`, so HTTP and gRPC operations use separate buckets.
 > - The `service-method` key uses HTTP route/path metadata or the gRPC full method name. Prefer `transport-service-method` unless cross-transport operations intentionally share quota.
 > - Server-side HTTP and gRPC limiters run after metadata extraction and token verification, so missing, malformed, or invalid authorization is rejected before it reaches the limiter. This is intentional; enforce quotas for those attempts with an external edge, gateway, ingress, load balancer, or service-mesh limiter.
+> - gRPC stream limiters consume one token when the stream opens and one token for each `RecvMsg` and `SendMsg` operation. Unary HTTP and gRPC requests consume one token per request/RPC.
 
 ---
 

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -219,8 +219,8 @@ func WithClientID(generator id.Generator) ClientOption {
 
 // WithClientLimiter enables client-side rate limiting interceptors.
 //
-// When configured, unary client calls and streams are rate-limited before being sent. If limiter is nil,
-// rate limiting is not enabled.
+// When configured, unary client calls are rate-limited before being sent. Client streams are rate-limited
+// when opened and while sending or receiving messages. If limiter is nil, rate limiting is not enabled.
 func WithClientLimiter(limiter *limiter.Client) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.limiter = limiter

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -209,7 +209,9 @@ func TestWatch(t *testing.T) {
 func TestWatchServerLimiter(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),
-		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
+		// Watch consumes one token for stream admission, one for the request RecvMsg,
+		// and one for the initial status SendMsg.
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 3)),
 	)
 	requireGRPCReady(t, world)
 

--- a/transport/grpc/limiter/client.go
+++ b/transport/grpc/limiter/client.go
@@ -1,0 +1,99 @@
+package limiter
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
+)
+
+// NewClientLimiter constructs a gRPC client-side rate limiter.
+//
+// If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
+//
+// The returned limiter is backed by [limiter.NewLimiter] and is registered with the provided lifecycle.
+// The `keys` map controls how request contexts are turned into limiter keys.
+func NewClientLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Client, error) {
+	if !cfg.IsEnabled() {
+		return nil, nil
+	}
+
+	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{rateLimiter}, nil
+}
+
+// Client wraps *[limiter.Limiter] for gRPC client integration.
+type Client struct {
+	*limiter.Limiter
+}
+
+// UnaryClientInterceptor returns a gRPC unary client interceptor that enforces rate limiting.
+//
+// The interceptor calls `limiter.Take(ctx)` before invoking the RPC:
+//
+//   - If `Take` returns an error, it returns [codes.Internal].
+//   - If the request is not allowed, it returns [codes.ResourceExhausted].
+//   - Otherwise, it invokes the underlying `invoker`.
+//
+// Callers should only install this interceptor when limiter is non-nil.
+func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, err := take(ctx, limiter.Limiter); err != nil {
+			return err
+		}
+
+		return invoker(ctx, fullMethod, req, resp, conn, opts...)
+	}
+}
+
+// StreamClientInterceptor returns a gRPC stream client interceptor that enforces rate limiting.
+//
+// The interceptor calls `limiter.Take(ctx)` before opening the stream, then meters each sent and received
+// stream message:
+//
+//   - If `Take` returns an error, it returns [codes.Internal].
+//   - If the stream is not allowed, it returns [codes.ResourceExhausted].
+//   - Otherwise, it invokes the underlying `streamer`.
+//
+// Callers should only install this interceptor when limiter is non-nil.
+func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		if _, err := take(ctx, limiter.Limiter); err != nil {
+			return nil, err
+		}
+
+		stream, err := streamer(ctx, desc, conn, fullMethod, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		return &clientStream{ClientStream: stream, ctx: ctx, limiter: limiter.Limiter}, nil
+	}
+}
+
+type clientStream struct {
+	grpc.ClientStream
+	ctx     context.Context
+	limiter *limiter.Limiter
+}
+
+func (s *clientStream) RecvMsg(m any) error {
+	if err := s.ClientStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	_, err := take(s.ctx, s.limiter)
+	return err
+}
+
+func (s *clientStream) SendMsg(m any) error {
+	if _, err := take(s.ctx, s.limiter); err != nil {
+		return err
+	}
+
+	return s.ClientStream.SendMsg(m)
+}

--- a/transport/grpc/limiter/doc.go
+++ b/transport/grpc/limiter/doc.go
@@ -15,6 +15,9 @@
 // gateway, ingress, load balancer, or service-mesh limiter when those attempts
 // need quota enforcement.
 //
+// Streaming interceptors take one token when a stream opens and also meter
+// each RecvMsg and SendMsg operation. Unary interceptors take one token per RPC.
+//
 // Start with [UnaryServerInterceptor] or [StreamServerInterceptor] for server-side limiting and
 // [UnaryClientInterceptor] or [StreamClientInterceptor] for client-side limiting.
 package limiter

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -2,10 +2,8 @@ package limiter
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
@@ -17,167 +15,15 @@ import (
 // from the request context.
 type KeyMap = limiter.KeyMap
 
-// NewServerLimiter constructs a gRPC server-side rate limiter.
-//
-// If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
-//
-// The returned limiter is backed by [limiter.NewLimiter] and is registered with the provided lifecycle.
-// The `keys` map controls how request contexts are turned into limiter keys (for example, per user-agent).
-func NewServerLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Server, error) {
-	if !cfg.IsEnabled() {
-		return nil, nil
-	}
-
-	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
+func take(ctx context.Context, limiter *limiter.Limiter) (string, error) {
+	ok, header, err := limiter.Take(ctx)
 	if err != nil {
-		return nil, err
+		return strings.Empty, status.SafeError(codes.Internal, err)
 	}
 
-	return &Server{rateLimiter}, nil
-}
-
-// Server wraps *[limiter.Limiter] for gRPC server integration.
-type Server struct {
-	*limiter.Limiter
-}
-
-// UnaryServerInterceptor returns a gRPC unary server interceptor that enforces rate limiting.
-//
-// Operation unary RPC methods (health/metrics/etc.) bypass limiting (see [github.com/alexfalkowski/go-service/v2/net/grpc/strings.IsOperationMethod]).
-// Stream RPCs do not bypass limiting because long-lived streams, such as health Watch, can hold server resources
-// until the client disconnects.
-//
-// On every request, the interceptor calls `limiter.Take(ctx)` to determine whether the request is allowed:
-//
-//   - If `Take` returns an error, the interceptor returns [codes.Internal].
-//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
-//   - If the request is not allowed, the interceptor returns [codes.ResourceExhausted].
-//   - Otherwise, it invokes the handler.
-//
-// Callers should only install this interceptor when limiter is non-nil.
-func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if strings.IsOperationMethod(info.FullMethod) {
-			return handler(ctx, req)
-		}
-
-		ok, header, err := limiter.Take(ctx)
-		if err != nil {
-			return nil, status.SafeError(codes.Internal, err)
-		}
-
-		_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", header))
-
-		if !ok {
-			return nil, status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
-		}
-
-		return handler(ctx, req)
-	}
-}
-
-// StreamServerInterceptor returns a gRPC stream server interceptor that enforces rate limiting.
-//
-// Unlike unary RPCs, operation streams are limited. This keeps long-lived streams, such as health Watch, from
-// bypassing the resource controls that protect regular service streams.
-//
-// The limiter is admission-only for streams: it takes one token when the stream is opened and does not meter
-// individual messages or stream lifetime. Use gRPC server options such as max_concurrent_streams, plus edge,
-// gateway, ingress, load-balancer, or service-mesh limits when long-lived stream occupancy needs a hard cap.
-//
-// On every stream, the interceptor calls `limiter.Take(ctx)` to determine whether the stream is allowed:
-//
-//   - If `Take` returns an error, the interceptor returns [codes.Internal].
-//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
-//   - If the stream is not allowed, the interceptor returns [codes.ResourceExhausted].
-//   - Otherwise, it invokes the handler.
-//
-// Callers should only install this interceptor when limiter is non-nil.
-func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
-	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		ok, header, err := limiter.Take(stream.Context())
-		if err != nil {
-			return status.SafeError(codes.Internal, err)
-		}
-
-		_ = stream.SetHeader(meta.Pairs("ratelimit", header))
-
-		if !ok {
-			return status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
-		}
-
-		return handler(srv, stream)
-	}
-}
-
-// NewClientLimiter constructs a gRPC client-side rate limiter.
-//
-// If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
-//
-// The returned limiter is backed by [limiter.NewLimiter] and is registered with the provided lifecycle.
-// The `keys` map controls how request contexts are turned into limiter keys.
-func NewClientLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Client, error) {
-	if !cfg.IsEnabled() {
-		return nil, nil
+	if !ok {
+		return header, status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
 	}
 
-	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Client{rateLimiter}, nil
-}
-
-// Client wraps *[limiter.Limiter] for gRPC client integration.
-type Client struct {
-	*limiter.Limiter
-}
-
-// UnaryClientInterceptor returns a gRPC unary client interceptor that enforces rate limiting.
-//
-// The interceptor calls `limiter.Take(ctx)` before invoking the RPC:
-//
-//   - If `Take` returns an error, it returns [codes.Internal].
-//   - If the request is not allowed, it returns [codes.ResourceExhausted].
-//   - Otherwise, it invokes the underlying `invoker`.
-//
-// Callers should only install this interceptor when limiter is non-nil.
-func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		ok, _, err := limiter.Take(ctx)
-		if err != nil {
-			return status.SafeError(codes.Internal, err)
-		}
-
-		if !ok {
-			return status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
-		}
-
-		return invoker(ctx, fullMethod, req, resp, conn, opts...)
-	}
-}
-
-// StreamClientInterceptor returns a gRPC stream client interceptor that enforces rate limiting.
-//
-// The interceptor calls `limiter.Take(ctx)` before opening the stream:
-//
-//   - If `Take` returns an error, it returns [codes.Internal].
-//   - If the stream is not allowed, it returns [codes.ResourceExhausted].
-//   - Otherwise, it invokes the underlying `streamer`.
-//
-// Callers should only install this interceptor when limiter is non-nil.
-func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
-	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		ok, _, err := limiter.Take(ctx)
-		if err != nil {
-			return nil, status.SafeError(codes.Internal, err)
-		}
-
-		if !ok {
-			return nil, status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
-		}
-
-		return streamer(ctx, desc, conn, fullMethod, opts...)
-	}
+	return header, nil
 }

--- a/transport/grpc/limiter/server.go
+++ b/transport/grpc/limiter/server.go
@@ -1,0 +1,128 @@
+package limiter
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
+)
+
+// NewServerLimiter constructs a gRPC server-side rate limiter.
+//
+// If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
+//
+// The returned limiter is backed by [limiter.NewLimiter] and is registered with the provided lifecycle.
+// The `keys` map controls how request contexts are turned into limiter keys (for example, per user-agent).
+func NewServerLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Server, error) {
+	if !cfg.IsEnabled() {
+		return nil, nil
+	}
+
+	rateLimiter, err := limiter.NewLimiter(lc, keys, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Server{rateLimiter}, nil
+}
+
+// Server wraps *[limiter.Limiter] for gRPC server integration.
+type Server struct {
+	*limiter.Limiter
+}
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor that enforces rate limiting.
+//
+// Operation unary RPC methods (health/metrics/etc.) bypass limiting (see [github.com/alexfalkowski/go-service/v2/net/grpc/strings.IsOperationMethod]).
+// Stream RPCs do not bypass limiting because long-lived streams, such as health Watch, can hold server resources
+// until the client disconnects.
+//
+// On every request, the interceptor calls `limiter.Take(ctx)` to determine whether the request is allowed:
+//
+//   - If `Take` returns an error, the interceptor returns [codes.Internal].
+//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
+//   - If the request is not allowed, the interceptor returns [codes.ResourceExhausted].
+//   - Otherwise, it invokes the handler.
+//
+// Callers should only install this interceptor when limiter is non-nil.
+func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if strings.IsOperationMethod(info.FullMethod) {
+			return handler(ctx, req)
+		}
+
+		header, err := take(ctx, limiter.Limiter)
+		if !strings.IsEmpty(header) {
+			_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", header))
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns a gRPC stream server interceptor that enforces rate limiting.
+//
+// Unlike unary RPCs, operation streams are limited. This keeps long-lived streams, such as health Watch, from
+// bypassing the resource controls that protect regular service streams.
+//
+// The limiter takes one token when the stream is opened, then meters each received and sent stream message.
+// Use gRPC server options such as max_concurrent_streams, plus edge, gateway, ingress, load-balancer, or
+// service-mesh limits when long-lived stream occupancy needs a hard cap.
+//
+// On every stream, the interceptor calls `limiter.Take(ctx)` to determine whether the stream is allowed:
+//
+//   - If `Take` returns an error, the interceptor returns [codes.Internal].
+//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
+//   - If the stream is not allowed, the interceptor returns [codes.ResourceExhausted].
+//   - Otherwise, it invokes the handler.
+//
+// Callers should only install this interceptor when limiter is non-nil.
+func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		header, err := take(stream.Context(), limiter.Limiter)
+		if !strings.IsEmpty(header) {
+			_ = stream.SetHeader(meta.Pairs("ratelimit", header))
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return handler(srv, &serverStream{ServerStream: stream, limiter: limiter.Limiter})
+	}
+}
+
+type serverStream struct {
+	grpc.ServerStream
+	limiter *limiter.Limiter
+}
+
+func (s *serverStream) RecvMsg(m any) error {
+	if err := s.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	header, err := take(s.Context(), s.limiter)
+	if !strings.IsEmpty(header) {
+		_ = s.SetHeader(meta.Pairs("ratelimit", header))
+	}
+
+	return err
+}
+
+func (s *serverStream) SendMsg(m any) error {
+	header, err := take(s.Context(), s.limiter)
+	if !strings.IsEmpty(header) {
+		_ = s.SetHeader(meta.Pairs("ratelimit", header))
+	}
+	if err != nil {
+		return err
+	}
+
+	return s.ServerStream.SendMsg(m)
+}

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -44,7 +44,7 @@ func TestServerLimiterUnary(t *testing.T) {
 }
 
 func TestServerLimiterStream(t *testing.T) {
-	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 3)), test.WithWorldGRPC())
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -128,7 +128,7 @@ func TestClientLimiterDenialDoesNotOpenBreaker(t *testing.T) {
 }
 
 func TestClientLimiterStream(t *testing.T) {
-	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 3)), test.WithWorldGRPC())
 
 	conn := requireGRPCConn(t, world)
 	defer conn.Close()
@@ -166,7 +166,7 @@ func TestServerLimiterUsesVerifiedUserIDUnary(t *testing.T) {
 func TestServerLimiterUsesVerifiedUserIDStream(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
-		test.WithWorldServerLimiter(test.NewLimiterConfig("user-id", "1s", 0)),
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-id", "1s", 3)),
 		test.WithWorldToken(&test.SequenceGenerator{}, test.AcceptingVerifier{}),
 		test.WithWorldGRPC(),
 	)


### PR DESCRIPTION
## What

- Meter streaming limiter tokens when streams open and for each `RecvMsg` and `SendMsg` operation.
- Split client and server limiter interceptors into dedicated files and document stream token semantics.

## Why

- Prevent long-lived streaming RPCs from bypassing quota after admission.
- Keep rate-limit status and header behavior consistent across unary and streaming paths.

## Testing

- `go test -count=1 ./transport/grpc` - passed
- `make lint` - passed
