### PR TITLE
feat(http): hash static cache validators

### DIFF
--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -226,36 +226,47 @@ func TestStaticFileUsesETagValidator(t *testing.T) {
 }
 
 func TestStaticPathValueUsesETagValidator(t *testing.T) {
-	mux := http.NewServeMux()
-	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
-		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
-		FileSystem: fstest.MapFS{
-			"static/asset.txt": &fstest.MapFile{Data: []byte("hello")},
-		},
-		Pool:   test.Pool,
-		Layout: test.Layout,
-	})
-	require.True(t, mvc.StaticPathValue("/{file...}", "file", "static", mvc.WithCacheValidators()))
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "simple", path: "/asset.txt"},
+		{name: "comma", path: "/a,b.txt"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mvc.Register(mvc.RegisterParams{
+				Mux:         mux,
+				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+				FileSystem: fstest.MapFS{
+					"static/asset.txt": &fstest.MapFile{Data: []byte("hello")},
+					"static/a,b.txt":   &fstest.MapFile{Data: []byte("hello")},
+				},
+				Pool:   test.Pool,
+				Layout: test.Layout,
+			})
+			require.True(t, mvc.StaticPathValue("/{file...}", "file", "static", mvc.WithCacheValidators()))
 
-	firstReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
-	firstRes := httptest.NewRecorder()
+			firstReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
+			firstRes := httptest.NewRecorder()
 
-	mux.ServeHTTP(firstRes, firstReq)
+			mux.ServeHTTP(firstRes, firstReq)
 
-	etag := firstRes.Header().Get("ETag")
-	require.Equal(t, http.StatusOK, firstRes.Code)
-	require.NotEmpty(t, etag)
-	test.RequireResponseBody(t, firstRes, "hello")
+			etag := firstRes.Header().Get("ETag")
+			require.Equal(t, http.StatusOK, firstRes.Code)
+			require.NotEmpty(t, etag)
+			test.RequireResponseBody(t, firstRes, "hello")
 
-	secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
-	secondReq.Header.Set("If-None-Match", etag)
-	secondRes := httptest.NewRecorder()
+			secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
+			secondReq.Header.Set("If-None-Match", etag)
+			secondRes := httptest.NewRecorder()
 
-	mux.ServeHTTP(secondRes, secondReq)
+			mux.ServeHTTP(secondRes, secondReq)
 
-	require.Equal(t, http.StatusNotModified, secondRes.Code)
-	test.RequireEmptyResponseBody(t, secondRes)
+			require.Equal(t, http.StatusNotModified, secondRes.Code)
+			test.RequireEmptyResponseBody(t, secondRes)
+		})
+	}
 }
 
 func TestViewRenderReturnsContextError(t *testing.T) {

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -1,6 +1,8 @@
 package mvc
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"io/fs"
 	"path"
 	"strconv"
@@ -14,6 +16,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 )
+
+// staticETagSeparator is a NUL byte field separator for ETag hash input.
+// Static file names cannot contain NUL, so this keeps name/size/mod-time boundaries unambiguous.
+const staticETagSeparator = "\x00"
 
 // StaticFile registers an HTTP GET route that serves the named file from the registered filesystem.
 //
@@ -167,14 +173,17 @@ func setStaticContentLength(res http.ResponseWriter, size int64) {
 }
 
 func staticETag(name string, info fs.FileInfo) string {
+	sum := sha256.Sum256(strings.Bytes(strings.Join(
+		staticETagSeparator,
+		name,
+		strconv.FormatInt(info.Size(), 10),
+		strconv.FormatInt(info.ModTime().UTC().UnixNano(), 10),
+	)))
+
 	// W/ marks a weak ETag: metadata freshness, not byte-for-byte content identity.
 	return strings.Concat(
 		`W/"`,
-		name,
-		"-",
-		strconv.FormatInt(info.Size(), 10),
-		"-",
-		strconv.FormatInt(info.ModTime().UTC().UnixNano(), 10),
+		hex.EncodeToString(sum[:]),
 		`"`,
 	)
 }


### PR DESCRIPTION
## What

- Static cache validator ETags now use a weak opaque SHA-256 metadata digest instead of embedding the raw file name in the quoted entity-tag value.
- The digest input still includes the static file name, size, and modification time, separated by a NUL byte so field boundaries are unambiguous.
- The `StaticPathValue` cache-validator test now covers both a normal file name and a valid comma-containing file name.

## Why

- Raw file names can contain commas, which are valid in paths but also delimit `If-None-Match` entity-tag lists.
- When a comma-containing file name was embedded directly in the ETag, the existing matcher split the quoted tag and missed an otherwise matching validator.
- Keeping the wire ETag opaque avoids filename syntax leaking into HTTP validator parsing while preserving metadata-based freshness checks.

## Testing

- `make package=net/http/mvc specs` - passed; covers static cache validators, including a comma-containing static path value.
- `make package=net/http/mvc lint` - passed; covers the changed MVC package for lint and duplicate-test issues.
