### PR TITLE
feat(encoding): clarify strict decoder behavior

### DIFF
--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -4,11 +4,12 @@
 //
 //   - it exposes [Encoder], a thin adapter that satisfies the repository's
 //     generic encoding abstraction while using readable indented encoding and
-//     standard library decoding
+//     strict standard library decoding
 //   - it re-exports common JSON helpers and types from the standard library so
 //     packages in this repository can depend on a single go-service JSON import
 //     path instead of importing encoding/json directly
 //
-// All marshaling and unmarshaling semantics remain those of the standard
-// library's encoding/json package.
+// Marshal and Valid preserve the standard library's encoding/json semantics.
+// Encoder and Unmarshal use the standard decoder with unknown fields and
+// trailing values rejected.
 package json

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -40,7 +40,7 @@ var defaultEncoder = &Encoder{}
 // NewEncoder returns an [Encoder] that satisfies
 // [github.com/alexfalkowski/go-service/v2/encoding.Encoder] while delegating to
 // the standard library's [encoding/json] implementation with readable indented
-// encoding and default decoding.
+// encoding and strict decoding.
 func NewEncoder() *Encoder {
 	return defaultEncoder
 }
@@ -48,7 +48,7 @@ func NewEncoder() *Encoder {
 // Encoder implements JSON encoding and decoding.
 //
 // It writes readable indented JSON and uses the standard library
-// [encoding/json] decoder.
+// [encoding/json] decoder with unknown fields and trailing values rejected.
 type Encoder struct{}
 
 // Encode writes v to w as JSON.
@@ -67,8 +67,8 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value, such as
 // `*MyStruct` or `*map[string]any`. Decode is equivalent to calling
-// `json.NewDecoder(r).Decode(v)`, then requiring the stream to contain no
-// additional JSON values.
+// `json.NewDecoder(r).Decode(v)` with unknown fields rejected, then requiring
+// the stream to contain no additional JSON values.
 //
 // Duplicate JSON object keys keep the standard library's last-wins behavior.
 func (e *Encoder) Decode(r io.Reader, v any) error {

--- a/encoding/toml/toml.go
+++ b/encoding/toml/toml.go
@@ -20,7 +20,7 @@ func NewEncoder() *Encoder {
 
 // Encoder implements TOML encoding and decoding.
 //
-// It uses BurntSushi/toml with default settings.
+// It uses BurntSushi/toml and rejects undecoded keys.
 type Encoder struct{}
 
 // Encode writes v to w as TOML.

--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -19,7 +19,7 @@ func NewEncoder() *Encoder {
 
 // Encoder implements YAML encoding and decoding.
 //
-// It uses go-yaml v3 with default settings.
+// It uses go-yaml v3 with unknown fields and trailing documents rejected.
 type Encoder struct{}
 
 // Encode writes v to w as YAML.
@@ -38,7 +38,8 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads YAML from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
-// Decode reads one YAML document and rejects additional documents in the same stream.
+// Decode reads one YAML document and rejects unknown fields and additional
+// documents in the same stream.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	decoder := yaml.NewDecoder(r)
 	decoder.KnownFields(true)


### PR DESCRIPTION
## What

- Clarified JSON package documentation so Marshal and Valid are described separately from strict Encoder and Unmarshal decoding behavior.
- Updated JSON, YAML, and TOML encoder comments to document unknown-field, trailing-value/document, and undecoded-key rejection.
- Kept the change documentation-only; no decoding behavior changed.

## Why

- The exported docs previously described default upstream decoder behavior, while the repository encoders intentionally enforce stricter decoding.
- Aligning the comments with the existing tests and implementation prevents callers from relying on permissive decoding that is not actually provided.

## Testing

- `gofmt -w encoding/json/doc.go encoding/json/json.go encoding/yaml/yaml.go encoding/toml/toml.go` - passed
- `go test ./encoding/json ./encoding/yaml ./encoding/toml` - passed
- `git diff --check` - passed
