### PR TITLE
docs(readme): clarify configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ func main() {
 }
 ```
 
+The `file:./config.yml` default above expects a non-empty config file. A minimal
+server config can start with the environment plus one enabled transport:
+
+```yaml
+environment: development
+transport:
+  http:
+    address: tcp://localhost:8000
+    timeout: 10s
+```
+
 Use `app.RunCode(context.Background())` from `main` when exiting the process. It
 returns `os.ExitCodeSuccess` on success, returns a requested non-zero shutdown
 exit code such as `os.ExitCodeServeFailure`, and returns `os.ExitCodeFailure`
@@ -313,7 +324,8 @@ feature:
 ```
 
 > [!NOTE]
-> - Presence enables the feature subsystem configuration-wise, but this repository does not construct a built-in OpenFeature provider from this config.
+> - `feature.Config` embeds client config; `IsEnabled` is true only when both the feature config and embedded client config are present. An empty `feature:` block is treated as disabled by feature config helpers.
+> - This repository does not construct a built-in OpenFeature provider from this config.
 > - Services that need a remote or custom provider should use `feature.Config` in their own provider constructor and provide the resulting `openfeature.FeatureProvider` in DI; `feature.Module` registers that supplied provider with the OpenFeature SDK lifecycle.
 
 ---
@@ -357,6 +369,9 @@ Config:
 id:
   kind: uuid
 ```
+
+> [!NOTE]
+> ID generators produce operational identifiers such as request ids, webhook ids, and token `jti` values. They are not a secret-material API and should not be used as passwords, bearer tokens, or other credentials. A nil `id` config selects `uuid`; sortable kinds such as `ksuid`, `ulid`, and `xid` expose ordering characteristics.
 
 ---
 
@@ -453,6 +468,9 @@ Supported built-in logger kinds:
 - `tint`
 - `otlp`
 
+Supported logger levels are `debug`, `info`, `warn`, and `error`. When `level`
+is unset, logging defaults to `info`; unknown values fail logger construction.
+
 #### JSON logger
 
 ```yaml
@@ -489,6 +507,8 @@ telemetry:
 
 > [!WARNING]
 > OTLP exporters reject non-loopback `http://` endpoints when headers are configured. Use HTTPS for remote collectors that require authorization headers; cleartext with headers is accepted only for local loopback endpoints.
+>
+> OTLP exporter endpoints must be set in go-service config fields such as `telemetry.logger.url`, `telemetry.metrics.url`, and `telemetry.tracer.url`. Standard OpenTelemetry endpoint environment variables such as `OTEL_EXPORTER_OTLP_ENDPOINT` are not used as fallback sources.
 
 ### Metrics
 
@@ -701,6 +721,7 @@ transport:
 
 > [!NOTE]
 > - `interval` is parsed as a Go duration string. Invalid values can fail fast.
+> - `tokens` and `interval` use the underlying in-memory store defaults when set to zero: `1` token per `1s`. Configure positive values for explicit quotas.
 > - `max_keys` caps the number of caller-derived keys that receive independent in-memory buckets. A zero value uses the default `4096`; additional distinct keys share one overflow bucket.
 > - The built-in limiter is an in-memory, per-process safeguard. Use it as a last resort and prefer an external edge, gateway, ingress, load balancer, or service-mesh limiter for production abuse protection.
 > - The `user-id` key uses the verified principal stored in metadata. For JWT/PASETO tokens this is the subject claim; for SSH tokens this is the verified key name. Prefer it when authenticated identity is available.
@@ -870,6 +891,9 @@ Set `ca` on server TLS config to require and verify client certificates for mTLS
 config to verify server certificates issued by the same local or private CA. `server_name` is only needed
 on clients when the dial address differs from the certificate DNS name.
 
+Server-side TLS requires a complete `cert` and `key` pair whenever TLS material is configured. `ca` enables
+client-certificate verification for mTLS, but a CA-only server TLS config fails startup.
+
 > [!IMPORTANT]
 > If you are using `go-service-template` or composing server transport bundles such as `module.Server` or `transport.Module`, the required transport registration is handled for you by DI.
 >
@@ -905,6 +929,38 @@ The transport client wrappers include optional circuit breakers:
   - Scope is per `fullMethod`.
   - Default failure codes are `Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, and `Internal`.
   - Errors with other gRPC codes are treated as successful for breaker accounting.
+
+### Client retries
+
+HTTP and gRPC client retry config uses the shared `transport/retry.Config` shape. Config types that embed
+`config/client.Config`, such as `feature.Config`, use the `retry` block under that client config:
+
+```yaml
+feature:
+  address: localhost:9000
+  retry:
+    timeout: 1s
+    backoff: 100ms
+    attempts: 3
+```
+
+When manually constructing HTTP or gRPC clients, pass the decoded retry config to
+`transport/http.WithClientRetry(...)` or `transport/grpc.WithClientRetry(...)`.
+
+`attempts` is the total number of attempts, including the initial call. A value
+of `0` or `1` means no retry beyond the first attempt; values above `10` are
+rejected during config validation.
+
+Default retry policy is intentionally conservative:
+
+- HTTP retries side-effect-safe methods (`GET`, `HEAD`, `OPTIONS`) or requests with a `Request-Id`.
+- HTTP retries response/status failures only for `429 Too Many Requests` and `503 Service Unavailable`, plus selected transport errors classified by `retryablehttp.DefaultRetryPolicy`.
+- gRPC retries AIP-style read methods named `Get*` or `List*`, or calls with a `Request-Id`.
+- gRPC retries only `Unavailable` by default.
+
+`Request-Id` identifies the logical request, not an individual wire attempt.
+Services that allow retried writes should treat it as the idempotency key and
+deduplicate repeated attempts when duplicate processing would be unsafe.
 
 ---
 
@@ -962,6 +1018,10 @@ debug:
     ca: file:test/certs/rootCA.pem
 ```
 
+Debug TLS uses the same server-side TLS contract as transports: `cert` and `key`
+are required whenever TLS material is configured, and `ca` adds client-certificate
+verification for mTLS.
+
 All debug endpoints are namespaced by service name: `/<name>/debug/...`.
 
 > [!WARNING]
@@ -1015,9 +1075,16 @@ Exported Go identifiers should have GoDoc comments, and each comment should star
 
 ### Development Dependencies
 
-For local TLS fixtures:
+Common repository targets expect these tools on `PATH`:
 
-- <https://github.com/FiloSottile/mkcert>
+- `make`
+- `gotestsum` for `make specs`
+- `fieldalignment` for `make lint`
+- `golangci-lint` for full `make lint` coverage (the wrapper no-ops when it is missing)
+- `govulncheck` and `trivy` for `make sec`
+- `mkcert` for local TLS fixtures and `make create-certs`
+- `buf` for `make generate`
+- `goda` and Graphviz `dot` for `make diagrams`
 
 ### Setup (repo)
 
@@ -1056,6 +1123,10 @@ make dep
 Tests are run with `-mod vendor`, so after dependency changes run `make dep` before `make specs`.
 
 ### Local integration dependencies
+
+`make start` uses the shared Docker-based environment from the sibling
+`../docker` repo. It requires Docker and may require GitHub SSH access if that
+sibling repo must be fetched.
 
 Start required services:
 

--- a/compress/compress.go
+++ b/compress/compress.go
@@ -29,6 +29,10 @@ type MapParams struct {
 
 // NewMap constructs a Map pre-populated with the default compressors keyed by kind.
 //
+// The standard [Module] supplies non-nil default compressor implementations. Direct
+// calls use the [MapParams] values exactly, so zero-value params register nil
+// implementations for the built-in keys.
+//
 // The returned map includes these kinds:
 //
 //   - "zstd"

--- a/config/client/config.go
+++ b/config/client/config.go
@@ -46,6 +46,9 @@ func (c *Config) IsEnabled() bool {
 
 // NewConfig constructs a client-side runtime TLS config from cfg.
 //
+// If cfg is nil or empty, NewConfig returns a TLS 1.2-or-newer config without
+// configured certificates, root CAs, or server name override.
+//
 // It uses CA as RootCAs and uses any configured certificate/key pair as the
 // client certificate presented to servers that request one. If ServerName is
 // configured, it is copied into the runtime TLS config for server certificate

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -76,6 +76,9 @@ func (c *Config) GetTimeout() time.Duration {
 
 // NewConfig constructs a server-side runtime TLS config from cfg.
 //
+// If cfg is nil or empty, NewConfig returns a TLS 1.2-or-newer config that does
+// not request client certificates.
+//
 // If cfg has a CA configured, NewConfig uses it as ClientCAs and sets
 // ClientAuth to [tls.RequireAndVerifyClientCert]. Without CA, the server config
 // does not request client certificates.

--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -34,6 +34,8 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
 // Decode rejects duplicate object keys and unknown destination fields.
+// Decode buffers all remaining input from r before decoding; callers should bound
+// untrusted or potentially large readers before calling it.
 func (e *Encoder) Decode(r io.Reader, v any) error {
 	data, _, err := io.ReadAll(r)
 	if err != nil {

--- a/id/ksuid/doc.go
+++ b/id/ksuid/doc.go
@@ -1,6 +1,8 @@
 // Package ksuid provides KSUID-based ID generation helpers used by go-service.
 //
 // This package integrates KSUID generation behind the go-service ID abstraction.
+// KSUID values are operational identifiers with time-sortable characteristics;
+// they are not secret material or bearer tokens.
 //
 // Start with the package-level constructors.
 package ksuid

--- a/id/nanoid/doc.go
+++ b/id/nanoid/doc.go
@@ -1,6 +1,8 @@
 // Package nanoid provides NanoID-based ID generation helpers used by go-service.
 //
 // This package integrates NanoID generation behind the go-service ID abstraction.
+// NanoID values produced here are operational identifiers, not secret material
+// or bearer tokens.
 //
 // Start with the package-level constructors.
 package nanoid

--- a/id/ulid/doc.go
+++ b/id/ulid/doc.go
@@ -1,6 +1,8 @@
 // Package ulid provides ULID-based ID generation helpers used by go-service.
 //
 // This package integrates ULID generation behind the go-service ID abstraction.
+// ULID values are operational identifiers with time-sortable characteristics;
+// they are not secret material or bearer tokens.
 //
 // Start with the package-level constructors.
 package ulid

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -26,7 +26,8 @@ type Client struct {
 	Lifecycle di.Lifecycle
 	// Logger logs client activity.
 	Logger *logger.Logger
-	// Tracer configures client tracing.
+	// Tracer is retained for world configuration symmetry. Client tracing follows
+	// the globally registered telemetry providers.
 	Tracer *tracer.Config
 	// Transport configures HTTP and gRPC client targets.
 	Transport *transport.Config
@@ -51,7 +52,7 @@ type Client struct {
 }
 
 // NewHTTP returns an HTTP client configured with the world's logger, retry policy,
-// token generator, limiter, tracing, and optional compression.
+// token generator, limiter, and optional compression.
 func (c *Client) NewHTTP(os ...httpbreaker.Option) (*http.Client, error) {
 	opts := []http.ClientOption{
 		http.WithClientLogger(c.Logger),
@@ -74,7 +75,7 @@ func (c *Client) NewHTTP(os ...httpbreaker.Option) (*http.Client, error) {
 }
 
 // NewGRPC returns a gRPC client connection configured with the world's interceptors,
-// retry policy, token generator, limiter, tracing, and optional compression.
+// retry policy, token generator, limiter, and optional compression.
 func (c *Client) NewGRPC(os ...grpcbreaker.Option) (*grpc.ClientConn, error) {
 	opts := []grpc.ClientOption{
 		grpc.WithClientUnaryInterceptors(),

--- a/token/jwt/doc.go
+++ b/token/jwt/doc.go
@@ -47,13 +47,16 @@
 // # Verification semantics and errors
 //
 // Verify validates a token for a given audience and returns the subject (sub) on success.
-// Verification enforces, in order:
+// Verification enforces:
 //
 //   - The signature algorithm is EdDSA.
 //   - The "kid" header exists and selects a configured verification key.
 //   - The issuer claim matches the configured Issuer.
 //   - The audience claim contains the expected audience.
 //   - Registered claim validity (exp/nbf/iat) using [github.com/golang-jwt/jwt/v4.RegisteredClaims.Valid].
+//
+// Upstream parsing, signature validation, and registered-claim validation can fail before
+// later go-service issuer, audience, and lifetime checks run.
 //
 // On failures, this package may return sentinel errors from token/errors for common
 // classes of validation issues (for example ErrInvalidAlgorithm, ErrInvalidKeyID,

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -113,6 +113,8 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 // This method returns sentinel errors from token/errors for some common classes of
 // failures (issuer/audience mismatches and validate-time algorithm/kid mismatches).
 // Parse/validation errors produced by the upstream JWT library may be returned as-is.
+// Upstream parse, signature, or registered-claim validation errors can be returned
+// before the local issuer, audience, required-claim, and lifetime checks run.
 func (t *Token) Verify(token, aud string) (string, error) {
 	if strings.IsEmpty(t.cfg.Issuer) || t.cfg.Expiration <= 0 {
 		return strings.Empty, errors.ErrInvalidConfig

--- a/transport/limiter/config.go
+++ b/transport/limiter/config.go
@@ -38,8 +38,8 @@ type Config struct {
 
 	// Tokens is the maximum number of tokens available per interval, per derived key.
 	//
-	// When Tokens is 0, the underlying store behavior is implementation-defined (it may reject all
-	// requests or behave as an always-empty bucket). Prefer configuring a positive value.
+	// When Tokens is 0, the underlying in-memory store applies its default of 1 token.
+	// Prefer configuring a positive value so the quota is explicit in service config.
 	Tokens uint64 `yaml:"tokens,omitempty" json:"tokens,omitempty" toml:"tokens,omitempty"`
 
 	// MaxKeys is the maximum number of caller-derived keys that get independent buckets.

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -71,6 +71,7 @@ type KeyMap map[string]KeyFunc
 //
 // Notes:
 //   - cfg.Interval is used directly as a typed duration decoded from config.
+//     The underlying in-memory store applies its default 1s interval when cfg.Interval is 0.
 //   - The underlying store constructor currently does not return an error (it is ignored).
 func NewLimiter(lc di.Lifecycle, keyMap KeyMap, cfg *Config) (*Limiter, error) {
 	if !cfg.IsEnabled() {


### PR DESCRIPTION
## What

- Expanded README guidance for minimal service config, feature client config enablement, ID generator boundaries, logging levels, OTLP endpoints, limiter defaults, TLS key-pair requirements, retry behavior, and local development prerequisites.
- Clarified GoDoc for TLS config construction, JWT verification errors, HJSON decode buffering, compression registry defaults, limiter defaults, internal test client tracing, and operational ID generators.
- Kept the change scoped to documentation and public comments; no runtime behavior changed.

## Why

- These gaps could mislead service owners about required config, retry/idempotency behavior, TLS startup requirements, telemetry endpoint sources, and which generated identifiers are safe to use as credentials.
- Clearer API comments also make direct package use safer by documenting nil, zero-value, upstream-error, and buffering contracts at the public entrypoints.

## Testing

- `git diff --check` - passed
- `go test ./config/client ./config/server ./token/jwt ./encoding/hjson ./compress/... ./id/... ./transport/limiter ./internal/test` - passed
- `make lint` - passed
