### PR TITLE
docs(http): clarify retry-after threshold

### DIFF
--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -12,8 +12,8 @@
 // all attempts fail. When retries are triggered by transport errors, the original error is preserved.
 //
 // Retry-After handling: when a retryable HTTP response includes a valid Retry-After seconds value or HTTP-date
-// whose delay is greater than the configured backoff, the response is returned without another attempt. Invalid,
-// absent, elapsed, or shorter Retry-After values do not suppress a retry.
+// whose delay is greater than the minimum jittered backoff, the response is returned without another attempt.
+// Invalid, absent, elapsed, or shorter Retry-After values do not suppress a retry.
 //
 // Default policy: if no policy is passed to NewRoundTripper, only side-effect-safe requests are eligible for
 // retry. This includes safe HTTP methods and requests carrying a Request-Id. In go-service, Request-Id

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -95,9 +95,9 @@ var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
 //
 // Retry-After behavior:
-// Valid Retry-After seconds values or HTTP-date values greater than the configured backoff suppress the
-// retry and return the current response to the caller. Invalid, absent, elapsed, or smaller Retry-After
-// values do not suppress a retry.
+// Valid Retry-After seconds values or HTTP-date values greater than the minimum jittered backoff suppress the
+// retry and return the current response to the caller. Invalid, absent, elapsed, or smaller Retry-After values
+// do not suppress a retry.
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
 	return &RoundTripper{
 		RoundTripper: hrt,


### PR DESCRIPTION
## What

- Clarify HTTP retry GoDoc so Retry-After suppression is described in terms of the minimum jittered backoff.
- Keep the existing retry implementation and tests unchanged; this updates the public comments to match the behavior already covered by package tests.

## Why

- The previous wording said Retry-After was compared with the configured backoff, but the implementation and tests use the minimum jittered backoff threshold.
- Making the docs match the tested behavior avoids presenting a stale contract for callers tuning retry backoff behavior.

## Testing

- `go test ./transport/http/retry` - passed
- `make specs package=transport/http/retry` - passed
- `make lint` - passed
