### PR TITLE
docs(readme): clarify public helper contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For direct package use in an existing module, add the library dependency with th
 go get github.com/alexfalkowski/go-service/v2
 ```
 
+Use the Go version declared in `go.mod` or newer when installing or building this module.
+
 ---
 
 ## 🧩 Dependency Injection (Fx)
@@ -180,6 +182,9 @@ The library provides a helper `config.NewConfig[T]` which:
 - decodes into `*T`
 - rejects an “empty” decoded value (guards against starting with a zero-value config)
 - validates the decoded config
+
+Because empty detection compares the decoded value with the zero value, `T` must be comparable. Config
+types containing maps, slices, or other non-comparable fields should use a custom decode/empty-check path.
 
 Example:
 
@@ -371,7 +376,7 @@ id:
 ```
 
 > [!NOTE]
-> ID generators produce operational identifiers such as request ids, webhook ids, and token `jti` values. They are not a secret-material API and should not be used as passwords, bearer tokens, or other credentials. A nil `id` config selects `uuid`; sortable kinds such as `ksuid`, `ulid`, and `xid` expose ordering characteristics.
+> ID generators produce operational identifiers such as request ids, webhook ids, and token `jti` values. They are not a secret-material API and should not be used as passwords, bearer tokens, or other credentials. Omit `id` entirely to select the `uuid` default. If `id` is present, `kind` must be one of the supported registered kinds. Sortable kinds such as `ksuid`, `ulid`, and `xid` expose ordering characteristics.
 
 ---
 
@@ -438,6 +443,8 @@ The framework provides Kubernetes-style endpoints:
 
 Successful health responses return HTTP 200 with the plain-text body `SERVING`.
 Missing or failing observers return HTTP 503 with the standard go-service error response.
+During server shutdown, `/readyz` also returns HTTP 503 after the lifecycle starts draining so
+orchestrators can stop sending new traffic before the listener fully stops.
 
 Built-in checker helpers under `health/checker` include DB connectivity checks and
 cache connectivity checks for pingable cache drivers such as Redis and ttlcache.
@@ -642,6 +649,9 @@ Important behavior:
 > [!IMPORTANT]
 > JWT generation and verification use Ed25519 key material from `jwt.keys`. Keep private key material only on services that mint tokens; verifiers only need public keys.
 
+All token `exp` values are Go duration strings and must be positive whole-second durations. Values such
+as `1s`, `15m`, and `24h` validate; sub-second values such as `500ms` do not.
+
 ### Paseto
 
 Paseto config:
@@ -761,6 +771,11 @@ Supported kinds:
 
 - `ntp`
 - `nts`
+
+Omit the `time` block to disable network time. If the block is present, `kind`
+must be `ntp` or `nts`; empty or unknown kinds fail startup with the time
+provider not found error. `address` is provider-specific and is used when the
+network time provider performs I/O.
 
 ---
 
@@ -909,6 +924,9 @@ on clients when the dial address differs from the certificate DNS name.
 Server-side TLS requires a complete `cert` and `key` pair whenever TLS material is configured. `ca` enables
 client-certificate verification for mTLS, but a CA-only server TLS config fails startup.
 
+gRPC clients use insecure transport credentials when TLS is not configured. That default is intended for
+local or platform-secured traffic; configure client TLS for calls outside that trusted boundary.
+
 > [!IMPORTANT]
 > If you are using `go-service-template` or composing server transport bundles such as `module.Server` or `transport.Module`, the required transport registration is handled for you by DI.
 >
@@ -1004,8 +1022,10 @@ crypto:
 
 > [!NOTE]
 > - AES keys must be 16/24/32 bytes after resolving the source string.
+> - HMAC keys should be high-entropy secrets and must remain private.
 > - RSA keys expect PKCS#1 PEM blocks (`RSA PUBLIC KEY` / `RSA PRIVATE KEY`) and must be at least 4096 bits.
 > - Ed25519 expects PKIX `PUBLIC KEY` and PKCS#8 `PRIVATE KEY` PEM blocks.
+> - SSH keys must be Ed25519 SSH keys: public keys use `authorized_keys` format and private keys use SSH private key format.
 
 ### Crypto Dependencies
 
@@ -1075,6 +1095,10 @@ GET http://localhost:6060/<name>/debug/fgprof?seconds=10
 ```http
 GET http://localhost:6060/<name>/debug/psutil
 ```
+
+The response is content-negotiated and contains a best-effort snapshot with `cpu`, `host`, `load`, `mem`,
+and `net` sections. Individual nested values may be empty or partially populated when the platform or
+runtime permissions do not expose a metric.
 
 <https://github.com/shirou/gopsutil>
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,8 @@ import (
 //  1. Empty detection: if the decoded value is considered empty (see [structs.IsEmpty]), NewConfig returns
 //     ErrInvalidConfig. This guards against accidentally starting with a zero-value configuration when the
 //     input is missing or does not populate any fields.
+//     Because this comparison uses the zero value of T, T must be comparable. Config types that contain
+//     slices, maps, or other non-comparable fields should use a custom decode/empty-check path instead.
 //
 //  2. Validation: the decoded value is validated using the provided Validator (go-playground/validator).
 //     Any validation errors are returned to the caller.

--- a/internal/test/benchmark.go
+++ b/internal/test/benchmark.go
@@ -18,6 +18,10 @@ func ResetTelemetry(tb testing.TB) {
 }
 
 // EnableMetrics installs the shared test meter provider.
+//
+// This mutates the process-global OpenTelemetry meter provider. Use
+// ResetTelemetry or a helper that resets telemetry when a test needs isolation
+// from other telemetry assertions in the same process.
 func EnableMetrics(tb testing.TB) {
 	tb.Helper()
 
@@ -33,6 +37,10 @@ func EnableMetrics(tb testing.TB) {
 }
 
 // EnableTracer installs the shared test tracer provider.
+//
+// This mutates the process-global OpenTelemetry tracer provider. Use
+// ResetTelemetry or EnableIsolatedSpanExporter when a test needs isolated span
+// assertions.
 func EnableTracer(tb testing.TB) {
 	tb.Helper()
 
@@ -47,6 +55,10 @@ func EnableTracer(tb testing.TB) {
 }
 
 // EnableTelemetry installs the shared test meter and tracer providers.
+//
+// This mutates process-global OpenTelemetry meter and tracer providers. Tests
+// that assert telemetry state should reset telemetry before and after the
+// assertion path.
 func EnableTelemetry(tb testing.TB) {
 	tb.Helper()
 

--- a/internal/test/metrics.go
+++ b/internal/test/metrics.go
@@ -141,6 +141,10 @@ func NewMeterProvider(lc di.Lifecycle, config *metrics.Config) (metrics.MeterPro
 }
 
 // EnableMetricsReader installs the shared test meter provider and returns its manual reader.
+//
+// It resets process-global telemetry before installation and again with
+// tb.Cleanup, so the returned reader can be used for isolated metric
+// assertions.
 func EnableMetricsReader(tb testing.TB) metrics.Reader {
 	tb.Helper()
 

--- a/internal/test/options.go
+++ b/internal/test/options.go
@@ -209,6 +209,11 @@ func WithWorldCacheDriver(driver driver.Driver) WorldOption {
 }
 
 // WithWorldRegisterCache registers the world's cache with the generic cache helpers.
+//
+// This mutates the package-level cache used by cache.Get and cache.Persist.
+// NewWorld resets that package-level registration with tb.Cleanup, so this
+// option is intended for tests that specifically exercise the generic cache
+// helpers.
 func WithWorldRegisterCache() WorldOption {
 	return worldOptionFunc(func(o *worldOpts) {
 		o.registerCache = true

--- a/internal/test/tracer.go
+++ b/internal/test/tracer.go
@@ -13,6 +13,9 @@ import (
 
 // RegisterTracer installs the shared test tracer provider on the supplied lifecycle.
 //
+// This mutates the process-global OpenTelemetry tracer provider through
+// telemetry/tracer registration. The supplied lifecycle owns provider shutdown.
+//
 // It panics through [runtime.Must] if tracer registration fails.
 func RegisterTracer(lc di.Lifecycle, config *tracer.Config) {
 	params := tracer.TracerParams{
@@ -27,6 +30,9 @@ func RegisterTracer(lc di.Lifecycle, config *tracer.Config) {
 }
 
 // EnableSpanExporter installs a synchronous tracer provider backed by a SpanExporter.
+//
+// This mutates the process-global OpenTelemetry tracer provider for the current
+// test and resets it to a no-op provider with tb.Cleanup.
 func EnableSpanExporter(tb testing.TB) *SpanExporter {
 	tb.Helper()
 
@@ -43,6 +49,10 @@ func EnableSpanExporter(tb testing.TB) *SpanExporter {
 }
 
 // EnableIsolatedSpanExporter resets telemetry and installs a synchronous span exporter.
+//
+// It resets process-global telemetry before installation and again with
+// tb.Cleanup, making it the preferred helper for tests that assert exported
+// spans.
 func EnableIsolatedSpanExporter(tb testing.TB) *SpanExporter {
 	tb.Helper()
 

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -42,10 +42,11 @@ func init() {
 // builders, telemetry config, cache handle, database config, and optional REST
 // client.
 //
-// NewWorld completes the package-level helper registrations during construction,
-// so callers only need to add any test-specific routes/handlers and then start
-// the lifecycle. Most tests should prefer Start or NewStartedWorld to ensure
-// cleanup is always registered with the testing framework.
+// Package-level helper registrations are installed during package initialization.
+// NewWorld builds the per-test harness; callers only need to add any
+// test-specific routes/handlers and then start the lifecycle. Most tests should
+// prefer Start or NewStartedWorld to ensure cleanup is always registered with
+// the testing framework.
 //
 //nolint:funlen
 func NewWorld(tb testing.TB, opts ...WorldOption) *World {

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -1,0 +1,52 @@
+package rest_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/rest"
+	"github.com/alexfalkowski/go-sync"
+)
+
+func ExampleGet() {
+	mux := http.NewServeMux()
+	pool := sync.NewBufferPool()
+	rest.Register(rest.RegisterParams{
+		Mux:     mux,
+		Content: exampleContent(pool),
+		Pool:    pool,
+	})
+
+	rest.Get("/hello", func(context.Context) (*exampleResponse, error) {
+		return &exampleResponse{Message: "hello"}, nil
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/hello", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	fmt.Println(res.Code)
+	fmt.Print(res.Body.String())
+	// Output:
+	// 200
+	// {
+	//   "message": "hello"
+	// }
+}
+
+type exampleResponse struct {
+	Message string `json:"message"`
+}
+
+func exampleContent(pool *sync.BufferPool) *content.Content {
+	return content.NewContent(
+		encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
+		pool,
+	)
+}

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -1,0 +1,55 @@
+package rpc_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
+	"github.com/alexfalkowski/go-sync"
+)
+
+func ExampleClient_Post() {
+	mux := http.NewServeMux()
+	pool := sync.NewBufferPool()
+	rpc.Register(rpc.RegisterParams{
+		Mux:     mux,
+		Content: exampleContent(pool),
+		Pool:    pool,
+	})
+
+	rpc.Route("/hello", func(_ context.Context, req *exampleRequest) (*exampleResponse, error) {
+		return &exampleResponse{Message: "hello " + req.Name}, nil
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := rpc.NewClient(server.URL, rpc.WithClientContentType("application/json"))
+	var res exampleResponse
+	if err := client.Post(context.Background(), "/hello", &exampleRequest{Name: "Mira"}, &res); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(res.Message)
+	// Output: hello Mira
+}
+
+type exampleRequest struct {
+	Name string `json:"name"`
+}
+
+type exampleResponse struct {
+	Message string `json:"message"`
+}
+
+func exampleContent(pool *sync.BufferPool) *content.Content {
+	return content.NewContent(
+		encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
+		pool,
+	)
+}


### PR DESCRIPTION
## What

- Clarifies first-use and configuration contracts in the project README, including the required Go toolchain, comparable config types, ID and network-time enablement, token expiration precision, TLS defaults, crypto key formats, health drain behavior, and psutil response shape.
- Adds executable REST and RPC first-use examples that show public package registration, JSON content setup, route registration, and request execution.
- Expands GoDoc for config loading and internal test helpers so maintainers can see package-global cache and telemetry side effects before using those helpers.

## Why

- Service authors and operators can now make configuration choices without reading lower-level package code to discover non-obvious defaults, validation, and security-sensitive behavior.
- Package consumers get executable REST/RPC examples for the package-level registration pattern, reducing the risk of incorrect setup.
- Maintainers get clearer lifecycle and global-state guidance for shared test helpers that can otherwise affect same-process tests.

## Testing

- `go test ./net/http/rest ./net/http/rpc` - passed
- `go test ./config ./internal/test ./cache ./telemetry/metrics ./telemetry/tracer` - passed
- `git diff --check` - passed
- `make lint` - passed
