### PR TITLE
feat(health): ping db pools concurrently

### DIFF
--- a/health/checker/db.go
+++ b/health/checker/db.go
@@ -54,14 +54,18 @@ func (c *DBChecker) Check(ctx context.Context) error {
 		return ErrNoConnections
 	}
 
-	errs := make([]error, 0, len(databases))
+	var group sync.ErrorsGroup
 	for _, database := range databases {
-		err := c.ping(ctx, database.db)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("db %s[%d]: %w", database.role, database.index, err))
-		}
+		group.Go(func() error {
+			err := c.ping(ctx, database.db)
+			if err != nil {
+				return fmt.Errorf("db %s[%d]: %w", database.role, database.index, err)
+			}
+
+			return nil
+		})
 	}
-	return errors.Join(errs...)
+	return group.Wait()
 }
 
 type database struct {


### PR DESCRIPTION
## What

- Ping all configured DB pools concurrently when running the DB checker.
- Preserve the existing per-pool timeout, role/index error wrapping, and joined error result.

## Why

- A multi-pool DB outage should not make one health check take the sum of every slow pool timeout.
- Bounding the check by the slowest pool improves startup readiness and health-state freshness during dependency failures.

## Testing

- `make package=health/checker specs` - passed
- `make package=health/checker lint` - passed
- `git diff --check` - passed
- `go test ./health/... ./transport/http/health ./transport/grpc/health` - passed
