### PR TITLE
docs(agents): centralize shared repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,8 @@
 # AGENTS.md
 
-## Shared skills
+## Shared guidance
 
-This repository uses the shared skills from `bin/skills/`. Read
-`bin/AGENTS.md` for the canonical shared skill list and use the smallest
-matching skill for the task.
+Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 
 ## Repo Snapshot
 


### PR DESCRIPTION
## What

- Update the `bin` submodule to the latest shared guidance release.
- Replace repeated shared skill boilerplate with a concise pointer to `bin/AGENTS.md`.
- Remove repository-local duplication for shared setup, validation, release, and harness defaults where the new shared `bin/AGENTS.md` now owns that guidance.

## Why

- Keeps repository `AGENTS.md` files focused on repo-specific guidance while moving cross-repository defaults to the shared `bin` submodule.
- Makes future updates to shared agent workflow expectations easier to release through a single submodule update.

## Testing

- `git diff --check` - passed
- `make lint` - passed
- Full CI was not run locally; this change is documentation and submodule-pointer scoped.

AI-assisted-by: [Codex](https://openai.com/codex/)
