### PR TITLE
feat(token): tighten config validation boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,14 @@ matching skill for the task.
   real client, route, or deployment contract that depends on strict weighted
   `Accept` negotiation for MVC 404 responses.
 - JWT verification requires both the expected algorithm and a `kid` header.
+- JWT, PASETO, and SSH token key material is intentionally loaded and checked
+  by the runtime `Generate` and `Verify` paths. Do not flag missing startup
+  warmup/validation for token key sources solely because bad, missing,
+  unreadable, or malformed administrator-supplied key material can surface
+  during token issuance or verification. Report only concrete bugs such as
+  panics, accepted weak or wrong key types/sizes, secret leakage, ignored
+  documented token config validation, or a public API promise that token key
+  material is fully resolved before runtime token operations.
 - Token tests should focus on repository-owned wrapper behavior. Do not flag or
   add tests that require hand-crafting upstream JWT/PASETO internals solely to
   prove library-owned parsing, signature, expiration, not-before, or

--- a/config/validator.go
+++ b/config/validator.go
@@ -7,6 +7,9 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+// FieldLevel aliases the upstream validator field-level interface for custom config validation rules.
+type FieldLevel = validator.FieldLevel
+
 // NewValidator constructs a Validator backed by go-playground/validator.
 //
 // It enables required-struct validation ([validator.WithRequiredStructEnabled]), which causes validation
@@ -26,30 +29,22 @@ func NewValidator() *Validator {
 	return &Validator{validate}
 }
 
-func validateConfigSize(fl validator.FieldLevel) bool {
-	field := fl.Field()
-	if !field.CanInt() {
-		return false
-	}
-
-	size := bytes.Size(field.Int())
-	return size >= 0 && size <= bytes.MaxConfigSize
-}
-
-func validateDurationSecondPrecision(fl validator.FieldLevel) bool {
-	field := fl.Field()
-	if !field.CanInt() {
-		return false
-	}
-
-	duration := time.Duration(field.Int())
-	return duration > 0 && duration%time.Second == 0
-}
-
 // Validator wraps a go-playground validator instance.
 //
 // It is used by `NewConfig[T]` to validate decoded configuration structs. You may use the embedded
 // `*validator.Validate` directly to register custom validations or to validate values manually.
 type Validator struct {
 	*validator.Validate
+}
+
+func validateConfigSize(fl FieldLevel) bool {
+	field := fl.Field()
+	size := bytes.Size(field.Int())
+	return size >= 0 && size <= bytes.MaxConfigSize
+}
+
+func validateDurationSecondPrecision(fl FieldLevel) bool {
+	field := fl.Field()
+	duration := time.Duration(field.Int())
+	return duration > 0 && duration%time.Second == 0
 }

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -17,30 +17,6 @@ type secondPrecisionDuration struct {
 	Duration time.Duration `validate:"duration_second_precision"`
 }
 
-type invalidConfigSizeFieldKind struct {
-	Size string `validate:"config_size"`
-}
-
-type invalidSecondPrecisionDurationFieldKind struct {
-	Duration string `validate:"duration_second_precision"`
-}
-
-func TestValidatorRejectsInvalidFieldKinds(t *testing.T) {
-	tests := []struct {
-		config any
-		name   string
-	}{
-		{name: "config size", config: &invalidConfigSizeFieldKind{Size: "64B"}},
-		{name: "duration second precision", config: &invalidSecondPrecisionDurationFieldKind{Duration: "1s"}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Error(t, test.Validator.Struct(tt.config))
-		})
-	}
-}
-
 func TestValidatorConfigSize(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/token/config.go
+++ b/token/config.go
@@ -16,8 +16,8 @@ import (
 //
 // Enablement is modeled by presence:
 //   - A nil *[Config] means "token support disabled" at the top level.
-//   - When enabled, individual token implementations may still be disabled if their
-//     nested configuration is nil (for example JWT == nil while Kind == "jwt").
+//   - When enabled, Kind must select a supported implementation and that
+//     implementation's nested configuration must be present.
 //
 // # Selecting an implementation (Kind)
 //
@@ -27,31 +27,32 @@ import (
 //   - "paseto": PASETO v4 public tokens (see package token/paseto)
 //   - "ssh": SSH-style signed tokens (see package token/ssh)
 //
-// The selected implementation's nested configuration should typically be provided
-// in the corresponding field (JWT/Paseto/SSH).
+// The selected implementation's nested configuration must be provided in the
+// corresponding field (JWT/Paseto/SSH).
 //
-// If Kind is unknown, the token facade treats the configuration as invalid and
-// [Token.Generate]/[Token.Verify] return [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig].
+// Config validation rejects unknown Kind values. If validation is bypassed, the
+// token facade treats the configuration as invalid and [Token.Generate]/[Token.Verify]
+// return [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig].
 type Config struct {
 	// JWT configures the JWT token implementation.
 	//
 	// When Kind == "jwt", this configuration is consumed by token/jwt.
-	JWT *jwt.Config `yaml:"jwt,omitempty" json:"jwt,omitempty" toml:"jwt,omitempty"`
+	JWT *jwt.Config `yaml:"jwt,omitempty" json:"jwt,omitempty" toml:"jwt,omitempty" validate:"required_if=Kind jwt"`
 
 	// Paseto configures the PASETO token implementation.
 	//
 	// When Kind == "paseto", this configuration is consumed by token/paseto.
-	Paseto *paseto.Config `yaml:"paseto,omitempty" json:"paseto,omitempty" toml:"paseto,omitempty"`
+	Paseto *paseto.Config `yaml:"paseto,omitempty" json:"paseto,omitempty" toml:"paseto,omitempty" validate:"required_if=Kind paseto"`
 
 	// SSH configures the SSH token implementation.
 	//
 	// When Kind == "ssh", this configuration is consumed by token/ssh.
-	SSH *ssh.Config `yaml:"ssh,omitempty" json:"ssh,omitempty" toml:"ssh,omitempty"`
+	SSH *ssh.Config `yaml:"ssh,omitempty" json:"ssh,omitempty" toml:"ssh,omitempty" validate:"required_if=Kind ssh"`
 
 	// Kind selects the token implementation to use.
 	//
 	// Supported values: "jwt", "paseto", "ssh".
-	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
+	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty" validate:"required,oneof=jwt paseto ssh"`
 }
 
 // IsEnabled reports whether token configuration is present.

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -149,6 +149,47 @@ func TestSSHSubjectMatchesActiveKey(t *testing.T) {
 	require.Equal(t, test.UserID.String(), sub)
 }
 
+func TestConfigRejectsInvalidValues(t *testing.T) {
+	valid := test.NewToken("jwt")
+	tests := []struct {
+		config *token.Config
+		name   string
+	}{
+		{
+			name:   "missing kind",
+			config: &token.Config{JWT: valid.JWT},
+		},
+		{
+			name:   "unknown kind",
+			config: &token.Config{Kind: "none"},
+		},
+		{
+			name:   "missing jwt config",
+			config: &token.Config{Kind: "jwt"},
+		},
+		{
+			name:   "missing paseto config",
+			config: &token.Config{Kind: "paseto"},
+		},
+		{
+			name:   "missing ssh config",
+			config: &token.Config{Kind: "ssh"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, test.Validator.Struct(tt.config))
+		})
+	}
+
+	for _, kind := range []string{"jwt", "paseto", "ssh"} {
+		t.Run(kind, func(t *testing.T) {
+			require.NoError(t, test.Validator.Struct(test.NewToken(kind)))
+		})
+	}
+}
+
 func TestUnknownKindConfig(t *testing.T) {
 	cfg := test.NewToken("none")
 	tkn := token.NewToken(test.Name, cfg, test.FS, nil)


### PR DESCRIPTION
## What

- Require the selected auth config block to be present when kind selects JWT, PASETO, or SSH, and reject missing or unknown auth kinds during config validation.
- Keep custom config validators on the repository-owned field-level alias and limit those validators to the int-like fields they are intended to handle.
- Document that JWT, PASETO, and SSH key material is intentionally resolved by runtime Generate and Verify paths so future reliability reviews do not resurface startup key warmup.

## Why

- Invalid auth kind/config combinations should fail at the configuration boundary instead of reaching facade dispatch paths.
- The validator helpers should match their actual supported field shapes without carrying defensive string-kind behavior that the repository does not support.
- Runtime key-source loading is the accepted token contract, so the agent guidance now narrows reviews to concrete runtime bugs or ignored validation.

## Testing

- `go test ./token ./token/jwt ./token/keys ./token/paseto ./token/ssh ./transport/http ./transport/grpc` - passed
- `go test ./token` - passed
- `make lint` - passed
- `make sec` - passed
- `make specs` - passed
