### PR TITLE
feat(debug): enforce receive size for diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,12 @@ matching skill for the task.
 
 - `config.NewDecoder` resolves `-config`/`-c` as `file:<path>`, `env:<ENV_VAR>`, or a default config file named for the service.
 - Default file lookup checks the executable directory, `$XDG_CONFIG_HOME/<serviceName>/`, and `/etc/<serviceName>/`.
-  When default lookup reaches the user config directory candidate, HOME or
-  XDG_CONFIG_HOME is expected to be available; missing both is treated as a
-  misconfigured runtime. Do not flag the resulting `os.UserConfigDir` panic as
-  a config issue. Services that do not want this environment contract should
-  pass an explicit `-config file:<path>` or `-config env:<ENV_VAR>` source.
+  Default lookup may resolve the user config directory before probing file
+  candidates, so HOME or XDG_CONFIG_HOME is expected to be available when
+  default lookup starts; missing both is treated as a misconfigured runtime. Do
+  not flag the resulting `os.UserConfigDir` panic as a config issue. Services
+  that do not want this environment contract should pass an explicit
+  `-config file:<path>` or `-config env:<ENV_VAR>` source.
 - Many config fields use source strings through `os.FS.ReadSource`: `env:NAME`, `file:/path`, or a literal value.
 - Service configuration files should contain configuration values and secret
   source references, not raw passwords or credentials.
@@ -78,6 +79,11 @@ matching skill for the task.
   service-mesh policy. Only report concrete bugs such as accidental listener
   changes, ignored explicit addresses, missing documented protections, or a
   public API promise of localhost-only debug binding.
+- `debug/internal/fgprof` intentionally delegates request handling to upstream
+  `github.com/felixge/fgprof.Handler`. Treat its cancellation behavior and
+  zero-sample profile export edge cases as upstream behavior, not local debug
+  findings, unless this repository adds local fgprof handler logic or promises
+  cancellation-aware profiling semantics.
 - `cli.RunCode` returns `os.ExitCodeSuccess` on success, preserves non-zero
   shutdown exit codes requested through `di.ExitCode(...)`, and otherwise
   returns `os.ExitCodeFailure`.

--- a/config/default.go
+++ b/config/default.go
@@ -42,10 +42,11 @@ type Default struct {
 //
 // The first match is opened and decoded using the encoder keyed by the discovered kind/extension.
 // If no configuration file is found, Decode returns ErrLocationMissing.
-// If default lookup reaches the user config directory candidate, the runtime is
-// expected to provide HOME or XDG_CONFIG_HOME so [os.UserConfigDir] can resolve.
-// Missing both is treated as a misconfigured runtime; use an explicit
-// "file:<path>" or "env:<ENV_VAR>" source to avoid the default lookup contract.
+// Default lookup may resolve the user config directory before probing file
+// candidates. The runtime is expected to provide HOME or XDG_CONFIG_HOME so
+// [os.UserConfigDir] can resolve. Missing both is treated as a misconfigured
+// runtime; use an explicit "file:<path>" or "env:<ENV_VAR>" source to avoid the
+// default lookup contract.
 //
 // Note: this decoder assumes the [encoding.Map] contains decoders for the supported kinds. In the standard
 // go-service module graph, those encoders are registered for you (for example via [encoding.Module] in

--- a/config/doc.go
+++ b/config/doc.go
@@ -15,10 +15,10 @@
 //   - otherwise: uses the default lookup, searching for "<serviceName>.{yaml,yml,hjson,toml,json}" in common
 //     locations (executable directory, user config dir, and /etc).
 //
-// Default lookup intentionally requires a valid user configuration directory environment when it reaches
-// the user config directory candidate. Runtimes using default lookup should provide HOME or
-// XDG_CONFIG_HOME. Services that do not want that environment contract should pass an explicit source
-// with "file:<path>" or "env:<ENV_VAR>".
+// Default lookup intentionally requires a valid user configuration directory environment before lookup starts.
+// It may resolve the user config directory before probing file candidates, so runtimes using default lookup
+// should provide HOME or XDG_CONFIG_HOME. Services that do not want that environment contract should pass an
+// explicit source with "file:<path>" or "env:<ENV_VAR>".
 //
 // # Decoding and validation
 //

--- a/debug/server.go
+++ b/debug/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/body"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
@@ -57,7 +58,8 @@ func NewServer(params ServerParams) (*Server, error) {
 		return nil, nil
 	}
 
-	httpServer := http.NewServer(params.Config.Options, params.Config.GetTimeout(), params.Mux)
+	handler := body.NewHandler(params.Mux, params.Config.GetMaxReceiveSize().Bytes())
+	httpServer := http.NewServer(params.Config.Options, params.Config.GetTimeout(), handler)
 
 	cfg, err := newConfig(params.FS, params.Config)
 	if err != nil {

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -3,12 +3,17 @@ package debug_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/config/server"
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/debug"
+	debughttp "github.com/alexfalkowski/go-service/v2/debug/http"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
 )
 
 var debugPaths = []string{
@@ -43,6 +48,57 @@ func TestInvalidServer(t *testing.T) {
 
 	_, err := debug.NewServer(params)
 	require.Error(t, err)
+}
+
+func TestMaxReceiveSize(t *testing.T) {
+	mux := debughttp.NewServeMux()
+	cfg := &debug.Config{
+		Config: &server.Config{
+			Address:        test.RandomAddress(),
+			Timeout:        5 * time.Second,
+			MaxReceiveSize: 1,
+		},
+	}
+	lc := fxtest.NewLifecycle(t)
+	debugServer, err := debug.NewServer(debug.ServerParams{
+		Shutdowner: test.NewShutdowner(),
+		Mux:        mux,
+		Config:     cfg,
+		FS:         test.FS,
+	})
+	require.NoError(t, err)
+	require.NoError(t, debug.Register(debug.RegisterParams{
+		Config:    cfg,
+		Lifecycle: lc,
+		Name:      test.Name,
+		Content:   test.Content,
+		Mux:       mux,
+	}))
+
+	service := debugServer.GetService()
+	service.Start()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, service.Stop(ctx))
+	})
+
+	_, host, ok := net.SplitNetworkAddress(test.BoundAddress(cfg.Address, service.String()))
+	require.True(t, ok)
+
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		"http://"+host+"/"+test.Name.String()+"/debug/pprof/symbol",
+		bytes.NewBufferString("too large"),
+	)
+	require.NoError(t, err)
+
+	res, err := http.NewClient(http.DefaultTransport, time.DefaultTimeout).Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 }
 
 func requireDebugEndpoints(t *testing.T, scheme string, options ...test.WorldOption) {

--- a/net/http/body/body.go
+++ b/net/http/body/body.go
@@ -1,0 +1,41 @@
+package body
+
+import (
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+)
+
+// NewHandler wraps handler with request body size enforcement.
+//
+// It rejects requests whose body exceeds limit before calling handler. For
+// accepted requests, it buffers and restores req.Body so downstream handlers can
+// read it normally.
+func NewHandler(handler http.Handler, limit int64) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.ContentLength > limit {
+			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
+			return
+		}
+
+		if req.Body == nil || req.Body == http.NoBody {
+			handler.ServeHTTP(res, req)
+			return
+		}
+
+		data, body, err := io.ReadAll(io.LimitReader(req.Body, limit+1))
+		if err != nil {
+			_ = status.WriteError(res, status.BadRequestError(err))
+			return
+		}
+		defer req.Body.Close()
+
+		if int64(len(data)) > limit {
+			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
+			return
+		}
+
+		req.Body = body
+		handler.ServeHTTP(res, req)
+	})
+}

--- a/net/http/body/doc.go
+++ b/net/http/body/doc.go
@@ -1,0 +1,2 @@
+// Package body provides request-body handling helpers for HTTP handlers.
+package body

--- a/transport/http/body/body.go
+++ b/transport/http/body/body.go
@@ -1,9 +1,8 @@
 package body
 
 import (
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/net/http/body"
 )
 
 // NewHandler constructs request body size limiting middleware.
@@ -18,28 +17,5 @@ type Handler struct {
 
 // ServeHTTP enforces the configured request body limit.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	if req.ContentLength > h.limit {
-		_ = status.WriteError(res, &http.MaxBytesError{Limit: h.limit})
-		return
-	}
-
-	if req.Body == nil || req.Body == http.NoBody {
-		next(res, req)
-		return
-	}
-
-	data, body, err := io.ReadAll(io.LimitReader(req.Body, h.limit+1))
-	if err != nil {
-		_ = status.WriteError(res, status.BadRequestError(err))
-		return
-	}
-	defer req.Body.Close()
-
-	if int64(len(data)) > h.limit {
-		_ = status.WriteError(res, &http.MaxBytesError{Limit: h.limit})
-		return
-	}
-
-	req.Body = body
-	next(res, req)
+	body.NewHandler(next, h.limit).ServeHTTP(res, req)
 }


### PR DESCRIPTION
## What

- Enforce the configured receive-size limit on the diagnostic HTTP server before debug endpoints read request bodies.
- Move the reusable request-body size limiter into `net/http/body` and keep the transport HTTP middleware delegating to the shared helper.
- Clarify reviewer guidance for default config lookup fail-fast behavior and upstream fgprof handler behavior.

## Why

- Body-reading diagnostic endpoints should honor the same configured payload boundary as the rest of the server stack.
- Sharing the limiter keeps debug and transport request-body handling consistent without duplicating middleware logic.
- The documentation updates record accepted runtime and upstream-dependency boundaries so future review passes do not raise dismissed issues again.

## Testing

- `go test ./debug/... ./transport/http/body ./net/http/...` - passed
- `make lint` - passed
