### PR TITLE
build(ci): use lightweight aggregate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,10 @@ jobs:
     resource_class: arm.large
   wait-all:
     docker:
-      - image: alexfalkowski/go:4.20
+      - image: alpine:latest
+    resource_class: small
     steps:
       - run: echo "all applicable jobs finished"
-    resource_class: arm.large
 
 workflows:
   go-service:


### PR DESCRIPTION
## What

- Kept `wait-all` as a real CircleCI job so GitHub still receives the aggregate check status.
- Switched the aggregate job image to `alpine:latest`.
- Reduced the aggregate job resource class from `arm.large` to `small`.
- Left the workflow dependency fan-in unchanged.

## Why

- The previous no-op approach avoided credits, but it did not report the `wait-all` check back to GitHub. This keeps the branch-protection signal while making the echo-only job cheaper to run.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `git diff --check` - passed
