### PR TITLE
docs(transport): clarify service wiring contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ grpcurl -plaintext -d '{"service":"<name>"}' localhost:9000 grpc.health.v1.Healt
 `Check` returns `SERVING` or `NOT_SERVING` for known services and `NotFound` for
 unknown services. `List` returns the current statuses for registered services.
 `Watch` streams status changes until the client cancels; unknown services stream
-`SERVICE_UNKNOWN`. Unary health RPCs bypass token verification and unary
-server-side limiting as operation RPCs. Health `Watch` is a stream and still
-uses stream limiting.
+`SERVICE_UNKNOWN`. Health operation RPCs bypass token verification. Unary
+`Check` and `List` also bypass unary server-side limiting, while health `Watch`
+is a stream and still uses stream limiting.
 
 These are modeled after [Kubernetes API health endpoints](https://kubernetes.io/docs/reference/using-api/health-checks/).
 
@@ -862,6 +862,7 @@ transport:
 > [!NOTE]
 > - Address may use `<network>://<address>` (for example `tcp://:8000`) or a raw listen address such as `:8000`, which defaults to the `tcp` network.
 > - If address is omitted, defaults are `tcp://:8080` (HTTP) and `tcp://:9090` (gRPC).
+> - `transport.grpc.timeout` bounds unary RPC handlers and feeds gRPC server keepalive/connection defaults; it does not cap stream lifetime. Long-lived streams remain open until client cancellation or stream-specific controls apply.
 > - `max_receive_size` limits inbound payload size. A zero value uses the default `4MB`.
 > - For HTTP, `max_receive_size` applies per request body. For gRPC, it applies per inbound unary request and per inbound stream message.
 > - MVC does not enforce its own body-size caps; supported HTTP server wiring applies `max_receive_size` before MVC handlers run, and go-service HTTP clients apply their configured response-size cap when reading responses.
@@ -982,7 +983,9 @@ When manually constructing HTTP or gRPC clients, pass the decoded retry config t
 
 `attempts` is the total number of attempts, including the initial call. A value
 of `0` or `1` means no retry beyond the first attempt; values above `10` are
-rejected during config validation.
+rejected during config validation. `timeout` is applied per attempt, not as a
+whole logical request budget, so total elapsed time can include multiple attempt
+timeouts plus backoff unless the caller's context or client timeout ends first.
 
 Default retry policy is intentionally conservative:
 

--- a/transport/config.go
+++ b/transport/config.go
@@ -5,22 +5,26 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 )
 
-// Config configures the transport layer for a service.
+// Config configures server-side transport wiring for a service.
 //
-// It is a top-level configuration object that enables and configures the supported
+// It is a top-level configuration object that enables and configures the supported server
 // transport stacks (currently HTTP and gRPC). Each nested transport config is optional:
-// when nil or disabled, the corresponding transport constructors typically return nil
-// and no server/client is created.
+// when nil or disabled, the corresponding server constructors typically return nil and no
+// server is created.
+//
+// Client construction uses explicit client options and client-side config types such as
+// [github.com/alexfalkowski/go-service/v2/config/client.Config]; transport.http and
+// transport.grpc are the server-side config trees.
 //
 // The struct tags are compatible with the repository's config decoder (YAML/JSON/TOML).
 type Config struct {
-	// GRPC configures the gRPC transport stack (client and server).
+	// GRPC configures the gRPC server transport stack.
 	//
 	// When nil or when the nested config is disabled, gRPC transport wiring is effectively
 	// turned off and constructors such as [github.com/alexfalkowski/go-service/v2/transport/grpc.NewServer] typically return nil.
 	GRPC *grpc.Config `yaml:"grpc,omitempty" json:"grpc,omitempty" toml:"grpc,omitempty"`
 
-	// HTTP configures the HTTP transport stack (client and server).
+	// HTTP configures the HTTP server transport stack.
 	//
 	// When nil or when the nested config is disabled, HTTP transport wiring is effectively
 	// turned off and constructors such as [github.com/alexfalkowski/go-service/v2/transport/http.NewServer] typically return nil.

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -69,9 +69,13 @@ func WithClientCompression() ClientOption {
 
 // WithClientTokenGenerator enables client-side token injection interceptors.
 //
-// When configured, the client will generate an Authorization token per RPC and attach it to outgoing
+// When configured, the client will generate Authorization tokens and attach them to outgoing
 // metadata (unary and streaming). The token is generated via gen and is typically scoped to the RPC's
 // full method name and the provided user id.
+//
+// Unary token generation runs inside the retry interceptor, so retryable unary calls may generate one
+// token per attempt. Streaming calls are not retried by the standard client chain and generate one token
+// when the stream is opened.
 func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.id = id
@@ -321,6 +325,8 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 //
 // The logger wraps retry, limiter, and breaker outcomes so local rejections are recorded.
 // Retry wraps the limiter and breaker so each retry attempt consumes quota and breaker capacity.
+// Token injection is inside retry, so each retried unary attempt can generate a fresh token while the
+// metadata request id remains stable for the logical RPC.
 // The limiter stays before the breaker so local quota denials are not counted as upstream failures.
 func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor {
 	resolved := options(opts...)

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -24,6 +24,8 @@ type Config = config.Config
 //
 // Policies describe operation safety, not transient failure classification. The retry interceptor still only retries
 // configured gRPC status codes after the policy allows the logical RPC.
+// When multiple non-nil policies are provided, all must allow the call. Nil policies are ignored; if every
+// provided policy is nil, the default [IdempotentMethods] policy is used.
 type Policy func(ctx context.Context, fullMethod string, req any) bool
 
 // StandardReadMethods allows retries for AIP-style read methods named Get* or List*.
@@ -65,6 +67,8 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 // When no policy is provided, only side-effect-safe unary RPCs are eligible for retry: AIP-style read methods,
 // or calls carrying a request-id idempotency contract. Callers that need different behavior can pass an
 // explicit policy.
+// Multiple non-nil policies are composed with logical AND, so any denying policy makes the RPC non-retryable.
+// Nil policies are ignored, and the default policy is used only when no non-nil policy is supplied.
 //
 // Notes:
 // This interceptor does not automatically retry on every error; application-level errors that map to other

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -16,6 +16,9 @@ import (
 //
 // If no round tripper is configured via [WithSenderRoundTripper], it uses the default HTTP transport.
 //
+// The sender follows only same-origin redirects. Cross-origin redirects are returned to the caller instead
+// of being followed so webhook signatures are not minted for redirected origins.
+//
 // Note: the provided hook must be configured appropriately (for example with the expected secret) for
 // signing to succeed.
 func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -19,6 +19,9 @@ import (
 // Enabled behavior:
 // When hook is non-nil, the returned Webhook adds go-service request-body buffering and header conventions
 // on top of the underlying Standard Webhooks signer/verifier.
+//
+// Signing requires a non-nil generator. Passing a nil generator is valid for verification-only use, but
+// calling [Webhook.Sign] or using the signing [RoundTripper] with a nil generator will panic.
 func NewWebhook(hook *hooks.Webhook, generator id.Generator) *Webhook {
 	if hook == nil {
 		return nil
@@ -43,7 +46,10 @@ type Webhook struct {
 
 // Sign signs an outbound webhook request.
 //
-// It reads and buffers the request body, restores `req.Body`, and then sets signature headers.
+// It reads and buffers the request body, closes the original body, replaces `req.Body` with a fresh
+// readable body, and then sets signature headers.
+//
+// A non-nil generator is required because Sign generates the Webhook-Id used in the signature.
 //
 // Headers set:
 //   - `Webhook-Id`
@@ -86,8 +92,8 @@ func (h *Webhook) Sign(req *http.Request) error {
 
 // Verify verifies the signature headers on an inbound webhook request.
 //
-// It reads and buffers the request body, restores `req.Body`, and then verifies the signature headers
-// using the underlying Standard Webhooks verifier.
+// It reads and buffers the request body, closes the original body, replaces `req.Body` with a fresh
+// readable body, and then verifies the signature headers using the underlying Standard Webhooks verifier.
 //
 // Security note:
 // This method intentionally does not add a second local size cap. Supported inbound use goes through
@@ -170,6 +176,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 //
 // The returned RoundTripper signs each request by buffering the request body, restoring `req.Body`, and
 // attaching the Standard Webhooks signature headers before delegating to the underlying transport.
+// A non-nil generator must have been supplied to [NewWebhook] for signing use.
 //
 // If hook is nil, the returned RoundTripper behaves as a pass-through wrapper.
 func NewRoundTripper(hook *Webhook, rt http.RoundTripper) *RoundTripper {

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -28,6 +28,8 @@ type Config = config.Config
 //
 // Policies describe operation safety, not transient failure classification. The retry transport still only retries
 // retryable responses/errors after the policy allows the logical request.
+// When multiple non-nil policies are provided, all must allow the request. Nil policies are ignored; if every
+// provided policy is nil, the default [IdempotentRequests] policy is used.
 type Policy func(req *http.Request) bool
 
 // SafeMethods allows retries for HTTP methods that should not have request side effects.
@@ -84,6 +86,9 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 // When no policy is provided, only side-effect-safe requests are eligible for retry: safe HTTP methods, or
 // requests carrying a request-id idempotency contract. Callers that need different behavior can pass an
 // explicit policy.
+// Multiple non-nil policies are composed with logical AND, so any denying policy makes the request
+// non-retryable. Nil policies are ignored, and the default policy is used only when no non-nil policy is
+// supplied.
 //
 // Exhaustion behavior:
 //   - If retries are exhausted after retryable HTTP responses, the final retryable response is returned.

--- a/transport/module.go
+++ b/transport/module.go
@@ -16,7 +16,7 @@ import (
 // Included submodules:
 //   - [github.com/alexfalkowski/go-service/v2/transport/grpc.Module]: gRPC transport server wiring (including TLS filesystem registration, interceptors, and health).
 //   - [github.com/alexfalkowski/go-service/v2/transport/http.Module]: HTTP transport server wiring (routing helpers, middleware, TLS filesystem registration, metrics, and health).
-//   - [github.com/alexfalkowski/go-service/v2/transport/http/events.Module]: CloudEvents HTTP wiring (sender/receiver helpers and webhook signing/verification adapters).
+//   - [github.com/alexfalkowski/go-service/v2/transport/http/events.Module]: CloudEvents HTTP receiver and webhook verification wiring.
 //
 // Server lifecycle wiring:
 // This module also provides [NewServers] (to collect enabled *[server.Service] instances) and registers


### PR DESCRIPTION
## What

- Clarifies health operation behavior, gRPC stream timeout semantics, and retry timeout budgeting in the README.
- Updates GoDoc to distinguish server-side config from client options and narrow CloudEvents DI wiring to receiver/webhook registration.
- Documents retry policy composition, per-attempt gRPC token generation, webhook signing/body ownership requirements, and CloudEvents sender redirect handling.

## Why

- Prevents service authors and operators from configuring the wrong tree or relying on incorrect auth, timeout, or retry assumptions.
- Makes non-obvious client and webhook lifecycle contracts discoverable from GoDoc before manual composition.

## Testing

- `git diff --check` - passed
- `go test ./transport/...` - passed
- `make package=transport lint` - passed, with the existing `gomodguard` deprecation warning and 0 issues.
