### PR TITLE
feat(http): classify context cancellations

### DIFF
--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"fmt"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -115,8 +116,10 @@ func DefaultMessage(code int) string {
 // Resolution order:
 //  1. If err implements Coder, return coder.Code().
 //  2. If err is a raw *[http.MaxBytesError], return StatusRequestEntityTooLarge (413).
-//  3. If err is a gRPC status error, map its gRPC code to an HTTP status code using the statusCodes table.
-//  4. Otherwise return StatusInternalServerError (500).
+//  3. If err wraps context.Canceled, return StatusClientClosedRequest (499).
+//  4. If err wraps context.DeadlineExceeded, return StatusGatewayTimeout (504).
+//  5. If err is a gRPC status error, map its gRPC code to an HTTP status code using the statusCodes table.
+//  6. Otherwise return StatusInternalServerError (500).
 func Code(err error) int {
 	if coder, ok := coderFromError(err); ok {
 		return coder.Code()
@@ -124,6 +127,14 @@ func Code(err error) int {
 
 	if isMaxBytesError(err) {
 		return http.StatusRequestEntityTooLarge
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return http.StatusClientClosedRequest
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout
 	}
 
 	s, ok := status.FromError(err)

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	grpcstatus "github.com/alexfalkowski/go-service/v2/net/grpc/status"
@@ -168,6 +169,23 @@ func TestCodeMapsUnknownGRPCStatusCodeToInternalServerError(t *testing.T) {
 	err := grpcstatus.Error(codes.Code(999), "unknown")
 
 	require.Equal(t, http.StatusInternalServerError, httpstatus.Code(err))
+}
+
+func TestCodeMapsContextErrors(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		name string
+		want int
+	}{
+		{name: "canceled", err: context.Canceled, want: http.StatusClientClosedRequest},
+		{name: "wrapped canceled", err: fmt.Errorf("wrapped: %w", context.Canceled), want: http.StatusClientClosedRequest},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: http.StatusGatewayTimeout},
+		{name: "wrapped deadline exceeded", err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded), want: http.StatusGatewayTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, httpstatus.Code(tc.err))
+		})
+	}
 }
 
 func TestWriteErrorReturnsWriteFailure(t *testing.T) {


### PR DESCRIPTION
## What

- Classify plain context cancellation errors in `net/http/status.Code`.
- Map `context.Canceled` to client-closed request responses and `context.DeadlineExceeded` to gateway timeout responses.
- Add coverage for direct and wrapped context cancellation and deadline errors.

## Why

- Plain request cancellations and deadline expirations should not inflate HTTP 5xx telemetry when they represent client disconnects or timeout conditions.
- This aligns plain context errors with the existing gRPC cancellation and deadline status mapping.

## Testing

- `go test ./net/http/status ./net/http/mvc ./transport/http/telemetry/logger` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
