### PR TITLE
feat(grpc): add time and trailer wrappers

### DIFF
--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -240,6 +240,14 @@ func SetHeader(ctx context.Context, md meta.Map) error {
 	return grpc.SetHeader(ctx, md)
 }
 
+// SetTrailer sets the trailer metadata that will be sent back to the client.
+//
+// This forwards to [grpc.SetTrailer]. It is typically called by a handler to add
+// response trailers.
+func SetTrailer(ctx context.Context, md meta.Map) error {
+	return grpc.SetTrailer(ctx, md)
+}
+
 // Header returns a call option that captures response header metadata.
 //
 // This forwards to [grpc.Header]. The provided map is populated by the client

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -36,6 +36,10 @@ func TestParseServiceMethod(t *testing.T) {
 	}
 }
 
+func TestSetTrailer(t *testing.T) {
+	require.NoError(t, grpc.SetTrailer(t.Context(), nil))
+}
+
 func TestNewServerWithAdvancedOptions(t *testing.T) {
 	opts := options.Map{
 		"max_concurrent_streams":   "7",

--- a/time/time.go
+++ b/time/time.go
@@ -63,6 +63,13 @@ func Since(t Time) Duration {
 	return Duration(time.Since(t))
 }
 
+// Until returns the duration until t.
+//
+// This is a thin wrapper around [time.Until] and does not change semantics.
+func Until(t Time) Duration {
+	return Duration(time.Until(t))
+}
+
 // Sleep pauses the current goroutine for at least the duration d.
 //
 // This is a thin wrapper around [time.Sleep] and does not change semantics.

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -19,3 +19,12 @@ func TestNewTimer(t *testing.T) {
 		require.FailNow(t, "timed out waiting for timer")
 	}
 }
+
+func TestUntil(t *testing.T) {
+	future := time.Now().Add(time.Hour.Duration())
+
+	duration := time.Until(future)
+
+	require.Positive(t, duration)
+	require.LessOrEqual(t, duration, time.Hour)
+}


### PR DESCRIPTION
## What

- Added `time.Until` as a thin wrapper around the standard library helper while returning the repository `time.Duration` type.
- Added `net/grpc.SetTrailer` as a thin wrapper around upstream trailer metadata handling.
- Added focused tests for both wrapper entrypoints.

## Why

- Keeps the repository wrapper packages complete for callers that use the go-service import paths instead of importing standard library or upstream gRPC packages directly.
- Preserves existing wrapper semantics without changing behavior beyond exposing the missing helper functions.

## Testing

- `go test ./time ./net/grpc -count=1` - passed
- `make lint` - passed
- `git diff --check` - passed
