### PR TITLE
feat(telemetry): sync provider gates and stage resources

### DIFF
--- a/telemetry/attributes/attributes.go
+++ b/telemetry/attributes/attributes.go
@@ -86,9 +86,10 @@ func ServiceVersion(version string) attribute.KeyValue {
 // DeploymentEnvironmentName returns a deployment.environment.name attribute for env.
 //
 // It maps common environment names onto the stable OpenTelemetry enum values:
-// "prod" and "production" become "production"; "staging" remains "staging";
-// "qa", "test", and "testing" become "test"; "dev" and "development" become
-// "development". Unknown or empty values default to "development".
+// "prod" and "production" become "production"; "stage" and "staging" become
+// "staging"; "qa", "test", and "testing" become "test"; "dev" and
+// "development" become "development". Unknown or empty values default to
+// "development".
 //
 // It is typically used when constructing a Resource to describe the deployment
 // environment.
@@ -99,7 +100,7 @@ func DeploymentEnvironmentName(env string) attribute.KeyValue {
 	switch env {
 	case "prod", "production":
 		return semconv.DeploymentEnvironmentNameProduction
-	case "staging":
+	case "stage", "staging":
 		return semconv.DeploymentEnvironmentNameStaging
 	case "qa", "test", "testing":
 		return semconv.DeploymentEnvironmentNameTest

--- a/telemetry/attributes/attributes_test.go
+++ b/telemetry/attributes/attributes_test.go
@@ -17,6 +17,7 @@ func TestDeploymentEnvironmentName(t *testing.T) {
 	}{
 		{name: "prod alias", value: "prod", expected: "production"},
 		{name: "production", value: "production", expected: "production"},
+		{name: "stage alias", value: "stage", expected: "staging"},
 		{name: "staging", value: "staging", expected: "staging"},
 		{name: "qa alias", value: "qa", expected: "test"},
 		{name: "test", value: "test", expected: "test"},

--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -156,5 +156,19 @@ func GetMeterProvider() MeterProvider {
 
 // SetMeterProvider installs the global OpenTelemetry meter provider.
 func SetMeterProvider(provider MeterProvider) {
+	setMeterProvider(provider, isEnabledProvider(provider))
+}
+
+func setMeterProvider(provider MeterProvider, isEnabled bool) {
 	otel.SetMeterProvider(provider)
+	enabled.Store(isEnabled)
+}
+
+func isEnabledProvider(provider MeterProvider) bool {
+	if provider == nil {
+		return false
+	}
+
+	_, ok := provider.(noop.MeterProvider)
+	return !ok
 }

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -67,8 +67,7 @@ type MeterProviderParams struct {
 // If metrics are disabled or Reader is nil, it installs and returns the package noop provider.
 func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	if !params.Config.IsEnabled() || params.Reader == nil {
-		enabled.Store(false)
-		SetMeterProvider(noopProvider)
+		setMeterProvider(noopProvider, false)
 		return noopProvider
 	}
 
@@ -80,8 +79,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		attributes.DeploymentEnvironmentName(params.Environment.String()),
 	)
 	provider := sdk.NewMeterProvider(sdk.WithReader(params.Reader), sdk.WithResource(attrs))
-	SetMeterProvider(provider)
-	enabled.Store(true)
+	setMeterProvider(provider, true)
 
 	params.Lifecycle.Append(di.Hook{
 		OnStart: func(_ context.Context) error {
@@ -92,8 +90,7 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		OnStop: func(ctx context.Context) error {
 			// Do not return error as this will stop all others.
 			_ = provider.Shutdown(ctx)
-			SetMeterProvider(noopProvider)
-			enabled.Store(false)
+			setMeterProvider(noopProvider, false)
 
 			return nil
 		},

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -18,6 +18,29 @@ func TestIsEnabled(t *testing.T) {
 	metrics.SetMeterProvider(metrics.NewNoopMeterProvider())
 	require.False(t, metrics.IsEnabled())
 
+	metrics.SetMeterProvider(nil)
+	require.False(t, metrics.IsEnabled())
+
+	manualProvider := metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(t),
+		Config:      &metrics.Config{},
+		Reader:      metrics.NewManualReader(),
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+	require.True(t, metrics.IsEnabled())
+
+	metrics.SetMeterProvider(metrics.NewNoopMeterProvider())
+	require.False(t, metrics.IsEnabled())
+
+	metrics.SetMeterProvider(manualProvider)
+	require.True(t, metrics.IsEnabled())
+
+	metrics.SetMeterProvider(metrics.NewNoopMeterProvider())
+	require.False(t, metrics.IsEnabled())
+
 	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	require.False(t, metrics.IsEnabled())
 

--- a/telemetry/tracer/provider.go
+++ b/telemetry/tracer/provider.go
@@ -1,6 +1,9 @@
 package tracer
 
-import "go.opentelemetry.io/otel"
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace/noop"
+)
 
 // GetProvider returns the global OpenTelemetry tracer provider.
 func GetProvider() Provider {
@@ -9,5 +12,19 @@ func GetProvider() Provider {
 
 // SetProvider installs the global OpenTelemetry tracer provider.
 func SetProvider(provider Provider) {
+	setProvider(provider, isEnabledProvider(provider))
+}
+
+func setProvider(provider Provider, isEnabled bool) {
 	otel.SetTracerProvider(provider)
+	enabled.Store(isEnabled)
+}
+
+func isEnabledProvider(provider Provider) bool {
+	if provider == nil {
+		return false
+	}
+
+	_, ok := provider.(noop.TracerProvider)
+	return !ok
 }

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -94,8 +94,7 @@ type TracerParams struct {
 // Shutdown errors are intentionally ignored to avoid blocking other stop hooks.
 func Register(params TracerParams) error {
 	if !params.Config.IsEnabled() {
-		enabled.Store(false)
-		SetProvider(noopProvider)
+		setProvider(noopProvider, false)
 		return nil
 	}
 
@@ -121,8 +120,7 @@ func Register(params TracerParams) error {
 		)
 
 		provider := sdk.NewTracerProvider(sdk.WithResource(attrs), sdk.WithBatcher(exporter))
-		SetProvider(provider)
-		enabled.Store(true)
+		setProvider(provider, true)
 
 		params.Lifecycle.Append(di.Hook{
 			OnStart: func(ctx context.Context) error {
@@ -132,8 +130,7 @@ func Register(params TracerParams) error {
 				// Do not return error as this will stop all others.
 				_ = provider.Shutdown(ctx)
 				_ = exporter.Shutdown(ctx)
-				SetProvider(noopProvider)
-				enabled.Store(false)
+				setProvider(noopProvider, false)
 
 				return nil
 			},

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -19,6 +19,17 @@ func TestIsEnabled(t *testing.T) {
 	tracer.SetProvider(tracer.NewNoopProvider())
 	require.False(t, tracer.IsEnabled())
 
+	tracer.SetProvider(nil)
+	require.False(t, tracer.IsEnabled())
+
+	provider := tracer.NewProvider()
+	tracer.SetProvider(provider)
+	require.True(t, tracer.IsEnabled())
+	require.NoError(t, provider.Shutdown(t.Context()))
+
+	tracer.SetProvider(tracer.NewNoopProvider())
+	require.False(t, tracer.IsEnabled())
+
 	require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	require.False(t, tracer.IsEnabled())
 


### PR DESCRIPTION
## What

- Map the documented `stage` environment alias to the OpenTelemetry staging resource value.
- Keep manual metrics and tracer provider setters synchronized with the package enablement gates.
- Add regression coverage for stage environment classification and manual provider re-installation.

## Why

- Staging services configured with `stage` should not be grouped with development telemetry.
- Installing a real global provider through this repository's public setters should enable the repository instrumentation gates instead of silently skipping HTTP, gRPC, SQL, and Redis telemetry.

## Testing

- `go test ./telemetry/attributes ./telemetry/logger ./telemetry/metrics ./telemetry/tracer ./net/http ./transport/grpc ./database/sql/driver ./cache/driver` - passed
- `make lint` - passed
