### PR TITLE
feat(compress): accept valid zstd windows

### DIFF
--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -1,12 +1,10 @@
 package compress_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/compress"
-	"github.com/alexfalkowski/go-service/v2/compress/errors"
 	"github.com/alexfalkowski/go-service/v2/compress/none"
 	"github.com/alexfalkowski/go-service/v2/compress/s2"
 	"github.com/alexfalkowski/go-service/v2/compress/snappy"
@@ -94,125 +92,6 @@ func TestModuleProvidesDefaultCompressors(t *testing.T) {
 	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			require.NotNil(t, compressors.Get(kind))
-		})
-	}
-}
-
-func TestNoneCompressorReturnsDataUnchanged(t *testing.T) {
-	cmp := none.NewCompressor()
-	data := strings.Bytes("hello")
-
-	compressed, err := cmp.Compress(data, bytes.Size(len(data)))
-	require.NoError(t, err)
-	require.Equal(t, data, compressed)
-
-	decompressed, err := cmp.Decompress(data, bytes.Size(len(data)))
-	require.NoError(t, err)
-	require.Equal(t, data, decompressed)
-}
-
-func TestExactSizeLimits(t *testing.T) {
-	for _, kind := range compressorKinds {
-		t.Run(kind, func(t *testing.T) {
-			cmp := test.Compressor.Get(kind)
-			data := strings.Bytes("hello")
-			size := bytes.Size(len(data))
-
-			compressed, err := cmp.Compress(data, size)
-			require.NoError(t, err)
-
-			decompressed, err := cmp.Decompress(compressed, size)
-			require.NoError(t, err)
-			require.Equal(t, data, decompressed)
-		})
-	}
-}
-
-func TestCompressRejectsTooLarge(t *testing.T) {
-	for _, kind := range compressorKinds {
-		t.Run(kind, func(t *testing.T) {
-			cmp := test.Compressor.Get(kind)
-
-			_, err := cmp.Compress(strings.Bytes("hello"), 4)
-			require.ErrorIs(t, err, errors.ErrTooLarge)
-		})
-	}
-}
-
-func TestDecompressRejectsTooLarge(t *testing.T) {
-	for _, kind := range compressorKinds {
-		t.Run(kind, func(t *testing.T) {
-			cmp := test.Compressor.Get(kind)
-
-			data := strings.Bytes("hello")
-			compressed, err := cmp.Compress(data, bytes.KB)
-			require.NoError(t, err)
-
-			_, err = cmp.Decompress(compressed, bytes.Size(len(data)-1))
-			require.ErrorIs(t, err, errors.ErrTooLarge)
-		})
-	}
-}
-
-func TestDecompressRejectsInvalidData(t *testing.T) {
-	for _, kind := range []string{"zstd", "s2", "snappy"} {
-		t.Run(kind, func(t *testing.T) {
-			cmp := test.Compressor.Get(kind)
-
-			_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
-			require.Error(t, err)
-			require.NotErrorIs(t, err, errors.ErrTooLarge)
-		})
-	}
-}
-
-func TestS2DecompressReturnsDecodedLenError(t *testing.T) {
-	cmp := test.Compressor.Get("s2")
-	data := []byte{0x80}
-
-	_, err := cmp.Decompress(data, bytes.KB)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errors.ErrTooLarge)
-}
-
-func TestSnappyDecompressReturnsDecodedLenError(t *testing.T) {
-	cmp := test.Compressor.Get("snappy")
-	data := []byte{0x80}
-
-	_, err := cmp.Decompress(data, bytes.KB)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errors.ErrTooLarge)
-}
-
-func TestZstdDecompressPreservesDecoderSizeError(t *testing.T) {
-	cmp := zstd.NewCompressor()
-
-	data := make([]byte, zstd.MinWindowSize+1)
-	encoded, err := cmp.Compress(data, bytes.Size(len(data)))
-	require.NoError(t, err)
-
-	_, err = cmp.Decompress(encoded, zstd.MinWindowSize)
-	require.ErrorIs(t, err, errors.ErrTooLarge)
-	require.ErrorIs(t, err, zstd.ErrDecoderSizeExceeded)
-}
-
-func TestZstdDecompressRejectsInvalidLimits(t *testing.T) {
-	cmp := zstd.NewCompressor()
-	data := strings.Bytes("hello")
-	encoded, err := cmp.Compress(data, bytes.KB)
-	require.NoError(t, err)
-
-	for _, tt := range []struct {
-		name string
-		size bytes.Size
-	}{
-		{name: "negative", size: -1},
-		{name: "max int64", size: math.MaxInt64},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			decoded, err := cmp.Decompress(encoded, tt.size)
-			require.ErrorIs(t, err, errors.ErrTooLarge)
-			require.Nil(t, decoded)
 		})
 	}
 }

--- a/compress/none/none_test.go
+++ b/compress/none/none_test.go
@@ -1,0 +1,38 @@
+package none_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/none"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressorReturnsDataUnchanged(t *testing.T) {
+	cmp := none.NewCompressor()
+	data := strings.Bytes("hello")
+
+	compressed, err := cmp.Compress(data, bytes.Size(len(data)))
+	require.NoError(t, err)
+	require.Equal(t, data, compressed)
+
+	decompressed, err := cmp.Decompress(data, bytes.Size(len(data)))
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+func TestCompressRejectsTooLarge(t *testing.T) {
+	cmp := none.NewCompressor()
+
+	_, err := cmp.Compress(strings.Bytes("hello"), 4)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsTooLarge(t *testing.T) {
+	cmp := none.NewCompressor()
+
+	_, err := cmp.Decompress(strings.Bytes("hello"), 4)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}

--- a/compress/s2/s2_test.go
+++ b/compress/s2/s2_test.go
@@ -1,0 +1,57 @@
+package s2_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/s2"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressor(t *testing.T) {
+	cmp := s2.NewCompressor()
+	data := strings.Bytes("hello")
+	size := bytes.Size(len(data))
+
+	compressed, err := cmp.Compress(data, size)
+	require.NoError(t, err)
+
+	decompressed, err := cmp.Decompress(compressed, size)
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+func TestCompressRejectsTooLarge(t *testing.T) {
+	cmp := s2.NewCompressor()
+
+	_, err := cmp.Compress(strings.Bytes("hello"), 4)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsTooLarge(t *testing.T) {
+	cmp := s2.NewCompressor()
+	data := strings.Bytes("hello")
+	compressed, err := cmp.Compress(data, bytes.KB)
+	require.NoError(t, err)
+
+	_, err = cmp.Decompress(compressed, bytes.Size(len(data)-1))
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsInvalidData(t *testing.T) {
+	cmp := s2.NewCompressor()
+
+	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressReturnsDecodedLenError(t *testing.T) {
+	cmp := s2.NewCompressor()
+
+	_, err := cmp.Decompress([]byte{0x80}, bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}

--- a/compress/snappy/snappy_test.go
+++ b/compress/snappy/snappy_test.go
@@ -1,0 +1,57 @@
+package snappy_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/snappy"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressor(t *testing.T) {
+	cmp := snappy.NewCompressor()
+	data := strings.Bytes("hello")
+	size := bytes.Size(len(data))
+
+	compressed, err := cmp.Compress(data, size)
+	require.NoError(t, err)
+
+	decompressed, err := cmp.Decompress(compressed, size)
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+func TestCompressRejectsTooLarge(t *testing.T) {
+	cmp := snappy.NewCompressor()
+
+	_, err := cmp.Compress(strings.Bytes("hello"), 4)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsTooLarge(t *testing.T) {
+	cmp := snappy.NewCompressor()
+	data := strings.Bytes("hello")
+	compressed, err := cmp.Compress(data, bytes.KB)
+	require.NoError(t, err)
+
+	_, err = cmp.Decompress(compressed, bytes.Size(len(data)-1))
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsInvalidData(t *testing.T) {
+	cmp := snappy.NewCompressor()
+
+	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressReturnsDecodedLenError(t *testing.T) {
+	cmp := snappy.NewCompressor()
+
+	_, err := cmp.Decompress([]byte{0x80}, bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -14,6 +14,8 @@ import (
 // MinWindowSize is the minimum decoder window size used by the underlying Zstandard implementation.
 const MinWindowSize = zstd.MinWindowSize
 
+const decoderMaxMemory = bytes.MaxConfigSize
+
 // ErrDecoderSizeExceeded is returned by the underlying Zstandard decoder when decoded size exceeds its limit.
 var ErrDecoderSizeExceeded = zstd.ErrDecoderSizeExceeded
 
@@ -57,10 +59,9 @@ func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 		return nil, compress.ErrTooLarge
 	}
 
-	maxMemory := uint64(max(limit, int64(MinWindowSize)))
 	decoder, err := zstd.NewReader(
 		bytes.NewReader(data),
-		zstd.WithDecoderMaxMemory(maxMemory),
+		zstd.WithDecoderMaxMemory(uint64(decoderMaxMemory)),
 	)
 	if err != nil {
 		return nil, err
@@ -69,14 +70,14 @@ func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 
 	decoded, _, err := io.ReadAll(io.LimitReader(decoder, limit+1))
 	if err != nil {
-		if errors.Is(err, ErrDecoderSizeExceeded) {
+		if errors.Is(err, ErrDecoderSizeExceeded) || errors.Is(err, zstd.ErrWindowSizeExceeded) {
 			return nil, fmt.Errorf("%w: %w", compress.ErrTooLarge, err)
 		}
 
 		return nil, err
 	}
 	if int64(len(decoded)) > limit {
-		return nil, compress.ErrTooLarge
+		return nil, fmt.Errorf("%w: %w", compress.ErrTooLarge, ErrDecoderSizeExceeded)
 	}
 
 	return decoded, nil

--- a/compress/zstd/zstd_test.go
+++ b/compress/zstd/zstd_test.go
@@ -1,0 +1,97 @@
+package zstd_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/zstd"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	compress "github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressor(t *testing.T) {
+	cmp := zstd.NewCompressor()
+	data := strings.Bytes("hello")
+	size := bytes.Size(len(data))
+
+	compressed, err := cmp.Compress(data, size)
+	require.NoError(t, err)
+
+	decompressed, err := cmp.Decompress(compressed, size)
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+func TestCompressRejectsTooLarge(t *testing.T) {
+	cmp := zstd.NewCompressor()
+
+	_, err := cmp.Compress(strings.Bytes("hello"), 4)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsTooLarge(t *testing.T) {
+	cmp := zstd.NewCompressor()
+	data := strings.Bytes("hello")
+	compressed, err := cmp.Compress(data, bytes.KB)
+	require.NoError(t, err)
+
+	_, err = cmp.Decompress(compressed, bytes.Size(len(data)-1))
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressRejectsInvalidData(t *testing.T) {
+	cmp := zstd.NewCompressor()
+
+	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errors.ErrTooLarge)
+}
+
+func TestDecompressPreservesDecoderSizeError(t *testing.T) {
+	cmp := zstd.NewCompressor()
+
+	data := make([]byte, zstd.MinWindowSize+1)
+	encoded, err := cmp.Compress(data, bytes.Size(len(data)))
+	require.NoError(t, err)
+
+	_, err = cmp.Decompress(encoded, zstd.MinWindowSize)
+	require.ErrorIs(t, err, errors.ErrTooLarge)
+	require.ErrorIs(t, err, zstd.ErrDecoderSizeExceeded)
+}
+
+func TestDecompressAllowsWindowLargerThanOutputLimit(t *testing.T) {
+	cmp := zstd.NewCompressor()
+	data := make([]byte, 64<<10)
+	encoder, err := compress.NewWriter(nil, compress.WithWindowSize(128<<10), compress.WithSingleSegment(false))
+	require.NoError(t, err)
+	defer encoder.Close()
+
+	encoded := encoder.EncodeAll(data, nil)
+	decoded, err := cmp.Decompress(encoded, bytes.Size(len(data)))
+	require.NoError(t, err)
+	require.Equal(t, data, decoded)
+}
+
+func TestDecompressRejectsInvalidLimits(t *testing.T) {
+	cmp := zstd.NewCompressor()
+	data := strings.Bytes("hello")
+	encoded, err := cmp.Compress(data, bytes.KB)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name string
+		size bytes.Size
+	}{
+		{name: "negative", size: -1},
+		{name: "max int64", size: math.MaxInt64},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			decoded, err := cmp.Decompress(encoded, tt.size)
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+			require.Nil(t, decoded)
+		})
+	}
+}


### PR DESCRIPTION
## What

- Allow zstd decompression to accept valid frames whose window is larger than the requested decoded output limit while still enforcing the caller-provided decoded size.
- Move codec-specific compression tests out of the root registry tests and into the owning codec packages.
- Keep the zstd window regression in the zstd package test, using the upstream zstd encoder only as test setup.

## Why

- Some valid non-single-segment zstd frames were rejected because the decoder memory/window limit was tied to the requested decoded output size instead of the repository byte-size policy.
- Splitting codec tests keeps root compression tests focused on registration and prevents zstd-specific setup from expanding the production API.

## Testing

- `go test ./compress/...` - passed
- `make lint` - passed
- Full `make specs` was not run; validation was scoped to the changed compression packages plus repository lint.
