### PR TITLE
feat(mvc): fix static validators and template collisions

### DIFF
--- a/net/http/mvc/funcs.go
+++ b/net/http/mvc/funcs.go
@@ -44,5 +44,9 @@ func NewFunctionMap(params FunctionMapParams) sprout.FunctionMap {
 	runtime.Must(handler.AddRegistry(strings.NewRegistry()))
 	runtime.Must(handler.AddRegistry(time.NewRegistry()))
 
-	return handler.Build()
+	functionMap := handler.Build()
+	// Sprout's shuffle uses a package-global math/rand.Source, which races during concurrent template renders.
+	delete(functionMap, "shuffle")
+
+	return functionMap
 }

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -125,6 +125,25 @@ func TestStaticFileRejectsDirectory(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, res.Code)
 }
 
+func TestStaticFileRejectsPermissionDenied(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Mux:         mux,
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  permissionFileSystem{},
+		Pool:        test.Pool,
+		Layout:      test.Layout,
+	})
+	require.True(t, mvc.StaticFile("/asset", "asset.txt"))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusForbidden, res.Code)
+}
+
 func TestStaticFileSetsCacheControl(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
@@ -174,15 +193,33 @@ func TestStaticFileUsesETagValidator(t *testing.T) {
 	require.Equal(t, modified.Format(http.TimeFormat), firstRes.Header().Get("Last-Modified"))
 	test.RequireResponseBody(t, firstRes, "hello")
 
-	secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
-	secondReq.Header.Set("If-None-Match", "W/"+etag)
-	secondRes := httptest.NewRecorder()
+	for _, tt := range []struct {
+		headers map[string]string
+		name    string
+		body    string
+		code    int
+	}{
+		{headers: map[string]string{"If-None-Match": "W/" + etag}, name: "etag", code: http.StatusNotModified},
+		{headers: map[string]string{"If-Modified-Since": modified.Format(http.TimeFormat)}, name: "modified", code: http.StatusNotModified},
+		{headers: map[string]string{"If-Modified-Since": modified.AddDate(0, 0, -1).Format(http.TimeFormat)}, name: "stale", body: "hello", code: http.StatusOK},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+			res := httptest.NewRecorder()
 
-	mux.ServeHTTP(secondRes, secondReq)
+			mux.ServeHTTP(res, req)
 
-	require.Equal(t, http.StatusNotModified, secondRes.Code)
-	require.Equal(t, etag, secondRes.Header().Get("ETag"))
-	test.RequireEmptyResponseBody(t, secondRes)
+			require.Equal(t, tt.code, res.Code)
+			if tt.body == "" {
+				test.RequireEmptyResponseBody(t, res)
+				return
+			}
+			test.RequireResponseBody(t, res, tt.body)
+		})
+	}
 }
 
 func TestStaticPathValueUsesETagValidator(t *testing.T) {
@@ -253,6 +290,56 @@ func TestViewRenderReturnsWriteError(t *testing.T) {
 	err := view.Render(ctx, &test.Model)
 
 	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestNewViewUsesLayoutPathWhenBasenameCollides(t *testing.T) {
+	for _, tt := range []struct {
+		view func() *mvc.View
+		name string
+		want string
+	}{
+		{
+			view: func() *mvc.View { return mvc.NewFullView("pages/full.tmpl") },
+			name: "full",
+			want: "full layout full page",
+		},
+		{
+			view: func() *mvc.View { return mvc.NewPartialView("pages/partial.tmpl") },
+			name: "partial",
+			want: "partial layout partial page",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mvc.Register(mvc.RegisterParams{
+				Mux:         mux,
+				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+				FileSystem: fstest.MapFS{
+					"views/full.tmpl":    &fstest.MapFile{Data: []byte(`full layout {{ block "content" . }}default{{ end }}`)},
+					"views/partial.tmpl": &fstest.MapFile{Data: []byte(`partial layout {{ block "content" . }}default{{ end }}`)},
+					"pages/full.tmpl":    &fstest.MapFile{Data: []byte(`view-root{{ define "content" }}full page{{ end }}`)},
+					"pages/partial.tmpl": &fstest.MapFile{Data: []byte(`view-root{{ define "content" }}partial page{{ end }}`)},
+				},
+				Pool:   test.Pool,
+				Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+			})
+
+			res := httptest.NewRecorder()
+			ctx := meta.WithContent(t.Context(), nil, res, nil)
+
+			err := tt.view().Render(ctx, &test.Model)
+
+			require.NoError(t, err)
+			test.RequireResponseBody(t, res, tt.want)
+		})
+	}
+}
+
+func TestLayoutNames(t *testing.T) {
+	layout := mvc.NewLayout("views/full.tmpl", "views/partial.tmpl")
+
+	require.Equal(t, "full.tmpl", layout.FullName())
+	require.Equal(t, "partial.tmpl", layout.PartialName())
 }
 
 func TestRouteErrorIncludesSafeModelAndRawMetaInTemplate(t *testing.T) {
@@ -582,4 +669,10 @@ func TestStaticFileSetsContentLength(t *testing.T) {
 type requestModel struct {
 	Method string
 	Path   string
+}
+
+type permissionFileSystem struct{}
+
+func (permissionFileSystem) Open(string) (fs.File, error) {
+	return nil, fs.ErrPermission
 }

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 )
 
 // StaticFile registers an HTTP GET route that serves the named file from the registered filesystem.
@@ -99,6 +100,10 @@ func serveFileWithCacheValidators(res http.ResponseWriter, req *http.Request, na
 		res.WriteHeader(http.StatusNotModified)
 		return
 	}
+	if strings.IsEmpty(req.Header.Get("If-None-Match")) && staticModifiedSinceMatches(req, info) {
+		res.WriteHeader(http.StatusNotModified)
+		return
+	}
 
 	writeStaticFile(res, name, f, info)
 }
@@ -113,6 +118,9 @@ func writeStaticFile(res http.ResponseWriter, name string, f fs.File, info fs.Fi
 func staticStatusCode(err error) int {
 	if errors.Is(err, fs.ErrNotExist) {
 		return http.StatusNotFound
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return http.StatusForbidden
 	}
 	return status.Code(err)
 }
@@ -137,6 +145,26 @@ func setStaticValidators(res http.ResponseWriter, etag string, info fs.FileInfo)
 	if !modified.IsZero() {
 		res.Header().Set("Last-Modified", modified.UTC().Format(http.TimeFormat))
 	}
+}
+
+func staticModifiedSinceMatches(req *http.Request, info fs.FileInfo) bool {
+	value := req.Header.Get("If-Modified-Since")
+	if strings.IsEmpty(value) {
+		return false
+	}
+
+	since, err := http.ParseTime(value)
+	if err != nil {
+		return false
+	}
+
+	modified := info.ModTime()
+	if modified.IsZero() {
+		return false
+	}
+
+	modified = modified.UTC().Truncate(time.Second.Duration())
+	return !modified.After(since)
 }
 
 func setStaticContentLength(res http.ResponseWriter, size int64) {

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -2,7 +2,8 @@ package mvc
 
 import (
 	"html/template"
-	"path/filepath"
+	"io/fs"
+	"path"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -12,6 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	httpmeta "github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -67,7 +69,7 @@ func (l *Layout) IsValid() bool {
 }
 
 func (l *Layout) name(name string) string {
-	return filepath.Base(name)
+	return path.Base(name)
 }
 
 // NewViewPair returns a full and partial View pair for name.
@@ -81,22 +83,34 @@ func NewViewPair(name string) (*View, *View) {
 //
 // It uses the package-level filesystem, layout, and template function map registered via mvc.Register.
 // If MVC is not defined, or if template parsing fails (missing files, parse errors), this function will
-// panic because it uses [template.Must].
+// panic.
 func NewFullView(name string) *View {
-	template := template.Must(template.New(strings.Empty).Funcs(fmap).ParseFS(fileSystem, layout.Full(), name))
-
-	return &View{name: layout.FullName(), template: template}
+	return newView(layout.Full(), name)
 }
 
 // NewPartialView parses the partial layout template and the view template from the registered filesystem.
 //
 // It uses the package-level filesystem, layout, and template function map registered via mvc.Register.
 // If MVC is not defined, or if template parsing fails (missing files, parse errors), this function will
-// panic because it uses [template.Must].
+// panic.
 func NewPartialView(name string) *View {
-	template := template.Must(template.New(strings.Empty).Funcs(fmap).ParseFS(fileSystem, layout.Partial(), name))
+	return newView(layout.Partial(), name)
+}
 
-	return &View{name: layout.PartialName(), template: template}
+func newView(layoutName, name string) *View {
+	tmpl := template.New(layoutName).Funcs(fmap)
+	parseTemplate(tmpl, layoutName)
+	parseTemplate(tmpl.New(name), name)
+
+	return &View{name: layoutName, template: tmpl}
+}
+
+func parseTemplate(tmpl *template.Template, name string) {
+	data, err := fs.ReadFile(fileSystem, name)
+	runtime.Must(err)
+
+	_, err = tmpl.Parse(string(data))
+	runtime.Must(err)
 }
 
 // View renders an HTML template.


### PR DESCRIPTION
## What

- Fix static file responses to return `403 Forbidden` for filesystem permission errors.
- Add `If-Modified-Since` support for static cache validators while keeping `If-None-Match` precedence.
- Parse MVC layouts and page templates under their full filesystem paths so basename collisions do not execute the wrong template.
- Remove Sprout's `shuffle` template function because it races during concurrent template renders.

## Why

- Static assets should classify permission failures as forbidden instead of internal server errors, and cache validators should support both entity tags and modification timestamps.
- MVC templates can live in different directories with the same basename, so template names need to preserve their registered filesystem paths.
- The template function map should avoid known unsafe concurrent behavior.

## Testing

- `gofmt -w net/http/mvc/funcs.go net/http/mvc/server_test.go net/http/mvc/static.go net/http/mvc/view.go` - passed
- `make package=net/http/mvc specs` - passed
- `make package=net/http/mvc golangci-lint` - passed
- `make package=net/http/mvc lint` - passed
- `git diff --check` - passed
