### PR TITLE
feat(config): reject unsupported source prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ Config input is routed by flags called `-config` and `-c`:
 
   The repository helper `make kind=configs/config encode-config` uses GNU `base64 -w 0`; on macOS/BSD, use `base64 | tr -d '\n'` for the equivalent single-line payload.
 
-- Otherwise (no `file:`/`env:` prefix), the decoder falls back to **default lookup**, searching for:
+- Unsupported explicit `kind:location` prefixes fail startup instead of falling back to another source.
+
+- Unprefixed values, including an empty value, fall back to **default lookup**, searching for:
 
   `<serviceName>.{yaml,yml,hjson,toml,json}`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -197,13 +197,27 @@ func TestInvalidCommonConfig(t *testing.T) {
 }
 
 func TestInvalidKindConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", test.FS.Join(home, ".config"))
+
+	configDir := os.UserConfigDir()
+	path := test.FS.Join(configDir, test.Name.String())
+
+	require.NoError(t, test.FS.MkdirAll(path, 0o777))
+
+	data, err := test.FS.ReadFile(test.Path("configs/config.yml"))
+	require.NoError(t, err)
+
+	require.NoError(t, test.FS.WriteFile(test.FS.Join(path, test.Name.String()+".yml"), data, 0o600))
+
 	set := flag.NewFlagSet("test")
 	set.AddConfig("test:test")
 
 	decoder := test.NewDecoder(set)
 
-	_, err := config.NewConfig[config.Config](decoder, test.Validator)
-	require.Error(t, err)
+	_, err = config.NewConfig[config.Config](decoder, test.Validator)
+	require.ErrorIs(t, err, config.ErrInvalidSource)
 }
 
 func TestNewConfigRejectsEmptyDecodedConfig(t *testing.T) {

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -39,20 +39,25 @@ type DecoderParams struct {
 //     encoder is used (e.g. ".yaml" -> "yaml", ".hjson" -> "hjson").
 //   - "env:<ENV_VAR>": uses the env decoder to read from the environment variable <ENV_VAR>.
 //     The variable value must be formatted as "<extension>:<base64-content>" (e.g. "yaml:..." or "hjson:...").
-//   - anything else (including empty): uses the default lookup decoder, which searches common
+//   - unprefixed values (including empty): use the default lookup decoder, which searches common
 //     locations for "<serviceName>.{yaml,yml,hjson,toml,json}".
+//   - unsupported explicit "kind:location" values fail with [ErrInvalidSource].
 //
 // The returned Decoder is safe for repeated calls to Decode; underlying behavior depends on the
 // selected implementation.
 func NewDecoder(params DecoderParams) Decoder {
-	kind, location := strings.CutColon(params.Flags.GetConfig())
+	kind, location, found := strings.CutColon(params.Flags.GetConfig())
+	if !found {
+		return NewDefault(params.Name, params.Encoder, params.FS)
+	}
+
 	switch kind {
 	case "file":
 		return NewFile(location, params.Encoder, params.FS)
 	case "env":
 		return NewENV(location, params.Encoder)
 	default:
-		return NewDefault(params.Name, params.Encoder, params.FS)
+		return invalidSourceDecoder{}
 	}
 }
 
@@ -66,4 +71,10 @@ type Decoder interface {
 	// The v parameter should be a pointer to the destination type. Implementations may return
 	// errors for missing inputs, unknown/unsupported kinds, I/O failures, or decode/unmarshal failures.
 	Decode(v any) error
+}
+
+type invalidSourceDecoder struct{}
+
+func (invalidSourceDecoder) Decode(any) error {
+	return ErrInvalidSource
 }

--- a/config/doc.go
+++ b/config/doc.go
@@ -12,8 +12,9 @@
 //     on the file extension.
 //   - "env:<ENV_VAR>": loads configuration from the environment variable named <ENV_VAR>. The variable
 //     value must be formatted as "<extension>:<base64-content>" (for example "yaml:...").
-//   - otherwise: uses the default lookup, searching for "<serviceName>.{yaml,yml,hjson,toml,json}" in common
+//   - unprefixed values use the default lookup, searching for "<serviceName>.{yaml,yml,hjson,toml,json}" in common
 //     locations (executable directory, user config dir, and /etc).
+//   - unsupported explicit "kind:location" values fail with [ErrInvalidSource].
 //
 // Default lookup intentionally requires a valid user configuration directory environment before lookup starts.
 // It may resolve the user config directory before probing file candidates, so runtimes using default lookup

--- a/config/env.go
+++ b/config/env.go
@@ -28,7 +28,7 @@ import (
 //
 // NewENV reads the environment variable once at construction time and stores the parsed kind and data.
 func NewENV(location string, enc *encoding.Map) *ENV {
-	kind, data := strings.CutColon(os.Getenv(location))
+	kind, data, _ := strings.CutColon(os.Getenv(location))
 	return &ENV{kind: kind, data: data, enc: enc}
 }
 

--- a/config/errors.go
+++ b/config/errors.go
@@ -30,4 +30,10 @@ var (
 	// (as determined by structs.IsEmpty), which helps prevent accidentally starting with a zero-value
 	// configuration.
 	ErrInvalidConfig = errors.New("config: invalid format")
+
+	// ErrInvalidSource is returned when an explicit configuration source uses an unsupported kind.
+	//
+	// Supported explicit sources are "file:<path>" and "env:<ENV_VAR>". Use an empty or unprefixed
+	// value to select default lookup.
+	ErrInvalidSource = errors.New("config: invalid source")
 )

--- a/flag/doc.go
+++ b/flag/doc.go
@@ -14,6 +14,8 @@
 //   - "file:/path/to/config.yaml" to read configuration from a file (decoder selected by extension)
 //   - "env:MY_CONFIG" to read configuration from an environment variable (typically "<kind>:<base64-content>")
 //
+// The config package treats unsupported explicit "kind:location" values as invalid.
+//
 // The [FlagSet] type in this package supports installing this convention via [FlagSet.AddConfig] and
 // retrieving it via [FlagSet.GetConfig]. The config subsystem ([config.NewDecoder]) consumes this value
 // to route to the appropriate decoder.

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -34,6 +34,8 @@ type FlagSet struct {
 //   - "file:/path/to/config.yaml" (decode kind inferred from file extension)
 //   - "env:MY_CONFIG" (read config payload from environment variable MY_CONFIG)
 //
+// The config package treats unsupported explicit "kind:location" values as invalid.
+//
 // The provided value is used as the default. AddConfig registers both flag names against the same
 // backing value, so if both aliases are supplied during parsing, the later parsed flag wins.
 //

--- a/os/fs.go
+++ b/os/fs.go
@@ -191,7 +191,7 @@ func (fs *FS) ExecutableDir() string {
 // storage. Callers that need to mutate the bytes should clone the returned
 // slice first.
 func (fs *FS) ReadSource(source string) ([]byte, error) {
-	kind, path := strings.CutColon(source)
+	kind, path, _ := strings.CutColon(source)
 	switch kind {
 	case "env":
 		if strings.IsEmpty(path) {

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -140,12 +140,10 @@ func Concat(ss ...string) string {
 // CutColon splits s on the first ":" and returns the parts before and after.
 //
 // If ":" is not present, before is the original input and after is [Empty].
-// Callers that need to distinguish presence with a boolean should use [Cut]
-// with ":" directly.
+// The returned boolean reports whether ":" was found.
 //
 // This helper is commonly used by go-service "source string" conventions where a
 // value is prefixed with a kind such as "env:NAME" or "file:/path".
-func CutColon(s string) (string, string) {
-	before, after, _ := Cut(s, ":")
-	return before, after
+func CutColon(s string) (string, string, bool) {
+	return Cut(s, ":")
 }

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -122,20 +122,22 @@ func TestCutColon(t *testing.T) {
 		s          string
 		wantBefore string
 		wantAfter  string
+		wantFound  bool
 	}{
-		{name: "env source", s: "env:NAME", wantBefore: "env", wantAfter: "NAME"},
-		{name: "file source with later colon", s: "file:/tmp/a:b", wantBefore: "file", wantAfter: "/tmp/a:b"},
+		{name: "env source", s: "env:NAME", wantBefore: "env", wantAfter: "NAME", wantFound: true},
+		{name: "file source with later colon", s: "file:/tmp/a:b", wantBefore: "file", wantAfter: "/tmp/a:b", wantFound: true},
 		{name: "missing colon", s: "literal", wantBefore: "literal", wantAfter: ""},
-		{name: "leading colon", s: ":value", wantBefore: "", wantAfter: "value"},
-		{name: "trailing colon", s: "env:", wantBefore: "env", wantAfter: ""},
+		{name: "leading colon", s: ":value", wantBefore: "", wantAfter: "value", wantFound: true},
+		{name: "trailing colon", s: "env:", wantBefore: "env", wantAfter: "", wantFound: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			before, after := strings.CutColon(test.s)
+			before, after, found := strings.CutColon(test.s)
 
 			require.Equal(t, test.wantBefore, before)
 			require.Equal(t, test.wantAfter, after)
+			require.Equal(t, test.wantFound, found)
 		})
 	}
 }


### PR DESCRIPTION
## What

- Reject unsupported explicit `kind:location` config sources instead of falling back to default lookup.
- Change `strings.CutColon` to return the colon-presence boolean and update in-repo callers.
- Document the config source routing behavior in GoDoc and README, including the intentional `CutColon` API break for callers that used two return values.

## Why

- A mistyped explicit source such as `fiel:/prod.yml` could previously start a service with an unrelated default config when one existed.
- Failing unsupported explicit prefixes makes config rollout mistakes visible at startup instead of silently running stale or unintended settings.

## Testing

- `go test ./strings ./config ./flag -count=1` - passed
- `make lint` - passed
- `make specs` - passed
