### PR TITLE
feat(transport): close webhook streams and guard limiter ttl

### DIFF
--- a/net/http/body/body.go
+++ b/net/http/body/body.go
@@ -6,6 +6,26 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 )
 
+// ReadAll reads and buffers req.Body.
+//
+// If req.Body is nil, ReadAll replaces it with [http.NoBody] before reading.
+// The returned [io.ReadCloser] is a fresh body over the captured bytes.
+// ReadAll does not close req.Body; callers that replace req.Body own closing the original stream.
+func ReadAll(req *http.Request) ([]byte, io.ReadCloser, error) {
+	if req.Body == nil {
+		req.Body = http.NoBody
+	}
+
+	return io.ReadAll(req.Body)
+}
+
+// Close closes body unless it is nil or [http.NoBody].
+func Close(body io.ReadCloser) {
+	if body != nil && body != http.NoBody {
+		_ = body.Close()
+	}
+}
+
 // NewHandler wraps handler with request body size enforcement.
 //
 // It rejects requests whose body exceeds limit before calling handler. For
@@ -28,7 +48,7 @@ func NewHandler(handler http.Handler, limit int64) http.Handler {
 			_ = status.WriteError(res, status.BadRequestError(err))
 			return
 		}
-		defer req.Body.Close()
+		defer Close(req.Body)
 
 		if int64(len(data)) > limit {
 			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})

--- a/net/http/body/body_test.go
+++ b/net/http/body/body_test.go
@@ -1,0 +1,42 @@
+package body_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/body"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAllHandlesNilBody(t *testing.T) {
+	req := &http.Request{}
+
+	data, bufferedBody, err := body.ReadAll(req)
+	require.NoError(t, err)
+	require.Empty(t, data)
+	require.NotNil(t, bufferedBody)
+	require.Equal(t, http.NoBody, req.Body)
+}
+
+func TestReadAllBuffersBody(t *testing.T) {
+	req := &http.Request{Body: &test.TrackedBody{Reader: strings.NewReader("body")}}
+
+	data, bufferedBody, err := body.ReadAll(req)
+	require.NoError(t, err)
+	require.Equal(t, []byte("body"), data)
+	require.NotNil(t, bufferedBody)
+}
+
+func TestCloseSkipsEmptyBody(t *testing.T) {
+	body.Close(nil)
+	body.Close(http.NoBody)
+}
+
+func TestCloseClosesBody(t *testing.T) {
+	trackedBody := &test.TrackedBody{Reader: strings.NewReader("body")}
+
+	body.Close(trackedBody)
+	require.True(t, trackedBody.Closed)
+}

--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -50,13 +50,13 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		meta.WithServiceMethod(meta.Ignored(req.URL.Path)),
 	)
 
-	cloned := req.Clone(ctx)
-	if cloned.Header == nil {
-		cloned.Header = http.Header{}
+	clonedReq := req.Clone(ctx)
+	if clonedReq.Header == nil {
+		clonedReq.Header = http.Header{}
 	}
-	clientSetRequestHeaders(cloned.Header, userAgent.Value(), requestID.Value())
+	clientSetRequestHeaders(clonedReq.Header, userAgent.Value(), requestID.Value())
 
-	return r.RoundTripper.RoundTrip(cloned)
+	return r.RoundTripper.RoundTrip(clonedReq)
 }
 
 func clientSetRequestHeaders(header http.Header, userAgent, requestID string) {

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/id"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/body"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/time"
 	hooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
@@ -62,12 +62,14 @@ func (h *Webhook) Sign(req *http.Request) error {
 		return nil
 	}
 
-	payload, body, err := readBody(req)
+	originalBody := req.Body
+	payload, bufferedBody, err := body.ReadAll(req)
 	if err != nil {
 		return err
 	}
+	defer body.Close(originalBody)
 
-	req.Body = body
+	req.Body = bufferedBody
 	if req.Header == nil {
 		req.Header = http.Header{}
 	}
@@ -104,26 +106,20 @@ func (h *Webhook) Verify(req *http.Request) error {
 		return nil
 	}
 
-	payload, body, err := readBody(req)
+	originalBody := req.Body
+	payload, bufferedBody, err := body.ReadAll(req)
 	if err != nil {
 		return err
 	}
+	defer body.Close(originalBody)
 
-	req.Body = body
+	req.Body = bufferedBody
 
 	if err := h.hook.Verify(payload, req.Header); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func readBody(req *http.Request) ([]byte, io.ReadCloser, error) {
-	if req.Body == nil {
-		req.Body = http.NoBody
-	}
-
-	return io.ReadAll(req.Body)
 }
 
 // Handler verifies webhook signatures on inbound requests.
@@ -209,21 +205,14 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 		return nil, http.ErrUseLastResponse, true
 	}
 
-	cloned := req.Clone(req.Context())
-	body := cloned.Body
-	if err := r.hook.Sign(cloned); err != nil {
-		closeBody(body)
+	clonedReq := req.Clone(req.Context())
+	originalBody := clonedReq.Body
+	if err := r.hook.Sign(clonedReq); err != nil {
+		body.Close(originalBody)
 
 		return nil, err, false
 	}
-	closeBody(body)
 
-	res, err := r.RoundTripper.RoundTrip(cloned)
+	res, err := r.RoundTripper.RoundTrip(clonedReq)
 	return res, err, false
-}
-
-func closeBody(body io.ReadCloser) {
-	if body != nil && body != http.NoBody {
-		_ = body.Close()
-	}
 }

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -41,6 +41,34 @@ func TestSignOverwritesHeaders(t *testing.T) {
 	require.NoError(t, hook.Verify(req))
 }
 
+func TestSignClosesOriginalBody(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+
+	require.NoError(t, hook.Sign(req))
+	require.True(t, body.Closed)
+}
+
+func TestVerifyClosesOriginalBody(t *testing.T) {
+	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
+	require.NoError(t, err)
+
+	hook := hooks.NewWebhook(webhook, &test.IDSequenceGenerator{IDs: []string{"id-1"}})
+	signReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	require.NoError(t, hook.Sign(signReq))
+
+	body := &test.TrackedBody{Reader: strings.NewReader("body")}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", body)
+	req.Header = signReq.Header.Clone()
+
+	require.NoError(t, hook.Verify(req))
+	require.True(t, body.Closed)
+}
+
 func TestSignAndVerifyNilBody(t *testing.T) {
 	webhook, err := webhooks.NewWebhook("whsec_dGVzdA==")
 	require.NoError(t, err)

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -188,18 +188,18 @@ func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Requ
 		return req.WithContext(ctx), nil
 	}
 
-	cloned := req.Clone(ctx)
+	clonedReq := req.Clone(ctx)
 	if req.GetBody == nil {
-		return cloned, nil
+		return clonedReq, nil
 	}
 
-	body, err := req.GetBody()
+	retryBody, err := req.GetBody()
 	if err != nil {
 		return nil, err
 	}
 
-	cloned.Body = body
-	return cloned, nil
+	clonedReq.Body = retryBody
+	return clonedReq, nil
 }
 
 type roundTripAttempt struct {

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -177,12 +177,12 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 	auth := meta.Ignored(strings.Join(strings.Space, header.BearerAuthorization, bytes.String(token)))
 	ctx := meta.WithAttributes(req.Context(), meta.WithAuthorization(auth))
 
-	cloned := req.Clone(ctx)
-	if cloned.Header == nil {
-		cloned.Header = http.Header{}
+	clonedReq := req.Clone(ctx)
+	if clonedReq.Header == nil {
+		clonedReq.Header = http.Header{}
 	}
-	cloned.Header.Set("Authorization", auth.Value())
+	clonedReq.Header.Set("Authorization", auth.Value())
 
-	res, err := r.RoundTripper.RoundTrip(cloned)
+	res, err := r.RoundTripper.RoundTrip(clonedReq)
 	return res, err, false
 }

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -1,6 +1,7 @@
 package limiter
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -15,6 +16,9 @@ import (
 
 // ErrMissingKey is returned when the configured key kind is not present in the KeyMap.
 var ErrMissingKey = errors.New("limiter: missing key")
+
+// ErrIntervalTooLarge is returned when the configured interval cannot be used safely.
+var ErrIntervalTooLarge = errors.New("limiter: interval too large")
 
 // NewKeyMap returns the default KeyMap used by the limiter.
 //
@@ -63,6 +67,7 @@ type KeyMap map[string]KeyFunc
 //
 // Errors:
 //   - Returns ErrMissingKey when cfg.Kind is not present in keys or maps to a nil KeyFunc.
+//   - Returns ErrIntervalTooLarge when cfg.Interval would overflow internal key tracking TTLs.
 //
 // Notes:
 //   - cfg.Interval is used directly as a typed duration decoded from config.
@@ -79,6 +84,10 @@ func NewLimiter(lc di.Lifecycle, keyMap KeyMap, cfg *Config) (*Limiter, error) {
 
 	sweepMinTTL := max(time.Hour.Duration(), cfg.Interval.Duration())
 	sweepInterval := time.Hour.Duration()
+	if sweepMinTTL > time.Duration(math.MaxInt64).Duration()-sweepInterval {
+		return nil, ErrIntervalTooLarge
+	}
+
 	config := &memorystore.Config{
 		Tokens:   cfg.Tokens,
 		Interval: cfg.Interval.Duration(),

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -3,6 +3,7 @@ package limiter_test
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"math"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -48,6 +49,16 @@ func TestValidLimiter(t *testing.T) {
 	require.NotNil(t, limiter)
 
 	require.NoError(t, limiter.Close(t.Context()))
+}
+
+func TestNewLimiterRejectsTooLargeInterval(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Duration(math.MaxInt64)}
+
+	lim, err := limiter.NewLimiter(lc, m, config)
+	require.Nil(t, lim)
+	require.ErrorIs(t, err, limiter.ErrIntervalTooLarge)
 }
 
 func TestTake(t *testing.T) {


### PR DESCRIPTION
## What

- Added shared HTTP body helpers for buffering request bodies and closing non-empty body streams.
- Updated webhook signing and verification to close consumed original bodies after replacing req.Body with a buffered reader.
- Reused the close helper in HTTP body limiting and rejected limiter intervals that would overflow internal key-tracker TTLs.
- Added regression coverage for nil/body buffering helpers, direct webhook body ownership, and oversized limiter intervals.

## Why

- Direct webhook signing and verification consumed request bodies and replaced req.Body without closing the original stream, which could leak file, pipe, or connection-backed bodies.
- Extremely large limiter intervals could overflow the key-tracker TTL and bypass the documented max_keys overflow bucket guarantee.

## Testing

- `go test ./net/http/body ./transport/http/body ./transport/http/hooks ./transport/limiter` - passed
- `make lint` - passed
- `make specs` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
