### PR TITLE
feat(events): add outbound sender timeout

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -376,9 +376,11 @@ func options(opts ...ClientOption) *clientOpts {
 	for _, o := range opts {
 		o.apply(resolved)
 	}
+
 	if resolved.timeout <= 0 {
 		resolved.timeout = time.DefaultTimeout
 	}
+
 	if resolved.generator == nil {
 		resolved.generator = uuid.NewGenerator()
 	}

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	transportevents "github.com/alexfalkowski/go-service/v2/transport/http/events"
 	httphooks "github.com/alexfalkowski/go-service/v2/transport/http/hooks"
 	events "github.com/cloudevents/sdk-go/v2"
@@ -145,6 +146,22 @@ func TestSenderUsesStructuredEncoding(t *testing.T) {
 	require.Contains(t, body, `"type":"example.type"`)
 }
 
+func TestSenderUsesDefaultTimeout(t *testing.T) {
+	start, deadline := sendWithDeadline(t)
+	remaining := time.Duration(deadline.Sub(start))
+
+	require.LessOrEqual(t, remaining, time.DefaultTimeout+time.Second)
+	require.Greater(t, remaining, 29*time.Second)
+}
+
+func TestSenderUsesConfiguredTimeout(t *testing.T) {
+	start, deadline := sendWithDeadline(t, transportevents.WithSenderTimeout(time.Second))
+	remaining := time.Duration(deadline.Sub(start))
+
+	require.LessOrEqual(t, remaining, time.Second+100*time.Millisecond)
+	require.Greater(t, remaining, 900*time.Millisecond)
+}
+
 func TestReceiveUsesServerMaxReceiveSizeBeforeWebhookVerification(t *testing.T) {
 	cfg := test.NewInsecureTransportConfig()
 	cfg.HTTP.MaxReceiveSize = 64
@@ -168,6 +185,32 @@ func TestReceiveUsesServerMaxReceiveSizeBeforeWebhookVerification(t *testing.T) 
 
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 	require.Nil(t, world.Event)
+}
+
+func sendWithDeadline(t *testing.T, opts ...transportevents.SenderOption) (time.Time, time.Time) {
+	t.Helper()
+
+	deadlines := make(chan time.Time, 1)
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		require.True(t, ok)
+		deadlines <- deadline
+
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody, Header: http.Header{}}, nil
+	})
+	opts = append(opts, transportevents.WithSenderRoundTripper(rt))
+	sender := transportevents.NewSender(nil, opts...)
+
+	e := events.NewEvent()
+	e.SetSource("example/uri")
+	e.SetType("example.type")
+	require.NoError(t, e.SetData(events.TextPlain, "test"))
+
+	start := time.Now()
+	result := sender.Send(events.ContextWithTarget(t.Context(), "http://example.com/events"), e)
+	requireACK(t, result)
+
+	return start, <-deadlines
 }
 
 func requireACK(t *testing.T, result protocol.Result) {

--- a/transport/http/events/options.go
+++ b/transport/http/events/options.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
+
+// SenderOption configures a CloudEvents HTTP sender.
+//
+// Sender options control how the CloudEvents client is constructed, primarily by selecting the underlying
+// HTTP transport used to send events.
+type SenderOption interface {
+	apply(opts *senderOptions)
+}
+
+type senderOptions struct {
+	roundTripper http.RoundTripper
+	timeout      time.Duration
+}
+
+type senderOptionFunc func(*senderOptions)
+
+func (f senderOptionFunc) apply(o *senderOptions) {
+	f(o)
+}
+
+// WithSenderRoundTripper configures the underlying HTTP RoundTripper used to send CloudEvents.
+//
+// This is an escape hatch for providing a custom transport (for example, one that is instrumented,
+// uses a custom proxy, or is a test double).
+func WithSenderRoundTripper(rt http.RoundTripper) SenderOption {
+	return senderOptionFunc(func(o *senderOptions) {
+		o.roundTripper = rt
+	})
+}
+
+// WithSenderTimeout configures the HTTP client timeout used when sending CloudEvents.
+//
+// A non-positive timeout uses [time.DefaultTimeout].
+func WithSenderTimeout(timeout time.Duration) SenderOption {
+	return senderOptionFunc(func(o *senderOptions) {
+		o.timeout = timeout
+	})
+}
+
+func options(opts ...SenderOption) *senderOptions {
+	resolved := &senderOptions{}
+	for _, o := range opts {
+		o.apply(resolved)
+	}
+
+	if resolved.roundTripper == nil {
+		resolved.roundTripper = http.Transport(nil)
+	}
+
+	if resolved.timeout <= 0 {
+		resolved.timeout = time.DefaultTimeout
+	}
+
+	return resolved
+}

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -11,34 +11,6 @@ import (
 	transport "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
-// SenderOption configures a CloudEvents HTTP sender.
-//
-// Sender options control how the CloudEvents client is constructed, primarily by selecting the underlying
-// HTTP transport used to send events.
-type SenderOption interface {
-	apply(opts *senderOptions)
-}
-
-type senderOptions struct {
-	roundTripper http.RoundTripper
-}
-
-type senderOptionFunc func(*senderOptions)
-
-func (f senderOptionFunc) apply(o *senderOptions) {
-	f(o)
-}
-
-// WithSenderRoundTripper configures the underlying HTTP RoundTripper used to send CloudEvents.
-//
-// This is an escape hatch for providing a custom transport (for example, one that is instrumented,
-// uses a custom proxy, or is a test double).
-func WithSenderRoundTripper(rt http.RoundTripper) SenderOption {
-	return senderOptionFunc(func(o *senderOptions) {
-		o.roundTripper = rt
-	})
-}
-
 // NewSender constructs a CloudEvents HTTP client that can sign outbound requests with the webhook hook.
 //
 // The constructed client uses the CloudEvents SDK HTTP transport. Outbound requests are wrapped with the
@@ -53,7 +25,7 @@ func WithSenderRoundTripper(rt http.RoundTripper) SenderOption {
 func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {
 	resolved := options(opts...)
 	rt := hooks.NewRoundTripper(hook, resolved.roundTripper)
-	httpClient := http.Client{Transport: rt, CheckRedirect: http.SameOriginRedirect}
+	httpClient := http.Client{Transport: rt, CheckRedirect: http.SameOriginRedirect, Timeout: resolved.timeout.Duration()}
 
 	sender, _ := events.NewClientHTTP(transport.WithClient(httpClient))
 	return &Sender{client: sender}
@@ -67,15 +39,4 @@ type Sender struct {
 // Send transmits event using structured CloudEvents encoding.
 func (s *Sender) Send(ctx context.Context, event events.Event) protocol.Result {
 	return s.client.Send(binding.WithForceStructured(ctx), event)
-}
-
-func options(opts ...SenderOption) *senderOptions {
-	resolved := &senderOptions{}
-	for _, o := range opts {
-		o.apply(resolved)
-	}
-	if resolved.roundTripper == nil {
-		resolved.roundTripper = http.Transport(nil)
-	}
-	return resolved
 }


### PR DESCRIPTION
## What

- Add a configurable timeout for the CloudEvents HTTP sender, with the existing shared default timeout applied when no timeout or a non-positive timeout is configured.
- Cover the default and explicitly configured sender timeout behavior through the public sender API.
- Include small option-layout whitespace cleanup in the gRPC client options path.

## Why

- Prevent outbound CloudEvents sends from relying only on caller cancellation when a downstream HTTP endpoint stalls or withholds a response.
- Preserve existing redirect and round tripper behavior while adding a bounded default for the sender's HTTP client.

## Testing

- `go test ./transport/http/events` - passed
- `go test ./transport/...` - passed
- `make lint` - passed
- `make sec` - passed
- `make specs` - passed
