### PR TITLE
docs(grpc): clarify transport auth and connection contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,8 @@ The model is based on Casbin RBAC:
 
 > [!NOTE]
 > `access.model` and `access.policy` are resolved through `os.FS.ReadSource`; use `file:` for files, `env:` for environment-provided content, or literal content.
+>
+> Access config builds an injectable controller for authorization checks. The built-in HTTP and gRPC token middleware authenticates tokens and stores the verified user id, but it does not automatically enforce Casbin policy. Services must call `HasAccess(...)` from handlers or install their own authorization middleware/interceptors where policy enforcement is required.
 
 ### JWT
 

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -292,10 +292,14 @@ func NewDialOptions(opts ...ClientOption) ([]grpc.DialOption, error) {
 // gRPC wrapper package directly.
 type ClientConn = grpc.ClientConn
 
-// NewClient constructs and dials a gRPC client connection to target.
+// NewClient constructs a gRPC client connection to target.
 //
 // It uses dial options derived from opts (see [NewDialOptions]) and adds OpenTelemetry stats handling
 // when tracing or metrics are enabled.
+//
+// No I/O is performed during construction; the returned connection connects automatically when it is
+// used for RPCs, or when Connect is called explicitly. Connection, resolver, and TLS handshake failures
+// surface from RPCs or explicit connection attempts rather than from NewClient itself.
 //
 // The returned connection should be closed by the caller when no longer needed.
 func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -80,8 +80,11 @@ func (s *Server) List(_ context.Context, _ *health.ListRequest) (*health.ListRes
 
 // Watch streams health status updates for a single service until the client cancels.
 //
-// The initial status is sent immediately. When the requested service is unknown,
-// Watch sends `SERVICE_UNKNOWN` and keeps the stream open until the client cancels.
+// An empty service watches the overall "grpc" transport health. Named services are looked up under
+// the "grpc" transport kind, matching [Server.Check] and [Server.List].
+//
+// The initial status is sent immediately. When the requested service is unknown, Watch sends
+// `SERVICE_UNKNOWN` and keeps the stream open until the client cancels.
 func (s *Server) Watch(req *health.Request, w health.WatchServer) error {
 	service := req.GetService()
 	if strings.IsEmpty(service) {

--- a/transport/grpc/module.go
+++ b/transport/grpc/module.go
@@ -13,7 +13,7 @@ import (
 //
 //   - transport registration for TLS filesystem access ([Register])
 //   - server-side rate limiting wiring ([NewServerLimiter])
-//   - token access control and token service wiring ([NewController], [NewToken])
+//   - token access-controller construction and token service wiring ([NewController], [NewToken])
 //   - token generator/verifier adapters for interceptor wiring
 //     ([github.com/alexfalkowski/go-service/v2/transport/grpc/token.NewGenerator],
 //     [github.com/alexfalkowski/go-service/v2/transport/grpc/token.NewVerifier])

--- a/transport/grpc/telemetry/logger/doc.go
+++ b/transport/grpc/telemetry/logger/doc.go
@@ -1,7 +1,8 @@
 // Package logger provides gRPC logging interceptors and wiring for go-service.
 //
 // This package integrates request/response logging into gRPC servers and clients via interceptors.
-// Ignorable methods bypass logging.
+// Server interceptors skip operation methods such as gRPC health checks. Client interceptors log client
+// RPC outcomes unless callers add their own filtering in the client interceptor chain.
 //
 // Logged attributes include system ("grpc"), service/method (derived from the full method name),
 // duration, and gRPC status code. Log level is derived from the status code (see CodeToLevel).

--- a/transport/grpc/token.go
+++ b/transport/grpc/token.go
@@ -11,6 +11,8 @@ import (
 //
 // When token auth is enabled (via cfg.Token), the returned controller can be used to authorize
 // authenticated subjects against configured access rules.
+// NewController only builds the controller; the built-in gRPC token interceptors authenticate requests
+// and store the verified user id, but they do not call the controller or enforce authorization policy.
 //
 // If cfg is disabled, it returns (nil, nil) so downstream wiring can treat access control as not configured.
 func NewController(cfg *Config, fs *os.FS) (token.AccessController, error) {

--- a/transport/grpc/token/doc.go
+++ b/transport/grpc/token/doc.go
@@ -3,6 +3,11 @@
 // This package integrates token-based authentication into gRPC servers (verification interceptors)
 // and gRPC clients (outgoing Authorization metadata injection).
 //
+// Access-control config constructs an injectable [AccessController]. The built-in gRPC token
+// interceptors authenticate tokens and store the verified subject in metadata; they do not enforce
+// authorization policy automatically. Services that need authorization must call [AccessController.HasAccess]
+// from handlers or install their own interceptor using the verified user id.
+//
 // Start with [UnaryServerInterceptor] / [StreamServerInterceptor] for server-side verification and
 // [UnaryClientInterceptor] / [StreamClientInterceptor] for client-side injection.
 package token


### PR DESCRIPTION
## What

- Clarifies that the higher-level client constructor creates a lazy client channel and does not validate connection, resolver, or TLS handshake success at construction time.
- Documents health watch observer lookup, server-only operation logging bypass, and the token access-controller boundary.
- Adds README guidance that access config builds an injectable authorization controller, while built-in token middleware authenticates and stores the verified user id without enforcing policy automatically.

## Why

- Service authors need the transport documentation to reflect where startup validation, health observation, logging filters, and authorization enforcement actually happen.
- The previous wording could lead readers to assume client construction performed network validation or that Casbin policy was automatically enforced by transport token middleware.

## Testing

- `make package=transport/grpc golangci-lint` - passed
- `make package=transport/grpc specs` - passed
- `git diff --check` - passed
