### PR TITLE
feat(transport): bound retry pressure during overload

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -21,6 +21,11 @@ import (
 // DefaultMaxHeaderBytes is an alias of [http.DefaultMaxHeaderBytes].
 const DefaultMaxHeaderBytes = http.DefaultMaxHeaderBytes
 
+// TimeFormat is the HTTP time format layout.
+//
+// It is an alias of [http.TimeFormat].
+const TimeFormat = http.TimeFormat
+
 // Client is an alias for [net/http.Client].
 //
 // It is provided so go-service code can depend on a consistent import path while preserving
@@ -247,6 +252,13 @@ func Handle(mux *ServeMux, pattern string, handler http.Handler) {
 // This is a thin wrapper around [net/http.StatusText].
 func StatusText(code int) string {
 	return http.StatusText(code)
+}
+
+// ParseTime parses an HTTP time value.
+//
+// This is a thin wrapper around [http.ParseTime] and does not change semantics.
+func ParseTime(value string) (time.Time, error) {
+	return http.ParseTime(value)
 }
 
 // NewServer constructs an HTTP server with common timeout defaults and supported protocol settings.

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -56,6 +56,16 @@ func TestProtocols(t *testing.T) {
 	require.True(t, protocols.UnencryptedHTTP2())
 }
 
+func TestParseTime(t *testing.T) {
+	now := time.Now().UTC()
+	value := now.Format(http.TimeFormat)
+
+	parsed, err := http.ParseTime(value)
+
+	require.NoError(t, err)
+	require.Equal(t, now.Truncate(time.Second.Duration()), parsed)
+}
+
 func TestTransport(t *testing.T) {
 	cfg := &tls.Config{}
 

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -48,6 +48,23 @@ func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsZero(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+func TestUnaryClientInterceptorClampsAttemptsAboveMax(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(&config.Config{
+		Attempts: config.MaxAttempts + 1,
+		Timeout:  time.Second,
+		Backoff:  time.Nanosecond,
+	})
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, int(config.MaxAttempts), calls)
+}
+
 func TestUnaryClientInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(&config.Config{
 		Attempts: 2,

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/body"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/retry"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -172,7 +173,7 @@ func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *
 	}
 
 	res, err := r.RoundTripper.RoundTrip(attemptReq)
-	if retryErr := attempt.retry(ctx, attemptCtx, req, res, err, r.maxRetries); retryErr != nil {
+	if retryErr := attempt.retry(ctx, attemptCtx, req, res, err, r.backoff, r.maxRetries); retryErr != nil {
 		return nil, retryErr
 	}
 
@@ -181,6 +182,36 @@ func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *
 
 func (r *RoundTripper) withAttemptTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeoutCause(ctx, r.timeout, ErrAttemptTimeout)
+}
+
+type roundTripAttempt struct {
+	attempt uint64
+}
+
+func (a *roundTripAttempt) retry(ctx, attemptCtx context.Context, req *http.Request, res *http.Response, err error, backoff time.Duration, maxRetries uint64) error {
+	ok, retryErr := shouldRetryAttempt(ctx, attemptCtx, res, err)
+	if !ok {
+		return nil
+	}
+	if !canRetry(req) {
+		return nil
+	}
+
+	retryErr = statusError(retryErr, err)
+	if res == nil {
+		a.attempt++
+		return retry.RetryableError(retryErr)
+	}
+	if a.attempt >= maxRetries {
+		return nil
+	}
+	if retryAfterDelayExceedsBackoff(res, backoff) {
+		return nil
+	}
+
+	closeResponse(res)
+	a.attempt++
+	return retry.RetryableError(retryErr)
 }
 
 func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Request, error) {
@@ -200,33 +231,6 @@ func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Requ
 
 	clonedReq.Body = retryBody
 	return clonedReq, nil
-}
-
-type roundTripAttempt struct {
-	attempt uint64
-}
-
-func (a *roundTripAttempt) retry(ctx, attemptCtx context.Context, req *http.Request, res *http.Response, err error, maxRetries uint64) error {
-	ok, retryErr := shouldRetryAttempt(ctx, attemptCtx, res, err)
-	if !ok {
-		return nil
-	}
-	if !canRetry(req) {
-		return nil
-	}
-
-	retryErr = statusError(retryErr, err)
-	if res == nil {
-		a.attempt++
-		return retry.RetryableError(retryErr)
-	}
-	if a.attempt >= maxRetries {
-		return nil
-	}
-
-	closeResponse(res)
-	a.attempt++
-	return retry.RetryableError(retryErr)
 }
 
 func shouldRetryAttempt(ctx, attemptCtx context.Context, res *http.Response, err error) (bool, error) {
@@ -279,8 +283,8 @@ func statusError(retryErr, err error) error {
 }
 
 func closeResponse(res *http.Response) {
-	if res != nil && res.Body != nil {
-		_ = res.Body.Close()
+	if res != nil {
+		body.Close(res.Body)
 	}
 }
 

--- a/transport/http/retry/retry_after.go
+++ b/transport/http/retry/retry_after.go
@@ -1,0 +1,69 @@
+package retry
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
+
+const (
+	retryAfterHeader     = "Retry-After"
+	maxRetryAfterDelay   = time.Duration(math.MaxInt64)
+	maxRetryAfterSeconds = uint64(maxRetryAfterDelay / time.Second)
+)
+
+func retryAfterDelayExceedsBackoff(res *http.Response, backoff time.Duration) bool {
+	return retryAfterDelay(res) > backoff
+}
+
+func retryAfterDelay(res *http.Response) time.Duration {
+	value := res.Header.Get(retryAfterHeader)
+	if value == "" {
+		return 0
+	}
+
+	if delay, ok := parseRetryAfterSeconds(value); ok {
+		return delay
+	}
+
+	return parseRetryAfterDate(value)
+}
+
+func parseRetryAfterSeconds(value string) (time.Duration, bool) {
+	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
+		if seconds == 0 {
+			return 0, true
+		}
+		if seconds > maxRetryAfterSeconds {
+			return maxRetryAfterDelay, true
+		}
+
+		return time.Duration(seconds) * time.Second, true
+	} else if isRetryAfterRangeError(err) {
+		return maxRetryAfterDelay, true
+	}
+
+	return 0, false
+}
+
+func parseRetryAfterDate(value string) time.Duration {
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+
+	delay := time.Until(when)
+	if delay <= 0 {
+		return 0
+	}
+
+	return delay
+}
+
+func isRetryAfterRangeError(err error) bool {
+	numErr, ok := errors.AsType[*strconv.NumError](err)
+	return ok && errors.Is(numErr.Err, strconv.ErrRange)
+}

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
+	config "github.com/alexfalkowski/go-service/v2/transport/retry"
 	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +70,26 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, rt.Calls)
 }
 
+func TestRoundTripperClampsAttemptsAboveMax(t *testing.T) {
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return test.ResponseWithStatus(http.StatusTooManyRequests), nil
+	})
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: config.MaxAttempts + 1,
+		Timeout:  time.Second,
+		Backoff:  time.Nanosecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+	require.Equal(t, int(config.MaxAttempts), calls)
+}
+
 func TestRoundTripperDoesNotPanicWithOmittedBackoff(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
@@ -99,6 +120,97 @@ func TestRoundTripperRetriesWithDefaultBackoff(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, 2, rt.Calls)
+}
+
+func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsBackoff(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		code       int
+	}{
+		{name: "too many requests seconds", code: http.StatusTooManyRequests, retryAfter: "2"},
+		{name: "service unavailable date", code: http.StatusServiceUnavailable, retryAfter: time.Now().Add(5 * time.Second.Duration()).UTC().Format(http.TimeFormat)},
+		{name: "too many requests overflow", code: http.StatusTooManyRequests, retryAfter: "999999999999999999999999999999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+				calls++
+				res := test.ResponseWithStatus(tt.code)
+				res.Header.Set("Retry-After", tt.retryAfter)
+
+				return res, nil
+			})
+			retrying := retry.NewRoundTripper(&retry.Config{
+				Attempts: 2,
+				Timeout:  time.Second,
+				Backoff:  time.Second,
+			}, rt)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+			res, err := retrying.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, tt.code, res.StatusCode)
+			require.Equal(t, 1, calls)
+		})
+	}
+}
+
+func TestRoundTripperRetriesWhenRetryAfterDoesNotExceedBackoff(t *testing.T) {
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			res := test.ResponseWithStatus(http.StatusTooManyRequests)
+			res.Header.Set("Retry-After", "1")
+
+			return res, nil
+		}
+
+		return test.ResponseWithStatus(http.StatusOK), nil
+	})
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  2 * time.Second,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 2, calls)
+}
+
+func TestRoundTripperRetriesWhenRetryAfterIsInvalid(t *testing.T) {
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			res := test.ResponseWithStatus(http.StatusTooManyRequests)
+			res.Header.Set("Retry-After", "invalid")
+
+			return res, nil
+		}
+
+		return test.ResponseWithStatus(http.StatusOK), nil
+	})
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Timeout:  time.Second,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 2, calls)
 }
 
 func TestRoundTripperUsesIndependentRetryBudgetPerRequest(t *testing.T) {

--- a/transport/retry/config.go
+++ b/transport/retry/config.go
@@ -8,6 +8,11 @@ const DefaultBackoff time.Duration = 100 * time.Millisecond
 // DefaultJitterPercent is the shared retry jitter applied around the configured base backoff.
 const DefaultJitterPercent uint64 = 20
 
+// MaxAttempts is the maximum retry attempt count, including the initial attempt.
+//
+// Keep Config.Attempts validation in sync with this value.
+const MaxAttempts uint64 = 10
+
 // Config configures retry behavior for an operation.
 //
 // This package defines configuration only; concrete retry behavior is implemented
@@ -44,16 +49,22 @@ type Config struct {
 	//   - Attempts == 0 leaves retries disabled using the transport's zero-value behavior.
 	//   - Attempts == 1 disables retries (single attempt only).
 	//   - Attempts > 1 allows up to Attempts-1 retries after the initial attempt.
-	Attempts uint64 `yaml:"attempts,omitempty" json:"attempts,omitempty" toml:"attempts,omitempty"`
+	//
+	// Decoded configuration rejects values above MaxAttempts. Direct public API construction is
+	// clamped by MaxAttempts and MaxRetries so transport callers cannot bypass the repository cap.
+	Attempts uint64 `yaml:"attempts,omitempty" json:"attempts,omitempty" toml:"attempts,omitempty" validate:"lte=10"`
 }
 
 // MaxAttempts returns the configured total attempt count, including the initial attempt.
 //
 // It preserves the zero value so transports that treat zero specially can retain their
-// upstream behavior.
+// upstream behavior. Values above MaxAttempts are clamped to MaxAttempts.
 func (c *Config) MaxAttempts() uint64 {
 	if c == nil {
 		return 0
+	}
+	if c.Attempts > MaxAttempts {
+		return MaxAttempts
 	}
 
 	return c.Attempts
@@ -88,9 +99,10 @@ func (c *Config) GetBackoff() time.Duration {
 //   - Attempts == 2 returns 1 retry.
 //   - Attempts == 3 returns 2 retries.
 func (c *Config) MaxRetries() uint64 {
-	if c == nil || c.Attempts <= 1 {
+	attempts := c.MaxAttempts()
+	if attempts <= 1 {
 		return 0
 	}
 
-	return c.Attempts - 1
+	return attempts - 1
 }

--- a/transport/retry/config_test.go
+++ b/transport/retry/config_test.go
@@ -25,6 +25,11 @@ func TestConfigRejectsNegativeDurations(t *testing.T) {
 	}
 }
 
+func TestConfigRejectsAttemptsAboveMax(t *testing.T) {
+	require.NoError(t, test.Validator.Struct(&retry.Config{Attempts: retry.MaxAttempts}))
+	require.Error(t, test.Validator.Struct(&retry.Config{Attempts: retry.MaxAttempts + 1}))
+}
+
 func TestConfigGetTimeout(t *testing.T) {
 	tests := []struct {
 		cfg  *retry.Config
@@ -74,6 +79,7 @@ func TestConfigMaxAttempts(t *testing.T) {
 		{name: "zero", want: 0},
 		{name: "one", attempts: 1, want: 1},
 		{name: "three", attempts: 3, want: 3},
+		{name: "above max", attempts: retry.MaxAttempts + 1, want: retry.MaxAttempts},
 	}
 
 	for _, tt := range tests {
@@ -100,6 +106,7 @@ func TestConfigMaxRetries(t *testing.T) {
 		{name: "one", attempts: 1, want: 0},
 		{name: "two", attempts: 2, want: 1},
 		{name: "three", attempts: 3, want: 2},
+		{name: "above max", attempts: retry.MaxAttempts + 1, want: retry.MaxAttempts - 1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

- Add a shared retry attempt cap and clamp direct retry config use through the existing retry getters.
- Make HTTP retry handling stop retrying overload responses when a valid Retry-After delay is longer than the configured backoff.
- Expose HTTP time parsing through the repository HTTP wrapper and keep Retry-After parsing in its own retry_after.go file.

## Why

- Prevent configuration mistakes or direct public API construction from creating excessive retry traffic.
- Reduce load against throttled or recovering upstreams when they explicitly ask clients to wait longer than this retry policy would.

## Testing

- `go test ./transport/retry ./transport/http/retry ./transport/grpc/retry` - passed
- `make specs` - passed
- `make lint` - passed
