### PR TITLE
docs(readme): clarify public api behavior notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ Supported stacks include:
 
 ### HTTP content types
 
-The HTTP REST and RPC helpers resolve encoders from the request `Content-Type`, falling back to the first `Accept` media type when `Content-Type` is absent.
+The HTTP REST and RPC helpers decode request bodies from the request `Content-Type`, falling back to JSON when `Content-Type` is absent or unknown. Response encoding uses the negotiated media type, falling back to the first `Accept` media type when `Content-Type` is absent.
 
 Built-in text/object payload media types include:
 

--- a/cli/application.go
+++ b/cli/application.go
@@ -27,8 +27,9 @@ type RegisterFunc = func(commander Commander)
 
 // NewApplication constructs an Application and invokes register to add subcommands.
 //
-// The returned Application is pre-populated with module-level Name and Version derived from the environment
-// (see [Name] and [Version]).
+// The returned Application is pre-populated with the current module-level [Name] and [Version] values.
+// Those variables are initialized from the environment at package init time and can be assigned directly
+// by tests or embedders that need post-init overrides.
 func NewApplication(register RegisterFunc) *Application {
 	app := &Application{name: Name, version: Version}
 	register(app)
@@ -146,7 +147,7 @@ func (a *Application) AddClient(name, description string, opts ...Option) *Comma
 // Run configures the underlying command runner with:
 //   - app name/description derived from a.name
 //   - version derived from a.version
-//   - sanitized process arguments (see [os.SanitizeArgs])
+//   - sanitized process arguments from the go-service [os.Args] variable (see [os.SanitizeArgs])
 //   - the provided context
 //
 // It returns any execution error from the underlying runner or command ExecFunc.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,13 +14,15 @@ var FS = os.NewFS()
 // Name is the CLI application name derived from the environment.
 //
 // The name is resolved via `env.NewName(FS)` and is used by [Application.Run] to populate the
-// command runner's app metadata (for example help text and descriptions).
+// command runner's app metadata (for example help text and descriptions). It is resolved at package
+// initialization; tests or embedders that need to change it after init should assign this variable directly.
 var Name = env.NewName(FS)
 
 // Version is the CLI application version derived from the environment.
 //
 // The version is resolved via `env.NewVersion()` and is used by [Application.Run] to populate the
-// command runner's version information.
+// command runner's version information. It is resolved at package initialization; tests or embedders that
+// need to change it after init should assign this variable directly.
 var Version = env.NewVersion()
 
 func provide() (*os.FS, env.Name, env.Version) {

--- a/config/module.go
+++ b/config/module.go
@@ -15,6 +15,10 @@ import "github.com/alexfalkowski/go-service/v2/di"
 //
 // Projection constructors are nil-safe by convention: if the parent feature is disabled (i.e. the parent
 // config pointer is nil), the projection returns nil so downstream modules treat that subsystem as disabled.
+//
+// Telemetry logger, metrics, and tracer projections also resolve configured header source strings by calling
+// [github.com/alexfalkowski/go-service/v2/telemetry/header.Map.MustSecrets]. Missing environment variables or
+// unreadable files therefore fail fast during startup projection rather than later exporter construction.
 var Module = di.Module(
 	di.Constructor(NewValidator), di.Constructor(NewDecoder), di.Constructor(NewConfig[Config]),
 	di.Constructor(cryptoAESConfig), di.Constructor(cryptoED25519Config),

--- a/config/validator.go
+++ b/config/validator.go
@@ -12,6 +12,10 @@ import (
 // It enables required-struct validation ([validator.WithRequiredStructEnabled]), which causes validation
 // tags like `required` to be applied to nested struct fields in a more strict/consistent way.
 //
+// It also registers repository-owned validation tags:
+//   - `config_size`: accepts integer-like byte sizes between 0 and [bytes.MaxConfigSize].
+//   - `duration_second_precision`: accepts positive durations that are exact multiples of one second.
+//
 // This constructor is typically wired via [Module] and consumed by `NewConfig[T]` to validate
 // decoded configuration before returning it to the caller.
 func NewValidator() *Validator {

--- a/crypto/tls/doc.go
+++ b/crypto/tls/doc.go
@@ -4,7 +4,7 @@
 // This package is the low-level runtime TLS surface for the repository. It
 // intentionally preserves standard library semantics while allowing internal
 // packages to depend on a go-service import path instead of importing
-// [github.com/alexfalkowski/go-service/v2/crypto/tls] directly.
+// [crypto/tls] directly.
 //
 // Use this package when code needs runtime TLS values such as *[tls.Config],
 // parsed certificates, protocol-version constants, or helpers such as

--- a/debug/internal/psutil/handler.go
+++ b/debug/internal/psutil/handler.go
@@ -31,9 +31,9 @@ func NewHandler(cont *content.Content) http.HandlerFunc {
 
 // Response is the response body returned by the psutil debug endpoint.
 //
-// All fields are optional and may be nil if collection failed or if the platform does not support the underlying
-// metric. Fields are tagged for common config/encoding formats (YAML/JSON/TOML) to support standard response
-// encoders used in go-service.
+// NewHandler always populates the top-level sections. Nested values may still be nil, empty, or partially
+// populated if collection failed or if the platform does not support the underlying metric. Fields are tagged
+// for common config/encoding formats (YAML/JSON/TOML) to support standard response encoders used in go-service.
 type Response struct {
 	// CPU contains CPU information and time statistics.
 	CPU *CPU `yaml:"cpu,omitempty" json:"cpu,omitempty" toml:"cpu,omitempty"`

--- a/encoding/hjson/doc.go
+++ b/encoding/hjson/doc.go
@@ -1,7 +1,7 @@
 // Package hjson provides HJSON encoding helpers and adapters used by go-service.
 //
 // This package integrates HJSON encoding/decoding behind the go-service encoding abstraction.
-// Decode rejects duplicate object keys.
+// Decode rejects duplicate object keys and unknown destination fields.
 //
 // Start with the package-level constructors.
 package hjson

--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -33,7 +33,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads HJSON from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
-// Decode rejects duplicate object keys.
+// Decode rejects duplicate object keys and unknown destination fields.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	data, _, err := io.ReadAll(r)
 	if err != nil {
@@ -59,7 +59,7 @@ func Marshal(v any) ([]byte, error) {
 
 // Unmarshal decodes HJSON data into v.
 //
-// It uses Decode, so it rejects duplicate object keys.
+// It uses Decode, so it rejects duplicate object keys and unknown destination fields.
 func Unmarshal(data []byte, v any) error {
 	return defaultEncoder.Decode(bytes.NewReader(data), v)
 }

--- a/encoding/proto/json.go
+++ b/encoding/proto/json.go
@@ -45,7 +45,7 @@ func (e *JSON) Encode(w io.Writer, v any) error {
 // [github.com/alexfalkowski/go-service/v2/encoding/errors.ErrInvalidType] without reading from r.
 //
 // Decode otherwise reads all remaining bytes from r (via [io.ReadAll]) before
-// unmarshaling.
+// unmarshaling. Unknown protobuf JSON fields are discarded during unmarshal.
 //
 // Any read error from [io.ReadAll] and any unmarshal error from [protojson.UnmarshalOptions.Unmarshal] is returned.
 func (e *JSON) Decode(r io.Reader, v any) error {

--- a/encoding/proto/text.go
+++ b/encoding/proto/text.go
@@ -45,7 +45,7 @@ func (e *Text) Encode(w io.Writer, v any) error {
 // [github.com/alexfalkowski/go-service/v2/encoding/errors.ErrInvalidType] without reading from r.
 //
 // Decode otherwise reads all remaining bytes from r (via [io.ReadAll]) before
-// unmarshaling.
+// unmarshaling. Unknown protobuf text fields are discarded during unmarshal.
 //
 // Any read error from [io.ReadAll] and any unmarshal error from [prototext.UnmarshalOptions.Unmarshal] is returned.
 func (e *Text) Decode(r io.Reader, v any) error {

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -22,19 +22,32 @@ import (
 
 // Client bundles the dependencies needed to construct instrumented HTTP and gRPC clients for tests.
 type Client struct {
-	Lifecycle    di.Lifecycle
-	Logger       *logger.Logger
-	Tracer       *tracer.Config
-	Transport    *transport.Config
-	TLS          *tls.Config
-	ID           id.Generator
+	// Lifecycle receives client-related lifecycle hooks.
+	Lifecycle di.Lifecycle
+	// Logger logs client activity.
+	Logger *logger.Logger
+	// Tracer configures client tracing.
+	Tracer *tracer.Config
+	// Transport configures HTTP and gRPC client targets.
+	Transport *transport.Config
+	// TLS configures client TLS.
+	TLS *tls.Config
+	// ID generates request identifiers.
+	ID id.Generator
+	// RoundTripper is the base HTTP transport for world clients.
 	RoundTripper http.RoundTripper
-	Meter        metrics.Meter
-	Generator    token.Generator
-	Retry        *retry.Config
-	HTTPLimiter  *httplimiter.Client
-	GRPCLimiter  *grpclimiter.Client
-	Compression  bool
+	// Meter provides metrics instrumentation for clients.
+	Meter metrics.Meter
+	// Generator generates outbound transport tokens.
+	Generator token.Generator
+	// Retry configures client retries.
+	Retry *retry.Config
+	// HTTPLimiter limits outbound HTTP requests.
+	HTTPLimiter *httplimiter.Client
+	// GRPCLimiter limits outbound gRPC requests.
+	GRPCLimiter *grpclimiter.Client
+	// Compression enables transport compression for world clients.
+	Compression bool
 }
 
 // NewHTTP returns an HTTP client configured with the world's logger, retry policy,

--- a/internal/test/options.go
+++ b/internal/test/options.go
@@ -119,7 +119,10 @@ func WithWorldCompression() WorldOption {
 	})
 }
 
-// WithWorldTransportConfig enables the transport servers with an explicit config override.
+// WithWorldTransportConfig overrides the world's transport config.
+//
+// Pair this with [WithWorldHTTP] or [WithWorldGRPC] when the test needs the corresponding transport
+// server registered.
 func WithWorldTransportConfig(config *transport.Config) WorldOption {
 	return worldOptionFunc(func(o *worldOpts) {
 		o.transport = config

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -20,23 +20,40 @@ import (
 
 // Server bundles the dependencies required to build HTTP, gRPC, and debug servers for tests.
 type Server struct {
-	Lifecycle       di.Lifecycle
-	Meter           metrics.Meter
-	Verifier        token.Verifier
-	Mux             *http.ServeMux
-	HTTPServer      *http.Server
-	GRPCServer      *grpc.Server
-	DebugServer     *debug.Server
+	// Lifecycle receives server start and stop hooks.
+	Lifecycle di.Lifecycle
+	// Meter provides metrics instrumentation for servers.
+	Meter metrics.Meter
+	// Verifier verifies inbound transport tokens.
+	Verifier token.Verifier
+	// Mux holds HTTP routes registered by tests.
+	Mux *http.ServeMux
+	// HTTPServer is populated when RegisterHTTP is true.
+	HTTPServer *http.Server
+	// GRPCServer is populated when RegisterGRPC is true.
+	GRPCServer *grpc.Server
+	// DebugServer is populated when RegisterDebug is true.
+	DebugServer *debug.Server
+	// TransportConfig configures HTTP and gRPC servers.
 	TransportConfig *transport.Config
-	DebugConfig     *debug.Config
-	Tracer          *tracer.Config
-	GRPCLimiter     *grpclimiter.Server
-	HTTPLimiter     *httplimiter.Server
-	Logger          *logger.Logger
-	Generator       id.Generator
-	RegisterHTTP    bool
-	RegisterGRPC    bool
-	RegisterDebug   bool
+	// DebugConfig configures the debug server.
+	DebugConfig *debug.Config
+	// Tracer configures server tracing.
+	Tracer *tracer.Config
+	// GRPCLimiter limits inbound gRPC requests.
+	GRPCLimiter *grpclimiter.Server
+	// HTTPLimiter limits inbound HTTP requests.
+	HTTPLimiter *httplimiter.Server
+	// Logger logs server activity.
+	Logger *logger.Logger
+	// Generator generates request identifiers.
+	Generator id.Generator
+	// RegisterHTTP enables HTTP server construction.
+	RegisterHTTP bool
+	// RegisterGRPC enables gRPC server construction.
+	RegisterGRPC bool
+	// RegisterDebug enables debug server construction.
+	RegisterDebug bool
 }
 
 // Register constructs and registers the enabled servers with the lifecycle.

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -143,22 +143,38 @@ func NewStartedWorld(tb testing.TB, opts ...WorldOption) *World {
 // scenarios with minimal boilerplate.
 type World struct {
 	t testing.TB
+	// Lifecycle controls startup and shutdown hooks for the test world.
 	*fxtest.Lifecycle
+	// ServeMux is the HTTP mux used by world HTTP handlers.
 	*http.ServeMux
+	// Logger is the test logger shared by world components.
 	*logger.Logger
+	// Tracer configures tracing for world transports and clients.
 	Tracer *tracer.Config
-	PG     *pg.Config
+	// PG configures the PostgreSQL test database.
+	PG *pg.Config
+	// Server builds and registers world HTTP, gRPC, and debug servers.
 	*Server
+	// Client builds world HTTP and gRPC clients.
 	*Client
+	// Event contains shared CloudEvents test helpers.
 	*events.Event
+	// Receiver receives CloudEvents through the world HTTP mux.
 	*transportevents.Receiver
+	// Cache is the configured world cache, when enabled.
 	*cache.Cache
+	// CachePinger checks cache connectivity for health tests.
 	CachePinger cache.Pinger
-	Sender      *transportevents.Sender
-	Rest        *rest.Client
+	// Sender sends CloudEvents through the world HTTP client.
+	Sender *transportevents.Sender
+	// Rest is the world REST client.
+	Rest *rest.Client
 
-	DB         *sql.DBs
+	// DB contains connected SQL test pools, when enabled.
+	DB *sql.DBs
+	// HTTPHealth is the world HTTP health server, when registered.
 	HTTPHealth *health.Server
+	// GRPCHealth is the world gRPC health server, when registered.
 	GRPCHealth *health.Server
 	httpClient *http.Client
 }

--- a/module/module.go
+++ b/module/module.go
@@ -24,7 +24,7 @@ import (
 // Library provides a baseline Fx module intended for reuse by both servers and clients.
 //
 // It wires common, transport-agnostic dependencies that many subsystems build upon:
-//   - [env.Module] (service identity values like name/version/id, user agent, etc.)
+//   - [env.Module] (ID/UserAgent/UserID constructors; Name and Version are supplied by CLI wiring or custom callers)
 //   - [compress.Module] (compression registry and default codecs)
 //   - [encoding.Module] (encoding registry and default encoders)
 //   - [crypto.Module] (crypto primitives and helpers)

--- a/net/http/rest/doc.go
+++ b/net/http/rest/doc.go
@@ -14,10 +14,10 @@
 //
 // The handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewHandler]
 // and [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
-//   - select an encoder based on the request Content-Type, falling back to the first Accept media type when
-//     Content-Type is absent,
-//   - decode request bodies (where applicable), and
-//   - encode responses using the negotiated media type.
+//   - decode request bodies (where applicable) from Content-Type, falling back to JSON when
+//     Content-Type is absent or unknown, and
+//   - encode responses using the negotiated media type, falling back to the first Accept media type
+//     when Content-Type is absent.
 //
 // Errors are written using net/http/status helpers.
 //

--- a/net/http/rpc/doc.go
+++ b/net/http/rpc/doc.go
@@ -13,10 +13,10 @@
 // "POST /greet.v1.Greeter/SayHello".
 //
 // Handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
-//   - selects an encoder based on the request Content-Type, falling back to the first Accept media type when
-//     Content-Type is absent,
-//   - decodes the request body into a request model, and
-//   - encodes the response model using the negotiated media type.
+//   - decodes the request body into a request model from Content-Type, falling back to JSON when
+//     Content-Type is absent or unknown, and
+//   - encodes the response model using the negotiated media type, falling back to the first Accept media type
+//     when Content-Type is absent.
 //
 // Errors are written using net/http/status helpers.
 //

--- a/os/os.go
+++ b/os/os.go
@@ -17,11 +17,12 @@ const ExitCodeFailure = 1
 // ExitCodeServeFailure indicates an asynchronous server Serve failure.
 const ExitCodeServeFailure = 2
 
-// Args is the process argument vector.
+// Args is the process argument vector used by go-service CLI helpers.
 //
-// It is an alias of [os.Args] and is provided so go-service code can depend on
-// go-service packages consistently while still using the underlying OS
-// implementation.
+// It is initialized from [os.Args] at package init time and is provided so
+// go-service code can depend on go-service packages consistently. Tests or
+// embedders that need to override arguments after init should assign Args
+// directly.
 var Args = os.Args
 
 // Stdout is the standard output file descriptor.

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -37,11 +37,14 @@
 //
 // # OTLP endpoint security
 //
-// Logger, metrics, and tracer OTLP exporters may send [Config.Headers] as outbound
-// request headers. When headers are configured, non-loopback "http://" endpoints
-// are rejected to avoid sending credential-bearing headers over cleartext
-// transport. Use "https://" for external collectors. Local development
-// collectors on "localhost" or loopback IP addresses may use "http://".
+// Logger, metrics, and tracer OTLP exporters may send per-signal Headers fields as outbound request
+// headers. When headers are configured, non-loopback "http://" endpoints are rejected to avoid sending
+// credential-bearing headers over cleartext transport. Use "https://" for external collectors. Local
+// development collectors on "localhost" or loopback IP addresses may use "http://".
+//
+// OTLP endpoints must be supplied through go-service config fields such as telemetry.logger.url,
+// telemetry.metrics.url, and telemetry.tracer.url. Standard OpenTelemetry endpoint environment variables
+// such as OTEL_EXPORTER_OTLP_ENDPOINT are not used as fallback sources by this package.
 //
 // # Global propagation (Register)
 //

--- a/telemetry/logger/config.go
+++ b/telemetry/logger/config.go
@@ -38,7 +38,8 @@ type Config struct {
 	// URL is the destination endpoint for the selected Kind, when applicable.
 	//
 	// For "otlp", this is the required OTLP/HTTP logs endpoint URL. It must be a
-	// valid HTTP URL.
+	// valid HTTP URL. Standard OpenTelemetry endpoint environment variables are not used as fallbacks;
+	// configure this value explicitly through go-service config.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`
 
 	// Level is the minimum log level to emit.

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -125,7 +125,7 @@ type LoggerParams struct {
 // NewLogger constructs the configured slog logger, installs it as the
 // process-wide default, and returns a wrapper with go-service logging helpers.
 //
-// When [CacheParams.Config] is nil, logging is disabled and NewLogger returns (nil,
+// When [LoggerParams.Config] is nil, logging is disabled and NewLogger returns (nil,
 // nil).
 //
 // When logging is enabled, NewLogger validates [Config.Level], builds the

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -29,7 +29,8 @@ type Config struct {
 	// URL is the destination endpoint for the selected Kind, when applicable.
 	//
 	// For "otlp", this is the required OTLP/HTTP metrics endpoint URL. It must be a
-	// valid HTTP URL.
+	// valid HTTP URL. Standard OpenTelemetry endpoint environment variables are not used as fallbacks;
+	// configure this value explicitly through go-service config.
 	//
 	// For "prometheus", URL is typically ignored by the exporter/reader implementation.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -24,7 +24,8 @@ type Config struct {
 	// URL is the destination endpoint for the selected Kind, when applicable.
 	//
 	// For "otlp", this is the required OTLP/HTTP traces endpoint URL. It must be a
-	// valid HTTP URL.
+	// valid HTTP URL. Standard OpenTelemetry endpoint environment variables are not used as fallbacks;
+	// configure this value explicitly through go-service config.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`
 }
 

--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -14,7 +14,7 @@ import (
 //   - Issuer: the expected issuer ("iss") value
 //   - Expiration: how long issued tokens should be valid
 //
-// # Expiration parsing and panics
+// # Expiration parsing and validation
 //
 // Token issuance uses Expiration directly. In config files it is encoded using the standard
 // Go duration string format, so invalid values fail during decoding. Expiration

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -15,14 +15,14 @@ const (
 	tokenVersion   = "v1"
 )
 
-// Signer is an alias for [golang.org/x/crypto/ssh.Signer].
+// Signer is an alias for [github.com/alexfalkowski/go-service/v2/crypto/ssh.Signer].
 //
-// It represents an object capable of producing signatures using SSH key material.
+// It represents a go-service SSH signer capable of producing signatures using SSH key material.
 type Signer = ssh.Signer
 
-// Verifier is an alias for [golang.org/x/crypto/ssh.Verifier].
+// Verifier is an alias for [github.com/alexfalkowski/go-service/v2/crypto/ssh.Verifier].
 //
-// It represents an object capable of verifying signatures produced by an SSH signer.
+// It represents a go-service SSH verifier capable of verifying signatures produced by an SSH signer.
 type Verifier = ssh.Verifier
 
 // NewToken constructs a Token using cfg and fs.
@@ -145,7 +145,8 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 //     class to avoid leaking whether a given key name exists.
 //   - If a matching key name exists but its verification config is missing/partial,
 //     Verify returns token/errors.ErrInvalidConfig.
-//   - Base64 decode errors and verifier loading errors are returned as-is.
+//   - Claim base64 decode errors are collapsed to crypto/errors.ErrInvalidMatch. Signature base64 decode
+//     errors and verifier loading errors are returned as-is.
 //
 // On success, Verify returns the extracted subject. For SSH tokens this subject
 // must match the signed key id. On failure, it always

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -68,6 +68,9 @@ func WithClientCompression() ClientOption {
 // When configured, the client will generate an Authorization token per request and add it to the outbound
 // request using the `Bearer` scheme. Token generation is typically scoped to the request path and the
 // configured user id.
+//
+// Token-enabled clients use [http.SameOriginRedirect] so credentials are not forwarded to cross-origin
+// redirect targets. Cross-origin redirects are returned to the caller as [http.ErrUseLastResponse].
 func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.id = id
@@ -253,6 +256,9 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 // The returned client:
 //   - uses the RoundTripper stack built by [NewRoundTripper], and
 //   - applies the configured client timeout (see [WithClientTimeout]).
+//
+// If token generation is enabled, the returned client uses [http.SameOriginRedirect] so cross-origin
+// redirects are returned to the caller instead of forwarding credentials.
 //
 // Note: [http.NewClient] wraps the provided transport with OpenTelemetry instrumentation when tracing
 // or metrics are enabled.

--- a/transport/http/events/hooks/doc.go
+++ b/transport/http/events/hooks/doc.go
@@ -7,6 +7,10 @@
 // When webhook support is disabled, the returned handler behaves as a pass-through and simply delegates to
 // the wrapped handler.
 //
+// Encoding:
+// Webhook-protected CloudEvents must use structured HTTP encoding. Binary-mode CloudEvents that carry
+// ce-* headers are rejected with [ErrBinaryEncoding] before signature verification.
+//
 // Replay protection:
 // This adapter uses [github.com/alexfalkowski/go-service/v2/transport/http/hooks] verification, which validates the signature and timestamp but does
 // not keep replay state. CloudEvents handlers that perform non-idempotent work must deduplicate or process

--- a/transport/http/events/hooks/hooks.go
+++ b/transport/http/events/hooks/hooks.go
@@ -25,6 +25,9 @@ type Webhook = hooks.Webhook
 // Replay protection is intentionally left to the wrapped handler; use the Webhook-Id or CloudEvent id to
 // deduplicate or process idempotently when duplicate valid deliveries would be unsafe.
 //
+// Webhook-protected CloudEvents must use structured HTTP encoding. Binary-mode CloudEvents that carry
+// ce-* headers are rejected with [ErrBinaryEncoding] before signature verification.
+//
 // If hook is nil, the returned handler behaves as a pass-through wrapper.
 func NewHandler(hook *Webhook, handler http.Handler) *Handler {
 	if hook == nil {
@@ -50,6 +53,10 @@ type Handler struct {
 // Replay protection:
 // The underlying middleware verifies the signature and timestamp but does not persist seen webhook ids. The
 // wrapped handler is responsible for idempotency or deduplication.
+//
+// Encoding:
+// Binary-mode CloudEvents that carry ce-* headers are rejected with [ErrBinaryEncoding] before signature
+// verification. Use structured HTTP encoding for webhook-protected CloudEvents.
 //
 // Disabled behavior:
 // If the inner webhook handler is nil, ServeHTTP delegates directly to the wrapped handler.

--- a/transport/http/events/receiver.go
+++ b/transport/http/events/receiver.go
@@ -37,7 +37,9 @@ func NewReceiver(mux *http.ServeMux, hook *hooks.Webhook) *Receiver {
 //
 // Middleware:
 // The receive handler is wrapped with the configured webhook hook handler, which typically verifies request
-// signatures before allowing events through.
+// signatures before allowing events through. When a webhook hook is configured, the handler supports
+// structured HTTP encoding only; binary-mode CloudEvents with ce-* headers are rejected before signature
+// verification.
 func (r *Receiver) Register(ctx context.Context, path string, receiver ReceiverFunc) {
 	handler := events.NewReceiveHandler(ctx, receiver)
 	handler = hooks.NewHandler(r.hook, handler)

--- a/transport/http/health/doc.go
+++ b/transport/http/health/doc.go
@@ -5,6 +5,6 @@
 //
 // Start with [Module] and [Register].
 //
-// Registration: some transports use package-level registration to inject filesystem access or instrumentation.
-// If you enable features that require registration, call [Register] during application startup before constructing clients/servers.
+// [Register] registers service-prefixed /healthz, /livez, and /readyz handlers on the configured mux.
+// [Module] wires that route registration into the HTTP transport graph.
 package health

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -191,6 +191,10 @@ type RoundTripper struct {
 // Disabled behavior:
 // If the configured hook is nil, RoundTrip delegates directly to the underlying RoundTripper without
 // mutating the request.
+//
+// Redirect behavior:
+// If the request is a cross-origin redirect, RoundTrip returns [http.ErrUseLastResponse] without signing
+// the redirected request.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
 }

--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -11,6 +11,10 @@
 // intermediate retryable responses before scheduling the next attempt and returns the final retryable response if
 // all attempts fail. When retries are triggered by transport errors, the original error is preserved.
 //
+// Retry-After handling: when a retryable HTTP response includes a valid Retry-After seconds value or HTTP-date
+// whose delay is greater than the configured backoff, the response is returned without another attempt. Invalid,
+// absent, elapsed, or shorter Retry-After values do not suppress a retry.
+//
 // Default policy: if no policy is passed to NewRoundTripper, only side-effect-safe requests are eligible for
 // retry. This includes safe HTTP methods and requests carrying a Request-Id. In go-service, Request-Id
 // identifies the logical request and is stable across retry attempts, so services that retry writes should

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -88,6 +88,11 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 // Exhaustion behavior:
 //   - If retries are exhausted after retryable HTTP responses, the final retryable response is returned.
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
+//
+// Retry-After behavior:
+// Valid Retry-After seconds values or HTTP-date values greater than the configured backoff suppress the
+// retry and return the current response to the caller. Invalid, absent, elapsed, or smaller Retry-After
+// values do not suppress a retry.
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
 	return &RoundTripper{
 		RoundTripper: hrt,

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -93,7 +93,7 @@ type ServerParams struct {
 //   - optional rate limiting ([github.com/alexfalkowski/go-service/v2/transport/http/limiter]) when `params.Limiter` is non-nil
 //   - inbound request body size limiting ([github.com/alexfalkowski/go-service/v2/transport/http/body])
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
-//   - gzip compression wrapping the mux not-found handler ([github.com/klauspost/compress/gzhttp.GzipHandler] with [http.NewNotFoundHandler])
+//   - gzip compression wrapping the final mux handler, including not-found fallbacks ([github.com/klauspost/compress/gzhttp.GzipHandler] with [http.NewNotFoundHandler])
 //
 // Token verification and rate limiting middleware typically treat "ignorable" paths (health/metrics/etc.)
 // as bypassable, so those endpoints do not require auth and do not consume limiter capacity by default.

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -157,6 +157,8 @@ type RoundTripper struct {
 // Failure behavior:
 //   - If token generation fails, it returns an unauthorized status error.
 //   - If token generation returns an empty token, it returns an unauthorized status error with [header.ErrInvalidAuthorization].
+//   - If the request is a cross-origin redirect, it returns [http.ErrUseLastResponse] without forwarding
+//     credentials to the redirected origin.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.ClosingRoundTripper(r.roundTrip).RoundTrip(req)
 }


### PR DESCRIPTION
## What

- Clarifies public behavior guidance for HTTP content negotiation, CloudEvents webhook encoding, credentialed HTTP redirects, Retry-After retry handling, and OTLP endpoint configuration.
- Aligns GoDoc for encoding strictness, config validation/projection behavior, telemetry references, token SSH aliases, TLS wrapper scope, debug psutil responses, and internal test harness fields.
- Removes the completed root doc-gap ledger after applying all recorded findings and optional follow-up wording.

## Why

- Prevents users and operators from relying on stale or incomplete documentation for request decoding, retries, exporter endpoints, webhook-protected events, and credentialed redirect handling.
- Makes generated GoDoc point at the actual public API contracts so maintainers and downstream consumers do not need to infer behavior from implementation or tests.

## Testing

- `go test ./net/http/content ./net/http/rest ./net/http/rpc ./transport/http/events/... ./transport/http ./transport/http/token ./transport/http/hooks ./transport/http/retry ./telemetry/... ./encoding/proto ./encoding/hjson ./config ./module ./env ./cli ./os ./token/ssh ./crypto/tls ./debug/... ./internal/test` - passed
- `go test ./token/paseto ./transport/http` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
