### PR TITLE
feat(encoding): reject config typos and ignore future proto fields

### DIFF
--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -42,6 +42,7 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 
 	options := hjson.DefaultDecoderOptions()
 	options.DisallowDuplicateKeys = true
+	options.DisallowUnknownFields = true
 
 	return hjson.UnmarshalWithOptions(data, v, options)
 }

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -55,6 +55,16 @@ func TestDecode(t *testing.T) {
 	require.Equal(t, "test", msg.Test)
 }
 
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	encoder := hjson.NewEncoder()
+	msg := &message{}
+
+	err := encoder.Decode(bytes.NewBufferString("{\n  test: test\n  extra: ignored\n}\n"), msg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra")
+}
+
 func TestDecodeReturnsReadError(t *testing.T) {
 	encoder := hjson.NewEncoder()
 	msg := &message{}

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -73,6 +73,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Duplicate JSON object keys keep the standard library's last-wins behavior.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(v); err != nil {
 		return err
 	}

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -46,6 +46,16 @@ func TestDecodeAcceptsTrailingWhitespace(t *testing.T) {
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	encoder := json.NewEncoder()
+	msg := &message{}
+
+	err := encoder.Decode(bytes.NewBufferString("{\"test\":\"test\",\"extra\":\"ignored\"}"), msg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra")
+}
+
 func TestDecodeRejectsTrailingData(t *testing.T) {
 	for _, input := range []string{
 		`{"test":"test"} garbage`,
@@ -90,4 +100,8 @@ func TestUnmarshalRejectsTrailingData(t *testing.T) {
 	err := json.Unmarshal([]byte("{\"test\":\"test\"}{\"extra\":\"value\"}"), &msg)
 
 	require.ErrorIs(t, err, errors.ErrTrailingData)
+}
+
+type message struct {
+	Test string `json:"test"`
 }

--- a/encoding/proto/json.go
+++ b/encoding/proto/json.go
@@ -47,7 +47,7 @@ func (e *JSON) Encode(w io.Writer, v any) error {
 // Decode otherwise reads all remaining bytes from r (via [io.ReadAll]) before
 // unmarshaling.
 //
-// Any read error from [io.ReadAll] and any unmarshal error from [protojson.Unmarshal] is returned.
+// Any read error from [io.ReadAll] and any unmarshal error from [protojson.UnmarshalOptions.Unmarshal] is returned.
 func (e *JSON) Decode(r io.Reader, v any) error {
 	msg, err := message(v)
 	if err != nil {
@@ -59,5 +59,5 @@ func (e *JSON) Decode(r io.Reader, v any) error {
 		return err
 	}
 
-	return protojson.Unmarshal(bytes, msg)
+	return protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(bytes, msg)
 }

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -109,6 +109,24 @@ func TestEncodersUseExpectedWireFormats(t *testing.T) {
 	})
 }
 
+func TestDecodeDiscardsUnknownFields(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		encoder := proto.NewJSON()
+
+		var decode health.Response
+		require.NoError(t, encoder.Decode(bytes.NewBufferString(`{"status":"SERVING","futureField":"ignored"}`), &decode))
+		require.Equal(t, health.Serving, decode.GetStatus())
+	})
+
+	t.Run("text", func(t *testing.T) {
+		encoder := proto.NewText()
+
+		var decode health.Response
+		require.NoError(t, encoder.Decode(bytes.NewBufferString("status: SERVING\nfuture_field: \"ignored\""), &decode))
+		require.Equal(t, health.Serving, decode.GetStatus())
+	})
+}
+
 func TestEncodeReturnsWriteError(t *testing.T) {
 	for _, tt := range protoEncoders() {
 		t.Run(tt.name, func(t *testing.T) {

--- a/encoding/proto/text.go
+++ b/encoding/proto/text.go
@@ -47,7 +47,7 @@ func (e *Text) Encode(w io.Writer, v any) error {
 // Decode otherwise reads all remaining bytes from r (via [io.ReadAll]) before
 // unmarshaling.
 //
-// Any read error from [io.ReadAll] and any unmarshal error from [prototext.Unmarshal] is returned.
+// Any read error from [io.ReadAll] and any unmarshal error from [prototext.UnmarshalOptions.Unmarshal] is returned.
 func (e *Text) Decode(r io.Reader, v any) error {
 	msg, err := message(v)
 	if err != nil {
@@ -59,5 +59,5 @@ func (e *Text) Decode(r io.Reader, v any) error {
 		return err
 	}
 
-	return prototext.Unmarshal(bytes, msg)
+	return prototext.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(bytes, msg)
 }

--- a/encoding/toml/toml.go
+++ b/encoding/toml/toml.go
@@ -1,6 +1,8 @@
 package toml
 
 import (
+	"fmt"
+
 	"github.com/BurntSushi/toml"
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/io"
@@ -32,11 +34,18 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
 //
-// This method intentionally discards metadata returned by BurntSushi/toml and returns only the
-// decode/unmarshal error (if any).
+// This method rejects keys that do not decode into v.
 func (e *Encoder) Decode(r io.Reader, v any) error {
-	_, err := toml.NewDecoder(r).Decode(v)
-	return err
+	meta, err := toml.NewDecoder(r).Decode(v)
+	if err != nil {
+		return err
+	}
+
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		return fmt.Errorf("toml: undecoded key %s", undecoded[0])
+	}
+
+	return nil
 }
 
 // Marshal encodes v as TOML.

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -56,12 +56,14 @@ func TestDecode(t *testing.T) {
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
-func TestDecodeIgnoresUndecodedMetadata(t *testing.T) {
+func TestDecodeRejectsUndecodedMetadata(t *testing.T) {
 	encoder := toml.NewEncoder()
 	msg := &message{}
 
-	require.NoError(t, encoder.Decode(bytes.NewBufferString("test = \"test\"\nextra = \"ignored\""), msg))
-	require.Equal(t, "test", msg.Test)
+	err := encoder.Decode(bytes.NewBufferString("test = \"test\"\nextra = \"ignored\""), msg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra")
 }
 
 type message struct {

--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -41,6 +41,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads one YAML document and rejects additional documents in the same stream.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	decoder := yaml.NewDecoder(r)
+	decoder.KnownFields(true)
 	if err := decoder.Decode(v); err != nil {
 		return err
 	}

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -54,6 +54,16 @@ func TestDecode(t *testing.T) {
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	encoder := yaml.NewEncoder()
+	msg := &message{}
+
+	err := encoder.Decode(bytes.NewBufferString("test: test\nextra: ignored"), msg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra")
+}
+
 func TestDecodeRejectsTrailingDocument(t *testing.T) {
 	for _, input := range []string{
 		"test: test\n---\ntest: other",
@@ -82,4 +92,8 @@ type marshalError struct{}
 
 func (m marshalError) MarshalYAML() (any, error) {
 	return nil, test.ErrFailed
+}
+
+type message struct {
+	Test string `yaml:"test"`
 }

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -13,9 +13,6 @@ max_entries = 1024
 [cache.options]
 url = "file:../test/secrets/redis"
 
-[cache.redis.addresses]
-server = "localhost:6379"
-
 [crypto.aes]
 key = "file:../test/secrets/aes"
 
@@ -81,7 +78,6 @@ address = "time.cloudflare.com"
 [transport.http]
 address = "tcp://localhost:11000"
 max_receive_size = "2MB"
-user_agent = "Service http/1.0"
 timeout = "10s"
 
 [transport.http.limiter]
@@ -95,11 +91,6 @@ write_timeout = "10s"
 idle_timeout = "10s"
 read_header_timeout = "10s"
 max_header_bytes = "32KB"
-
-[transport.http.retry]
-backoff = "100ms"
-timeout = "1s"
-attempts = 3
 
 [transport.http.token]
 kind = "jwt"
@@ -120,7 +111,6 @@ private = "file:../test/secrets/ed25519_private"
 [transport.grpc]
 address = "tcp://localhost:12000"
 max_receive_size = "3MB"
-user_agent = "Service grpc/1.0"
 timeout = "10s"
 
 [transport.grpc.limiter]
@@ -140,11 +130,6 @@ max_header_list_size = "16MB"
 initial_window_size = "1MB"
 initial_conn_window_size = "2MB"
 max_send_msg_size = "8MB"
-
-[transport.grpc.retry]
-backoff = "100ms"
-timeout = "1s"
-attempts = 3
 
 [transport.grpc.token]
 kind = "jwt"


### PR DESCRIPTION
## What

- Make JSON, YAML, HJSON, and TOML decoders reject unknown struct fields or undecoded TOML keys.
- Make protobuf JSON and text decoders discard unknown fields so newer clients can send forward-compatible payloads.
- Remove stale TOML fixture keys that strict decoding correctly identified as unused.

## Why

- Misspelled reliability-sensitive configuration should fail fast instead of silently falling back to defaults.
- Protobuf JSON and text request bodies should tolerate fields added by newer clients during rolling deploys, matching binary protobuf compatibility more closely.

## Testing

- `git diff --check` - passed
- `go test ./encoding/json ./encoding/yaml ./encoding/hjson ./encoding/toml ./config` - passed
- `go test ./encoding/proto` - passed
- `go test ./encoding/... ./config/... ./net/http/content ./transport/http` - passed
- `gmake lint` - passed
- Full `gmake specs` not run locally; scoped validation covered the changed encoders, config fixture path, HTTP content path, and repository lint.
