### PR TITLE
feat(grpc): preserve health watch limiter status

### DIFF
--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -239,6 +239,29 @@ func TestWatchServerLimiter(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
+func TestWatchServerLimiterStatusSend(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"),
+		test.WithWorldTelemetry("otlp"),
+		// Watch consumes one token for stream admission and one for the request
+		// RecvMsg, leaving none for the initial status SendMsg.
+		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 2)),
+	)
+	requireGRPCReady(t, world)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+	req := &health.Request{Service: test.Name.String()}
+
+	wc, err := client.Watch(t.Context(), req)
+	require.NoError(t, err)
+
+	_, err = wc.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
 func TestInvalidWatch(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -97,6 +97,10 @@ func (s *Server) Watch(req *health.Request, w health.WatchServer) error {
 		if next != current {
 			current = next
 			if err := w.Send(&health.Response{Status: current}); err != nil {
+				if _, ok := status.FromError(err); ok {
+					return err
+				}
+
 				return status.Error(codes.Canceled, "stream has ended")
 			}
 		}


### PR DESCRIPTION
## What

- Preserve existing gRPC status errors returned while health `Watch` sends status updates, so stream limiter rejections reach clients unchanged.
- Add coverage for the stream limiter case where watch admission and request receive succeed but the initial health status send is rate-limited.

## Why

- Health watch streams previously flattened send-time limiter failures to `Canceled`, making configured `ResourceExhausted` rejections look like ordinary stream closure.

## Testing

- `go test ./transport/grpc/health ./transport/grpc/limiter` - passed
- `make lint` - passed
- `make package=transport/grpc/health specs` - passed; the target ran the broader repository specs and included `TestWatchServerLimiterStatusSend`.
