### PR TITLE
build(project): check generated test protos in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
           key: go-service-go-lint-cache-v2-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}
           paths:
             - ~/.cache/golangci-lint
+      - run: make generate-stale
       - run: make sec
       - run: make specs
       - run: make benchmarks

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,8 @@ http-content-benchmarks:
 
 # Generate for tests.
 generate:
-	@make -C internal/test generate
+	@$(MAKE) -C internal/test generate
+
+# Check generated test protobuf outputs are fresh.
+generate-stale:
+	@$(MAKE) -C internal/test stale


### PR DESCRIPTION
## What

- Add a `generate-stale` root target for the internal test protobuf fixtures.
- Wire the target into CircleCI before security, specs, and benchmarks.
- Use `$(MAKE)` for the existing internal test generation target.

## Why

- The repository commits generated internal test protobuf outputs, but CI did not verify they stayed fresh.
- The new check catches stale generated fixtures before tests run while keeping the validation scoped to internal test data.

## Testing

- `gmake -C internal/test generate` - passed.
- `git diff --exit-code -- internal/test` - passed.
- `gmake generate-stale` - not run to completion before commit because the target intentionally fails on any working-tree diff; generated fixture paths were checked directly instead.
