### PR TITLE
feat(transport): share access policy across protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,24 +603,71 @@ Supported token `kind` values:
 
 ### Access control (Casbin)
 
-Access control is configured inside transport token config:
+Access control is configured once at the transport level and shared by all
+enabled HTTP and gRPC server stacks:
 
 ```yaml
 transport:
-  http:
-    token:
-      access:
-        model: file:./config/rbac.conf
-        policy: file:./config/rbac.csv
+  access:
+    model: file:./config/rbac.conf
+    policy: file:./config/rbac.csv
 ```
+
+When `access` is configured, the standard HTTP and gRPC server stacks enforce
+the policy after token authentication and before application handlers run. Omit
+`access` to leave transport authorization disabled.
 
 The model is based on Casbin RBAC:
 <https://github.com/casbin/casbin/blob/master/examples/rbac_model.conf>
 
+Example `rbac.conf`:
+
+```ini
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+```
+
+Policies use the verified user id as `sub`, `meta.TransportServiceMethod` as
+`obj`, and `invoke` as `act`. Example `rbac.csv`:
+
+```csv
+p, reader, http:GET /users/{id}, invoke
+p, writer, http:POST /users, invoke
+p, greeter, grpc:/greet.v1.GreeterService/SayHello, invoke
+g, frontend, reader
+g, admin, reader
+g, admin, writer
+g, billing-service, greeter
+```
+
+The `p` rows define permissions and must match the model's `p = sub, obj, act`
+shape, so they include `invoke`. The `g` rows define role membership and match
+`g = _, _`, so they only contain `subject, role`.
+
+For HTTP servers the object uses the matched route pattern when available, such
+as `http:GET /users/{id}`. HTTP tokens are authenticated against the concrete
+request method and path, such as `GET /users/123`; access policy enforcement
+uses the canonical route pattern. gRPC tokens are authenticated against the full
+method name, such as `/greet.v1.GreeterService/SayHello`; access policy
+enforcement uses the transport service-method object, such as
+`grpc:/greet.v1.GreeterService/SayHello`.
+
 > [!NOTE]
 > `access.model` and `access.policy` are resolved through `os.FS.ReadSource`; use `file:` for files, `env:` for environment-provided content, or literal content.
 >
-> Access config builds an injectable controller for authorization checks. The built-in HTTP and gRPC token middleware authenticates tokens and stores the verified user id, but it does not automatically enforce Casbin policy. Services must call `HasAccess(...)` from handlers or install their own authorization middleware/interceptors where policy enforcement is required.
+> Access config builds an injectable controller for authorization checks. The built-in HTTP and gRPC server stacks authenticate tokens, store the verified user id, and enforce the configured Casbin policy before application handlers run.
 
 ### JWT
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/structs"
 	"github.com/alexfalkowski/go-service/v2/telemetry"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
@@ -152,6 +153,13 @@ func pgConfig(cfg *Config) *pg.Config {
 func timeConfig(cfg *Config) *time.Config {
 	if cfg.Time.IsEnabled() {
 		return cfg.Time
+	}
+	return nil
+}
+
+func accessConfig(cfg *Config) *access.Config {
+	if cfg.Transport.IsEnabled() {
+		return cfg.Transport.Access
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -323,9 +323,9 @@ func verifyTimeConfig(t *testing.T, cfg *config.Config) {
 func verifyGRPCConfig(t *testing.T, cfg *config.Config) {
 	t.Helper()
 
+	require.Equal(t, "file:../test/configs/rbac.conf", cfg.Transport.Access.Model)
+	require.Equal(t, "file:../test/configs/rbac.csv", cfg.Transport.Access.Policy)
 	require.True(t, cfg.Transport.GRPC.Token.IsEnabled())
-	require.Equal(t, "file:../test/configs/rbac.conf", cfg.Transport.GRPC.Token.Access.Model)
-	require.Equal(t, "file:../test/configs/rbac.csv", cfg.Transport.GRPC.Token.Access.Policy)
 	require.Equal(t, "jwt", cfg.Transport.GRPC.Token.Kind)
 	require.Equal(t, time.Hour, cfg.Transport.GRPC.Token.JWT.Expiration)
 	require.Equal(t, "iss", cfg.Transport.GRPC.Token.JWT.Issuer)
@@ -362,8 +362,6 @@ func verifyHTTPConfig(t *testing.T, cfg *config.Config) {
 	t.Helper()
 
 	require.True(t, cfg.Transport.HTTP.Token.IsEnabled())
-	require.Equal(t, "file:../test/configs/rbac.conf", cfg.Transport.HTTP.Token.Access.Model)
-	require.Equal(t, "file:../test/configs/rbac.csv", cfg.Transport.HTTP.Token.Access.Policy)
 	require.Equal(t, "jwt", cfg.Transport.HTTP.Token.Kind)
 	require.Equal(t, time.Hour, cfg.Transport.HTTP.Token.JWT.Expiration)
 	require.Equal(t, "iss", cfg.Transport.HTTP.Token.JWT.Issuer)

--- a/config/module.go
+++ b/config/module.go
@@ -27,5 +27,5 @@ var Module = di.Module(
 	di.Constructor(debugConfig), di.Constructor(idConfig), di.Constructor(timeConfig),
 	di.Constructor(pgConfig), di.Constructor(featureConfig), di.Constructor(hooksConfig),
 	di.Constructor(loggerConfig), di.Constructor(tracerConfig), di.Constructor(metricsConfig),
-	di.Constructor(grpcConfig), di.Constructor(httpConfig),
+	di.Constructor(accessConfig), di.Constructor(grpcConfig), di.Constructor(httpConfig),
 )

--- a/internal/test/di.go
+++ b/internal/test/di.go
@@ -25,10 +25,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/time"
-	gt "github.com/alexfalkowski/go-service/v2/transport/grpc/token"
+	"github.com/alexfalkowski/go-service/v2/token/access"
+	grpctoken "github.com/alexfalkowski/go-service/v2/transport/grpc/token"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/events"
-	ht "github.com/alexfalkowski/go-service/v2/transport/http/token"
+	httptoken "github.com/alexfalkowski/go-service/v2/transport/http/token"
 	"github.com/open-feature/go-sdk/openfeature"
 	webhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
 )
@@ -148,9 +149,10 @@ func invokeEnvironment(_ env.Name, _ env.UserAgent, _ env.Version) {}
 
 func invokeNetwork(_ time.Network) {}
 
-func invokeAccessController(_ ht.AccessController, _ gt.AccessController) {}
+func invokeAccessController(_ access.Controller) {}
 
-func invokeTokens(_ ht.Generator, _ ht.Verifier, _ gt.Generator, _ gt.Verifier) {}
+func invokeTokens(_ httptoken.Generator, _ httptoken.Verifier, _ grpctoken.Generator, _ grpctoken.Verifier) {
+}
 
 func invokeDB(_ *sql.DBs) {}
 

--- a/internal/test/options.go
+++ b/internal/test/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/token"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
@@ -20,6 +21,7 @@ type WorldOption interface {
 
 type worldOpts struct {
 	verifier      token.Verifier
+	access        access.Controller
 	rt            http.RoundTripper
 	generator     token.Generator
 	logger        *logger.Logger
@@ -261,6 +263,13 @@ func WithWorldToken(generator token.Generator, verifier token.Verifier) WorldOpt
 	return worldOptionFunc(func(o *worldOpts) {
 		o.generator = generator
 		o.verifier = verifier
+	})
+}
+
+// WithWorldAccessController overrides the access controller used by world servers.
+func WithWorldAccessController(controller access.Controller) WorldOption {
+	return worldOptionFunc(func(o *worldOpts) {
+		o.access = controller
 	})
 }
 

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/token"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
@@ -26,6 +27,8 @@ type Server struct {
 	Meter metrics.Meter
 	// Verifier verifies inbound transport tokens.
 	Verifier token.Verifier
+	// Access controls inbound transport authorization.
+	Access access.Controller
 	// Mux holds HTTP routes registered by tests.
 	Mux *http.ServeMux
 	// HTTPServer is populated when RegisterHTTP is true.
@@ -77,7 +80,7 @@ func (s *Server) Register() error {
 			Logger:   s.Logger,
 			Limiter:  s.HTTPLimiter,
 			Handlers: []http.ChainedHandler{&EmptyHandler{}},
-			Verifier: s.Verifier, ID: s.Generator, UserID: UserID,
+			Verifier: s.Verifier, Access: s.Access, ID: s.Generator, UserID: UserID,
 			Name: Name, UserAgent: UserAgent, Version: Version,
 		}
 
@@ -96,7 +99,7 @@ func (s *Server) Register() error {
 			Shutdowner: sh,
 			Config:     s.TransportConfig.GRPC,
 			Logger:     s.Logger,
-			Verifier:   s.Verifier, ID: s.Generator, UserID: UserID,
+			Verifier:   s.Verifier, Access: s.Access, ID: s.Generator, UserID: UserID,
 			UserAgent: UserAgent, Version: Version,
 			Limiter: s.GRPCLimiter,
 		}

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -77,7 +77,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 		Meter: meter, Mux: mux,
 		GRPCLimiter: grpcServerLimiter,
 		HTTPLimiter: httpServerLimiter,
-		Verifier:    os.verifier, Generator: generator,
+		Verifier:    os.verifier, Access: os.access, Generator: generator,
 		RegisterHTTP: os.http, RegisterGRPC: os.grpc, RegisterDebug: os.debug,
 	}
 	require.NoError(tb, server.Register())

--- a/net/grpc/meta/meta.go
+++ b/net/grpc/meta/meta.go
@@ -71,6 +71,13 @@ func WithUserID(value meta.Value) Pair {
 	return meta.WithUserID(value)
 }
 
+// UserID returns the user ID attribute stored on ctx.
+//
+// If no value is present, it returns the zero-value [meta.Value].
+func UserID(ctx context.Context) meta.Value {
+	return meta.UserID(ctx)
+}
+
 // IPAddr returns the stored IP address attribute from ctx.
 //
 // If no value is present, it returns the zero-value [meta.Value].

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -98,7 +98,7 @@ func TestRoundTripperStoresServiceMethod(t *testing.T) {
 }
 
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
-	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -112,7 +112,7 @@ func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 }
 
 func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
-	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -125,21 +125,23 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 }
 
 func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
-	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /users/{id}", func(http.ResponseWriter, *http.Request) {})
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), mux)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)
-	req.Pattern = "GET /users/{id}"
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
 		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("GET /users/{id}"), meta.ServiceMethod(req.Context()))
+		require.Equal(t, "GET /users/{id}", req.Pattern)
 		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})
 }
 
 func TestHandlerStoresGeolocationAsIgnored(t *testing.T) {
-	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	handler := httpmeta.NewHandler(env.Name("service"), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	req.Header.Set("Geolocation", "geo:47,11")

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -17,9 +17,10 @@ import (
 //
 // The returned handler extracts request metadata into the request context and sets standard response headers.
 // It is designed to be used early in the server middleware chain so downstream middleware and handlers can
-// rely on a populated context (for example, logging, auth, rate limiting, and tracing).
-func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, generator id.Generator) *Handler {
-	return &Handler{name: name, userAgent: userAgent, serviceVersion: version.String(), generator: generator}
+// rely on a populated context (for example, logging, auth, rate limiting, and tracing). When mux is non-nil,
+// the handler uses it to resolve the matched route pattern before downstream middleware runs.
+func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, generator id.Generator, mux *http.ServeMux) *Handler {
+	return &Handler{name: name, userAgent: userAgent, serviceVersion: version.String(), generator: generator, mux: mux}
 }
 
 // Handler extracts request metadata and stores it in the request context.
@@ -29,6 +30,7 @@ func NewHandler(name env.Name, userAgent env.UserAgent, version env.Version, gen
 // parseable).
 type Handler struct {
 	generator      id.Generator
+	mux            *http.ServeMux
 	name           env.Name
 	userAgent      env.UserAgent
 	serviceVersion string
@@ -81,7 +83,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		meta.WithTransport(meta.Ignored("http")),
 		meta.WithUserAgent(userAgent),
 		meta.WithRequestID(requestID),
-		meta.WithServiceMethod(serverServiceMethod(req)),
+		meta.WithServiceMethod(serverServiceMethod(h.mux, req)),
 		meta.WithIPAddr(ip),
 		meta.WithIPAddrKind(kind),
 		meta.WithGeolocation(geolocation),
@@ -123,9 +125,16 @@ func serverRequestID(ctx context.Context, generator id.Generator, req *http.Requ
 	return meta.String(generator.Generate())
 }
 
-func serverServiceMethod(req *http.Request) meta.Value {
+func serverServiceMethod(mux *http.ServeMux, req *http.Request) meta.Value {
 	if !strings.IsEmpty(req.Pattern) {
 		return meta.Ignored(req.Pattern)
+	}
+
+	if mux != nil {
+		if _, pattern := mux.Handler(req); !strings.IsEmpty(pattern) {
+			req.Pattern = pattern
+			return meta.Ignored(pattern)
+		}
 	}
 
 	return meta.Ignored(req.URL.Path)

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -88,6 +88,10 @@
     address: "time.cloudflare.com"
   }
   transport: {
+    access: {
+      model: "file:../test/configs/rbac.conf"
+      policy: "file:../test/configs/rbac.csv"
+    }
     http: {
       address: "tcp://localhost:11000"
       max_receive_size: 2MB
@@ -105,10 +109,6 @@
       }
       timeout: "10s"
       token: {
-        access: {
-          model: "file:../test/configs/rbac.conf"
-          policy: "file:../test/configs/rbac.csv"
-        }
         kind: jwt
         jwt: {
           iss: iss
@@ -146,10 +146,6 @@
       }
       timeout: "10s"
       token: {
-        access: {
-          model: "file:../test/configs/rbac.conf"
-          policy: "file:../test/configs/rbac.csv"
-        }
         kind: jwt
         jwt: {
           iss: iss

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -75,6 +75,10 @@ Authorization = "file:../test/secrets/telemetry"
 kind = "nts"
 address = "time.cloudflare.com"
 
+[transport.access]
+model = "file:../test/configs/rbac.conf"
+policy = "file:../test/configs/rbac.csv"
+
 [transport.http]
 address = "tcp://localhost:11000"
 max_receive_size = "2MB"
@@ -94,10 +98,6 @@ max_header_bytes = "32KB"
 
 [transport.http.token]
 kind = "jwt"
-
-[transport.http.token.access]
-model = "file:../test/configs/rbac.conf"
-policy = "file:../test/configs/rbac.csv"
 
 [transport.http.token.jwt]
 iss = "iss"
@@ -133,10 +133,6 @@ max_send_msg_size = "8MB"
 
 [transport.grpc.token]
 kind = "jwt"
-
-[transport.grpc.token.access]
-model = "file:../test/configs/rbac.conf"
-policy = "file:../test/configs/rbac.csv"
 
 [transport.grpc.token.jwt]
 iss = "iss"

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -59,6 +59,9 @@ time:
   kind: nts
   address: time.cloudflare.com
 transport:
+  access:
+    model: file:../test/configs/rbac.conf
+    policy: file:../test/configs/rbac.csv
   http:
     address: tcp://localhost:11000
     max_receive_size: 2MB
@@ -74,9 +77,6 @@ transport:
       max_header_bytes: 32KB
     timeout: 10s
     token:
-      access:
-        model: file:../test/configs/rbac.conf
-        policy: file:../test/configs/rbac.csv
       kind: "jwt"
       jwt:
         iss: "iss"
@@ -107,9 +107,6 @@ transport:
       max_send_msg_size: 8MB
     timeout: 10s
     token:
-      access:
-        model: file:../test/configs/rbac.conf
-        policy: file:../test/configs/rbac.csv
       kind: "jwt"
       jwt:
         iss: "iss"

--- a/test/configs/rbac.csv
+++ b/test/configs/rbac.csv
@@ -1,2 +1,2 @@
-p, alice, service, read
-p, bob, service, write
+p, frontend, grpc:/greet.v1.GreeterService/SayHello, invoke
+p, admin-api, grpc:/greet.v1.GreeterService/ListGreetings, invoke

--- a/token/access/access.go
+++ b/token/access/access.go
@@ -1,21 +1,28 @@
 package access
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	persist "github.com/casbin/casbin/v2/persist/string-adapter"
 )
 
-// Controller answers authorization questions for a user, system, and action.
+// ErrAccessDenied is returned by transport integrations when a policy denies access.
+var ErrAccessDenied = errors.New("access: transport policy denied")
+
+// Controller answers authorization questions for request contexts.
 //
 // Implementations typically evaluate a policy and return whether the permission is
 // granted, along with any evaluation/IO error.
 type Controller interface {
-	// HasAccess reports whether user is allowed to perform action on system.
+	// HasAccess reports whether the context's verified user id is allowed to invoke the context's
+	// transport service-method.
 	// The returned bool indicates whether access is granted. If an error is
 	// returned, the boolean result should not be trusted.
-	HasAccess(user, system, action string) (bool, error)
+	HasAccess(ctx context.Context) (bool, error)
 }
 
 // NewController constructs a Controller from cfg.
@@ -61,11 +68,10 @@ type CasbinController struct {
 	enforcer *casbin.Enforcer
 }
 
-// HasAccess evaluates whether user is allowed to perform action on system.
+// HasAccess evaluates the request context using the controller's configured policy.
 //
-// It calls the configured Casbin enforcer as:
-//
-//	c.enforcer.Enforce(user, system, action)
-func (c *CasbinController) HasAccess(user, system, action string) (bool, error) {
-	return c.enforcer.Enforce(user, system, action)
+// The context is expected to contain a verified user id and transport service-method metadata, as populated
+// by the standard HTTP and gRPC transport middleware.
+func (c *CasbinController) HasAccess(ctx context.Context) (bool, error) {
+	return c.enforcer.Enforce(meta.UserID(ctx).Value(), meta.TransportServiceMethod(ctx).Value(), "invoke")
 }

--- a/token/access/access_test.go
+++ b/token/access/access_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/stretchr/testify/require"
@@ -28,26 +29,50 @@ func TestHasAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name   string
-		user   string
-		system string
-		action string
-		access bool
+		name          string
+		user          string
+		transport     string
+		serviceMethod string
+		access        bool
 	}{
-		{name: "allowed read", user: "alice", system: "service", action: "read", access: true},
-		{name: "denied wrong action", user: "alice", system: "service", action: "write"},
-		{name: "denied wrong user", user: "bob", system: "service", action: "read"},
-		{name: "denied unknown user", user: "carol", system: "service", action: "read"},
-		{name: "denied unknown system", user: "alice", system: "other", action: "read"},
+		{name: "allowed say hello", user: "frontend", transport: "grpc", serviceMethod: "/greet.v1.GreeterService/SayHello", access: true},
+		{name: "denied wrong method", user: "frontend", transport: "grpc", serviceMethod: "/greet.v1.GreeterService/ListGreetings"},
+		{name: "denied wrong user", user: "admin-api", transport: "grpc", serviceMethod: "/greet.v1.GreeterService/SayHello"},
+		{name: "denied unknown user", user: "guest", transport: "grpc", serviceMethod: "/greet.v1.GreeterService/SayHello"},
+		{name: "denied unknown transport", user: "frontend", transport: "http", serviceMethod: "/greet.v1.GreeterService/SayHello"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ok, err := controller.HasAccess(tt.user, tt.system, tt.action)
+			ctx := meta.WithAttributes(t.Context(),
+				meta.WithUserID(meta.String(tt.user)),
+				meta.WithTransport(meta.String(tt.transport)),
+				meta.WithServiceMethod(meta.String(tt.serviceMethod)),
+			)
+
+			ok, err := controller.HasAccess(ctx)
 			require.NoError(t, err)
 			require.Equal(t, tt.access, ok)
 		})
 	}
+}
+
+func TestHasAccessUsesTransportServiceMethod(t *testing.T) {
+	controller, err := access.NewController(&access.Config{
+		Model:  test.FilePath("configs/rbac.conf"),
+		Policy: "p, frontend, http:GET /users/{id}, invoke",
+	}, test.FS)
+	require.NoError(t, err)
+
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithUserID(meta.String("frontend")),
+		meta.WithTransport(meta.String("http")),
+		meta.WithServiceMethod(meta.String("GET /users/{id}")),
+	)
+
+	ok, err := controller.HasAccess(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestNewControllerErrors(t *testing.T) {
@@ -116,7 +141,13 @@ func TestHasAccessWithEnvSources(t *testing.T) {
 	}, test.FS)
 	require.NoError(t, err)
 
-	ok, err := controller.HasAccess("alice", "service", "read")
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithUserID(meta.String("frontend")),
+		meta.WithTransport(meta.String("grpc")),
+		meta.WithServiceMethod(meta.String("/greet.v1.GreeterService/SayHello")),
+	)
+
+	ok, err := controller.HasAccess(ctx)
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -134,7 +165,13 @@ func TestHasAccessWithLiteralSources(t *testing.T) {
 	}, test.FS)
 	require.NoError(t, err)
 
-	ok, err := controller.HasAccess("alice", "service", "read")
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithUserID(meta.String("frontend")),
+		meta.WithTransport(meta.String("grpc")),
+		meta.WithServiceMethod(meta.String("/greet.v1.GreeterService/SayHello")),
+	)
+
+	ok, err := controller.HasAccess(ctx)
 	require.NoError(t, err)
 	require.True(t, ok)
 }

--- a/token/access/config.go
+++ b/token/access/config.go
@@ -2,10 +2,11 @@ package access
 
 import "github.com/alexfalkowski/go-service/v2/os"
 
-// Config configures access control model and policy loading for the access Controller.
+// Config configures access-control model and policy loading for the access Controller.
 //
 // The config is consumed by NewController, which constructs a Casbin-backed
-// controller/enforcer using the configured model and policy sources.
+// controller/enforcer using the configured model and policy sources. The standard HTTP and gRPC transport
+// stacks enforce a configured controller after token authentication.
 //
 // # Model and policy sources
 //

--- a/token/access/doc.go
+++ b/token/access/doc.go
@@ -1,16 +1,24 @@
 // Package access provides authorization (access control) helpers used by go-service.
 //
-// This package is focused on answering the question "is subject X allowed to do Y?"
-// based on an authorization policy. It currently provides:
+// This package is focused on answering the question "is the verified request
+// subject allowed to invoke this transport operation?" based on an authorization
+// policy. It currently provides:
 //
 //   - Controller: an interface for permission checks.
 //   - A Casbin-backed implementation of Controller.
 //
 // # Access checks
 //
-// [Controller.HasAccess] expects separate user, system, and action values. The
-// implementation treats system as the authorization object and action as the
-// operation being requested.
+// [Controller.HasAccess] expects a request context populated by the transport
+// metadata middleware. The Casbin request tuple is:
+//
+//   - sub: [github.com/alexfalkowski/go-service/v2/meta.UserID]
+//   - obj: [github.com/alexfalkowski/go-service/v2/meta.TransportServiceMethod]
+//   - act: "invoke"
+//
+// HTTP servers use the matched route pattern as the service-method when one is
+// available, for example "http:GET /users/{id}". gRPC servers use the full RPC
+// method, for example "grpc:/package.Service/Method".
 //
 // # Casbin implementation
 //

--- a/token/config.go
+++ b/token/config.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/token/jwt"
 	"github.com/alexfalkowski/go-service/v2/token/paseto"
 	"github.com/alexfalkowski/go-service/v2/token/ssh"
@@ -33,20 +32,7 @@ import (
 //
 // If Kind is unknown, the token facade treats the configuration as invalid and
 // [Token.Generate]/[Token.Verify] return [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig].
-//
-// # Access control (Access)
-//
-// Access configures optional access-control policy wiring (see package
-// token/access). It is orthogonal to the token kind: some services may use token
-// verification to establish identity (subject) and then evaluate permissions via
-// Access.
 type Config struct {
-	// Access configures access control policy used by token/access.
-	//
-	// This is used to answer authorization checks (for example "user has permission X")
-	// and is typically used in addition to authentication (token verification).
-	Access *access.Config `yaml:"access,omitempty" json:"access,omitempty" toml:"access,omitempty"`
-
 	// JWT configures the JWT token implementation.
 	//
 	// When Kind == "jwt", this configuration is consumed by token/jwt.

--- a/transport/access.go
+++ b/transport/access.go
@@ -1,0 +1,14 @@
+package transport
+
+import (
+	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/token/access"
+)
+
+// NewAccessController constructs the shared transport access controller.
+//
+// If transport config or access config is omitted, it returns (nil, nil) so server stacks can treat access
+// control as disabled. When configured, the returned controller is shared by the HTTP and gRPC server stacks.
+func NewAccessController(cfg *access.Config, fs *os.FS) (access.Controller, error) {
+	return access.NewController(cfg, fs)
+}

--- a/transport/access_test.go
+++ b/transport/access_test.go
@@ -1,0 +1,21 @@
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/transport"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAccessControllerWithoutAccessConfig(t *testing.T) {
+	controller, err := transport.NewAccessController(nil, test.FS)
+	require.NoError(t, err)
+	require.Nil(t, controller)
+}
+
+func TestNewAccessControllerWithAccessConfig(t *testing.T) {
+	controller, err := transport.NewAccessController(test.NewAccessConfig(), test.FS)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+}

--- a/transport/config.go
+++ b/transport/config.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 )
@@ -18,6 +19,14 @@ import (
 //
 // The struct tags are compatible with the repository's config decoder (YAML/JSON/TOML).
 type Config struct {
+	// Access configures shared authorization policy for all enabled transport server stacks.
+	//
+	// When nil, transport access control is disabled. When configured, the same controller is injected into
+	// HTTP and gRPC server middleware/interceptors, and policies distinguish protocols through
+	// meta.TransportServiceMethod values such as "http:GET /users/{id}" or
+	// "grpc:/package.Service/Method".
+	Access *access.Config `yaml:"access,omitempty" json:"access,omitempty" toml:"access,omitempty"`
+
 	// GRPC configures the gRPC server transport stack.
 	//
 	// When nil or when the nested config is disabled, gRPC transport wiring is effectively

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/token"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	"github.com/stretchr/testify/require"
 )
@@ -156,6 +157,30 @@ func TestValidAuthUnary(t *testing.T) {
 			require.Equal(t, "Hello test", resp.GetMessage())
 		})
 	}
+}
+
+func TestAccessDeniedUnary(t *testing.T) {
+	controller, err := access.NewController(&access.Config{
+		Model:  test.FilePath("configs/rbac.conf"),
+		Policy: "p, " + test.UserID.String() + ", grpc:/greet.v1.GreeterService/Other, invoke",
+	}, test.FS)
+	require.NoError(t, err)
+
+	world := test.NewStartedWorld(t,
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldToken(test.NewGenerator("test", nil), test.NewVerifier("test")),
+		test.WithWorldAccessController(controller),
+		test.WithWorldGRPC(),
+	)
+
+	conn := test.RequireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+	req := &v1.SayHelloRequest{Name: "test"}
+
+	_, err = client.SayHello(t.Context(), req)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
 func TestUnknownTokenKindAuthUnary(t *testing.T) {

--- a/transport/grpc/module.go
+++ b/transport/grpc/module.go
@@ -13,7 +13,7 @@ import (
 //
 //   - transport registration for TLS filesystem access ([Register])
 //   - server-side rate limiting wiring ([NewServerLimiter])
-//   - token access-controller construction and token service wiring ([NewController], [NewToken])
+//   - token service wiring ([NewToken])
 //   - token generator/verifier adapters for interceptor wiring
 //     ([github.com/alexfalkowski/go-service/v2/transport/grpc/token.NewGenerator],
 //     [github.com/alexfalkowski/go-service/v2/transport/grpc/token.NewVerifier])
@@ -25,7 +25,6 @@ import (
 var Module = di.Module(
 	di.Register(Register),
 	di.Constructor(NewServerLimiter),
-	di.Constructor(NewController),
 	di.Constructor(NewToken),
 	di.Constructor(token.NewGenerator),
 	di.Constructor(token.NewVerifier),

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
@@ -32,6 +33,7 @@ import (
 //   - `Logger`: enables server-side RPC outcome logging when non-nil.
 //   - `Limiter`: enables server-side rate limiting when non-nil.
 //   - `Verifier`: enables server-side token verification when non-nil.
+//   - `Access`: enables server-side access control when non-nil.
 //   - `Unary`/`Stream`: allow callers to inject additional interceptors (and are optional in DI).
 type ServerParams struct {
 	di.In
@@ -63,6 +65,9 @@ type ServerParams struct {
 	// Verifier enables server-side token verification when non-nil.
 	Verifier token.Verifier
 
+	// Access enables server-side access control when non-nil.
+	Access access.Controller
+
 	// Unary are additional unary server interceptors to append after the standard chain.
 	Unary []grpc.UnaryServerInterceptor `optional:"true"`
 
@@ -78,10 +83,10 @@ type ServerParams struct {
 // The constructed server includes:
 //   - OpenTelemetry stats handling when tracing or metrics are enabled.
 //   - A unary interceptor chain that performs metadata extraction/injection, applies the configured
-//     server timeout, and optionally logging, token verification, and rate limiting, followed by any
-//     user-provided interceptors.
+//     server timeout, and optionally logging, token verification, rate limiting, and access control,
+//     followed by any user-provided interceptors.
 //   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging,
-//     token verification, and rate limiting, followed by any user-provided interceptors.
+//     token verification, rate limiting, and access control, followed by any user-provided interceptors.
 //
 // TLS:
 // If TLS is enabled in config, server credentials are built from `params.Config.TLS`. Certificate/key
@@ -176,6 +181,10 @@ func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInte
 		uis = append(uis, limiter.UnaryServerInterceptor(params.Limiter))
 	}
 
+	if params.Access != nil {
+		uis = append(uis, token.UnaryAccessServerInterceptor(params.Access))
+	}
+
 	uis = append(uis, interceptors...)
 
 	return grpc.ChainUnaryInterceptor(uis...)
@@ -194,6 +203,10 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 
 	if params.Limiter != nil {
 		sis = append(sis, limiter.StreamServerInterceptor(params.Limiter))
+	}
+
+	if params.Access != nil {
+		sis = append(sis, token.StreamAccessServerInterceptor(params.Access))
 	}
 
 	sis = append(sis, interceptors...)

--- a/transport/grpc/token.go
+++ b/transport/grpc/token.go
@@ -7,21 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
 )
 
-// NewController constructs an access controller for gRPC token authorization.
-//
-// When token auth is enabled (via cfg.Token), the returned controller can be used to authorize
-// authenticated subjects against configured access rules.
-// NewController only builds the controller; the built-in gRPC token interceptors authenticate requests
-// and store the verified user id, but they do not call the controller or enforce authorization policy.
-//
-// If cfg is disabled, it returns (nil, nil) so downstream wiring can treat access control as not configured.
-func NewController(cfg *Config, fs *os.FS) (token.AccessController, error) {
-	if !cfg.IsEnabled() || !cfg.Token.IsEnabled() {
-		return nil, nil
-	}
-	return token.NewAccessController(cfg.Token, fs)
-}
-
 // NewToken constructs a token service for gRPC transport integration.
 //
 // The returned service is responsible for generating and verifying tokens according to cfg.Token (for example,

--- a/transport/grpc/token/doc.go
+++ b/transport/grpc/token/doc.go
@@ -3,11 +3,12 @@
 // This package integrates token-based authentication into gRPC servers (verification interceptors)
 // and gRPC clients (outgoing Authorization metadata injection).
 //
-// Access-control config constructs an injectable [AccessController]. The built-in gRPC token
-// interceptors authenticate tokens and store the verified subject in metadata; they do not enforce
-// authorization policy automatically. Services that need authorization must call [AccessController.HasAccess]
-// from handlers or install their own interceptor using the verified user id.
+// Shared transport access-control config constructs an injectable controller. The built-in gRPC token
+// verification interceptors authenticate tokens and store the verified subject in metadata. The built-in
+// access interceptors enforce configured authorization policy using that subject and the transport
+// service-method.
 //
 // Start with [UnaryServerInterceptor] / [StreamServerInterceptor] for server-side verification and
-// [UnaryClientInterceptor] / [StreamClientInterceptor] for client-side injection.
+// [UnaryAccessServerInterceptor] / [StreamAccessServerInterceptor] for server-side authorization.
+// Use [UnaryClientInterceptor] / [StreamClientInterceptor] for client-side injection.
 package token

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -17,23 +17,6 @@ import (
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 )
 
-// NewAccessController constructs an access controller when token auth is enabled.
-//
-// The controller is responsible for evaluating access rules associated with token-authenticated subjects.
-// If cfg is disabled, it returns (nil, nil) so callers can treat access control as not configured.
-func NewAccessController(cfg *token.Config, fs *os.FS) (AccessController, error) {
-	if !cfg.IsEnabled() {
-		return nil, nil
-	}
-	return access.NewController(cfg.Access, fs)
-}
-
-// AccessController is an alias for [github.com/alexfalkowski/go-service/v2/token/access.Controller].
-//
-// It is exposed from this package so callers can refer to the access controller type from the gRPC token
-// integration layer.
-type AccessController access.Controller
-
 // NewToken constructs a token service when token auth is enabled.
 //
 // The returned service is responsible for generating and verifying tokens according to cfg (for example,
@@ -137,6 +120,61 @@ func StreamServerInterceptor(id env.UserID, verifier Verifier) grpc.StreamServer
 		wrapped.WrappedContext = ctx
 
 		return handler(srv, wrapped)
+	}
+}
+
+// UnaryAccessServerInterceptor returns a gRPC unary server interceptor that enforces access policy.
+//
+// Operation RPC methods bypass access control. For application RPCs, a missing verified user id is treated
+// as unauthenticated, a policy denial returns [codes.PermissionDenied], and policy evaluation errors return
+// [codes.Internal].
+func UnaryAccessServerInterceptor(controller access.Controller) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if strings.IsOperationMethod(info.FullMethod) {
+			return handler(ctx, req)
+		}
+
+		if meta.UserID(ctx).IsEmpty() {
+			return nil, status.SafeError(codes.Unauthenticated, header.ErrInvalidAuthorization)
+		}
+
+		ok, err := controller.HasAccess(ctx)
+		if err != nil {
+			return nil, status.SafeError(codes.Internal, err)
+		}
+		if !ok {
+			return nil, status.SafeError(codes.PermissionDenied, access.ErrAccessDenied)
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// StreamAccessServerInterceptor returns a gRPC stream server interceptor that enforces access policy.
+//
+// Operation RPC methods bypass access control. For application RPCs, a missing verified user id is treated
+// as unauthenticated, a policy denial returns [codes.PermissionDenied], and policy evaluation errors return
+// [codes.Internal].
+func StreamAccessServerInterceptor(controller access.Controller) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if strings.IsOperationMethod(info.FullMethod) {
+			return handler(srv, stream)
+		}
+
+		ctx := stream.Context()
+		if meta.UserID(ctx).IsEmpty() {
+			return status.SafeError(codes.Unauthenticated, header.ErrInvalidAuthorization)
+		}
+
+		ok, err := controller.HasAccess(ctx)
+		if err != nil {
+			return status.SafeError(codes.Internal, err)
+		}
+		if !ok {
+			return status.SafeError(codes.PermissionDenied, access.ErrAccessDenied)
+		}
+
+		return handler(srv, stream)
 	}
 }
 

--- a/transport/grpc/token/token_test.go
+++ b/transport/grpc/token/token_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
 	"github.com/stretchr/testify/require"
 )
@@ -43,8 +46,104 @@ func TestStreamClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 	require.Nil(t, stream)
 }
 
+func TestUnaryAccessServerInterceptor(t *testing.T) {
+	for _, tt := range accessServerTests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.user != "" {
+				ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.String(tt.user)))
+			}
+			interceptor := token.UnaryAccessServerInterceptor(tt.controller)
+			called := false
+
+			_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: tt.method}, func(context.Context, any) (any, error) {
+				called = true
+				return nil, nil
+			})
+
+			require.Equal(t, tt.code, status.Code(err))
+			require.Equal(t, tt.called, called)
+		})
+	}
+}
+
+func TestStreamAccessServerInterceptor(t *testing.T) {
+	for _, tt := range accessServerTests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.user != "" {
+				ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.String(tt.user)))
+			}
+			interceptor := token.StreamAccessServerInterceptor(tt.controller)
+			stream := &test.MetaServerStream{Ctx: ctx}
+			called := false
+
+			err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: tt.method}, func(any, grpc.ServerStream) error {
+				called = true
+				return nil
+			})
+
+			require.Equal(t, tt.code, status.Code(err))
+			require.Equal(t, tt.called, called)
+		})
+	}
+}
+
 type staticTokenGenerator string
 
 func (g staticTokenGenerator) Generate(_, _ string) ([]byte, error) {
 	return []byte(g), nil
+}
+
+type accessServerTest struct {
+	controller accessControllerFunc
+	method     string
+	name       string
+	user       string
+	code       codes.Code
+	called     bool
+}
+
+var accessServerTests = []accessServerTest{
+	{
+		name:       "operation method bypasses access",
+		method:     "/grpc.health.v1.Health/Check",
+		code:       codes.OK,
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return false, test.ErrInvalid }),
+		called:     true,
+	},
+	{
+		name:       "missing user id is unauthenticated",
+		method:     "/greet.v1.GreeterService/SayHello",
+		code:       codes.Unauthenticated,
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return true, nil }),
+	},
+	{
+		name:       "controller error is internal",
+		method:     "/greet.v1.GreeterService/SayHello",
+		code:       codes.Internal,
+		user:       "frontend",
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return false, test.ErrInvalid }),
+	},
+	{
+		name:       "access denial is permission denied",
+		method:     "/greet.v1.GreeterService/SayHello",
+		code:       codes.PermissionDenied,
+		user:       "frontend",
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return false, nil }),
+	},
+	{
+		name:       "access grant calls handler",
+		method:     "/greet.v1.GreeterService/SayHello",
+		code:       codes.OK,
+		user:       "frontend",
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return true, nil }),
+		called:     true,
+	},
+}
+
+type accessControllerFunc func(context.Context) (bool, error)
+
+func (f accessControllerFunc) HasAccess(ctx context.Context) (bool, error) {
+	return f(ctx)
 }

--- a/transport/grpc/token_test.go
+++ b/transport/grpc/token_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewControllerWithoutTokenConfig(t *testing.T) {
-	controller, err := grpc.NewController(test.NewGRPCTransportConfig(), test.FS)
-	require.NoError(t, err)
-	require.Nil(t, controller)
-}
-
 func TestNewTokenWithoutTokenConfig(t *testing.T) {
 	tkn := grpc.NewToken(test.Name, test.NewGRPCTransportConfig(), nil, nil)
 	require.Nil(t, tkn)

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/token"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,6 +80,33 @@ func TestValidAuthUnary(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.NotEmpty(t, body)
+}
+
+func TestAccessDeniedUnary(t *testing.T) {
+	controller, err := access.NewController(&access.Config{
+		Model:  test.FilePath("configs/rbac.conf"),
+		Policy: "p, " + test.UserID.String() + ", http:POST /other, invoke",
+	}, test.FS)
+	require.NoError(t, err)
+
+	world := test.NewStartedWorld(t,
+		test.WithWorldTelemetry("otlp"),
+		test.WithWorldToken(test.NewGenerator("test", nil), test.NewVerifier("test")),
+		test.WithWorldAccessController(controller),
+		test.WithWorldHTTP(),
+	)
+
+	rpc.Route("/hello", test.SuccessSayHello)
+
+	header := http.Header{}
+	header.Set(content.TypeKey, media.JSON)
+
+	url := world.PathServerURL("http", "hello")
+
+	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, res.StatusCode)
+	require.Equal(t, "http: forbidden", body)
 }
 
 func TestAuthDoesNotBypassApplicationMetricsPath(t *testing.T) {

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -35,7 +35,6 @@ var Module = di.Module(
 	di.Register(rpc.Register),
 	di.Register(rest.Register),
 	di.Constructor(NewServerLimiter),
-	di.Constructor(NewController),
 	di.Constructor(NewToken),
 	di.Constructor(token.NewGenerator),
 	di.Constructor(token.NewVerifier),

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/http/body"
 	"github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
@@ -33,6 +34,7 @@ import (
 //   - `Logger`: enables server-side request logging middleware when non-nil.
 //   - `Limiter`: enables server-side rate limiting middleware when non-nil.
 //   - `Verifier`: enables server-side token verification middleware when non-nil.
+//   - `Access`: enables server-side access control middleware when non-nil.
 //   - `Handlers`: allows callers to inject additional chained middleware (and is optional in DI).
 type ServerParams struct {
 	di.In
@@ -73,6 +75,9 @@ type ServerParams struct {
 	// Verifier enables server-side token verification middleware when non-nil.
 	Verifier token.Verifier
 
+	// Access enables server-side access control middleware when non-nil.
+	Access access.Controller
+
 	// Handlers are additional chained handlers to insert into the middleware chain.
 	//
 	// These handlers are applied in the order provided.
@@ -91,10 +96,11 @@ type ServerParams struct {
 //
 // The server is built using Negroni and composes middleware in this order inside that instrumentation wrapper
 // (first listed runs first):
-//   - metadata extraction/injection and response headers ([github.com/alexfalkowski/go-service/v2/net/http/meta])
+//   - metadata extraction/injection, route-pattern resolution, and response headers ([github.com/alexfalkowski/go-service/v2/net/http/meta])
 //   - optional logging ([github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger]) when `params.Logger` is non-nil
 //   - optional token verification ([github.com/alexfalkowski/go-service/v2/transport/http/token]) when `params.Verifier` is non-nil
 //   - optional rate limiting ([github.com/alexfalkowski/go-service/v2/transport/http/limiter]) when `params.Limiter` is non-nil
+//   - optional access control ([github.com/alexfalkowski/go-service/v2/transport/http/token]) when `params.Access` is non-nil
 //   - inbound request body size limiting ([github.com/alexfalkowski/go-service/v2/transport/http/body])
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - gzip compression wrapping the final mux handler, including not-found fallbacks ([github.com/klauspost/compress/gzhttp.GzipHandler] with [http.NewNotFoundHandler])
@@ -121,7 +127,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	}
 
 	neg := NewChainedHandlers()
-	neg.Use(meta.NewHandler(params.Name, params.UserAgent, params.Version, params.ID))
+	neg.Use(meta.NewHandler(params.Name, params.UserAgent, params.Version, params.ID, params.Mux))
 
 	if params.Logger != nil {
 		neg.Use(logger.NewHandler(params.Name, params.Logger))
@@ -133,6 +139,10 @@ func NewServer(params ServerParams) (*Server, error) {
 
 	if params.Limiter != nil {
 		neg.Use(limiter.NewHandler(params.Name, params.Limiter))
+	}
+
+	if params.Access != nil {
+		neg.Use(token.NewAccessHandler(params.Name, params.Access))
 	}
 
 	neg.Use(body.NewHandler(params.Config.GetMaxReceiveSize().Bytes()))

--- a/transport/http/token.go
+++ b/transport/http/token.go
@@ -7,19 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 )
 
-// NewController constructs an access controller for HTTP token authorization.
-//
-// When token auth is enabled (via cfg.Token), the returned controller can be used to authorize
-// authenticated subjects against configured access rules.
-//
-// If cfg is disabled, it returns (nil, nil) so downstream wiring can treat access control as not configured.
-func NewController(cfg *Config, fs *os.FS) (token.AccessController, error) {
-	if !cfg.IsEnabled() || !cfg.Token.IsEnabled() {
-		return nil, nil
-	}
-	return token.NewAccessController(cfg.Token, fs)
-}
-
 // NewToken constructs a token service for HTTP transport integration.
 //
 // The returned service is responsible for generating and verifying tokens according to cfg.Token (for example,

--- a/transport/http/token/doc.go
+++ b/transport/http/token/doc.go
@@ -1,7 +1,9 @@
 // Package token provides HTTP token middleware and wiring for go-service.
 //
-// This package integrates token-based authentication into HTTP servers (verification middleware)
-// and HTTP clients (Authorization header injection).
+// This package integrates token-based authentication into HTTP servers (verification middleware),
+// token-based authorization into HTTP servers (access-control middleware), and HTTP clients
+// (Authorization header injection).
 //
-// Start with [NewHandler] for server-side verification and [NewRoundTripper] for client-side injection.
+// Start with [NewHandler] for server-side verification, [NewAccessHandler] for server-side access control,
+// and [NewRoundTripper] for client-side injection.
 package token

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -14,24 +14,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/token/access"
 )
 
-// NewAccessController constructs an access controller when token auth is enabled.
-//
-// The controller is responsible for evaluating access rules associated with token-authenticated subjects.
-//
-// If cfg is disabled, it returns (nil, nil) so callers can treat access control as not configured.
-func NewAccessController(cfg *token.Config, fs *os.FS) (AccessController, error) {
-	if !cfg.IsEnabled() {
-		return nil, nil
-	}
-	return access.NewController(cfg.Access, fs)
-}
-
-// AccessController is an alias for [github.com/alexfalkowski/go-service/v2/token/access.Controller].
-//
-// It is exposed from this package so callers can refer to the access controller type from the HTTP token
-// integration layer.
-type AccessController access.Controller
-
 // NewToken constructs a token service when token auth is enabled.
 //
 // The returned service is responsible for generating and verifying tokens according to cfg (for example,
@@ -89,7 +71,7 @@ type Handler struct {
 // Service-owned operation paths (health/metrics/etc.) bypass verification (see [github.com/alexfalkowski/go-service/v2/net/http/strings.IsOperationPath]).
 //
 // The handler expects an Authorization value to be available in the request context (typically injected by
-// [github.com/alexfalkowski/go-service/v2/net/http/meta.Handler]). It verifies the token using verifier, scoping verification to the request path.
+// [github.com/alexfalkowski/go-service/v2/net/http/meta.Handler]). It verifies the token using verifier, scoping verification to the request method and path.
 //
 // Behavior:
 //   - If verification fails, it writes an HTTP 401 error response and does not call next.
@@ -105,7 +87,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	ctx := req.Context()
 	auth := meta.Authorization(ctx).Value()
 
-	sub, err := h.verifier.Verify(strings.Bytes(auth), req.URL.Path)
+	sub, err := h.verifier.Verify(strings.Bytes(auth), audience(req))
 	if err != nil {
 		_ = status.WriteError(res, status.UnauthorizedError(err))
 		return
@@ -113,6 +95,49 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 
 	ctx = meta.WithAttributes(ctx, meta.WithUserID(meta.Ignored(sub)))
 	next(res, req.WithContext(ctx))
+}
+
+// NewAccessHandler constructs server-side access-control middleware.
+//
+// Callers should only install this handler when controller is non-nil.
+func NewAccessHandler(name env.Name, controller access.Controller) *AccessHandler {
+	return &AccessHandler{name: name, controller: controller}
+}
+
+// AccessHandler enforces access policy for token-authenticated requests.
+type AccessHandler struct {
+	controller access.Controller
+	name       env.Name
+}
+
+// ServeHTTP checks the verified user id against the configured access policy.
+//
+// Service-owned operation paths (health/metrics/etc.) bypass access control. For application paths, a
+// missing verified user id is treated as unauthenticated, a policy denial is written as HTTP 403, and policy
+// evaluation errors are written as HTTP 500.
+func (h *AccessHandler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	if strings.IsOperationPath(h.name, req.URL.Path) {
+		next(res, req)
+		return
+	}
+
+	ctx := req.Context()
+	if meta.UserID(ctx).IsEmpty() {
+		_ = status.WriteError(res, status.UnauthorizedError(header.ErrInvalidAuthorization))
+		return
+	}
+
+	ok, err := h.controller.HasAccess(ctx)
+	if err != nil {
+		_ = status.WriteError(res, status.InternalServerError(err))
+		return
+	}
+	if !ok {
+		_ = status.WriteError(res, status.SafeError(http.StatusForbidden, access.ErrAccessDenied))
+		return
+	}
+
+	next(res, req)
 }
 
 // NewGenerator returns a [Generator] backed by token.
@@ -128,8 +153,8 @@ func NewGenerator(token *Token) Generator {
 
 // Generator is an alias for [token.Generator].
 //
-// Generators create Authorization tokens for outbound HTTP requests, typically scoped to the request path
-// and a caller identity (user id).
+// Generators create Authorization tokens for outbound HTTP requests, typically scoped to the request method
+// and path plus a caller identity (user id).
 type Generator token.Generator
 
 // NewRoundTripper constructs client-side token injection middleware for HTTP requests.
@@ -151,8 +176,8 @@ type RoundTripper struct {
 
 // RoundTrip sets the Authorization header using a generated token.
 //
-// For each request, it generates a token scoped to the request path and the configured user id and then
-// writes it as a single `Bearer` token in the Authorization header.
+// For each request, it generates a token scoped to the request method and path and the configured user id
+// and then writes it as a single `Bearer` token in the Authorization header.
 //
 // Failure behavior:
 //   - If token generation fails, it returns an unauthorized status error.
@@ -168,7 +193,7 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 		return nil, http.ErrUseLastResponse, true
 	}
 
-	token, err := r.generator.Generate(req.URL.Path, r.id.String())
+	token, err := r.generator.Generate(audience(req), r.id.String())
 	if err != nil {
 		return nil, status.UnauthorizedError(err), true
 	}
@@ -187,4 +212,8 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 
 	res, err := r.RoundTripper.RoundTrip(clonedReq)
 	return res, err, false
+}
+
+func audience(req *http.Request) string {
+	return strings.Join(strings.Space, req.Method, req.URL.Path)
 }

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -1,10 +1,13 @@
 package token_test
 
 import (
+	"context"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -49,6 +52,63 @@ func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
 	require.Nil(t, req.Header)
+}
+
+func TestRoundTripperGeneratesTokenForMethodPath(t *testing.T) {
+	generator := &audienceGenerator{token: "fresh-token"}
+	roundTripper := token.NewRoundTripper(
+		env.UserID("service-user"),
+		generator,
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "Bearer fresh-token", req.Header.Get("Authorization"))
+
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, "http://example.com/users/123", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Equal(t, "DELETE /users/123", generator.aud)
+	require.Equal(t, "service-user", generator.sub)
+}
+
+func TestHandlerVerifiesTokenForMethodPath(t *testing.T) {
+	verifier := &audienceVerifier{token: "fresh-token"}
+	handler := token.NewHandler(env.Name("service"), env.UserID("user-id"), verifier)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPatch, "/users/123", http.NoBody)
+	require.NoError(t, err)
+	req = req.WithContext(meta.WithAttributes(req.Context(), meta.WithAuthorization(meta.String("fresh-token"))))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {})
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "PATCH /users/123", verifier.aud)
+}
+
+func TestAccessHandler(t *testing.T) {
+	for _, tt := range accessHandlerTests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := token.NewAccessHandler(env.Name("service"), tt.controller)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
+			require.NoError(t, err)
+			if tt.user != strings.Empty {
+				req = req.WithContext(meta.WithAttributes(req.Context(), meta.WithUserID(meta.String(tt.user))))
+			}
+			res := httptest.NewRecorder()
+			called := false
+
+			handler.ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {
+				called = true
+			})
+
+			require.Equal(t, tt.status, res.Code)
+			require.Equal(t, tt.called, called)
+		})
+	}
 }
 
 func TestRoundTripperClosesBodyOnGenerateError(t *testing.T) {
@@ -110,4 +170,84 @@ func TestRoundTripperClosesBodyOnCrossOriginRedirect(t *testing.T) {
 	require.Nil(t, res)
 	require.ErrorIs(t, err, http.ErrUseLastResponse)
 	require.True(t, body.Closed)
+}
+
+type audienceGenerator struct {
+	aud   string
+	sub   string
+	token string
+}
+
+func (g *audienceGenerator) Generate(aud, sub string) ([]byte, error) {
+	g.aud = aud
+	g.sub = sub
+
+	return []byte(g.token), nil
+}
+
+type audienceVerifier struct {
+	aud   string
+	token string
+}
+
+func (v *audienceVerifier) Verify(token []byte, aud string) (string, error) {
+	v.aud = aud
+	if string(token) != v.token {
+		return strings.Empty, test.ErrInvalid
+	}
+
+	return test.UserID.String(), nil
+}
+
+type accessHandlerTest struct {
+	controller accessControllerFunc
+	name       string
+	path       string
+	user       string
+	status     int
+	called     bool
+}
+
+var accessHandlerTests = []accessHandlerTest{
+	{
+		name:       "operation path bypasses access",
+		path:       "/service/healthz",
+		status:     http.StatusOK,
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return false, test.ErrInvalid }),
+		called:     true,
+	},
+	{
+		name:       "missing user id is unauthorized",
+		path:       "/users/123",
+		status:     http.StatusUnauthorized,
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return true, nil }),
+	},
+	{
+		name:       "controller error is internal server error",
+		path:       "/users/123",
+		status:     http.StatusInternalServerError,
+		user:       "frontend",
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return false, test.ErrInvalid }),
+	},
+	{
+		name:       "access denial is forbidden",
+		path:       "/users/123",
+		status:     http.StatusForbidden,
+		user:       "frontend",
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return false, nil }),
+	},
+	{
+		name:       "access grant calls next",
+		path:       "/users/123",
+		status:     http.StatusOK,
+		user:       "frontend",
+		controller: accessControllerFunc(func(context.Context) (bool, error) { return true, nil }),
+		called:     true,
+	},
+}
+
+type accessControllerFunc func(context.Context) (bool, error)
+
+func (f accessControllerFunc) HasAccess(ctx context.Context) (bool, error) {
+	return f(ctx)
 }

--- a/transport/http/token_test.go
+++ b/transport/http/token_test.go
@@ -12,22 +12,6 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestNewControllerWithoutTokenConfig(t *testing.T) {
-	controller, err := http.NewController(test.NewHTTPTransportConfig(), test.FS)
-	require.NoError(t, err)
-	require.Nil(t, controller)
-}
-
-func TestNewControllerWithTokenConfig(t *testing.T) {
-	cfg := test.NewHTTPTransportConfig()
-	cfg.Token = test.NewToken("jwt")
-	cfg.Token.Access = test.NewAccessConfig()
-
-	controller, err := http.NewController(cfg, test.FS)
-	require.NoError(t, err)
-	require.NotNil(t, controller)
-}
-
 func TestNewTokenWithoutTokenConfig(t *testing.T) {
 	tkn := http.NewToken(test.Name, test.NewHTTPTransportConfig(), nil, nil)
 	require.Nil(t, tkn)

--- a/transport/module.go
+++ b/transport/module.go
@@ -29,6 +29,7 @@ var Module = di.Module(
 	grpc.Module,
 	http.Module,
 	events.Module,
+	di.Constructor(NewAccessController),
 	di.Constructor(NewServers),
 	di.Register(server.Register),
 )


### PR DESCRIPTION
## What
- Enforce configured token access policies in the standard HTTP and gRPC server stacks after token authentication and rate limiting.
- Change access checks to use request context metadata: verified user id, `meta.TransportServiceMethod`, and the `invoke` action.
- Resolve HTTP route patterns in metadata so HTTP access policies can use canonical objects such as `http:GET /users/{id}`.
- Bind HTTP token audiences to concrete request method/path values while keeping access policy enforcement on canonical route patterns.
- Move access control configuration to one shared `transport.access` block for HTTP and gRPC instead of duplicating it under each protocol token config.
- Use one shared `token/access.Controller` across both transport server stacks and remove protocol-specific access-controller constructors.
- Update RBAC examples/fixtures and README docs for shared policy files that include both HTTP and gRPC objects.
- Add direct branch coverage for HTTP access middleware and gRPC unary/stream access interceptors, and remove the unused gRPC metadata re-export.

## Why
- Makes authorization a centralized server-side default when access policy is configured, instead of relying on individual handlers to call policy checks.
- Avoids duplicated HTTP/gRPC access config and prevents policy drift between protocols.
- Keeps token authentication configuration protocol-specific while making authorization policy a transport-wide concern.
- Preserves protocol separation in policy data through `meta.TransportServiceMethod` values such as `http:GET /users/{id}` and `grpc:/greet.v1.GreeterService/SayHello`.
- Exercises authorization bypass, missing identity, controller error, denial, and success paths directly at the middleware/interceptor layer.

## Testing
- `go test ./config ./transport ./transport/http ./transport/grpc ./transport/http/token ./transport/grpc/token ./token/access`
- `go test ./cli ./module ./internal/test`
- `go test ./token ./config/client ./config/server`
- `go test ./transport/http/token ./transport/grpc/token ./net/grpc/meta`
- `go test -cover ./transport/http/token ./transport/grpc/token ./net/grpc/meta`
- `go test ./...`

AI-assisted-by: codex
