### PR TITLE
feat(http): align retry load control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,24 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   deduplicate by request id when duplicate processing would be unsafe. Do not
   flag the default HTTP/gRPC retry policy merely because metadata injects
   request ids before retry.
+- HTTP retry intentionally does not apply `transport/retry.Config.Timeout` as a
+  per-attempt timeout. HTTP response bodies are caller-owned after `RoundTrip`
+  returns, and tying retry-owned attempt contexts to returned bodies requires
+  response body wrapping that can hide optional body interfaces. Bound outbound
+  HTTP calls with the request context or `http.Client.Timeout`; do not flag the
+  absence of HTTP retry per-attempt timeout unless a public API starts promising
+  that timeout or the retry layer reintroduces owned response-body lifecycle
+  handling.
+- HTTP and gRPC client retry/load-control ordering intentionally match at the
+  supported transport stack level: metadata is outside retry so `Request-Id`
+  stays logical-request scoped, retry wraps the client limiter and breaker so
+  each attempt consumes local quota and breaker capacity, and token generation
+  remains inside retry so each wire attempt gets a fresh token. HTTP local
+  limiter and breaker rejections are marked with `net/http/status.LocalError`
+  and are terminal, not retried as upstream 429/503 responses. Do not flag
+  retry/load-control ordering unless a supported stack regresses from this
+  contract, local load-control rejections become retryable, or a public API
+  starts promising a different composition.
 - `net/http/status.Code(err)` usually returns a valid HTTP status code because
   repository code should construct HTTP status errors with the constants exposed
   by `net/http` (for example `http.StatusBadRequest`) or intentionally supported

--- a/net/http/status/status.go
+++ b/net/http/status/status.go
@@ -37,6 +37,24 @@ func SafeError(code int, err error) error {
 	return &statusError{code: code, error: err.Error(), msg: msg, err: err}
 }
 
+// LocalError wraps err to mark an HTTP status error as produced by local client-side controls.
+//
+// Retry middleware can use this marker to distinguish local load-control rejections from upstream
+// HTTP 429/503 responses that may be worth retrying.
+func LocalError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &localError{err: err}
+}
+
+// IsLocalError reports whether err was wrapped by LocalError.
+func IsLocalError(err error) bool {
+	_, ok := errors.AsType[*localError](err)
+	return ok
+}
+
 // InternalServerError wraps err with StatusInternalServerError (500) unless err already carries a status code.
 //
 // This is a convenience wrapper over FromError.
@@ -196,4 +214,18 @@ func (s *statusError) SafeMessage() string {
 // Unwrap returns the wrapped cause, if any.
 func (s *statusError) Unwrap() error {
 	return s.err
+}
+
+type localError struct {
+	err error
+}
+
+// Error returns the diagnostic error message.
+func (e *localError) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns the wrapped cause, if any.
+func (e *localError) Unwrap() error {
+	return e.err
 }

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -84,6 +84,20 @@ func TestSafeErrorKeepsWrappedCoder(t *testing.T) {
 	require.Same(t, err, httpstatus.SafeError(http.StatusBadRequest, err))
 }
 
+func TestLocalError(t *testing.T) {
+	err := httpstatus.LocalError(httpstatus.SafeError(http.StatusTooManyRequests, test.ErrInvalid))
+
+	require.True(t, httpstatus.IsLocalError(err))
+	require.True(t, httpstatus.IsError(err))
+	require.ErrorIs(t, err, test.ErrInvalid)
+	require.Equal(t, http.StatusTooManyRequests, httpstatus.Code(err))
+	require.Equal(t, test.ErrInvalid.Error(), err.Error())
+}
+
+func TestLocalErrorAllowsNil(t *testing.T) {
+	require.NoError(t, httpstatus.LocalError(nil))
+}
+
 func TestSafeErrorUsesRequestEntityTooLargeForMaxBytesError(t *testing.T) {
 	err := httpstatus.SafeError(http.StatusBadRequest, &http.MaxBytesError{Limit: 1})
 

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -121,10 +121,10 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 
 func localRejectionError(err error) error {
 	if errors.Is(err, breaker.ErrTooManyRequests) {
-		return status.SafeError(http.StatusTooManyRequests, err)
+		return status.LocalError(status.SafeError(http.StatusTooManyRequests, err))
 	}
 	if errors.Is(err, breaker.ErrOpenState) {
-		return status.ServiceUnavailableError(err)
+		return status.LocalError(status.ServiceUnavailableError(err))
 	}
 
 	return err

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -105,9 +105,9 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 
 // WithClientRetry enables retry behavior for outbound HTTP requests.
 //
-// When configured, the composed RoundTripper will apply per-attempt timeouts and retry failed requests
-// according to cfg (attempt count, backoff, and which status codes are considered retryable).
-// Optional policies decide whether a logical request is eligible for retry.
+// When configured, the composed RoundTripper will retry failed requests according to cfg (attempt count,
+// backoff, and which status codes are considered retryable). Optional policies decide whether a logical
+// request is eligible for retry.
 //
 // When no policy is provided, only side-effect-safe requests are eligible for retry: safe HTTP methods, or
 // requests carrying a request-id idempotency contract. Callers that need different behavior can pass an
@@ -203,9 +203,9 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 //
 //   - meta injection (User-Agent, Request-Id)
 //   - logger (optional)
+//   - retry (optional)
 //   - limiter (optional)
 //   - breaker (optional)
-//   - retry (optional)
 //   - token injection (optional)
 //   - compression (optional)
 //   - base transport
@@ -213,6 +213,7 @@ func WithClientLimiter(limiter *limiter.Client) ClientOption {
 // Notes:
 //   - [WithClientRoundTripper] short-circuits base transport selection and TLS config construction.
 //   - Token injection remains inside retry so a fresh token is generated for each retry attempt.
+//   - Retry wraps limiter and breaker so each retry attempt consumes quota and breaker capacity.
 //   - The limiter stays outside the breaker so local quota denials are not counted as upstream failures.
 func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 	resolved := options(opts...)
@@ -230,16 +231,16 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 		hrt = token.NewRoundTripper(resolved.id, resolved.gen, hrt)
 	}
 
-	if resolved.retry != nil {
-		hrt = retry.NewRoundTripper(resolved.retry, hrt, resolved.retryPolicies...)
-	}
-
 	if resolved.breaker {
 		hrt = breaker.NewRoundTripper(hrt, resolved.breakerOptions...)
 	}
 
 	if resolved.limiter != nil {
 		hrt = limiter.NewRoundTripper(resolved.limiter, hrt)
+	}
+
+	if resolved.retry != nil {
+		hrt = retry.NewRoundTripper(resolved.retry, hrt, resolved.retryPolicies...)
 	}
 
 	if resolved.logger != nil {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -8,8 +8,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/time"
 	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
+	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
+	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
+	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,4 +97,60 @@ func TestRoundTripperWithTokenDoesNotSendAuthorizationToCrossOriginRedirect(t *t
 	require.Nil(t, res)
 	require.Equal(t, "Bearer secret", trustedAuthorization)
 	require.Empty(t, attackerAuthorization)
+}
+
+func TestRoundTripperRetriesThroughClientLimiter(t *testing.T) {
+	clientLimiter, err := httplimiter.NewClientLimiter(
+		test.NoopLifecycle{},
+		limiter.NewKeyMap(),
+		test.NewLimiterConfig("user-agent", "1m", 1),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientLimiter.Close(t.Context())) })
+
+	base := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	rt, err := transporthttp.NewRoundTripper(
+		transporthttp.WithClientRoundTripper(base),
+		transporthttp.WithClientLimiter(clientLimiter),
+		transporthttp.WithClientRetry(&retry.Config{Attempts: 2, Backoff: time.Nanosecond}),
+		transporthttp.WithClientUserAgent(test.UserAgent),
+	)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, http.StatusTooManyRequests, status.Code(err))
+	require.Equal(t, 1, base.Calls)
+}
+
+func TestRoundTripperRetriesThroughClientBreaker(t *testing.T) {
+	base := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
+	rt, err := transporthttp.NewRoundTripper(
+		transporthttp.WithClientRoundTripper(base),
+		transporthttp.WithClientRetry(&retry.Config{Attempts: 2, Backoff: time.Nanosecond}),
+		transporthttp.WithClientBreaker(
+			breaker.WithSettings(breaker.Settings{
+				ReadyToTrip: func(counts breaker.Counts) bool {
+					return counts.ConsecutiveFailures >= 1
+				},
+			}),
+			breaker.WithFailureStatuses(http.StatusServiceUnavailable),
+		),
+	)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, http.StatusServiceUnavailable, status.Code(err))
+	require.Equal(t, 1, base.Calls)
 }

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -149,7 +149,7 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 	}
 
 	if !ok {
-		return nil, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests)), true
+		return nil, status.LocalError(status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests))), true
 	}
 
 	res, err := r.RoundTripper.RoundTrip(req)

--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -1,7 +1,6 @@
 // Package retry provides HTTP retry middleware for go-service clients.
 //
 // The package exposes a transport-level retrying `http.RoundTripper` that:
-//   - applies a per-attempt timeout,
 //   - retries responses and HTTP status errors only for selected HTTP status codes,
 //   - keeps `retryablehttp.DefaultRetryPolicy` classification for transport errors,
 //   - replays request bodies on subsequent attempts when `req.GetBody` is available, and

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -1,8 +1,6 @@
 package retry
 
 import (
-	"fmt"
-
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/meta"
@@ -12,7 +10,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/retry"
 	"github.com/alexfalkowski/go-service/v2/time"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
-	"github.com/alexfalkowski/go-sync"
 	retryable "github.com/hashicorp/go-retryablehttp"
 )
 
@@ -20,7 +17,6 @@ import (
 //
 // It describes the retry policy used by NewRoundTripper:
 //   - `Attempts`: maximum number of attempts including the initial attempt.
-//   - `Timeout`: per-attempt timeout duration.
 //   - `Backoff`: base delay between retries.
 type Config = config.Config
 
@@ -65,14 +61,10 @@ func IdempotentRequests(req *http.Request) bool {
 // `429 Too Many Requests` or `503 Service Unavailable`.
 var ErrInvalidStatusCode = errors.New("retry: invalid status code")
 
-// ErrAttemptTimeout is the cause recorded when a retry attempt times out.
-var ErrAttemptTimeout = fmt.Errorf("retry: attempt timeout: %w", sync.ErrTimeout)
-
-// NewRoundTripper constructs a RoundTripper that applies per-attempt timeouts and retries.
+// NewRoundTripper constructs a RoundTripper that applies retries.
 //
 // The constructed RoundTripper wraps hrt and, for each request:
 //   - checks whether the request is eligible for retry using policies, and
-//   - applies a per-attempt timeout derived from `cfg.GetTimeout()`, and
 //   - retries responses and status errors with retryable HTTP status codes, and
 //   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`, and
 //   - waits a jittered backoff derived from `cfg.GetBackoff()` between attempts.
@@ -103,7 +95,6 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 		RoundTripper: hrt,
 		backoff:      cfg.GetBackoff(),
 		policy:       composePolicy(policies),
-		timeout:      cfg.GetTimeout(),
 		maxRetries:   cfg.MaxRetries(),
 	}
 }
@@ -111,7 +102,6 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 // RoundTripper wraps an underlying [http.RoundTripper] and retries requests according to its configuration.
 //
 // Each attempt:
-//   - runs the underlying [http.RoundTripper.RoundTrip] with a derived per-attempt timeout,
 //   - re-creates the request body for subsequent attempts when `req.GetBody` is available, and
 //   - retries only selected HTTP status codes for responses and status errors.
 //   - retries recoverable transport errors using `retryablehttp.DefaultRetryPolicy`.
@@ -124,14 +114,12 @@ type RoundTripper struct {
 	http.RoundTripper
 	policy     Policy
 	backoff    time.Duration
-	timeout    time.Duration
 	maxRetries uint64
 }
 
 // RoundTrip executes the request and retries according to the configured backoff policy.
 //
 // For each attempt:
-//   - it derives a child context with a timeout (`r.timeout`) and executes the underlying RoundTripper with it,
 //   - it clones the request and replays the body when needed,
 //   - it checks whether the response/status error carries a retryable HTTP status code, and
 //   - it uses `retryablehttp.DefaultRetryPolicy` for transport error classification, and
@@ -174,32 +162,25 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 }
 
 func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *roundTripAttempt) (*http.Response, error) {
-	attemptCtx, cancel := r.withAttemptTimeout(ctx)
-	defer cancel()
-
-	attemptReq, err := request(req, attemptCtx, attempt.attempt)
+	attemptReq, err := request(req, ctx, attempt.attempt)
 	if err != nil {
 		return nil, err
 	}
 
 	res, err := r.RoundTripper.RoundTrip(attemptReq)
-	if retryErr := attempt.retry(ctx, attemptCtx, req, res, err, r.backoff, r.maxRetries); retryErr != nil {
+	if retryErr := attempt.retry(ctx, req, res, err, r.backoff, r.maxRetries); retryErr != nil {
 		return nil, retryErr
 	}
 
 	return res, err
 }
 
-func (r *RoundTripper) withAttemptTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeoutCause(ctx, r.timeout, ErrAttemptTimeout)
-}
-
 type roundTripAttempt struct {
 	attempt uint64
 }
 
-func (a *roundTripAttempt) retry(ctx, attemptCtx context.Context, req *http.Request, res *http.Response, err error, backoff time.Duration, maxRetries uint64) error {
-	ok, retryErr := shouldRetryAttempt(ctx, attemptCtx, res, err)
+func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *http.Response, err error, backoff time.Duration, maxRetries uint64) error {
+	ok, retryErr := shouldRetryAttempt(ctx, res, err)
 	if !ok {
 		return nil
 	}
@@ -243,14 +224,9 @@ func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Requ
 	return clonedReq, nil
 }
 
-func shouldRetryAttempt(ctx, attemptCtx context.Context, res *http.Response, err error) (bool, error) {
+func shouldRetryAttempt(ctx context.Context, res *http.Response, err error) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
-	}
-
-	if err := attemptCtx.Err(); err != nil {
-		cause := context.Cause(attemptCtx)
-		return errors.Is(cause, ErrAttemptTimeout), cause
 	}
 
 	if isTransportError(res, err) {
@@ -258,6 +234,10 @@ func shouldRetryAttempt(ctx, attemptCtx context.Context, res *http.Response, err
 	}
 
 	if err != nil {
+		if status.IsLocalError(err) {
+			return false, err
+		}
+
 		return isRetryableStatusCode(status.Code(err)), err
 	}
 

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
-	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +39,6 @@ func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 			rt := &test.StatusSequenceRoundTripper{Codes: tt.codes}
 			retrying := retry.NewRoundTripper(&retry.Config{
 				Attempts: 2,
-				Timeout:  time.Second,
 				Backoff:  time.Millisecond,
 			}, rt)
 
@@ -58,7 +56,6 @@ func TestRoundTripperDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -78,7 +75,6 @@ func TestRoundTripperClampsAttemptsAboveMax(t *testing.T) {
 	})
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: config.MaxAttempts + 1,
-		Timeout:  time.Second,
 		Backoff:  time.Nanosecond,
 	}, rt)
 
@@ -94,7 +90,6 @@ func TestRoundTripperDoesNotPanicWithOmittedBackoff(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 1,
-		Timeout:  time.Second,
 	}, rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -111,7 +106,6 @@ func TestRoundTripperRetriesWithDefaultBackoff(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 	}, rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
@@ -148,7 +142,6 @@ func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsMinimumBackoff(t *testing.
 			})
 			retrying := retry.NewRoundTripper(&retry.Config{
 				Attempts: 2,
-				Timeout:  time.Second,
 				Backoff:  tt.backoff,
 			}, rt)
 
@@ -177,7 +170,6 @@ func TestRoundTripperRetriesWhenRetryAfterDoesNotExceedBackoff(t *testing.T) {
 	})
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  2 * time.Second,
 	}, rt)
 
@@ -204,7 +196,6 @@ func TestRoundTripperRetriesWhenRetryAfterIsInvalid(t *testing.T) {
 	})
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -223,7 +214,6 @@ func TestRoundTripperUsesIndependentRetryBudgetPerRequest(t *testing.T) {
 	}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -243,7 +233,6 @@ func TestRoundTripperDoesNotRetryUnhandledStatusCode(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusInternalServerError, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -259,7 +248,6 @@ func TestRoundTripperDoesNotRetryWhenPolicyDeniesRequest(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt, retry.SafeMethods)
 
@@ -275,7 +263,6 @@ func TestRoundTripperDoesNotRetryUnsafeRequestByDefault(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -291,7 +278,6 @@ func TestRoundTripperRetriesWhenPolicyAllowsRequestID(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt, retry.IdempotentRequests)
 
@@ -308,7 +294,6 @@ func TestRoundTripperReturnsLastRetryableResponseWhenExhausted(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusTooManyRequests}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -324,7 +309,6 @@ func TestRoundTripperReturnsFinalRetryableResponseWhenExhausted(t *testing.T) {
 	rt := &test.BodySequenceRoundTripper{Responses: []string{"first failure", "second failure"}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -361,7 +345,6 @@ func TestRoundTripperClosesRetryableResponseBeforeNextAttempt(t *testing.T) {
 
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  100 * time.Millisecond,
 		Backoff:  time.Millisecond,
 	}, transport)
 
@@ -379,7 +362,6 @@ func TestRoundTripperReplaysRequestBodyAcrossRetries(t *testing.T) {
 	rt := &test.RequestBodyRecorderRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -397,7 +379,6 @@ func TestRoundTripperReplaysRequestBodyAfterTransportError(t *testing.T) {
 	rt := &test.TransportErrorThenSuccessRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -416,7 +397,6 @@ func TestRoundTripperUsesOriginalBodyOnFirstAttempt(t *testing.T) {
 	rt := &test.OriginalBodyRoundTripper{Original: body}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -440,7 +420,6 @@ func TestRoundTripperDoesNotRetryNonReplayableRequestBody(t *testing.T) {
 	rt := &test.RequestBodyRecorderRoundTripper{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -460,7 +439,6 @@ func TestRoundTripperReturnsGetBodyError(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -481,7 +459,6 @@ func TestRoundTripperClosesBodyWhenContextAlreadyCanceled(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusOK}}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -505,7 +482,6 @@ func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
 	rt := &test.ErrorRoundTripper{Err: status.Errorf(http.StatusTooManyRequests, "limiter: too many requests")}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -518,12 +494,28 @@ func TestRoundTripperPreservesRetryableStatusError(t *testing.T) {
 	require.Equal(t, 2, rt.Calls)
 }
 
+func TestRoundTripperDoesNotRetryLocalStatusError(t *testing.T) {
+	rt := &test.ErrorRoundTripper{Err: status.LocalError(status.Errorf(http.StatusTooManyRequests, "limiter: too many requests"))}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, http.StatusTooManyRequests, status.Code(err))
+	require.Equal(t, 1, rt.Calls)
+}
+
 func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
 	wantErr := io.ErrUnexpectedEOF
 	rt := &test.ErrorRoundTripper{Err: wantErr}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -535,36 +527,10 @@ func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
 	require.Equal(t, 2, rt.Calls)
 }
 
-func TestRoundTripperRetriesAttemptTimeout(t *testing.T) {
-	var calls int
-	transport := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		calls++
-		if calls == 1 {
-			<-req.Context().Done()
-			return nil, req.Context().Err()
-		}
-
-		return test.ResponseWithStatus(http.StatusOK), nil
-	})
-	retrying := retry.NewRoundTripper(&retry.Config{
-		Attempts: 2,
-		Timeout:  50 * time.Millisecond,
-		Backoff:  time.Millisecond,
-	}, transport)
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-
-	res, err := retrying.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, 2, calls)
-}
-
 func TestRoundTripperDoesNotRetryUnhandledTransportError(t *testing.T) {
 	rt := &test.ErrorRoundTripper{Err: status.Errorf(http.StatusInternalServerError, "internal")}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, rt)
 
@@ -582,7 +548,6 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	generator := &test.SequenceGenerator{}
 	retrying := retry.NewRoundTripper(&retry.Config{
 		Attempts: 2,
-		Timeout:  time.Second,
 		Backoff:  time.Millisecond,
 	}, token.NewRoundTripper(env.UserID("user-id"), generator, rt))
 
@@ -593,42 +558,4 @@ func TestRoundTripperDoesNotAccumulateAuthorizationHeadersAcrossRetries(t *testi
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, rt.AuthValues)
 	require.Equal(t, []int{1, 1}, rt.AuthCounts)
-}
-
-func TestRoundTripperUsesDefaultAttemptTimeoutWhenTimeoutIsZero(t *testing.T) {
-	var deadlineSet bool
-	transport := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		_, deadlineSet = req.Context().Deadline()
-		return test.ResponseWithStatus(http.StatusOK), nil
-	})
-	retrying := retry.NewRoundTripper(&retry.Config{
-		Attempts: 1,
-		Timeout:  0,
-		Backoff:  time.Millisecond,
-	}, transport)
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-
-	res, err := retrying.RoundTrip(req)
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	require.True(t, deadlineSet)
-}
-
-func TestRoundTripperSetsAttemptTimeoutCause(t *testing.T) {
-	transport := &test.CauseRoundTripper{Wait: true}
-	retrying := retry.NewRoundTripper(&retry.Config{
-		Attempts: 1,
-		Timeout:  time.Nanosecond,
-		Backoff:  time.Millisecond,
-	}, transport)
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-
-	res, err := retrying.RoundTrip(req)
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	require.ErrorIs(t, transport.Err, context.DeadlineExceeded)
-	require.ErrorIs(t, transport.Cause, retry.ErrAttemptTimeout)
-	require.ErrorIs(t, transport.Cause, sync.ErrTimeout)
 }

--- a/transport/retry/config.go
+++ b/transport/retry/config.go
@@ -24,10 +24,10 @@ const MaxAttempts uint64 = 10
 // Timeout and Backoff are typed durations encoded as Go duration strings in config
 // (see [time.ParseDuration]), such as "250ms", "5s", or "1m".
 type Config struct {
-	// Timeout is the per-attempt timeout duration.
+	// Timeout is a transport-specific timeout duration.
 	//
-	// When interpreted by a transport, each attempt is typically bounded
-	// independently (for example by deriving a per-attempt context deadline).
+	// Transports that support per-attempt deadlines use it to bound attempts independently.
+	// Other transports may rely on the caller's request context or client timeout instead.
 	//
 	// Value encoding: Go duration string (for example "250ms", "5s").
 	// A zero value applies time.DefaultTimeout. Negative values are invalid.
@@ -70,7 +70,7 @@ func (c *Config) MaxAttempts() uint64 {
 	return c.Attempts
 }
 
-// GetTimeout returns the configured per-attempt retry timeout.
+// GetTimeout returns the configured transport-specific retry timeout.
 //
 // A nil receiver or a non-positive value falls back to [time.DefaultTimeout].
 func (c *Config) GetTimeout() time.Duration {

--- a/transport/retry/doc.go
+++ b/transport/retry/doc.go
@@ -11,7 +11,7 @@
 //
 //   - Attempts: the maximum number of attempts for a single logical operation,
 //     including the initial attempt (so Attempts=1 means "no retries").
-//   - Timeout: a per-attempt timeout. Each attempt is bounded independently.
+//   - Timeout: a transport-specific timeout knob. Transports that support per-attempt deadlines bound each attempt independently.
 //   - Backoff: a delay inserted between failed attempts.
 //
 // Timeout and Backoff are typed durations. In config files they are encoded as
@@ -24,7 +24,7 @@
 // like this:
 //
 //   - Attempts limits how many times the operation will be tried.
-//   - Timeout is applied per attempt (usually by deriving a context with a deadline).
+//   - Timeout may be applied per attempt, depending on the transport.
 //   - Backoff is applied between attempts, often as a fixed sleep; some transports may
 //     apply additional logic (for example jitter) on top of this base value.
 //
@@ -40,7 +40,7 @@
 // A common convention is:
 //   - Attempts == 0: retries disabled using the transport's zero-value behavior.
 //   - Attempts == 1: retries disabled.
-//   - Timeout == 0: treated as "unspecified" and replaced with [time.DefaultTimeout].
+//   - Timeout == 0: treated as "unspecified" and replaced with [time.DefaultTimeout] by transports that use it.
 //   - Backoff == 0: treated as "unspecified" and replaced with DefaultBackoff.
 //
 // # Usage


### PR DESCRIPTION
## What

- HTTP retry no longer creates retry-owned per-attempt contexts, so successful response bodies stay governed by the caller-owned request context and `http.Client.Timeout` after `RoundTrip` returns.
- The HTTP client stack now places retry outside the client limiter and breaker, while keeping metadata outside retry and token generation inside retry.
- Local HTTP limiter and breaker rejections are marked with `net/http/status.LocalError` so retry treats them as terminal instead of retrying them as upstream `429` or `503` failures.
- Retry configuration/docs and `AGENTS.md` now document the HTTP timeout boundary and the intended HTTP/gRPC retry/load-control ordering.

## Why

- A retry-owned per-attempt context can cancel a response body before the caller has a chance to read it.
- HTTP retry attempts should consume limiter quota and breaker capacity per wire attempt, matching the supported gRPC client behavior and avoiding hidden downstream request multiplication.
- Upstream retryable `429`/`503` responses should remain retryable, but local load-control rejections should not trigger additional local retries.

## Testing

- `make package=transport/http specs` - passed; covers the composed HTTP client stack, including retry through limiter and breaker.
- `make package=transport/http/retry specs` - passed; covers retry classification, including terminal local status errors.
- `make package=net/http/status specs` - passed; covers `LocalError` wrapping, status extraction, and unwrapping behavior.
- `make package=transport/http/breaker specs` - passed; covers breaker local rejection behavior.
- `make package=transport/http/limiter specs` - passed; covers limiter local denial behavior.
- `make package=transport/retry specs` - passed; covers shared retry config behavior.
- `make package=transport/http lint` - passed.
- `make package=transport/http/retry lint` - passed.
- `make package=net/http/status lint` - passed.
- `make package=transport/retry lint` - passed.
