### PR TITLE
feat(transport): isolate limiter buckets and parallelize shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ on clients when the dial address differs from the certificate DNS name.
 > [!IMPORTANT]
 > If you are using `go-service-template` or composing server transport bundles such as `module.Server` or `transport.Module`, the required transport registration is handled for you by DI.
 >
-> `module.Client` does not wire transports by default. Add `transport.Module`, the relevant transport submodule, or call the transport-level `Register(...)` functions when a client process constructs HTTP or gRPC TLS config from source strings such as `file:`.
+> `module.Client` does not wire transports by default. When a client process constructs HTTP or gRPC TLS config from source strings such as `file:`, call the relevant transport-level `Register(...)` functions, such as `transport/http.Register(...)` or `transport/grpc.Register(...)`.
 >
 > You only need to call transport-level `Register(...)` functions yourself when you intentionally wire transports manually or compose lower-level packages outside the transport module graph.
 >

--- a/net/server/register.go
+++ b/net/server/register.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/slices"
+	"github.com/alexfalkowski/go-sync"
 )
 
 // Register wires server services into the application lifecycle.
@@ -27,10 +28,14 @@ func Register(lc di.Lifecycle, services []*Service) {
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
-			errs := make([]error, 0, len(services))
-			for _, s := range services {
-				errs = append(errs, s.Stop(ctx))
+			errs := make([]error, len(services))
+			var wg sync.WaitGroup
+			for i, s := range services {
+				wg.Go(func() {
+					errs[i] = s.Stop(ctx)
+				})
 			}
+			wg.Wait()
 
 			return errors.Join(errs...)
 		},

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/server"
@@ -55,6 +56,29 @@ func TestRegisterStartsAllServices(t *testing.T) {
 	require.Equal(t, 1, second.Shutdowns, "second shutdowns")
 }
 
+func TestRegisterStopsServicesConcurrently(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	first := newBlockingShutdownServer()
+	second := newShutdownContextServer()
+	sh := test.NewShutdowner()
+
+	server.Register(lc, []*server.Service{
+		server.NewService("first", first, nil, sh),
+		server.NewService("second", second, nil, sh),
+	})
+
+	require.NoError(t, lc.Start(t.Context()))
+	waitForRegisteredService(t, first.Done)
+	waitForRegisteredService(t, second.Done)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+
+	err := lc.Stop(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, <-second.ShutdownErrs)
+}
+
 func TestRegisterSnapshotsServices(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	original := test.NewObservableServer(nil, nil)
@@ -83,4 +107,56 @@ func waitForRegisteredService(t *testing.T, done <-chan struct{}) {
 	case <-time.After(time.Second):
 		require.Fail(t, "registered service was not started")
 	}
+}
+
+func newBlockingShutdownServer() *blockingShutdownServer {
+	return &blockingShutdownServer{Done: make(chan struct{})}
+}
+
+type blockingShutdownServer struct {
+	Done chan struct{}
+}
+
+func (s *blockingShutdownServer) Serve() error {
+	close(s.Done)
+
+	return nil
+}
+
+func (*blockingShutdownServer) Shutdown(ctx context.Context) error {
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+func (*blockingShutdownServer) String() string {
+	return "test"
+}
+
+func newShutdownContextServer() *shutdownContextServer {
+	return &shutdownContextServer{
+		Done:         make(chan struct{}),
+		ShutdownErrs: make(chan error, 1),
+	}
+}
+
+type shutdownContextServer struct {
+	Done         chan struct{}
+	ShutdownErrs chan error
+}
+
+func (s *shutdownContextServer) Serve() error {
+	close(s.Done)
+
+	return nil
+}
+
+func (s *shutdownContextServer) Shutdown(ctx context.Context) error {
+	s.ShutdownErrs <- ctx.Err()
+
+	return nil
+}
+
+func (*shutdownContextServer) String() string {
+	return "test"
 }

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -150,13 +150,15 @@ func (l *Limiter) Close(ctx context.Context) error {
 
 func key(value meta.Value) string {
 	rawKey := value.Value()
+	// Namespace every store key representation so caller-controlled raw values
+	// cannot collide with internal empty sentinels or oversized-key hashes.
 	if strings.IsEmpty(rawKey) {
-		return "<empty>"
+		return "empty:"
 	}
 	if len(rawKey) <= maxKeySize {
-		return rawKey
+		return strings.Concat("raw:", strconv.Itoa(len(rawKey)), ":", rawKey)
 	}
 
 	sum := sha256.Sum256([]byte(rawKey))
-	return strings.Concat("sha256:", hex.EncodeToString(sum[:]))
+	return strings.Concat("hash:sha256:", hex.EncodeToString(sum[:]))
 }

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -1,6 +1,8 @@
 package limiter_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -160,6 +162,11 @@ func TestTakeUsesSingleBucketForEmptyKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("<empty>"))))
+	require.NoError(t, err)
+	require.True(t, ok, "raw reserved empty literal should use its own bucket")
+	require.Equal(t, "limit=1, remaining=0", header)
 }
 
 func TestTakeSupportsOversizedKeys(t *testing.T) {
@@ -190,6 +197,35 @@ func TestTakeSupportsOversizedKeys(t *testing.T) {
 	ok, header, err = limiter.Take(second)
 	require.NoError(t, err)
 	require.True(t, ok)
+	require.Equal(t, "limit=1, remaining=0", header)
+}
+
+func TestTakeDoesNotCollideOversizedKeysWithRawHashKeys(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Second}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	oversized := strings.Repeat("a", 1024)
+	sum := sha256.Sum256([]byte(oversized))
+	rawHash := strings.Concat("sha256:", hex.EncodeToString(sum[:]))
+	oversizedCtx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String(oversized)))
+	rawHashCtx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String(rawHash)))
+
+	ok, header, err := limiter.Take(oversizedCtx)
+	require.NoError(t, err)
+	require.True(t, ok, "oversized key should take its own bucket")
+	require.Equal(t, "limit=1, remaining=0", header)
+
+	ok, header, err = limiter.Take(rawHashCtx)
+	require.NoError(t, err)
+	require.True(t, ok, "raw hash-looking key should use its own bucket")
 	require.Equal(t, "limit=1, remaining=0", header)
 }
 


### PR DESCRIPTION
## What

- Stop registered server services concurrently during lifecycle shutdown while preserving joined shutdown errors.
- Namespace limiter bucket keys so internal empty and hashed representations cannot collide with raw caller-provided key values.
- Clarify client TLS registration docs so `module.Client` users call the relevant transport registration functions instead of adding the full server transport module.

## Why

- Every registered server should receive the same remaining shutdown budget instead of later services inheriting a context already exhausted by an earlier slow shutdown.
- Rate limits should be isolated by the actual derived identity, including values that look like internal sentinel or hash formats.
- Client-only applications should not be guided toward composing server transport wiring when they only need TLS source-string registration.

## Testing

- `go test ./net/server ./transport/limiter` - passed
- `make lint` - passed
