### PR TITLE
feat(compress): normalize codec size errors

### DIFF
--- a/compress/s2/s2.go
+++ b/compress/s2/s2.go
@@ -2,7 +2,8 @@ package s2
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	compress "github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/klauspost/compress/s2"
 )
 
@@ -23,10 +24,10 @@ type Compressor struct{}
 // An error is returned if data exceeds size.
 func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 	if int64(len(data)) > size.Bytes() {
-		return nil, errors.ErrTooLarge
+		return nil, compress.ErrTooLarge
 	}
 	if s2.MaxEncodedLen(len(data)) < 0 {
-		return nil, errors.ErrTooLarge
+		return nil, compress.ErrTooLarge
 	}
 
 	return s2.Encode(nil, data), nil
@@ -38,10 +39,14 @@ func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 	decodedLen, err := s2.DecodedLen(data)
 	if err != nil {
+		if errors.Is(err, s2.ErrTooLarge) {
+			return nil, compress.ErrTooLarge
+		}
+
 		return nil, err
 	}
 	if int64(decodedLen) > size.Bytes() {
-		return nil, errors.ErrTooLarge
+		return nil, compress.ErrTooLarge
 	}
 
 	return s2.Decode(nil, data)

--- a/compress/snappy/snappy.go
+++ b/compress/snappy/snappy.go
@@ -2,7 +2,8 @@ package snappy
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	compress "github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/klauspost/compress/snappy"
 )
 
@@ -23,10 +24,10 @@ type Compressor struct{}
 // An error is returned if data exceeds size.
 func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 	if int64(len(data)) > size.Bytes() {
-		return nil, errors.ErrTooLarge
+		return nil, compress.ErrTooLarge
 	}
 	if snappy.MaxEncodedLen(len(data)) < 0 {
-		return nil, errors.ErrTooLarge
+		return nil, compress.ErrTooLarge
 	}
 
 	return snappy.Encode(nil, data), nil
@@ -38,10 +39,14 @@ func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 	decodedLen, err := snappy.DecodedLen(data)
 	if err != nil {
+		if errors.Is(err, snappy.ErrTooLarge) {
+			return nil, compress.ErrTooLarge
+		}
+
 		return nil, err
 	}
 	if int64(decodedLen) > size.Bytes() {
-		return nil, errors.ErrTooLarge
+		return nil, compress.ErrTooLarge
 	}
 
 	return snappy.Decode(nil, data)

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -70,7 +70,7 @@ func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 
 	decoded, _, err := io.ReadAll(io.LimitReader(decoder, limit+1))
 	if err != nil {
-		if errors.Is(err, ErrDecoderSizeExceeded) || errors.Is(err, zstd.ErrWindowSizeExceeded) {
+		if errors.Is(err, ErrDecoderSizeExceeded) {
 			return nil, fmt.Errorf("%w: %w", compress.ErrTooLarge, err)
 		}
 


### PR DESCRIPTION
## What

- Keeps malformed zstd window errors from being reported as configured size-limit failures.
- Maps S2 and Snappy upstream oversized decoded-length errors to the shared `compress/errors.ErrTooLarge` sentinel.
- Leaves other corrupt-input decode errors unchanged; no 32-bit regression test is added because this project and CI do not run 32-bit builds.

## Why

- Callers can distinguish actual size-limit failures from malformed compressed data more consistently across supported codecs.
- The S2 and Snappy mapping removes an architecture-specific sentinel mismatch, while the zstd change avoids treating malformed frames as configured-size failures.

## Testing

- `go test ./compress/s2 ./compress/snappy ./compress/zstd` - passed
- `make lint` - passed
- `make package=compress specs` - passed
- No 32-bit target was run; CI does not cover 32-bit and dedicated 32-bit regression coverage was intentionally omitted.

AI-assisted-by: [Codex](https://openai.com/codex/)
