### PR TITLE
feat(grpc): shed limited streams before signing

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -372,12 +372,14 @@ func streamDialOption(opts *clientOpts) grpc.DialOption {
 		stream = append(stream, logger.StreamClientInterceptor(opts.logger))
 	}
 
-	if opts.gen != nil {
-		stream = append(stream, token.StreamClientInterceptor(opts.id, opts.gen))
-	}
-
+	// gRPC chains stream interceptors outermost-first, so keep the limiter before token injection
+	// to shed over-quota stream opens before token generation does key loading or signing work.
 	if opts.limiter != nil {
 		stream = append(stream, limiter.StreamClientInterceptor(opts.limiter))
+	}
+
+	if opts.gen != nil {
+		stream = append(stream, token.StreamClientInterceptor(opts.id, opts.gen))
 	}
 
 	return grpc.WithChainStreamInterceptor(stream...)

--- a/transport/grpc/limiter/server.go
+++ b/transport/grpc/limiter/server.go
@@ -138,9 +138,18 @@ func (s *serverStream) SendMsg(m any) error {
 }
 
 func setHeader(ctx context.Context, decision limiter.Decision) {
-	_ = grpc.SetHeader(ctx, meta.Pairs("ratelimit", decision.Header(), "ratelimit-policy", decision.PolicyHeader()))
+	_ = grpc.SetHeader(ctx, limiterMetadata(decision))
 }
 
 func setStreamHeader(stream grpc.ServerStream, decision limiter.Decision) {
-	_ = stream.SetHeader(meta.Pairs("ratelimit", decision.Header(), "ratelimit-policy", decision.PolicyHeader()))
+	md := limiterMetadata(decision)
+	// Streaming headers may already be sent after the first response message; use trailers for later
+	// limiter decisions so clients can still observe the current quota state on stream errors.
+	if err := stream.SetHeader(md); err != nil {
+		stream.SetTrailer(md)
+	}
+}
+
+func limiterMetadata(decision limiter.Decision) meta.Map {
+	return meta.Pairs("ratelimit", decision.Header(), "ratelimit-policy", decision.PolicyHeader())
 }


### PR DESCRIPTION
## What

- Put the client stream limiter before token injection so over-quota stream opens are rejected before token generation work starts.
- Preserve rate-limit metadata for long-lived server streams by falling back to trailers when response headers have already been sent.
- Added comments at both gRPC-sensitive spots to document the interceptor order and stream metadata behavior.

## Why

- This keeps client-side overload shedding aligned with unary calls and avoids spending signing or key-source work on stream opens that local quota will reject.
- It also keeps late stream quota decisions observable to clients and operators after the initial stream headers are no longer mutable.

## Testing

- `make package=transport/grpc specs` - passed
- `make package=transport/grpc lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
