### PR TITLE
feat(mvc): add static cache validators

### DIFF
--- a/net/http/mvc/example_test.go
+++ b/net/http/mvc/example_test.go
@@ -64,6 +64,80 @@ func ExampleNotFound() {
 	// Not Found
 }
 
+func ExampleStaticFile() {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  exampleFileSystem(),
+		Pool:        sync.NewBufferPool(),
+		Layout:      mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	mvc.StaticFile(
+		"/asset.txt",
+		"static/asset.txt",
+		mvc.WithCacheControl("public, max-age=60"),
+		mvc.WithCacheValidators(),
+	)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	etag := res.Header().Get("ETag")
+	fmt.Println(res.Code)
+	fmt.Println(res.Header().Get("Cache-Control"))
+	fmt.Println(etag != "")
+
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
+	req.Header.Set("If-None-Match", etag)
+	res = httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	fmt.Println(res.Code)
+	fmt.Println(res.Body.Len())
+	// Output:
+	// 200
+	// public, max-age=60
+	// true
+	// 304
+	// 0
+}
+
+func ExampleStaticPathValue() {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  exampleFileSystem(),
+		Pool:        sync.NewBufferPool(),
+		Layout:      mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+	})
+
+	mvc.StaticPathValue("/{file...}", "file", "static", mvc.WithCacheValidators())
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	etag := res.Header().Get("ETag")
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
+	req.Header.Set("If-None-Match", etag)
+	res = httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	fmt.Println(res.Code)
+	fmt.Println(res.Body.Len())
+	// Output:
+	// 304
+	// 0
+}
+
 type examplePage struct {
 	Title string
 }
@@ -73,5 +147,6 @@ func exampleFileSystem() fstest.MapFS {
 		"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
 		"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
 		"views/page.tmpl":    &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Title }}{{ end }}`)},
+		"static/asset.txt":   &fstest.MapFile{Data: []byte("hello")},
 	}
 }

--- a/net/http/mvc/options.go
+++ b/net/http/mvc/options.go
@@ -1,0 +1,35 @@
+package mvc
+
+// StaticOption configures static file response behavior.
+type StaticOption func(*staticOptions)
+
+type staticOptions struct {
+	cacheControl    string
+	cacheValidators bool
+}
+
+// WithCacheControl sets the Cache-Control response header for a static route.
+func WithCacheControl(value string) StaticOption {
+	return func(options *staticOptions) {
+		options.cacheControl = value
+	}
+}
+
+// WithCacheValidators adds ETag and Last-Modified response headers for a static route.
+//
+// When a request's If-None-Match header matches the generated ETag, the route responds with
+// 304 Not Modified and no body.
+func WithCacheValidators() StaticOption {
+	return func(options *staticOptions) {
+		options.cacheValidators = true
+	}
+}
+
+func options(opts ...StaticOption) *staticOptions {
+	options := &staticOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -1,14 +1,8 @@
 package mvc
 
 import (
-	"io/fs"
-	"path"
-	"strconv"
-
-	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
-	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -99,104 +93,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 	return true
 }
 
-// StaticFile registers an HTTP GET route that serves the named file from the registered filesystem.
-//
-// It returns false when MVC is not defined (see IsDefined).
-func StaticFile(pattern, name string) bool {
-	if !IsDefined() {
-		return false
-	}
-
-	handler := func(res http.ResponseWriter, req *http.Request) {
-		serveFile(res, name)
-	}
-
-	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
-	return true
-}
-
-// StaticPathValue registers an HTTP GET route that serves a file chosen by a path value.
-//
-// The file name is built under prefix from a validated request path value. Invalid paths and
-// traversal attempts are rejected with HTTP 400.
-//
-// It returns false when MVC is not defined (see IsDefined).
-func StaticPathValue(pattern, value, prefix string) bool {
-	if !IsDefined() {
-		return false
-	}
-
-	handler := func(res http.ResponseWriter, req *http.Request) {
-		cleaned := path.Clean(req.PathValue(value))
-		if cleaned == "." || cleaned != req.PathValue(value) || !fs.ValidPath(cleaned) || strings.Contains(cleaned, `\`) {
-			res.WriteHeader(staticStatusCode(status.BadRequestError(fs.ErrInvalid)))
-			return
-		}
-
-		name := path.Join(prefix, cleaned)
-		serveFile(res, name)
-	}
-
-	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
-	return true
-}
-
-func serveFile(res http.ResponseWriter, name string) {
-	f, err := fileSystem.Open(name)
-	if err != nil {
-		res.WriteHeader(staticStatusCode(err))
-		return
-	}
-	defer f.Close()
-
-	info, err := f.Stat()
-	if err != nil {
-		res.WriteHeader(staticStatusCode(err))
-		return
-	}
-	if info.IsDir() {
-		res.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	setStaticContentType(res, name)
-	setStaticContentLength(res, info.Size())
-	res.WriteHeader(http.StatusOK)
-	_, _ = io.Copy(res, f)
-}
-
-func staticStatusCode(err error) int {
-	if errors.Is(err, fs.ErrNotExist) {
-		return http.StatusNotFound
-	}
-	return status.Code(err)
-}
-
-func setStaticContentType(res http.ResponseWriter, name string) {
-	mediaType := media.TypeByExtension(path.Ext(name))
-	if !strings.IsEmpty(mediaType) {
-		res.Header().Set(content.TypeKey, media.MustParse(mediaType).WithUTF8())
-	}
-}
-
-func setStaticContentLength(res http.ResponseWriter, size int64) {
-	if size >= 0 {
-		res.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-	}
-}
-
-func writeView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) {
-	if err := renderView(ctx, res, view, model, code); err != nil {
-		res.WriteHeader(status.Code(err))
-	}
-}
-
 func writeNotFound(req *http.Request, res http.ResponseWriter) {
-	if notFoundController == nil {
-		res.WriteHeader(http.StatusNotFound)
-		return
-	}
-
 	err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
 	res.Header().Set(content.TypeKey, htmlContentType)
 	ctx := req.Context()
@@ -207,25 +104,4 @@ func writeNotFound(req *http.Request, res http.ResponseWriter) {
 	if err := renderView(ctx, res, view, model, http.StatusNotFound); err != nil {
 		res.WriteHeader(status.Code(err))
 	}
-}
-
-func renderView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) error {
-	if view == nil {
-		return ErrMissingView
-	}
-
-	buffer := pool.Get()
-	defer pool.Put(buffer)
-
-	if err := view.render(ctx, buffer, model); err != nil {
-		return err
-	}
-
-	writeBuffer(res, code, buffer)
-	return nil
-}
-
-func writeBuffer(res http.ResponseWriter, code int, buffer *bytes.Buffer) {
-	res.WriteHeader(code)
-	_, _ = buffer.WriteTo(res)
 }

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,6 +123,99 @@ func TestStaticFileRejectsDirectory(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusNotFound, res.Code)
+}
+
+func TestStaticFileSetsCacheControl(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/asset.txt": &fstest.MapFile{Data: []byte("hello")},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticFile("/asset.txt", "static/asset.txt", mvc.WithCacheControl("public, max-age=60")))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "public, max-age=60", res.Header().Get("Cache-Control"))
+	require.Empty(t, res.Header().Get("ETag"))
+	test.RequireResponseBody(t, res, "hello")
+}
+
+func TestStaticFileUsesETagValidator(t *testing.T) {
+	modified := time.Now().UTC()
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/asset.txt": &fstest.MapFile{Data: []byte("hello"), ModTime: modified},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticFile("/asset.txt", "static/asset.txt", mvc.WithCacheValidators()))
+
+	firstReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+	firstRes := httptest.NewRecorder()
+
+	mux.ServeHTTP(firstRes, firstReq)
+
+	etag := firstRes.Header().Get("ETag")
+	require.Equal(t, http.StatusOK, firstRes.Code)
+	require.NotEmpty(t, etag)
+	require.Equal(t, modified.Format(http.TimeFormat), firstRes.Header().Get("Last-Modified"))
+	test.RequireResponseBody(t, firstRes, "hello")
+
+	secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+	secondReq.Header.Set("If-None-Match", "W/"+etag)
+	secondRes := httptest.NewRecorder()
+
+	mux.ServeHTTP(secondRes, secondReq)
+
+	require.Equal(t, http.StatusNotModified, secondRes.Code)
+	require.Equal(t, etag, secondRes.Header().Get("ETag"))
+	test.RequireEmptyResponseBody(t, secondRes)
+}
+
+func TestStaticPathValueUsesETagValidator(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem: fstest.MapFS{
+			"static/asset.txt": &fstest.MapFile{Data: []byte("hello")},
+		},
+		Pool:   test.Pool,
+		Layout: test.Layout,
+	})
+	require.True(t, mvc.StaticPathValue("/{file...}", "file", "static", mvc.WithCacheValidators()))
+
+	firstReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+	firstRes := httptest.NewRecorder()
+
+	mux.ServeHTTP(firstRes, firstReq)
+
+	etag := firstRes.Header().Get("ETag")
+	require.Equal(t, http.StatusOK, firstRes.Code)
+	require.NotEmpty(t, etag)
+	test.RequireResponseBody(t, firstRes, "hello")
+
+	secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+	secondReq.Header.Set("If-None-Match", etag)
+	secondRes := httptest.NewRecorder()
+
+	mux.ServeHTTP(secondRes, secondReq)
+
+	require.Equal(t, http.StatusNotModified, secondRes.Code)
+	test.RequireEmptyResponseBody(t, secondRes)
 }
 
 func TestViewRenderReturnsContextError(t *testing.T) {

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -1,0 +1,180 @@
+package mvc
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"path"
+	"strconv"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+// StaticFile registers an HTTP GET route that serves the named file from the registered filesystem.
+//
+// It returns false when MVC is not defined (see IsDefined).
+func StaticFile(pattern, name string, opts ...StaticOption) bool {
+	if !IsDefined() {
+		return false
+	}
+
+	options := options(opts...)
+	handler := func(res http.ResponseWriter, req *http.Request) {
+		serveFile(res, req, name, options)
+	}
+
+	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
+	return true
+}
+
+// StaticPathValue registers an HTTP GET route that serves a file chosen by a path value.
+//
+// The file name is built under prefix from a validated request path value. Invalid paths and
+// traversal attempts are rejected with HTTP 400.
+//
+// It returns false when MVC is not defined (see IsDefined).
+func StaticPathValue(pattern, value, prefix string, opts ...StaticOption) bool {
+	if !IsDefined() {
+		return false
+	}
+
+	options := options(opts...)
+	handler := func(res http.ResponseWriter, req *http.Request) {
+		cleaned := path.Clean(req.PathValue(value))
+		if cleaned == "." || cleaned != req.PathValue(value) || !fs.ValidPath(cleaned) || strings.Contains(cleaned, `\`) {
+			res.WriteHeader(staticStatusCode(status.BadRequestError(fs.ErrInvalid)))
+			return
+		}
+
+		name := path.Join(prefix, cleaned)
+		serveFile(res, req, name, options)
+	}
+
+	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
+	return true
+}
+
+func serveFile(res http.ResponseWriter, req *http.Request, name string, options *staticOptions) {
+	f, err := fileSystem.Open(name)
+	if err != nil {
+		res.WriteHeader(staticStatusCode(err))
+		return
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		res.WriteHeader(staticStatusCode(err))
+		return
+	}
+	if info.IsDir() {
+		res.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	setStaticCacheControl(res, options)
+	if options.cacheValidators {
+		serveFileWithCacheValidators(res, req, name, f, info)
+		return
+	}
+
+	writeStaticFile(res, name, f, info)
+}
+
+func serveFileWithCacheValidators(res http.ResponseWriter, req *http.Request, name string, f fs.File, info fs.FileInfo) {
+	etag, err := staticETag(name)
+	if err != nil {
+		res.WriteHeader(staticStatusCode(err))
+		return
+	}
+
+	setStaticValidators(res, etag, info)
+	if staticETagMatches(req.Header.Get("If-None-Match"), etag) {
+		res.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	writeStaticFile(res, name, f, info)
+}
+
+func writeStaticFile(res http.ResponseWriter, name string, f fs.File, info fs.FileInfo) {
+	setStaticContentLength(res, info.Size())
+	setStaticContentType(res, name)
+	res.WriteHeader(http.StatusOK)
+	_, _ = io.Copy(res, f)
+}
+
+func staticStatusCode(err error) int {
+	if errors.Is(err, fs.ErrNotExist) {
+		return http.StatusNotFound
+	}
+	return status.Code(err)
+}
+
+func setStaticContentType(res http.ResponseWriter, name string) {
+	mediaType := media.TypeByExtension(path.Ext(name))
+	if !strings.IsEmpty(mediaType) {
+		res.Header().Set(content.TypeKey, media.MustParse(mediaType).WithUTF8())
+	}
+}
+
+func setStaticCacheControl(res http.ResponseWriter, options *staticOptions) {
+	if !strings.IsEmpty(options.cacheControl) {
+		res.Header().Set("Cache-Control", options.cacheControl)
+	}
+}
+
+func setStaticValidators(res http.ResponseWriter, etag string, info fs.FileInfo) {
+	res.Header().Set("ETag", etag)
+
+	modified := info.ModTime()
+	if !modified.IsZero() {
+		res.Header().Set("Last-Modified", modified.UTC().Format(http.TimeFormat))
+	}
+}
+
+func setStaticContentLength(res http.ResponseWriter, size int64) {
+	if size >= 0 {
+		res.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	}
+}
+
+func staticETag(name string) (string, error) {
+	f, err := fileSystem.Open(name)
+	if err != nil {
+		return strings.Empty, err
+	}
+	defer f.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return strings.Empty, err
+	}
+
+	return strings.Concat(`"`, hex.EncodeToString(hash.Sum(nil)), `"`), nil
+}
+
+func staticETagMatches(value, etag string) bool {
+	for {
+		candidate, rest, found := strings.Cut(value, ",")
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || candidate == etag || staticWeakETagMatches(candidate, etag) {
+			return true
+		}
+		if !found {
+			return false
+		}
+
+		value = rest
+	}
+}
+
+func staticWeakETagMatches(candidate, etag string) bool {
+	return strings.HasPrefix(candidate, "W/") && candidate[2:] == etag
+}

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -4,11 +4,14 @@ import (
 	"html/template"
 	"path/filepath"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/meta"
-	hm "github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	httpmeta "github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -130,7 +133,7 @@ func (v *View) Render(ctx context.Context, model any) error {
 		return err
 	}
 
-	_, err := buffer.WriteTo(hm.Response(ctx))
+	_, err := buffer.WriteTo(httpmeta.Response(ctx))
 	return err
 }
 
@@ -145,4 +148,31 @@ func (v *View) render(ctx context.Context, writer io.Writer, model any) error {
 	}
 
 	return v.template.ExecuteTemplate(writer, v.name, template)
+}
+
+func writeView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) {
+	if err := renderView(ctx, res, view, model, code); err != nil {
+		res.WriteHeader(status.Code(err))
+	}
+}
+
+func renderView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) error {
+	if view == nil {
+		return ErrMissingView
+	}
+
+	buffer := pool.Get()
+	defer pool.Put(buffer)
+
+	if err := view.render(ctx, buffer, model); err != nil {
+		return err
+	}
+
+	writeBuffer(res, code, buffer)
+	return nil
+}
+
+func writeBuffer(res http.ResponseWriter, code int, buffer *bytes.Buffer) {
+	res.WriteHeader(code)
+	_, _ = buffer.WriteTo(res)
 }


### PR DESCRIPTION
## What

- Add optional cache-control and cache-validator options to MVC static routes.
- Support ETag, Last-Modified, and If-None-Match 304 responses for StaticFile and StaticPathValue.
- Add executable MVC examples for the static route cache options.
- Move static-serving helpers into static.go, static options into options.go, and view rendering helpers into view.go.

## Why

- Lets services avoid repeated static asset transfers without duplicating static file serving logic.
- Keeps existing static route behavior unchanged unless callers opt into the new options.
- Documents the public API through executable examples so downstream callers can copy the intended usage.

## Testing

- `gmake package=net/http/mvc specs` - passed; covers static cache-control, ETag/Last-Modified headers, If-None-Match 304 handling, weak ETag matching, path-value static routes, and the new executable examples.
- `gmake lint` - passed.
- `gmake specs` - passed; 1975 tests.

AI-assisted-by: [Codex](https://openai.com/codex/)
