### PR TITLE
docs(http): clarify webhook signing and readiness drain contracts

### DIFF
--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -19,8 +19,8 @@ import (
 // The sender follows only same-origin redirects. Cross-origin redirects are returned to the caller instead
 // of being followed so webhook signatures are not minted for redirected origins.
 //
-// Note: the provided hook must be configured appropriately (for example with the expected secret) for
-// signing to succeed.
+// Note: the provided hook must be configured for signing use, including the expected secret and a non-nil
+// id generator passed to [github.com/alexfalkowski/go-service/v2/transport/http/hooks.NewWebhook].
 func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {
 	resolved := options(opts...)
 	rt := hooks.NewRoundTripper(hook, resolved.roundTripper)

--- a/transport/http/health/health.go
+++ b/transport/http/health/health.go
@@ -28,6 +28,8 @@ type RegisterParams struct {
 	Mux *http.ServeMux
 
 	// Drain tracks whether the server lifecycle has started shutting down.
+	//
+	// When omitted, /readyz does not report drain state and only reflects the registered readiness observer.
 	Drain *server.Drain `optional:"true"`
 
 	// Name is the service name used both for route prefixing and observer lookup.
@@ -44,7 +46,7 @@ type RegisterParams struct {
 //
 //   - HTTP 200 with the plain-text body "SERVING" when the observer reports no error.
 //   - HTTP 503 when the observer is missing or reports an error.
-//   - HTTP 503 for `/readyz` after the server lifecycle starts draining.
+//   - HTTP 503 for `/readyz` after the server lifecycle starts draining, when params.Drain is provided.
 //
 // Error responses are written with [status.WriteError], and successful responses are written with
 // [status.WriteText]. Callers are expected to have request metadata middleware in place if they want


### PR DESCRIPTION
## What

- Clarify the CloudEvents sender signing contract for webhook-enabled senders.
- Document that readiness drain reporting only applies when HTTP health registration receives a drain tracker.

## Why

- Direct package consumers need to know the non-obvious setup required for webhook signing so they do not build a sender with a verifier-only webhook.
- Manual health registration should make the optional drain dependency clear so service authors understand what `/readyz` reports during shutdown.

## Testing

- `make package=transport/http lint` - passed
- Validation was scoped to the changed GoDoc-only HTTP transport files.
