### PR TITLE
docs(readme): clarify configuration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Config input is routed by flags called `-config` and `-c`:
 
   HJSON works the same way, for example `hjson:<base64-content>`.
 
-  The repository helper `make kind=status encode-config` uses GNU `base64 -w 0`; on macOS/BSD, use `base64 | tr -d '\n'` for the equivalent single-line payload.
+  The repository helper `make kind=configs/config encode-config` uses GNU `base64 -w 0`; on macOS/BSD, use `base64 | tr -d '\n'` for the equivalent single-line payload.
 
 - Otherwise (no `file:`/`env:` prefix), the decoder falls back to **default lookup**, searching for:
 
@@ -367,7 +367,7 @@ Postgres config embeds common pool + DSN config (`database/sql/config.Config`), 
 
 `module.Server` and `module.Client` both include `sql.Module`, which currently wires PostgreSQL support via `database/sql/pg.Module`.
 
-Enablement is presence-based: a nil `sql` block or a nil `sql.pg` block disables SQL wiring. When enabled, the pgx stdlib driver is registered under the name `pg`, master/slave DSNs are resolved using the source-string rules described above, OpenTelemetry `database/sql` stats metrics are registered, and the resulting pools are closed on lifecycle stop.
+Enablement is presence-based: a nil `sql` block or a nil `sql.pg` block disables SQL wiring. When enabled, the pgx stdlib driver is registered under the name `pg`, and master/slave DSNs are resolved using the source-string rules described above. Enabled PostgreSQL config must provide at least one non-empty `masters[].url` or `slaves[].url`. Driver instrumentation is installed when tracing or metrics are enabled, OpenTelemetry `database/sql` stats metrics are registered when metrics are enabled, and the resulting pools are closed on lifecycle stop.
 
 Example (with source strings for DSNs):
 

--- a/cli/application.go
+++ b/cli/application.go
@@ -51,7 +51,7 @@ type Application struct {
 //
 // The returned *[Command] embeds a *[flag.FlagSet]. The flag set is parsed before DI startup and is then
 // provided into the DI container so constructors can consume parsed flag values. Command names must be
-// unique across the application.
+// unique across the application. Duplicate command names panic with an error that wraps [ErrCommandRegistered].
 //
 // Execution semantics:
 //   - parse the command args into the command's FlagSet
@@ -99,7 +99,7 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 //
 // The returned *[Command] embeds a *[flag.FlagSet]. The flag set is parsed before DI startup and is then
 // provided into the DI container so constructors can consume parsed flag values. Command names must be
-// unique across the application.
+// unique across the application. Duplicate command names panic with an error that wraps [ErrCommandRegistered].
 //
 // Execution semantics:
 //   - parse the command args into the command's FlagSet

--- a/database/sql/config/config.go
+++ b/database/sql/config/config.go
@@ -12,6 +12,7 @@ import (
 //
 // [Config.Masters] and [Config.Slaves] contain DSNs (connection strings) expressed as go-service "source strings"
 // (literal values, `file:` paths, or `env:` references) that are resolved by [os.FS.ReadSource].
+// Enabled SQL configurations must provide at least one master or slave DSN, and each resolved DSN must be non-empty.
 type Config struct {
 	// Masters is the set of primary (read-write) datasource DSNs.
 	//

--- a/database/sql/config/doc.go
+++ b/database/sql/config/doc.go
@@ -18,5 +18,7 @@
 //   - "file:/path/to/dsn" to read from a file, or
 //   - any other value treated as a literal DSN.
 //
+// Enabled SQL configurations must provide at least one master or slave DSN, and each resolved DSN must be non-empty.
+//
 // Start with [Config] and [DSN].
 package config

--- a/database/sql/doc.go
+++ b/database/sql/doc.go
@@ -26,7 +26,8 @@
 // # Master/slave pools and telemetry
 //
 // Driver integrations typically open master/slave connection pools, configure pool limits/lifetimes,
-// and register OpenTelemetry instrumentation/metrics for [database/sql] connections.
+// wrap drivers with OpenTelemetry instrumentation when tracing or metrics are enabled, and register
+// [database/sql] stats metrics when metrics are enabled.
 //
 // Start with [Module] and [Config].
 package sql

--- a/database/sql/module.go
+++ b/database/sql/module.go
@@ -14,8 +14,9 @@ import (
 // At present it includes only PostgreSQL support via [github.com/alexfalkowski/go-service/v2/database/sql/pg.Module], but the module shape
 // is intentionally extensible for additional SQL drivers in the future.
 //
-// Driver-specific constructors read DSNs/pool settings from config, open master/slave pools, register
-// OpenTelemetry instrumentation/metrics, and attach lifecycle hooks that close pools on shutdown.
+// Driver-specific constructors read DSNs/pool settings from config, open master/slave pools, install
+// OpenTelemetry driver instrumentation when tracing or metrics are enabled, register DB stats metrics
+// when metrics are enabled, and attach lifecycle hooks that close pools on shutdown.
 var Module = di.Module(
 	pg.Module,
 )

--- a/database/sql/pg/doc.go
+++ b/database/sql/pg/doc.go
@@ -2,20 +2,23 @@
 //
 // This package integrates the [github.com/jackc/pgx/v5/stdlib] PostgreSQL driver with go-service SQL wiring by:
 //
-//   - registering the pgx stdlib [database/sql] driver under the name "pg" with OpenTelemetry instrumentation, and
+//   - registering the pgx stdlib [database/sql] driver under the name "pg", with OpenTelemetry instrumentation
+//     when tracing or metrics are enabled, and
 //   - providing an [Open] constructor that creates master/slave connection pools using the shared SQL driver helpers.
 //
 // # Configuration and enablement
 //
 // PostgreSQL configuration is optional. By convention, a nil *[Config] (or nil embedded config) is treated as
 // "disabled", and constructors such as [Open] return (nil, nil) when disabled.
+// Enabled PostgreSQL configuration must provide at least one non-empty master or replica DSN.
 //
 // # Master/slave pools
 //
 // [Open] resolves master and replica DSNs from configuration (DSNs are
 // expressed as go-service "source strings"), connects using the shared
 // master/slave pool abstraction used by the repository, applies pool settings
-// (max lifetime/open/idle), and registers OpenTelemetry DB stats metrics.
+// (max lifetime/open/idle), and registers OpenTelemetry DB stats metrics when
+// metrics are enabled.
 //
 // The package returns [github.com/alexfalkowski/go-service/v2/database/sql/driver.DBs], which embeds the upstream pool
 // collection and is aliased by the root [github.com/alexfalkowski/go-service/v2/database/sql] package as

--- a/database/sql/pg/module.go
+++ b/database/sql/pg/module.go
@@ -4,8 +4,8 @@ import "github.com/alexfalkowski/go-service/v2/di"
 
 // Module wires PostgreSQL ([github.com/alexfalkowski/go-service/v2/database/sql]) support into [go.uber.org/fx]/[go.uber.org/dig].
 //
-// It registers the [github.com/jackc/pgx/v5/stdlib] driver under the name "pg" (with OpenTelemetry instrumentation)
-// and provides a constructor that opens master/slave connection pools.
+// It registers the [github.com/jackc/pgx/v5/stdlib] driver under the name "pg" (with OpenTelemetry instrumentation
+// when tracing or metrics are enabled) and provides a constructor that opens master/slave connection pools.
 //
 // Provided components:
 //   - Registration: [Register]

--- a/database/sql/pg/pg.go
+++ b/database/sql/pg/pg.go
@@ -13,8 +13,8 @@ import (
 //
 // The registration is performed via [github.com/alexfalkowski/go-service/v2/database/sql/driver.Register], which wraps
 // the underlying driver with OpenTelemetry instrumentation via
-// [github.com/alexfalkowski/go-service/v2/database/sql/telemetry]. The returned error from registration is
-// intentionally ignored.
+// [github.com/alexfalkowski/go-service/v2/database/sql/telemetry] when tracing or metrics are enabled.
+// The returned error from registration is intentionally ignored.
 //
 // Register is typically called during process initialization via DI wiring (see [Module]).
 func Register() {
@@ -27,8 +27,9 @@ func Register() {
 //
 // Enabled behavior: Connect delegates to the shared SQL driver helper to:
 //   - resolve master and replica DSNs (expressed as go-service "source strings"),
+//   - require at least one non-empty master or replica DSN,
 //   - connect using the previously registered driver name "pg",
-//   - register OpenTelemetry DB stats metrics, and
+//   - register OpenTelemetry DB stats metrics when metrics are enabled, and
 //   - apply connection pool limits/lifetime.
 //
 // The returned type wraps the upstream master/slave pool collection and is

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -44,6 +44,8 @@ type ProviderParams struct {
 //   - Register appends lifecycle hooks that set the OpenFeature provider during application start and
 //     shut down the OpenFeature SDK during application stop.
 //
+// Register panics if OpenFeature metrics hook construction fails for a provided MetricProvider.
+//
 // Register uses OpenFeature's package-level SDK APIs, so provider registration, hooks, and shutdown are
 // process-global effects.
 func Register(params ProviderParams) {

--- a/module/module.go
+++ b/module/module.go
@@ -49,7 +49,7 @@ var Library = di.Module(
 // It builds on [Library] and adds server-oriented wiring commonly needed by services:
 //   - [debug.Module] (debug server + diagnostic endpoints)
 //   - [config.Module] (config decoding + validation + common sub-config projections)
-//   - [Module] (logging/tracing/metrics wiring)
+//   - [telemetry.Module] (logging/tracing/metrics wiring)
 //   - [cache.Module] (cache drivers, cache facade, and package-level cache registration)
 //   - [feature.Module] (OpenFeature client + optional provider registration)
 //   - [sql.Module] (SQL database wiring; currently PostgreSQL)
@@ -80,7 +80,7 @@ var Server = di.Module(
 // It builds on [Library] and adds client-oriented wiring commonly needed by client processes
 // and batch jobs:
 //   - [config.Module] (config decoding + validation + common sub-config projections)
-//   - [Module] (logging/tracing/metrics wiring)
+//   - [telemetry.Module] (logging/tracing/metrics wiring)
 //   - [cache.Module] (cache drivers/facade; optional by config)
 //   - [feature.Module] (OpenFeature client + optional provider registration)
 //   - [hooks.Module] (Standard Webhooks helpers; used by HTTP hook integrations)

--- a/net/http/mvc/funcs.go
+++ b/net/http/mvc/funcs.go
@@ -28,6 +28,8 @@ type FunctionMapParams struct {
 }
 
 // NewFunctionMap builds a FunctionMap with common sprout registries enabled.
+//
+// It panics if any provided or built-in sprout registry cannot be added.
 // List of registries can be found at https://docs.atom.codes/sprout/registries/list-of-all-registries
 func NewFunctionMap(params FunctionMapParams) sprout.FunctionMap {
 	handler := sprout.New(sprout.WithLogger(params.Logger), sprout.WithSafeFuncs(true))

--- a/token/ssh/doc.go
+++ b/token/ssh/doc.go
@@ -72,9 +72,11 @@
 //
 // This scheme authenticates possession of a key (via signature verification) and binds
 // that to a logical subject/key id, audience, and validity window. It does not provide
-// nonce/jti replay protection for repeated calls to the same audience inside the
-// validity window. If your use case requires one-time-use tokens, prefer JWT or
-// PASETO token kinds with jti tracking or layer additional checks at a higher level.
+// replay protection for repeated calls to the same audience inside the validity
+// window. JWT and PASETO tokens include generated jti values that callers can
+// store and check, but this repository does not maintain replay state for any
+// token kind. If your use case requires one-time-use tokens, add durable
+// caller-owned replay tracking at a higher level.
 //
 // # Relationship to the top-level token facade
 //


### PR DESCRIPTION
## What

- Clarify configuration and public API documentation for encoded config helpers, SQL DSN requirements, SQL telemetry enablement, module bundle contents, token replay expectations, and panic contracts.
- Keep the changes documentation-only, with no runtime behavior changes.

## Why

- The previous docs left several concrete gaps for service authors and operators: a copy-paste helper command referenced a missing fixture, SQL enablement requirements and telemetry gates were ambiguous, replay guidance implied tracking this library does not provide, and a few public APIs had undocumented panic paths.
- Tightening those contracts makes generated GoDoc and first-use README guidance match the code paths users rely on.

## Testing

- `go test ./cli ./module ./token/ssh ./feature ./net/http/mvc ./database/sql/config ./database/sql` - passed
- `go test ./database/sql/pg -run 'TestConfigIsEnabled|TestDisabledConfig'` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
