### PR TITLE
feat(http): close webhook bodies on read failures

### DIFF
--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -69,11 +69,12 @@ func (h *Webhook) Sign(req *http.Request) error {
 	}
 
 	originalBody := req.Body
+	defer body.Close(originalBody)
+
 	payload, bufferedBody, err := body.ReadAll(req)
 	if err != nil {
 		return err
 	}
-	defer body.Close(originalBody)
 
 	req.Body = bufferedBody
 	if req.Header == nil {
@@ -113,11 +114,12 @@ func (h *Webhook) Verify(req *http.Request) error {
 	}
 
 	originalBody := req.Body
+	defer body.Close(originalBody)
+
 	payload, bufferedBody, err := body.ReadAll(req)
 	if err != nil {
 		return err
 	}
-	defer body.Close(originalBody)
 
 	req.Body = bufferedBody
 
@@ -217,10 +219,7 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 	}
 
 	clonedReq := req.Clone(req.Context())
-	originalBody := clonedReq.Body
 	if err := r.hook.Sign(clonedReq); err != nil {
-		body.Close(originalBody)
-
 		return nil, err, false
 	}
 


### PR DESCRIPTION
## What

- Close original webhook request bodies when signing or verification fails while buffering the body.
- Let webhook signing own read-error cleanup so the round tripper no longer performs a duplicate close.

## Why

- Keeps webhook body ownership consistent on error paths and avoids leaving close-sensitive request bodies open after unreadable payloads.

## Testing

- `go test ./transport/http/...` - passed
- `make lint` - passed
- `go test -count=1 ./transport/http/hooks` - passed
- `git diff --check` - passed
- No new tests were added per request; validation relies on existing hook package coverage for the affected transport path.

AI-assisted-by: [Codex](https://openai.com/codex/)
