### PR TITLE
feat(reliability): bound shutdown and runtime resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,13 @@ matching skill for the task.
   startup failure exits the process. Report only concrete same-process reuse bugs
   in supported tests/tools, ignored successful shutdown cleanup, or an API
   promise that failed startup is recoverable in the same process.
+- Telemetry logger, metrics, and tracer shutdown hooks intentionally ignore
+  provider/exporter shutdown errors so one telemetry flush failure does not stop
+  later lifecycle shutdown hooks. Do not flag swallowed telemetry shutdown
+  export errors as reliability gaps solely because operators will not see those
+  final flush failures; report only concrete bugs such as shutdown hooks not
+  running, globals not resetting after successful shutdown, or a public API
+  promise to surface telemetry shutdown errors.
 - `cache.Register(...)` sets the package-level cache used by generic cache helpers.
   It is intentionally called by the supported wiring path during startup/test
   setup, not as a concurrent runtime reconfiguration API. Do not flag
@@ -344,3 +351,16 @@ matching skill for the task.
 
 - CI initializes submodules, prepares certs/services, then runs dependency, lint, security, spec, benchmark, and coverage targets.
 - Check CI config for exact service images, ports, and command order.
+- CircleCI intentionally uses floating `latest` tags for selected dependency
+  sidecars, such as `alexfalkowski/status:latest` and `grafana/mimir:latest`,
+  so upstream sidecar breakage is caught by CI. Do not flag those floating CI
+  sidecar tags as reliability, release-safety, or reproducibility gaps solely
+  because they can change; report only concrete breakage such as CI no longer
+  starting the required service, waiting on the wrong port, or using an image
+  that no longer satisfies the documented test dependency.
+- CircleCI `store_artifacts` and `store_test_results` steps run after earlier
+  failed steps by default. Do not flag missing `when: always` on those steps as
+  a reliability or diagnostics gap solely because earlier validation commands
+  can fail; report only concrete artifact/report collection breakage, such as
+  wrong paths, missing generated reports, cancellation/runtime-timeout cases
+  that the repo claims to preserve, or unsupported CircleCI behavior changes.

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ cache:
   compressor: zstd
   encoder: json
   max_size: 4MB
+  max_entries: 1024
   options:
     url: env:CACHE_URL
 ```
@@ -264,6 +265,7 @@ cache:
 > - For normal values, unknown or empty `encoder` values fall back to `json`.
 > - Cache operations use `plain` for `io.WriterTo`/`io.ReaderFrom` stream values and `proto` for protobuf messages, regardless of the configured `encoder`.
 > - `max_size` limits encoded cache values before compression, after compression, and after decompression. A zero value uses the default `4MB`.
+> - `max_entries` limits entries retained by bounded in-memory cache drivers and must be greater than zero.
 > - `options` is backend-specific and decoded as `map[string]any`.
 
 ---
@@ -360,7 +362,7 @@ Server commands created through `cli.Application.AddServer` include `runtime.Mod
 
 SQL root config is `database/sql.Config`, with Postgres under `sql.pg`.
 
-Postgres config embeds common pool + DSN config (`database/sql/config.Config`), including master/slave DSNs and pool sizes.
+Postgres config embeds common pool + DSN config (`database/sql/config.Config`), including master/slave DSNs and pool sizes. Enabled SQL configs must set positive `max_open_conns` and `max_idle_conns`; `max_idle_conns` must not exceed `max_open_conns`.
 
 `module.Server` and `module.Client` both include `sql.Module`, which currently wires PostgreSQL support via `database/sql/pg.Module`.
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -260,7 +260,7 @@ func TestWriteToOnlyUsesConfiguredEncoderOnGet(t *testing.T) {
 
 func TestMissingCache(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
-	cfg := &config.Config{Kind: "sync"}
+	cfg := &config.Config{Kind: "sync", MaxEntries: config.DefaultMaxEntries}
 
 	d, err := driver.NewDriver(driver.DriverParams{
 		Lifecycle: lc,
@@ -287,7 +287,7 @@ func TestMissingCache(t *testing.T) {
 }
 
 func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
-	cfg := &config.Config{Kind: "sync"}
+	cfg := &config.Config{Kind: "sync", MaxEntries: config.DefaultMaxEntries}
 	c := cache.NewCache(cache.CacheParams{
 		Config:     cfg,
 		Compressor: test.Compressor,

--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -2,6 +2,9 @@ package config
 
 import "github.com/alexfalkowski/go-service/v2/bytes"
 
+// DefaultMaxEntries is the default maximum number of entries for bounded in-memory cache drivers.
+const DefaultMaxEntries = 1024
+
 // Config configures the cache subsystem.
 type Config struct {
 	// Options contains implementation-specific configuration for the selected Kind.
@@ -28,7 +31,10 @@ type Config struct {
 	// In config files it is encoded as a human-readable SI size string (for example "64B", "2MB", "4GB").
 	//
 	// A zero value applies [bytes.DefaultSize]. Values must be between 0 and [bytes.MaxConfigSize].
-	MaxSize bytes.Size `yaml:"max_size,omitempty" json:"max_size,omitempty" toml:"max_size,omitempty" validate:"config_size"`
+	MaxSize bytes.Size `yaml:"max_size" json:"max_size" toml:"max_size" validate:"config_size"`
+
+	// MaxEntries limits the number of entries retained by bounded in-memory cache drivers.
+	MaxEntries int `yaml:"max_entries" json:"max_entries" toml:"max_entries" validate:"gt=0"`
 }
 
 // IsEnabled reports whether caching is enabled.
@@ -45,4 +51,15 @@ func (c *Config) GetMaxSize() bytes.Size {
 	}
 
 	return c.MaxSize
+}
+
+// GetMaxEntries returns the configured cache entry limit.
+//
+// A nil receiver or a zero value falls back to [DefaultMaxEntries].
+func (c *Config) GetMaxEntries() int {
+	if c == nil || c.MaxEntries == 0 {
+		return DefaultMaxEntries
+	}
+
+	return c.MaxEntries
 }

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -10,36 +10,83 @@ import (
 )
 
 func TestGetMaxSize(t *testing.T) {
-	t.Run("nil", func(t *testing.T) {
-		var cfg *config.Config
-		require.Equal(t, bytes.DefaultSize, cfg.GetMaxSize())
-	})
+	tests := []struct {
+		cfg  *config.Config
+		name string
+		size bytes.Size
+	}{
+		{
+			name: "nil",
+			size: bytes.DefaultSize,
+		},
+		{
+			name: "zero",
+			cfg:  &config.Config{},
+			size: bytes.DefaultSize,
+		},
+		{
+			name: "explicit",
+			cfg:  &config.Config{MaxSize: 64},
+			size: bytes.Size(64),
+		},
+	}
 
-	t.Run("zero", func(t *testing.T) {
-		cfg := &config.Config{}
-		require.Equal(t, bytes.DefaultSize, cfg.GetMaxSize())
-	})
-
-	t.Run("explicit", func(t *testing.T) {
-		cfg := &config.Config{MaxSize: 64}
-		require.Equal(t, bytes.Size(64), cfg.GetMaxSize())
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.size, tt.cfg.GetMaxSize())
+		})
+	}
 }
 
-func TestConfigRejectsNegativeMaxSize(t *testing.T) {
-	cfg := &config.Config{MaxSize: -1}
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		cfg  *config.Config
+		name string
+		err  bool
+	}{
+		{
+			name: "valid",
+			cfg:  &config.Config{MaxEntries: config.DefaultMaxEntries},
+		},
+		{
+			name: "valid max size",
+			cfg:  &config.Config{MaxSize: bytes.MaxConfigSize, MaxEntries: config.DefaultMaxEntries},
+		},
+		{
+			name: "valid max entries",
+			cfg:  &config.Config{MaxEntries: 1},
+		},
+		{
+			name: "negative max size",
+			cfg:  &config.Config{MaxSize: -1, MaxEntries: config.DefaultMaxEntries},
+			err:  true,
+		},
+		{
+			name: "oversized max size",
+			cfg:  &config.Config{MaxSize: bytes.MaxConfigSize + 1, MaxEntries: config.DefaultMaxEntries},
+			err:  true,
+		},
+		{
+			name: "zero max entries",
+			cfg:  &config.Config{MaxEntries: 0},
+			err:  true,
+		},
+		{
+			name: "negative max entries",
+			cfg:  &config.Config{MaxEntries: -1},
+			err:  true,
+		},
+	}
 
-	require.Error(t, test.Validator.Struct(cfg))
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := test.Validator.Struct(tt.cfg)
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
 
-func TestConfigAcceptsMaxSize(t *testing.T) {
-	cfg := &config.Config{MaxSize: bytes.MaxConfigSize}
-
-	require.NoError(t, test.Validator.Struct(cfg))
-}
-
-func TestConfigRejectsOversizedMaxSize(t *testing.T) {
-	cfg := &config.Config{MaxSize: bytes.MaxConfigSize + 1}
-
-	require.Error(t, test.Validator.Struct(cfg))
+			require.NoError(t, err)
+		})
+	}
 }

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -20,6 +20,6 @@
 // # TTL resolution
 //
 // TTL handling depends on the selected driver. The built-in in-memory "sync"
-// driver stores values in process memory and expires entries lazily when they
-// are read.
+// driver stores a bounded number of values in process memory, expires entries
+// when they are read, and removes expired entries before saving new values.
 package cache

--- a/cache/driver/doc.go
+++ b/cache/driver/doc.go
@@ -21,8 +21,8 @@
 // The standard config fixtures provide that shape; callers that build config manually should validate it
 // before calling [NewDriver].
 //
-// The built-in "sync" driver uses an in-process [github.com/alexfalkowski/go-sync.Map] and lazily expires
-// entries when they are read.
+// The built-in "sync" driver uses a bounded in-process cache and expires entries
+// when they are read or before new values are saved.
 //
 // If the configured kind is unknown, [NewDriver] returns [ErrNotFound].
 //

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -86,7 +86,7 @@ func NewDriver(params DriverParams) (Driver, error) {
 	case "redis":
 		return newRedisDriver(params)
 	case "sync":
-		return &syncDriver{}, nil
+		return newSyncDriver(cfg.GetMaxEntries()), nil
 	default:
 		return nil, ErrNotFound
 	}

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -24,7 +24,7 @@ func TestNewDriver(t *testing.T) {
 		wantNil bool
 	}{
 		{name: "disabled", wantNil: true},
-		{name: "sync", config: &config.Config{Kind: "sync"}},
+		{name: "sync", config: &config.Config{Kind: "sync", MaxEntries: config.DefaultMaxEntries}},
 		{name: "unknown", config: &config.Config{Kind: "unknown"}, err: driver.ErrNotFound, wantNil: true},
 	}
 
@@ -43,7 +43,7 @@ func TestNewDriver(t *testing.T) {
 }
 
 func TestIsMissingError(t *testing.T) {
-	cfg := &config.Config{Kind: "sync"}
+	cfg := &config.Config{Kind: "sync", MaxEntries: config.DefaultMaxEntries}
 
 	d, err := driver.NewDriver(driver.DriverParams{Config: cfg})
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestSyncDriverHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync"}})
+	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync", MaxEntries: config.DefaultMaxEntries}})
 	require.NoError(t, err)
 	require.ErrorIs(t, d.Save(ctx, "key", "value", 0), context.Canceled)
 	_, err = d.Fetch(ctx, "key")
@@ -139,7 +139,7 @@ func TestSyncDriverHonorsCanceledContext(t *testing.T) {
 }
 
 func TestSyncDriverExpiresEntries(t *testing.T) {
-	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync"}})
+	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync", MaxEntries: config.DefaultMaxEntries}})
 	require.NoError(t, err)
 
 	require.NoError(t, d.Save(t.Context(), "key", "value", time.Nanosecond))
@@ -153,6 +153,46 @@ func TestSyncDriverExpiresEntries(t *testing.T) {
 
 	_, err = d.Fetch(t.Context(), "key")
 	require.ErrorIs(t, err, driver.ErrMissing)
+}
+
+func TestSyncDriverEvictsEntryAtCapacity(t *testing.T) {
+	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync", MaxEntries: 2}})
+	require.NoError(t, err)
+
+	require.NoError(t, d.Save(t.Context(), "first", "1", 0))
+	require.NoError(t, d.Save(t.Context(), "second", "2", 0))
+
+	require.NoError(t, d.Save(t.Context(), "third", "3", 0))
+
+	value, err := d.Fetch(t.Context(), "third")
+	require.NoError(t, err)
+	require.Equal(t, "3", value)
+
+	var misses int
+	for _, key := range []string{"first", "second"} {
+		_, err = d.Fetch(t.Context(), key)
+		if driver.IsMissingError(err) {
+			misses++
+		}
+	}
+	require.Equal(t, 1, misses)
+}
+
+func TestSyncDriverCleansExpiredEntriesOnSave(t *testing.T) {
+	d, err := driver.NewDriver(driver.DriverParams{Config: &config.Config{Kind: "sync", MaxEntries: 1}})
+	require.NoError(t, err)
+
+	require.NoError(t, d.Save(t.Context(), "expired", "old", time.Nanosecond))
+	require.Eventually(t, func() bool {
+		require.NoError(t, d.Save(t.Context(), "new", "value", 0))
+
+		_, err = d.Fetch(t.Context(), "expired")
+		return errors.Is(err, driver.ErrMissing)
+	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
+
+	value, err := d.Fetch(t.Context(), "new")
+	require.NoError(t, err)
+	require.Equal(t, "value", value)
 }
 
 func redisMetricCount(t *testing.T, reader metrics.Reader) int {

--- a/cache/driver/sync.go
+++ b/cache/driver/sync.go
@@ -7,7 +7,9 @@ import (
 )
 
 type syncDriver struct {
-	items sync.Map[string, syncEntry]
+	items      map[string]syncEntry
+	maxEntries int
+	mu         sync.Mutex
 }
 
 type syncEntry struct {
@@ -15,12 +17,22 @@ type syncEntry struct {
 	value     string
 }
 
+func newSyncDriver(maxEntries int) *syncDriver {
+	return &syncDriver{
+		items:      make(map[string]syncEntry),
+		maxEntries: max(maxEntries, 1),
+	}
+}
+
 func (d *syncDriver) Delete(ctx context.Context, key string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	d.items.Delete(key)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.deleteEntry(key)
 
 	return nil
 }
@@ -30,13 +42,16 @@ func (d *syncDriver) Fetch(ctx context.Context, key string) (string, error) {
 		return "", err
 	}
 
-	entry, ok := d.items.Load(key)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	entry, ok := d.items[key]
 	if !ok {
 		return "", ErrMissing
 	}
 
 	if !entry.expiresAt.IsZero() && time.Now().After(entry.expiresAt) {
-		d.items.CompareAndDelete(key, entry)
+		d.deleteEntry(key)
 
 		return "", ErrExpired
 	}
@@ -49,7 +64,10 @@ func (d *syncDriver) Flush(ctx context.Context) error {
 		return err
 	}
 
-	d.items.Clear()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	clear(d.items)
 
 	return nil
 }
@@ -59,12 +77,43 @@ func (d *syncDriver) Save(ctx context.Context, key, value string, lifetime time.
 		return err
 	}
 
-	d.items.Store(key, syncEntry{
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.deleteExpired()
+	if _, ok := d.items[key]; !ok {
+		d.evictIfFull()
+	}
+
+	d.items[key] = syncEntry{
 		expiresAt: expiresAt(lifetime),
 		value:     value,
-	})
+	}
 
 	return nil
+}
+
+func (d *syncDriver) deleteExpired() {
+	now := time.Now()
+	for key, entry := range d.items {
+		if !entry.expiresAt.IsZero() && now.After(entry.expiresAt) {
+			d.deleteEntry(key)
+		}
+	}
+}
+
+func (d *syncDriver) evictIfFull() {
+	for len(d.items) >= d.maxEntries {
+		for key := range d.items {
+			d.deleteEntry(key)
+
+			break
+		}
+	}
+}
+
+func (d *syncDriver) deleteEntry(key string) {
+	delete(d.items, key)
 }
 
 func expiresAt(lifetime time.Duration) time.Time {

--- a/cli/application.go
+++ b/cli/application.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/cristalhq/acmd"
 )
 
@@ -74,7 +75,7 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 			opts := append(slices.Clone(opts), server.module(), runtime.Module)
 			app := di.New(opts...)
 
-			if err := app.Start(ctx); err != nil {
+			if err := a.start(ctx, app); err != nil {
 				return a.prefix(name, err)
 			}
 
@@ -85,7 +86,7 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 			case <-ctx.Done():
 			}
 
-			return a.shutdownError(name, app.Stop(a.stopContext(ctx)), code)
+			return a.shutdownError(name, a.stop(ctx, app), code)
 		},
 	}
 	runtime.Must(a.register(command))
@@ -121,7 +122,7 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 			opts := append(slices.Clone(opts), client.module())
 			app := di.New(opts...)
 
-			if err := app.Start(ctx); err != nil {
+			if err := a.start(ctx, app); err != nil {
 				return a.prefix(name, err)
 			}
 
@@ -132,7 +133,7 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 			default:
 			}
 
-			return a.shutdownError(name, app.Stop(a.stopContext(ctx)), code)
+			return a.shutdownError(name, a.stop(ctx, app), code)
 		},
 	}
 	runtime.Must(a.register(command))
@@ -211,10 +212,24 @@ func (a *Application) code(err error) int {
 	return os.ExitCodeFailure
 }
 
-func (a *Application) stopContext(ctx context.Context) context.Context {
+func (a *Application) start(ctx context.Context, app *di.App) error {
+	startCtx, cancel := context.WithTimeout(ctx, time.Duration(app.StartTimeout()))
+	defer cancel()
+
+	return app.Start(startCtx)
+}
+
+func (a *Application) stop(ctx context.Context, app *di.App) error {
+	stopCtx, cancel := a.stopContext(ctx, app)
+	defer cancel()
+
+	return app.Stop(stopCtx)
+}
+
+func (a *Application) stopContext(ctx context.Context, app *di.App) (context.Context, context.CancelFunc) {
 	if ctx.Err() != nil {
-		return context.WithoutCancel(ctx)
+		ctx = context.WithoutCancel(ctx)
 	}
 
-	return ctx
+	return context.WithTimeout(ctx, time.Duration(app.StopTimeout()))
 }

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 )
 
 func TestApplicationClientRunCodeOnSuccess(t *testing.T) {
@@ -82,6 +84,32 @@ func TestApplicationClientRecoversFromPanic(t *testing.T) {
 	err := app.Run(t.Context())
 	require.Error(t, err)
 	require.ErrorContains(t, err, `panic: "bad client"`)
+}
+
+func TestApplicationClientStartUsesFxTimeout(t *testing.T) {
+	test.SetupCLI("client")
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddClient(
+				"client",
+				"Start the client.",
+				di.NoLogger,
+				fx.StartTimeout((10 * time.Millisecond).Duration()),
+				di.Register(func(lc di.Lifecycle) {
+					lc.Append(di.Hook{
+						OnStart: func(ctx context.Context) error {
+							<-ctx.Done()
+
+							return ctx.Err()
+						},
+					})
+				}),
+			)
+		},
+	)
+
+	require.ErrorIs(t, app.Run(t.Context()), context.DeadlineExceeded)
 }
 
 func TestApplicationClientShutdownExitCodeIsReturned(t *testing.T) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1,15 +1,18 @@
 package cli_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/cli"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 )
 
 func TestApplicationServerRun(t *testing.T) {
@@ -141,6 +144,60 @@ func TestApplicationServerHonorsContextCancellation(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(time.Second):
 		require.FailNow(t, "timed out waiting for server stop hook")
+	}
+}
+
+func TestApplicationServerStopAfterCancellationUsesFxTimeout(t *testing.T) {
+	test.SetupCLI("server")
+
+	started := make(chan struct{})
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			c.AddServer(
+				"server",
+				"Start the server.",
+				di.NoLogger,
+				di.Constructor(slog.Default),
+				fx.StopTimeout((10 * time.Millisecond).Duration()),
+				di.Register(func(lc di.Lifecycle) {
+					lc.Append(di.Hook{
+						OnStart: func(context.Context) error {
+							close(started)
+
+							return nil
+						},
+						OnStop: func(ctx context.Context) error {
+							<-ctx.Done()
+
+							return ctx.Err()
+						},
+					})
+				}),
+			)
+		},
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run(ctx)
+	}()
+
+	select {
+	case <-started:
+	case err := <-errCh:
+		require.FailNow(t, "server exited before startup completed", err.Error())
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for server startup")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for server shutdown after cancellation")
 	}
 }
 

--- a/database/sql/config/config.go
+++ b/database/sql/config/config.go
@@ -32,10 +32,10 @@ type Config struct {
 	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime,omitempty" json:"conn_max_lifetime,omitempty" toml:"conn_max_lifetime,omitempty" validate:"gte=0"`
 
 	// MaxOpenConns is the maximum number of open connections to the database.
-	MaxOpenConns int `yaml:"max_open_conns,omitempty" json:"max_open_conns,omitempty" toml:"max_open_conns,omitempty" validate:"gte=0"`
+	MaxOpenConns int `yaml:"max_open_conns" json:"max_open_conns" toml:"max_open_conns" validate:"gt=0"`
 
 	// MaxIdleConns is the maximum number of connections in the idle connection pool.
-	MaxIdleConns int `yaml:"max_idle_conns,omitempty" json:"max_idle_conns,omitempty" toml:"max_idle_conns,omitempty" validate:"gte=0"`
+	MaxIdleConns int `yaml:"max_idle_conns" json:"max_idle_conns" toml:"max_idle_conns" validate:"gt=0,ltefield=MaxOpenConns"`
 }
 
 // IsEnabled reports whether SQL configuration is present.

--- a/database/sql/config/config_test.go
+++ b/database/sql/config/config_test.go
@@ -9,27 +9,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigRejectsNegativeConnMaxLifetime(t *testing.T) {
-	cfg := &config.Config{ConnMaxLifetime: -time.Second}
-	require.Error(t, test.Validator.Struct(cfg))
-}
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		cfg  *config.Config
+		name string
+		err  bool
+	}{
+		{
+			name: "valid",
+			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: 1},
+		},
+		{
+			name: "negative conn max lifetime",
+			cfg:  &config.Config{ConnMaxLifetime: -time.Second, MaxOpenConns: 1, MaxIdleConns: 1},
+			err:  true,
+		},
+		{
+			name: "negative max open conns",
+			cfg:  &config.Config{MaxOpenConns: -1, MaxIdleConns: 1},
+			err:  true,
+		},
+		{
+			name: "zero max open conns",
+			cfg:  &config.Config{MaxOpenConns: 0, MaxIdleConns: 1},
+			err:  true,
+		},
+		{
+			name: "negative max idle conns",
+			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: -1},
+			err:  true,
+		},
+		{
+			name: "zero max idle conns",
+			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: 0},
+			err:  true,
+		},
+		{
+			name: "max idle conns greater than max open conns",
+			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: 2},
+			err:  true,
+		},
+	}
 
-func TestConfigAllowsZeroValues(t *testing.T) {
-	cfg := &config.Config{}
-	require.NoError(t, test.Validator.Struct(cfg))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := test.Validator.Struct(tt.cfg)
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestConfigIsEnabled(t *testing.T) {
 	require.False(t, (*config.Config)(nil).IsEnabled())
 	require.True(t, (&config.Config{}).IsEnabled())
-}
-
-func TestConfigRejectsNegativeMaxOpenConns(t *testing.T) {
-	cfg := &config.Config{MaxOpenConns: -1}
-	require.Error(t, test.Validator.Struct(cfg))
-}
-
-func TestConfigRejectsNegativeMaxIdleConns(t *testing.T) {
-	cfg := &config.Config{MaxIdleConns: -1}
-	require.Error(t, test.Validator.Struct(cfg))
 }

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -330,6 +330,7 @@ func NewCacheConfig(kind, compressor, encoder, secret string) *cache.Config {
 	return &cache.Config{
 		Kind:       kind,
 		Compressor: compressor, Encoder: encoder,
+		MaxEntries: cache.DefaultMaxEntries,
 		Options: map[string]any{
 			"url": FilePath("secrets/" + secret),
 		},

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -37,7 +37,9 @@
 //   - initial_conn_window_size: SI size string such as 4MB
 //   - max_send_msg_size: SI size string such as 16MB
 //
-// The timeout argument is also used as the keepalive ping Timeout.
+// The timeout argument is also used as the keepalive ping Timeout. Request
+// handler timeouts are applied by higher-level transport wiring, not by
+// NewServer itself.
 //
 // NewServer always enables server reflection via reflection.Register.
 //

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -264,6 +264,20 @@ func TimeoutUnaryClientInterceptor(d time.Duration) grpc.UnaryClientInterceptor 
 	return timeout.UnaryClientInterceptor(d.Duration())
 }
 
+// TimeoutUnaryServerInterceptor returns a unary server interceptor that applies a per-RPC timeout.
+//
+// The interceptor wraps the incoming context with d before invoking the next handler.
+// Existing earlier deadlines are preserved because the derived context cannot extend
+// the parent context's deadline.
+func TimeoutUnaryServerInterceptor(d time.Duration) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		timedCtx, cancel := context.WithTimeout(ctx, d)
+		defer cancel()
+
+		return handler(timedCtx, req)
+	}
+}
+
 // UseCompressor returns a CallOption that requests message compression by name.
 //
 // This forwards to [grpc.UseCompressor]. The compressor must be registered with
@@ -336,15 +350,14 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 // NewServer constructs a *[grpc.Server] with standard keepalive configuration and reflection enabled.
 //
 // Keepalive enforcement, connection establishment timeout, and server parameters are
-// populated from options using the following duration keys (falling back to timeout
-// when a key is not present):
+// populated from options using the following duration keys:
 //
-//   - keepalive_enforcement_policy_ping_min_time
-//   - keepalive_max_connection_idle
-//   - keepalive_max_connection_age
-//   - keepalive_max_connection_age_grace
-//   - keepalive_ping_time
-//   - connection_timeout
+//   - keepalive_enforcement_policy_ping_min_time (falls back to timeout)
+//   - keepalive_max_connection_idle (falls back to timeout)
+//   - keepalive_max_connection_age (falls back to the gRPC default)
+//   - keepalive_max_connection_age_grace (falls back to the gRPC default)
+//   - keepalive_ping_time (falls back to timeout)
+//   - connection_timeout (falls back to timeout)
 //
 // In addition, the provided timeout is used as the keepalive ping Timeout.
 //
@@ -371,8 +384,8 @@ func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption)
 	}))
 	serverOptions = append(serverOptions, grpc.KeepaliveParams(keepalive.ServerParameters{
 		MaxConnectionIdle:     options.NonNegativeDuration("keepalive_max_connection_idle", timeout).Duration(),
-		MaxConnectionAge:      options.NonNegativeDuration("keepalive_max_connection_age", timeout).Duration(),
-		MaxConnectionAgeGrace: options.NonNegativeDuration("keepalive_max_connection_age_grace", timeout).Duration(),
+		MaxConnectionAge:      options.NonNegativeDuration("keepalive_max_connection_age", 0).Duration(),
+		MaxConnectionAgeGrace: options.NonNegativeDuration("keepalive_max_connection_age_grace", 0).Duration(),
 		Time:                  options.NonNegativeDuration("keepalive_ping_time", timeout).Duration(),
 		Timeout:               timeout.Duration(),
 	}))

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -10,6 +10,7 @@
     encoder: proto
     compressor: snappy
     max_size: 4MB
+    max_entries: 1024
     options: {
       url: "file:../test/secrets/redis"
     }

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -9,6 +9,7 @@ kind = "redis"
 encoder = "proto"
 compressor = "snappy"
 max_size = "4MB"
+max_entries = 1024
 [cache.options]
 url = "file:../test/secrets/redis"
 

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -7,6 +7,7 @@ cache:
   encoder: proto
   compressor: snappy
   max_size: 4MB
+  max_entries: 1024
   options:
     url: file:../test/secrets/redis
 crypto:

--- a/test/configs/invalid_trace.yml
+++ b/test/configs/invalid_trace.yml
@@ -6,6 +6,7 @@ cache:
   kind: redis
   encoder: proto
   compressor: snappy
+  max_entries: 1024
   options:
     url: file:../test/secrets/redis
 crypto:

--- a/transport/grpc/doc.go
+++ b/transport/grpc/doc.go
@@ -1,7 +1,7 @@
 // Package grpc contains gRPC transport wiring for services built with go-service.
 //
 // It provides constructors, interceptors, and Fx module wiring for:
-//   - gRPC servers ([NewServer]) with standardized interceptors (metadata, logging, auth, rate limiting, etc.).
+//   - gRPC servers ([NewServer]) with standardized interceptors (metadata, unary timeout, logging, auth, rate limiting, etc.).
 //   - gRPC clients ([NewClient]) with standardized dial options and client interceptors (metadata, auth,
 //     logging, unary timeout/retry/breaker policy, etc.).
 //

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -206,6 +206,34 @@ func TestWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
+func TestWatchStaysOpenPastServerTimeout(t *testing.T) {
+	cfg := test.NewInsecureTransportConfig()
+	cfg.GRPC.Timeout = 500 * time.Millisecond
+	world := newGRPCHealthWorld(t, test.StatusURL("200"),
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldTransportConfig(cfg),
+	)
+	requireGRPCReady(t, world)
+
+	conn := requireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := health.NewClient(conn)
+	req := &health.Request{Service: test.Name.String()}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	wc, err := client.Watch(ctx, req)
+	require.NoError(t, err)
+
+	resp, err := wc.Recv()
+	require.NoError(t, err)
+
+	require.Equal(t, health.Serving, resp.GetStatus())
+	requireWatchStaysOpenUntilCancelAfter(t, cancel, wc, 2*time.Second)
+}
+
 func TestWatchServerLimiter(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),
@@ -429,6 +457,12 @@ func TestWatchStatusChanges(t *testing.T) {
 func requireWatchStaysOpenUntilCancel(t *testing.T, cancel context.CancelFunc, wc health.WatchClient) {
 	t.Helper()
 
+	requireWatchStaysOpenUntilCancelAfter(t, cancel, wc, 150*time.Millisecond)
+}
+
+func requireWatchStaysOpenUntilCancelAfter(t *testing.T, cancel context.CancelFunc, wc health.WatchClient, d time.Duration) {
+	t.Helper()
+
 	errCh := make(chan error, 1)
 	go func() {
 		_, err := wc.Recv()
@@ -438,7 +472,7 @@ func requireWatchStaysOpenUntilCancel(t *testing.T, cancel context.CancelFunc, w
 	select {
 	case err := <-errCh:
 		require.FailNow(t, "watch stream closed unexpectedly", err.Error())
-	case <-time.After(150 * time.Millisecond):
+	case <-time.After(d):
 	}
 
 	cancel()

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -77,8 +77,9 @@ type ServerParams struct {
 //
 // The constructed server includes:
 //   - OpenTelemetry stats handling when tracing or metrics are enabled.
-//   - A unary interceptor chain that performs metadata extraction/injection, and optionally logging,
-//     token verification, and rate limiting, followed by any user-provided interceptors.
+//   - A unary interceptor chain that performs metadata extraction/injection, applies the configured
+//     server timeout, and optionally logging, token verification, and rate limiting, followed by any
+//     user-provided interceptors.
 //   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging,
 //     token verification, and rate limiting, followed by any user-provided interceptors.
 //
@@ -158,7 +159,10 @@ func (s *Server) GetService() *grpcserver.Service {
 }
 
 func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInterceptor) grpc.ServerOption {
-	uis := []grpc.UnaryServerInterceptor{meta.UnaryServerInterceptor(params.UserAgent, params.Version, params.ID)}
+	uis := []grpc.UnaryServerInterceptor{
+		meta.UnaryServerInterceptor(params.UserAgent, params.Version, params.ID),
+		grpc.TimeoutUnaryServerInterceptor(params.Config.GetTimeout()),
+	}
 
 	if params.Logger != nil {
 		uis = append(uis, logger.UnaryServerInterceptor(params.Logger))


### PR DESCRIPTION
## What

- Bound the in-memory sync cache with a positive `max_entries` setting, documented the setting, and added eviction/expired-entry cleanup coverage.
- Require positive SQL pool limits for enabled SQL configs and document the `max_idle_conns <= max_open_conns` constraint.
- Apply Fx start/stop timeouts in CLI application lifecycle handling, including shutdown after caller cancellation.
- Add gRPC unary server timeout wiring while leaving streaming health watches open past the server timeout, and document related gRPC timeout behavior.
- Document accepted reliability review boundaries in `AGENTS.md` for CI sidecars, CircleCI artifact collection, and telemetry shutdown errors.

## Why

- Closes the confirmed reliability gaps around unbounded local cache growth, invalid SQL pool sizing, lifecycle timeout enforcement, and unary gRPC server request deadlines while keeping intentional shutdown and streaming behavior explicit.

## Testing

- `make dep` - passed
- `make lint` - passed
- `go test ./cache/... ./database/sql/config ./cli ./net/grpc ./transport/grpc/...` - passed
- `make sec` - passed
- `git diff --check` - passed
- `make specs` - failed in unchanged `transport/http` race coverage: `TestErrorRPC/mapped/hjson` reports a data race between returning a pooled buffer in `transport/http/rpc_test.go` and the HTTP transport still reading the request body

AI-assisted-by: [Codex](https://openai.com/codex/)
