### PR TITLE
feat(grpc): report drain state and quota metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ transport:
 > - The `transport-service-method` key prefixes the service-method value with the transport name, such as `http:GET /users/{id}` or `grpc:/users.v1.Users/Get`, so HTTP and gRPC operations use separate buckets.
 > - The `service-method` key uses HTTP route/path metadata or the gRPC full method name. Prefer `transport-service-method` unless cross-transport operations intentionally share quota.
 > - Server-side HTTP and gRPC limiters run after metadata extraction and token verification, so missing, malformed, or invalid authorization is rejected before it reaches the limiter. This is intentional; enforce quotas for those attempts with an external edge, gateway, ingress, load balancer, or service-mesh limiter.
+> - Server-side HTTP limiters set `RateLimit` and `RateLimit-Policy` headers; denied HTTP requests also set `Retry-After` when reset timing is available. Server-side gRPC limiters set `ratelimit` and `ratelimit-policy` response metadata.
 > - gRPC stream limiters consume one token when the stream opens and one token for each `RecvMsg` and `SendMsg` operation. Unary HTTP and gRPC requests consume one token per request/RPC.
 
 ---

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -87,6 +87,7 @@ func ServerFailureOption() di.Option {
 		di.Register(func(lc di.Lifecycle, sh di.Shutdowner) {
 			server.Register(server.RegisterParams{
 				Lifecycle: lc,
+				Drain:     server.NewDrain(),
 				Services: []*server.Service{
 					server.NewService("test", DelayedFailingServer{}, nil, sh),
 				},

--- a/internal/test/health.go
+++ b/internal/test/health.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/health"
 	healthchecker "github.com/alexfalkowski/go-service/v2/health/checker"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
 	grpchealth "github.com/alexfalkowski/go-service/v2/transport/grpc/health"
 	httphealth "github.com/alexfalkowski/go-service/v2/transport/http/health"
@@ -17,11 +18,12 @@ import (
 // It delegates to [github.com/alexfalkowski/go-service/v2/transport/http/health.Register] using the shared test service name and the
 // provided health server so integration-style tests can exercise the same route registration
 // path used in production wiring.
-func RegisterHealth(mux *http.ServeMux, server *server.Server) {
+func RegisterHealth(mux *http.ServeMux, server *server.Server, drain *netserver.Drain) {
 	params := httphealth.RegisterParams{
 		Name:   Name,
 		Server: server,
 		Mux:    mux,
+		Drain:  drain,
 	}
 
 	httphealth.Register(params)
@@ -31,7 +33,7 @@ func RegisterHealth(mux *http.ServeMux, server *server.Server) {
 func (w *World) RegisterHTTPHealth(name, url string, observations ...HealthObservation) *server.Server {
 	server := w.HealthServer(name, url)
 	w.observeHealth(server, name, observations...)
-	RegisterHealth(w.Mux, server)
+	RegisterHealth(w.Mux, server, w.Drain)
 	w.HTTPHealth = server
 
 	return server
@@ -42,7 +44,7 @@ func (w *World) RegisterGRPCHealth(name, url string, observations ...HealthObser
 	server := w.HealthServer(name, url)
 	w.observeHealth(server, name, observations...)
 
-	grpcServer := grpchealth.NewServer(grpchealth.ServerParams{Server: server})
+	grpcServer := grpchealth.NewServer(grpchealth.ServerParams{Server: server, Drain: w.Drain})
 	grpchealth.Register(grpchealth.RegisterParams{
 		Registrar: w.GRPCServer.ServiceRegistrar(),
 		Server:    grpcServer,

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -37,6 +37,8 @@ type Server struct {
 	GRPCServer *grpc.Server
 	// DebugServer is populated when RegisterDebug is true.
 	DebugServer *debug.Server
+	// Drain tracks server lifecycle shutdown state.
+	Drain *server.Drain
 	// TransportConfig configures HTTP and gRPC servers.
 	TransportConfig *transport.Config
 	// DebugConfig configures the debug server.
@@ -126,7 +128,7 @@ func (s *Server) Register() error {
 		servers = append(servers, debugServer.GetService())
 	}
 
-	server.Register(server.RegisterParams{Lifecycle: s.Lifecycle, Services: servers})
+	server.Register(server.RegisterParams{Lifecycle: s.Lifecycle, Drain: s.Drain, Services: servers})
 
 	return nil
 }

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http/events"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
+	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/net/url"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry"
@@ -56,6 +57,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	lc := fxtest.NewLifecycle(tb)
 	tracer := NewOTLPTracerConfig()
 	generator := uuid.NewGenerator()
+	drain := server.NewDrain()
 	os := worldOptions(opts...)
 
 	logger, err := createLogger(lc, os)
@@ -74,7 +76,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	server := &Server{
 		Lifecycle: lc, Logger: logger, Tracer: tracer,
 		TransportConfig: transportCfg, DebugConfig: debugCfg,
-		Meter: meter, Mux: mux,
+		Meter: meter, Mux: mux, Drain: drain,
 		GRPCLimiter: grpcServerLimiter,
 		HTTPLimiter: httpServerLimiter,
 		Verifier:    os.verifier, Access: os.access, Generator: generator,

--- a/net/server/drain.go
+++ b/net/server/drain.go
@@ -10,28 +10,33 @@ var ErrDraining = errors.New("server: draining")
 
 // Drain tracks whether server shutdown has started.
 type Drain struct {
+	done     chan struct{}
 	draining sync.Bool
 }
 
 // NewDrain creates a drain state tracker.
 func NewDrain() *Drain {
-	return &Drain{}
+	return &Drain{done: make(chan struct{})}
 }
 
 // Start marks the server lifecycle as draining.
+//
+// Start must be called once for a drain instance.
 func (d *Drain) Start() {
-	if d == nil {
-		return
-	}
-
 	d.draining.Store(true)
+	close(d.done)
 }
 
 // Error returns ErrDraining after Start has been called.
 func (d *Drain) Error() error {
-	if d == nil || !d.draining.Load() {
+	if !d.draining.Load() {
 		return nil
 	}
 
 	return ErrDraining
+}
+
+// Done returns a channel that is closed after Start has been called.
+func (d *Drain) Done() <-chan struct{} {
+	return d.done
 }

--- a/net/server/register.go
+++ b/net/server/register.go
@@ -16,7 +16,7 @@ type RegisterParams struct {
 	Lifecycle di.Lifecycle
 
 	// Drain tracks whether shutdown has started.
-	Drain *Drain `optional:"true"`
+	Drain *Drain
 
 	// Services are the server services managed by the lifecycle.
 	Services []*Service
@@ -26,7 +26,7 @@ type RegisterParams struct {
 //
 // It appends an Fx lifecycle hook that:
 //   - OnStart: starts each provided *[Service] by calling `Start()`.
-//   - OnStop: marks the optional drain state, stops each provided *[Service] by calling `Stop(ctx)`,
+//   - OnStop: marks the drain state, stops each provided *[Service] by calling `Stop(ctx)`,
 //     and returns the joined shutdown errors.
 //
 // Callers should ensure the slice does not contain nil entries.

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -21,6 +21,7 @@ func TestRegisterStopErrors(t *testing.T) {
 
 	server.Register(server.RegisterParams{
 		Lifecycle: lc,
+		Drain:     server.NewDrain(),
 		Services: []*server.Service{
 			server.NewService("first", first, nil, sh),
 			server.NewService("second", second, nil, sh),
@@ -47,6 +48,7 @@ func TestRegisterStartsAllServices(t *testing.T) {
 
 	server.Register(server.RegisterParams{
 		Lifecycle: lc,
+		Drain:     server.NewDrain(),
 		Services: []*server.Service{
 			server.NewService("first", first, nil, sh),
 			server.NewService("second", second, nil, sh),
@@ -70,6 +72,7 @@ func TestRegisterStopsServicesConcurrently(t *testing.T) {
 
 	server.Register(server.RegisterParams{
 		Lifecycle: lc,
+		Drain:     server.NewDrain(),
 		Services: []*server.Service{
 			server.NewService("first", first, nil, sh),
 			server.NewService("second", second, nil, sh),
@@ -114,6 +117,35 @@ func TestRegisterStartsDrainBeforeStoppingServices(t *testing.T) {
 	require.ErrorIs(t, drain.Error(), server.ErrDraining)
 }
 
+func TestDrainDoneClosesWhenStarted(t *testing.T) {
+	drain := server.NewDrain()
+
+	select {
+	case <-drain.Done():
+		require.Fail(t, "drain should not be done before start")
+	default:
+	}
+
+	drain.Start()
+
+	select {
+	case <-drain.Done():
+	case <-time.After(time.Second):
+		require.Fail(t, "drain done channel did not close after start")
+	}
+}
+
+func TestDrainDoneClosesWhenStartedBeforeDone(t *testing.T) {
+	drain := server.NewDrain()
+	drain.Start()
+
+	select {
+	case <-drain.Done():
+	case <-time.After(time.Second):
+		require.Fail(t, "drain done channel did not close after start")
+	}
+}
+
 func TestRegisterSnapshotsServices(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	original := test.NewObservableServer(nil, nil)
@@ -123,7 +155,7 @@ func TestRegisterSnapshotsServices(t *testing.T) {
 		server.NewService("original", original, nil, sh),
 	}
 
-	server.Register(server.RegisterParams{Lifecycle: lc, Services: services})
+	server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: services})
 	services[0] = server.NewService("replacement", replacement, nil, sh)
 
 	require.NoError(t, lc.Start(t.Context()))

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -72,7 +72,7 @@ func BenchmarkGRPC(b *testing.B) {
 		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
-		server.Register(server.RegisterParams{Lifecycle: lc, Services: []*server.Service{g.GetService()}})
+		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
 
 		lc.RequireStart()
 
@@ -116,7 +116,7 @@ func BenchmarkGRPC(b *testing.B) {
 		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
-		server.Register(server.RegisterParams{Lifecycle: lc, Services: []*server.Service{g.GetService()}})
+		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
 		errors.Register(errors.NewHandler(logger))
 
 		lc.RequireStart()
@@ -163,7 +163,7 @@ func BenchmarkGRPC(b *testing.B) {
 		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
-		server.Register(server.RegisterParams{Lifecycle: lc, Services: []*server.Service{g.GetService()}})
+		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
 		errors.Register(errors.NewHandler(logger))
 
 		lc.RequireStart()

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
 	grpchealth "github.com/alexfalkowski/go-service/v2/transport/grpc/health"
 	"github.com/alexfalkowski/go-sync"
@@ -81,6 +82,24 @@ func TestInvalidCheck(t *testing.T) {
 	resp, err := client.Check(ctx, req)
 	require.NoError(t, err)
 
+	require.Equal(t, health.NotServing, resp.GetStatus())
+}
+
+func TestCheckDrains(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+
+	drain := netserver.NewDrain()
+	server := grpchealth.NewServer(grpchealth.ServerParams{Server: world.GRPCHealth, Drain: drain})
+
+	resp, err := server.Check(t.Context(), &health.Request{Service: test.Name.String()})
+	require.NoError(t, err)
+	require.Equal(t, health.Serving, resp.GetStatus())
+
+	drain.Start()
+
+	resp, err = server.Check(t.Context(), &health.Request{Service: test.Name.String()})
+	require.NoError(t, err)
 	require.Equal(t, health.NotServing, resp.GetStatus())
 }
 
@@ -177,6 +196,24 @@ func TestList(t *testing.T) {
 		test.Name.String(): {Status: health.Serving},
 	}
 	require.Equal(t, expected, resp.GetStatuses())
+}
+
+func TestListDrains(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+
+	drain := netserver.NewDrain()
+	server := grpchealth.NewServer(grpchealth.ServerParams{Server: world.GRPCHealth, Drain: drain})
+
+	resp, err := server.List(t.Context(), &health.ListRequest{})
+	require.NoError(t, err)
+	require.Equal(t, health.Serving, resp.GetStatuses()[test.Name.String()].GetStatus())
+
+	drain.Start()
+
+	resp, err = server.List(t.Context(), &health.ListRequest{})
+	require.NoError(t, err)
+	require.Equal(t, health.NotServing, resp.GetStatuses()[test.Name.String()].GetStatus())
 }
 
 func TestWatch(t *testing.T) {
@@ -418,7 +455,7 @@ func TestWatchStatusChanges(t *testing.T) {
 
 	world := newGRPCHealthWorld(t, probe.URL, test.WithWorldTelemetry("otlp"))
 
-	watcher := grpchealth.NewServer(grpchealth.ServerParams{Server: world.GRPCHealth})
+	watcher := grpchealth.NewServer(grpchealth.ServerParams{Server: world.GRPCHealth, Drain: netserver.NewDrain()})
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
@@ -450,6 +487,37 @@ func TestWatchStatusChanges(t *testing.T) {
 		require.Equal(t, codes.Canceled, status.Code(err))
 	case <-time.After(time.Second):
 		require.FailNow(t, "watch stream did not stop after cancellation")
+	}
+}
+
+func TestWatchDrains(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+
+	drain := netserver.NewDrain()
+	watcher := grpchealth.NewServer(grpchealth.ServerParams{Server: world.GRPCHealth, Drain: drain})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stream := test.NewWatchStream(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(&health.Request{Service: test.Name.String()}, stream)
+	}()
+
+	resp := requireWatchResponse(t, stream.Responses)
+	require.Equal(t, health.Serving, resp.GetStatus())
+
+	drain.Start()
+
+	resp = requireWatchResponse(t, stream.Responses)
+	require.Equal(t, health.NotServing, resp.GetStatus())
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch stream did not stop after drain")
 	}
 }
 

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -1,19 +1,20 @@
 package health
 
 import (
-	"github.com/alexfalkowski/go-health/v2/server"
+	healthserver "github.com/alexfalkowski/go-health/v2/server"
 	"github.com/alexfalkowski/go-health/v2/watcher"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // ServerParams defines dependencies for constructing the gRPC health [Server] implementation.
 //
-// It is an Fx parameter struct ([di.In]) that provides the underlying *[health.Server]
+// It is an Fx parameter struct ([di.In]) that provides the underlying *[healthserver.Server]
 // from [github.com/alexfalkowski/go-health/v2/server], which maintains health observers.
 type ServerParams struct {
 	di.In
@@ -21,32 +22,36 @@ type ServerParams struct {
 	// Server is the underlying health server that stores and exposes health observers.
 	//
 	// It is expected to be non-nil when this gRPC health service is wired.
-	Server *server.Server
+	Server *healthserver.Server
+
+	// Drain tracks whether the server lifecycle has started shutting down.
+	Drain *netserver.Drain
 }
 
 // NewServer constructs a new gRPC health [Server] implementation.
 //
 // The returned server implements the standard gRPC health service
 // (`grpc.health.v1.Health`) and delegates health state lookups to the provided
-// underlying *[health.Server].
+// underlying *[healthserver.Server].
 func NewServer(params ServerParams) *Server {
-	return &Server{server: params.Server}
+	return &Server{server: params.Server, drain: params.Drain}
 }
 
 // Server implements the standard gRPC health service.
 //
-// It exposes health state by querying observers registered in the underlying *[health.Server].
+// It exposes health state by querying observers registered in the underlying *[healthserver.Server].
 // The service is typically used by load balancers and orchestration systems to determine whether
 // a server is serving traffic.
 type Server struct {
 	health.UnimplementedServer
-	server *server.Server
+	server *healthserver.Server
+	drain  *netserver.Drain
 }
 
 // Check returns the health status for a single service.
 //
 // The requested service name is taken from `req.GetService()`. The health state is resolved by looking up
-// an observer from the underlying *[health.Server] using the "grpc" transport kind.
+// an observer from the underlying *[healthserver.Server] using the "grpc" transport kind.
 //
 // Error mapping:
 //   - If the requested service does not exist, it returns [codes.NotFound].
@@ -54,7 +59,7 @@ type Server struct {
 func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response, error) {
 	service := req.GetService()
 	if strings.IsEmpty(service) {
-		return &health.Response{Status: healthStatus(s.server.Error("grpc"))}, nil
+		return &health.Response{Status: s.healthStatus(s.server.Error("grpc"))}, nil
 	}
 
 	observer, err := s.server.Observer(service, "grpc")
@@ -62,7 +67,7 @@ func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response
 		return nil, status.SafeError(codes.NotFound, err)
 	}
 
-	return &health.Response{Status: healthStatus(observer.Error())}, nil
+	return &health.Response{Status: s.healthStatus(observer.Error())}, nil
 }
 
 // List returns the health status for all registered services.
@@ -72,7 +77,7 @@ func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response
 func (s *Server) List(_ context.Context, _ *health.ListRequest) (*health.ListResponse, error) {
 	res := &health.ListResponse{Statuses: map[string]*health.Response{}}
 	for name, observer := range s.server.Observers("grpc") {
-		res.Statuses[name] = &health.Response{Status: healthStatus(observer.Error())}
+		res.Statuses[name] = &health.Response{Status: s.healthStatus(observer.Error())}
 	}
 
 	return res, nil
@@ -110,17 +115,31 @@ func (s *Server) watch(w health.WatchServer, sub watcher.Subscription) error {
 				return status.Error(codes.Canceled, "watch has ended")
 			}
 
-			next := healthStatus(err)
+			next := s.healthStatus(err)
 			if next != current {
 				current = next
 				if err := sendStatus(w, current); err != nil {
 					return err
 				}
 			}
+		case <-s.drain.Done():
+			if current != health.NotServing {
+				return sendStatus(w, health.NotServing)
+			}
+
+			return nil
 		case <-w.Context().Done():
 			return status.SafeError(codes.Canceled, w.Context().Err())
 		}
 	}
+}
+
+func (s *Server) healthStatus(err error) health.Status {
+	if s.drain.Error() != nil {
+		return health.NotServing
+	}
+
+	return healthStatus(err)
 }
 
 func healthStatus(err error) health.Status {

--- a/transport/grpc/limiter/client.go
+++ b/transport/grpc/limiter/client.go
@@ -33,17 +33,22 @@ type Client struct {
 
 // UnaryClientInterceptor returns a gRPC unary client interceptor that enforces rate limiting.
 //
-// The interceptor calls `limiter.Take(ctx)` before invoking the RPC:
+// The interceptor calls `limiter.TakeDecision(ctx)` before invoking the RPC:
 //
-//   - If `Take` returns an error, it returns [codes.Internal].
+//   - If `TakeDecision` returns an error, it returns [codes.Internal].
 //   - If the request is not allowed, it returns [codes.ResourceExhausted].
 //   - Otherwise, it invokes the underlying `invoker`.
 //
 // Callers should only install this interceptor when limiter is non-nil.
 func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		if _, err := take(ctx, limiter.Limiter); err != nil {
+		decision, err := take(ctx, limiter.Limiter)
+		if err != nil {
 			return err
+		}
+
+		if !decision.Allowed() {
+			return limitError()
 		}
 
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
@@ -52,18 +57,23 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 
 // StreamClientInterceptor returns a gRPC stream client interceptor that enforces rate limiting.
 //
-// The interceptor calls `limiter.Take(ctx)` before opening the stream, then meters each sent and received
+// The interceptor calls `limiter.TakeDecision(ctx)` before opening the stream, then meters each sent and received
 // stream message:
 //
-//   - If `Take` returns an error, it returns [codes.Internal].
+//   - If `TakeDecision` returns an error, it returns [codes.Internal].
 //   - If the stream is not allowed, it returns [codes.ResourceExhausted].
 //   - Otherwise, it invokes the underlying `streamer`.
 //
 // Callers should only install this interceptor when limiter is non-nil.
 func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		if _, err := take(ctx, limiter.Limiter); err != nil {
+		decision, err := take(ctx, limiter.Limiter)
+		if err != nil {
 			return nil, err
+		}
+
+		if !decision.Allowed() {
+			return nil, limitError()
 		}
 
 		stream, err := streamer(ctx, desc, conn, fullMethod, opts...)
@@ -86,13 +96,26 @@ func (s *clientStream) RecvMsg(m any) error {
 		return err
 	}
 
-	_, err := take(s.ctx, s.limiter)
-	return err
+	decision, err := take(s.ctx, s.limiter)
+	if err != nil {
+		return err
+	}
+
+	if !decision.Allowed() {
+		return limitError()
+	}
+
+	return nil
 }
 
 func (s *clientStream) SendMsg(m any) error {
-	if _, err := take(s.ctx, s.limiter); err != nil {
+	decision, err := take(s.ctx, s.limiter)
+	if err != nil {
 		return err
+	}
+
+	if !decision.Allowed() {
+		return limitError()
 	}
 
 	return s.ClientStream.SendMsg(m)

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -5,7 +5,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
 
@@ -15,15 +14,15 @@ import (
 // from the request context.
 type KeyMap = limiter.KeyMap
 
-func take(ctx context.Context, limiter *limiter.Limiter) (string, error) {
-	ok, header, err := limiter.Take(ctx)
+func take(ctx context.Context, rateLimiter *limiter.Limiter) (limiter.Decision, error) {
+	decision, err := rateLimiter.TakeDecision(ctx)
 	if err != nil {
-		return strings.Empty, status.SafeError(codes.Internal, err)
+		return decision, status.SafeError(codes.Internal, err)
 	}
 
-	if !ok {
-		return header, status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
-	}
+	return decision, nil
+}
 
-	return header, nil
+func limitError() error {
+	return status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
 }

--- a/transport/grpc/limiter/server.go
+++ b/transport/grpc/limiter/server.go
@@ -39,10 +39,10 @@ type Server struct {
 // Stream RPCs do not bypass limiting because long-lived streams, such as health Watch, can hold server resources
 // until the client disconnects.
 //
-// On every request, the interceptor calls `limiter.Take(ctx)` to determine whether the request is allowed:
+// On every request, the interceptor calls `limiter.TakeDecision(ctx)` to determine whether the request is allowed:
 //
 //   - If `Take` returns an error, the interceptor returns [codes.Internal].
-//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
+//   - It attaches "ratelimit" and "ratelimit-policy" response metadata describing the current decision.
 //   - If the request is not allowed, the interceptor returns [codes.ResourceExhausted].
 //   - Otherwise, it invokes the handler.
 //
@@ -53,12 +53,14 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 			return handler(ctx, req)
 		}
 
-		header, err := take(ctx, limiter.Limiter)
-		if !strings.IsEmpty(header) {
-			_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", header))
-		}
+		decision, err := take(ctx, limiter.Limiter)
 		if err != nil {
 			return nil, err
+		}
+
+		setHeader(ctx, decision)
+		if !decision.Allowed() {
+			return nil, limitError()
 		}
 
 		return handler(ctx, req)
@@ -74,23 +76,24 @@ func UnaryServerInterceptor(limiter *Server) grpc.UnaryServerInterceptor {
 // Use gRPC server options such as max_concurrent_streams, plus edge, gateway, ingress, load-balancer, or
 // service-mesh limits when long-lived stream occupancy needs a hard cap.
 //
-// On every stream, the interceptor calls `limiter.Take(ctx)` to determine whether the stream is allowed:
+// On every stream, the interceptor calls `limiter.TakeDecision(ctx)` to determine whether the stream is allowed:
 //
 //   - If `Take` returns an error, the interceptor returns [codes.Internal].
-//   - If `Take` returns a header string, it is attached to response metadata as the "ratelimit" header.
+//   - It attaches "ratelimit" and "ratelimit-policy" response metadata describing the current decision.
 //   - If the stream is not allowed, the interceptor returns [codes.ResourceExhausted].
 //   - Otherwise, it invokes the handler.
 //
 // Callers should only install this interceptor when limiter is non-nil.
 func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		header, err := take(stream.Context(), limiter.Limiter)
-		if !strings.IsEmpty(header) {
-			_ = stream.SetHeader(meta.Pairs("ratelimit", header))
-		}
-
+		decision, err := take(stream.Context(), limiter.Limiter)
 		if err != nil {
 			return err
+		}
+
+		setStreamHeader(stream, decision)
+		if !decision.Allowed() {
+			return limitError()
 		}
 
 		return handler(srv, &serverStream{ServerStream: stream, limiter: limiter.Limiter})
@@ -107,22 +110,37 @@ func (s *serverStream) RecvMsg(m any) error {
 		return err
 	}
 
-	header, err := take(s.Context(), s.limiter)
-	if !strings.IsEmpty(header) {
-		_ = s.SetHeader(meta.Pairs("ratelimit", header))
-	}
-
-	return err
-}
-
-func (s *serverStream) SendMsg(m any) error {
-	header, err := take(s.Context(), s.limiter)
-	if !strings.IsEmpty(header) {
-		_ = s.SetHeader(meta.Pairs("ratelimit", header))
-	}
+	decision, err := take(s.Context(), s.limiter)
 	if err != nil {
 		return err
 	}
 
+	setStreamHeader(s, decision)
+	if !decision.Allowed() {
+		return limitError()
+	}
+
+	return nil
+}
+
+func (s *serverStream) SendMsg(m any) error {
+	decision, err := take(s.Context(), s.limiter)
+	if err != nil {
+		return err
+	}
+
+	setStreamHeader(s, decision)
+	if !decision.Allowed() {
+		return limitError()
+	}
+
 	return s.ServerStream.SendMsg(m)
+}
+
+func setHeader(ctx context.Context, decision limiter.Decision) {
+	_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", decision.Header(), "ratelimit-policy", decision.PolicyHeader()))
+}
+
+func setStreamHeader(stream grpc.ServerStream, decision limiter.Decision) {
+	_ = stream.SetHeader(meta.Pairs("ratelimit", decision.Header(), "ratelimit-policy", decision.PolicyHeader()))
 }

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -29,12 +29,14 @@ func TestServerLimiterUnary(t *testing.T) {
 	_, err := client.SayHello(t.Context(), req, grpc.Header(&header))
 	require.NoError(t, err)
 	require.NotEmpty(t, header.Get("ratelimit"))
+	require.NotEmpty(t, header.Get("ratelimit-policy"))
 
 	rejectedHeader := grpcmeta.Map{}
 	_, err = client.SayHello(t.Context(), req, grpc.Header(&rejectedHeader))
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 	require.NotEmpty(t, rejectedHeader.Get("ratelimit"))
+	require.NotEmpty(t, rejectedHeader.Get("ratelimit-policy"))
 }
 
 func TestServerLimiterStream(t *testing.T) {
@@ -63,6 +65,7 @@ func TestServerLimiterStreamHeader(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, allowed.Header.Get("ratelimit"))
+	require.NotEmpty(t, allowed.Header.Get("ratelimit-policy"))
 
 	rejected := &test.MetaServerStream{Ctx: ctx}
 	err = interceptor(nil, rejected, &grpc.StreamServerInfo{FullMethod: "/greet.v1.GreeterService/SayStreamHello"}, func(any, grpc.ServerStream) error {
@@ -71,6 +74,7 @@ func TestServerLimiterStreamHeader(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 	require.NotEmpty(t, rejected.Header.Get("ratelimit"))
+	require.NotEmpty(t, rejected.Header.Get("ratelimit-policy"))
 }
 
 func TestClientLimiterUnary(t *testing.T) {
@@ -98,6 +102,37 @@ func TestClientLimiterStream(t *testing.T) {
 
 	_ = sayStreamHello(t, client)
 	err := sayStreamHello(t, client)
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestClientLimiterStreamRecvRejected(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 2)), test.WithWorldGRPC())
+
+	conn := test.RequireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&v1.SayStreamHelloRequest{Name: "test"}))
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestClientLimiterStreamSendRejected(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 1)), test.WithWorldGRPC())
+
+	conn := test.RequireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
 	require.Error(t, err)
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -7,6 +7,7 @@ import (
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestServer(t *testing.T) {
 	require.NoError(t, err)
 
 	c := test.NewInsecureTransportConfig()
-	s := &test.Server{Lifecycle: lc, Logger: logger, TransportConfig: c, Mux: mux}
+	s := &test.Server{Lifecycle: lc, Logger: logger, TransportConfig: c, Mux: mux, Drain: netserver.NewDrain()}
 	require.NoError(t, s.Register())
 
 	lc.RequireStart()

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -87,7 +87,7 @@ func BenchmarkHTTP(b *testing.B) {
 		require.NoError(b, err)
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
-		server.Register(server.RegisterParams{Lifecycle: lc, Services: []*server.Service{h.GetService()}})
+		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
 
 		lc.RequireStart()
 
@@ -137,7 +137,7 @@ func BenchmarkHTTP(b *testing.B) {
 		require.NoError(b, err)
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
-		server.Register(server.RegisterParams{Lifecycle: lc, Services: []*server.Service{h.GetService()}})
+		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
 		errors.Register(errors.NewHandler(logger))
 
 		lc.RequireStart()
@@ -190,7 +190,7 @@ func BenchmarkHTTP(b *testing.B) {
 		require.NoError(b, err)
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
-		server.Register(server.RegisterParams{Lifecycle: lc, Services: []*server.Service{h.GetService()}})
+		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
 		errors.Register(errors.NewHandler(logger))
 
 		lc.RequireStart()

--- a/transport/http/health/health.go
+++ b/transport/http/health/health.go
@@ -28,9 +28,7 @@ type RegisterParams struct {
 	Mux *http.ServeMux
 
 	// Drain tracks whether the server lifecycle has started shutting down.
-	//
-	// When omitted, /readyz does not report drain state and only reflects the registered readiness observer.
-	Drain *server.Drain `optional:"true"`
+	Drain *server.Drain
 
 	// Name is the service name used both for route prefixing and observer lookup.
 	Name env.Name
@@ -46,7 +44,7 @@ type RegisterParams struct {
 //
 //   - HTTP 200 with the plain-text body "SERVING" when the observer reports no error.
 //   - HTTP 503 when the observer is missing or reports an error.
-//   - HTTP 503 for `/readyz` after the server lifecycle starts draining, when params.Drain is provided.
+//   - HTTP 503 for `/readyz` after the server lifecycle starts draining.
 //
 // Error responses are written with [status.WriteError], and successful responses are written with
 // [status.WriteText]. Callers are expected to have request metadata middleware in place if they want

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -60,7 +60,7 @@ type Handler struct {
 //
 // Behavior:
 //   - If the limiter returns an error, it writes an internal server error response.
-//   - If the limiter returns a header string, it is added to the response as the "RateLimit" header.
+//   - It writes RateLimit and RateLimit-Policy headers describing the current decision.
 //   - If the request is not allowed, it writes an HTTP 429 response with Retry-After when reset timing is available.
 //   - Otherwise it calls next.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
@@ -77,7 +77,8 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		return
 	}
 
-	res.Header().Add("RateLimit", decision.Header())
+	res.Header().Set("RateLimit", decision.Header())
+	res.Header().Set("RateLimit-Policy", decision.PolicyHeader())
 
 	if !decision.Allowed() {
 		if resetAfter := decision.ResetAfterSeconds(); resetAfter > 0 {

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -49,7 +49,8 @@ func TestServerLimiter(t *testing.T) {
 			res, _, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
-			require.NotEmpty(t, res.Header.Get("Ratelimit"))
+			require.Equal(t, `"default";r=0;t=1`, res.Header.Get("Ratelimit"))
+			require.Equal(t, `"default";q=1;w=1`, res.Header.Get("Ratelimit-Policy"))
 		})
 	}
 }
@@ -71,7 +72,8 @@ func TestServerLimiterSetsRetryAfter(t *testing.T) {
 	res, _, err = world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
-	require.NotEmpty(t, res.Header.Get("Ratelimit"))
+	require.Contains(t, res.Header.Get("Ratelimit"), `"default";r=0;t=`)
+	require.Equal(t, `"default";q=1;w=3600`, res.Header.Get("Ratelimit-Policy"))
 	retryAfter, err := strconv.ParseUint(res.Header.Get("Retry-After"), 10, 64)
 	require.NoError(t, err)
 	require.Positive(t, retryAfter)
@@ -96,7 +98,8 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 	res, _, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, http.Header{}, http.NoBody)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
-	require.NotEmpty(t, res.Header.Get("Ratelimit"))
+	require.Equal(t, `"default";r=0;t=1`, res.Header.Get("Ratelimit"))
+	require.Equal(t, `"default";q=1;w=1`, res.Header.Get("Ratelimit-Policy"))
 }
 
 func TestClientLimiter(t *testing.T) {

--- a/transport/limiter/decision.go
+++ b/transport/limiter/decision.go
@@ -4,9 +4,10 @@ import "github.com/alexfalkowski/go-service/v2/time"
 
 // Decision describes the result of one limiter take attempt.
 type Decision struct {
-	header     string
-	resetAfter time.Duration
-	allowed    bool
+	header       string
+	policyHeader string
+	resetAfter   time.Duration
+	allowed      bool
 }
 
 // Allowed reports whether the limited operation may proceed.
@@ -19,6 +20,11 @@ func (d Decision) Header() string {
 	return d.header
 }
 
+// PolicyHeader returns the RateLimit-Policy header value for this decision.
+func (d Decision) PolicyHeader() string {
+	return d.policyHeader
+}
+
 // ResetAfter returns the remaining duration before the limiter bucket resets.
 func (d Decision) ResetAfter() time.Duration {
 	return d.resetAfter
@@ -26,14 +32,5 @@ func (d Decision) ResetAfter() time.Duration {
 
 // ResetAfterSeconds returns ResetAfter rounded up to whole seconds.
 func (d Decision) ResetAfterSeconds() uint64 {
-	if d.resetAfter <= 0 {
-		return 0
-	}
-
-	seconds := uint64(d.resetAfter / time.Second)
-	if d.resetAfter%time.Second != 0 {
-		seconds++
-	}
-
-	return seconds
+	return durationSeconds(d.resetAfter)
 }

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -13,6 +13,11 @@ import (
 	"github.com/sethvargo/go-limiter/memorystore"
 )
 
+// limiterPolicy identifies the quota policy described by the RateLimit fields.
+// The HTTPAPI draft uses "default" for a single default quota policy:
+// https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers#section-4
+const limiterPolicy = "default"
+
 // ErrMissingKey is returned when the configured key kind is not present in the KeyMap.
 var ErrMissingKey = errors.New("limiter: missing key")
 
@@ -61,8 +66,9 @@ func NewLimiter(lc di.Lifecycle, keyMap KeyMap, cfg *Config) (*Limiter, error) {
 	}
 	store, _ := memorystore.New(config)
 	limiter := &Limiter{
-		store: store,
-		key:   k,
+		store:  store,
+		key:    k,
+		window: limiterWindow(cfg.Interval),
 		keys: &keys{
 			values:  map[string]time.Time{},
 			ttl:     time.Duration(sweepMinTTL + sweepInterval),
@@ -84,9 +90,10 @@ func NewLimiter(lc di.Lifecycle, keyMap KeyMap, cfg *Config) (*Limiter, error) {
 // Limits are enforced per derived key string (see KeyFunc/KeyMap). This limiter uses an in-memory
 // store, so limits are process-local and are not shared across replicas.
 type Limiter struct {
-	store limiter.Store
-	key   KeyFunc
-	keys  *keys
+	store  limiter.Store
+	key    KeyFunc
+	keys   *keys
+	window time.Duration
 }
 
 // Take attempts to take a token for the key derived from ctx.
@@ -97,9 +104,8 @@ type Limiter struct {
 //
 // Return values:
 //   - ok: false when the rate limit is exceeded for the derived key, true otherwise.
-//   - header: a human-readable header value formatted as:
-//     "limit=<tokens>, remaining=<remaining>".
-//     The values represent the store-reported token limit and remaining tokens after this attempt.
+//   - header: the RateLimit header value formatted as `"default";r=<remaining>;t=<reset_seconds>`.
+//     The values represent the store-reported remaining tokens after this attempt and reset timing.
 //   - error: any error returned by the underlying store.
 //
 // Note: callers are responsible for deciding how to surface the header value (e.g. in HTTP response headers).
@@ -115,18 +121,44 @@ func (l *Limiter) TakeDecision(ctx context.Context) (Decision, error) {
 		return Decision{}, err
 	}
 
-	header := strings.Concat(
-		"limit=",
-		strconv.FormatUint(tokens, 10),
-		", remaining=",
-		strconv.FormatUint(remaining, 10),
-	)
+	resetAfter := resetAfter(reset)
 
 	return Decision{
-		allowed:    ok,
-		header:     header,
-		resetAfter: resetAfter(reset),
+		allowed:      ok,
+		header:       rateLimitHeader(remaining, durationSeconds(resetAfter)),
+		policyHeader: rateLimitPolicyHeader(tokens, durationSeconds(l.window)),
+		resetAfter:   resetAfter,
 	}, nil
+}
+
+func rateLimitHeader(remaining, resetAfter uint64) string {
+	return strings.Concat(
+		`"`,
+		limiterPolicy,
+		`";r=`,
+		strconv.FormatUint(remaining, 10),
+		";t=",
+		strconv.FormatUint(resetAfter, 10),
+	)
+}
+
+func rateLimitPolicyHeader(tokens, window uint64) string {
+	return strings.Concat(
+		`"`,
+		limiterPolicy,
+		`";q=`,
+		strconv.FormatUint(tokens, 10),
+		";w=",
+		strconv.FormatUint(window, 10),
+	)
+}
+
+func limiterWindow(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return time.Second
+	}
+
+	return interval
 }
 
 func resetAfter(reset uint64) time.Duration {
@@ -137,6 +169,19 @@ func resetAfter(reset uint64) time.Duration {
 
 	//nolint:gosec // Reset delay is bounded by the validated limiter interval from the internal store.
 	return time.Duration(reset - now)
+}
+
+func durationSeconds(duration time.Duration) uint64 {
+	if duration <= 0 {
+		return 0
+	}
+
+	seconds := uint64(duration / time.Second)
+	if duration%time.Second != 0 {
+		seconds++
+	}
+
+	return seconds
 }
 
 // Close closes the underlying store and releases any associated resources.

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -80,17 +80,39 @@ func TestTake(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(first)
 	require.NoError(t, err)
 	require.False(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(second)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
+}
+
+func TestTakeDecisionHeaders(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	m := limiter.KeyMap{"user-agent": meta.UserAgent}
+	config := &limiter.Config{Kind: "user-agent", Tokens: 2, Interval: 1500 * time.Millisecond}
+
+	limiter, err := limiter.NewLimiter(lc, m, config)
+	require.NoError(t, err)
+	require.NotNil(t, limiter)
+	defer func() {
+		require.NoError(t, limiter.Close(t.Context()))
+	}()
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+	decision, err := limiter.TakeDecision(ctx)
+
+	require.NoError(t, err)
+	require.True(t, decision.Allowed())
+	require.Equal(t, `"default";r=1;t=2`, decision.Header())
+	require.Equal(t, `"default";q=2;w=2`, decision.PolicyHeader())
+	require.Equal(t, uint64(2), decision.ResetAfterSeconds())
 }
 
 func TestTakeCapsActiveKeys(t *testing.T) {
@@ -113,27 +135,27 @@ func TestTakeCapsActiveKeys(t *testing.T) {
 	ok, header, err := limiter.Take(first)
 	require.NoError(t, err)
 	require.True(t, ok, "first key should get an admitted bucket")
-	require.Equal(t, "limit=2, remaining=1", header)
+	require.Equal(t, `"default";r=1;t=1`, header)
 
 	ok, header, err = limiter.Take(second)
 	require.NoError(t, err)
 	require.True(t, ok, "second key should take from the overflow bucket")
-	require.Equal(t, "limit=2, remaining=1", header)
+	require.Equal(t, `"default";r=1;t=1`, header)
 
 	ok, header, err = limiter.Take(third)
 	require.NoError(t, err)
 	require.True(t, ok, "third key should share the overflow bucket")
-	require.Equal(t, "limit=2, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(fourth)
 	require.NoError(t, err)
 	require.False(t, ok, "fourth key should be denied by the exhausted overflow bucket")
-	require.Equal(t, "limit=2, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(first)
 	require.NoError(t, err)
 	require.True(t, ok, "admitted key should keep its independent bucket")
-	require.Equal(t, "limit=2, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 }
 
 func TestTakeSupportsCustomKeyKind(t *testing.T) {
@@ -157,21 +179,21 @@ func TestTakeSupportsCustomKeyKind(t *testing.T) {
 		ok, header, err := limiter.Take(first)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, "limit=1, remaining=0", header)
+		require.Equal(t, `"default";r=0;t=1`, header)
 	})
 
 	t.Run("denies exhausted tenant", func(t *testing.T) {
 		ok, header, err := limiter.Take(first)
 		require.NoError(t, err)
 		require.False(t, ok)
-		require.Equal(t, "limit=1, remaining=0", header)
+		require.Equal(t, `"default";r=0;t=1`, header)
 	})
 
 	t.Run("uses independent bucket for second tenant", func(t *testing.T) {
 		ok, header, err := limiter.Take(second)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, "limit=1, remaining=0", header)
+		require.Equal(t, `"default";r=0;t=1`, header)
 	})
 }
 
@@ -193,14 +215,14 @@ func TestTakeRefillsAfterConfiguredInterval(t *testing.T) {
 		ok, header, err := limiter.Take(ctx)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, "limit=1, remaining=0", header)
+		require.Equal(t, `"default";r=0;t=1`, header)
 	})
 
 	t.Run("denies exhausted bucket", func(t *testing.T) {
 		ok, header, err := limiter.Take(ctx)
 		require.NoError(t, err)
 		require.False(t, ok)
-		require.Equal(t, "limit=1, remaining=0", header)
+		require.Equal(t, `"default";r=0;t=1`, header)
 	})
 
 	t.Run("refills after interval", func(t *testing.T) {
@@ -228,17 +250,17 @@ func TestTakeUsesSingleBucketForEmptyKeys(t *testing.T) {
 	ok, header, err := limiter.Take(t.Context())
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.Blank())))
 	require.NoError(t, err)
 	require.False(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("<empty>"))))
 	require.NoError(t, err)
 	require.True(t, ok, "raw reserved empty literal should use its own bucket")
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 }
 
 func TestTakeSupportsOversizedKeys(t *testing.T) {
@@ -259,17 +281,17 @@ func TestTakeSupportsOversizedKeys(t *testing.T) {
 	ok, header, err := limiter.Take(first)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(first)
 	require.NoError(t, err)
 	require.False(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(second)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 }
 
 func TestTakeDoesNotCollideOversizedKeysWithRawHashKeys(t *testing.T) {
@@ -293,12 +315,12 @@ func TestTakeDoesNotCollideOversizedKeysWithRawHashKeys(t *testing.T) {
 	ok, header, err := limiter.Take(oversizedCtx)
 	require.NoError(t, err)
 	require.True(t, ok, "oversized key should take its own bucket")
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 
 	ok, header, err = limiter.Take(rawHashCtx)
 	require.NoError(t, err)
 	require.True(t, ok, "raw hash-looking key should use its own bucket")
-	require.Equal(t, "limit=1, remaining=0", header)
+	require.Equal(t, `"default";r=0;t=1`, header)
 }
 
 func TestNewKeyMap(t *testing.T) {


### PR DESCRIPTION
## What

- Report transport drain state through gRPC health checks, lists, and watches so draining servers move to NOT_SERVING consistently with HTTP readiness.
- Make server drain dependencies explicit across lifecycle, HTTP health, gRPC health, and test wiring.
- Emit structured RateLimit and RateLimit-Policy values for HTTP responses and matching ratelimit and ratelimit-policy metadata for server-side gRPC limiter decisions.

## Why

- gRPC-native health clients and load balancers need the same shutdown signal that HTTP readiness already exposes, otherwise rollout traffic can continue targeting a server after drain begins.
- Rate limit clients need interoperable quota metadata instead of a custom comma-separated string, and both transports should expose the same current-limit and policy information.

## Testing

- `go test -count=1 ./net/server ./transport/...` - passed; covers drain lifecycle behavior, HTTP/gRPC health drain reporting, and transport limiter header/metadata behavior.
- `make lint` - passed with the existing gomodguard deprecation warning and 0 issues.
- `make specs` - not run locally; the focused transport suite covers the changed packages, while full CI specs also depend on the repository sidecar setup.

AI-assisted-by: [Codex](https://openai.com/codex/)
