### PR TITLE
feat(grpc): drain unknown health watches

### DIFF
--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -415,6 +415,37 @@ func TestNotFoundWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
+func TestNotFoundWatchDrains(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+
+	drain := netserver.NewDrain()
+	watcher := grpchealth.NewServer(grpchealth.ServerParams{Server: world.GRPCHealth, Drain: drain})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stream := test.NewWatchStream(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watcher.Watch(&health.Request{Service: "bob"}, stream)
+	}()
+
+	resp := requireWatchResponse(t, stream.Responses)
+	require.Equal(t, health.ServiceUnknown, resp.GetStatus())
+
+	drain.Start()
+
+	resp = requireWatchResponse(t, stream.Responses)
+	require.Equal(t, health.NotServing, resp.GetStatus())
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch stream did not stop after drain")
+	}
+}
+
 func TestIgnoreAuthWatch(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -89,7 +89,7 @@ func (s *Server) List(_ context.Context, _ *health.ListRequest) (*health.ListRes
 // the "grpc" transport kind, matching [Server.Check] and [Server.List].
 //
 // The initial status is sent immediately. When the requested service is unknown, Watch sends
-// `SERVICE_UNKNOWN` and keeps the stream open until the client cancels.
+// `SERVICE_UNKNOWN` and keeps the stream open until the client cancels or the server drains.
 func (s *Server) Watch(req *health.Request, w health.WatchServer) error {
 	service := req.GetService()
 	if strings.IsEmpty(service) {
@@ -98,7 +98,7 @@ func (s *Server) Watch(req *health.Request, w health.WatchServer) error {
 
 	observer, err := s.server.Observer(service, "grpc")
 	if err != nil {
-		return sendUnknownStatus(w)
+		return s.sendUnknownStatus(w)
 	}
 
 	return s.watch(w, observer.Watch())
@@ -142,22 +142,25 @@ func (s *Server) healthStatus(err error) health.Status {
 	return healthStatus(err)
 }
 
+func (s *Server) sendUnknownStatus(w health.WatchServer) error {
+	if err := sendStatus(w, health.ServiceUnknown); err != nil {
+		return err
+	}
+
+	select {
+	case <-s.drain.Done():
+		return sendStatus(w, health.NotServing)
+	case <-w.Context().Done():
+		return status.SafeError(codes.Canceled, w.Context().Err())
+	}
+}
+
 func healthStatus(err error) health.Status {
 	if err != nil {
 		return health.NotServing
 	}
 
 	return health.Serving
-}
-
-func sendUnknownStatus(w health.WatchServer) error {
-	if err := sendStatus(w, health.ServiceUnknown); err != nil {
-		return err
-	}
-
-	<-w.Context().Done()
-
-	return status.SafeError(codes.Canceled, w.Context().Err())
 }
 
 func sendStatus(w health.WatchServer, st health.Status) error {


### PR DESCRIPTION
## What

- Unknown-service health watch streams now observe server drain and emit `NOT_SERVING` before returning.
- The existing unknown-service `SERVICE_UNKNOWN` response is preserved before the stream waits for client cancellation or drain.

## Why

- A client holding a watch open for an unknown service could delay graceful shutdown until the stop context forced a hard stop.
- Aligning unknown-service watches with known-service watches lets draining servers close health streams cleanly.

## Testing

- `make package=transport/grpc/health specs` - passed
- `make package=transport/grpc/health lint` - passed
- Added `TestNotFoundWatchDrains` to cover the unknown-service watch drain path.
