### PR TITLE
feat(http): run first retry attempt directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   absence of HTTP retry per-attempt timeout unless a public API starts promising
   that timeout or the retry layer reintroduces owned response-body lifecycle
   handling.
+- HTTP retry intentionally runs the first attempt directly after its initial
+  request-context cancellation check, then uses the retry/backoff helper only
+  for later attempts. This keeps request-body ownership simple: an already
+  canceled request is closed locally, while any non-canceled request body is
+  handed to the inner `RoundTripper` on the first attempt. Do not reintroduce
+  per-attempt ownership flags or synthetic tests for the tiny cancellation
+  window before the first attempt unless the retry architecture changes. Local
+  redirect sentinels such as `net/http.ErrUseLastResponse` are terminal retry
+  outcomes, not transport failures to retry.
 - HTTP and gRPC client retry/load-control ordering intentionally match at the
   supported transport stack level: metadata is outside retry so `Request-Id`
   stays logical-request scoped, retry wraps the client limiter and breaker so

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -151,28 +151,48 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 
 	attempt := &roundTripAttempt{}
 
+	res, err, retrying := r.attempt(req.Context(), req, attempt)
+	if !retrying {
+		return res, err, false
+	}
+
+	res, err = r.retry(req.Context(), req, attempt, err)
+	return res, err, false
+}
+
+func (r *RoundTripper) retry(ctx context.Context, req *http.Request, attempt *roundTripAttempt, retryErr error) (*http.Response, error) {
+	firstRetry := true
 	operation := func(ctx context.Context) (*http.Response, error) {
-		return r.attempt(ctx, req, attempt)
+		if firstRetry {
+			firstRetry = false
+			return nil, retry.RetryableError(retryErr)
+		}
+
+		res, err, retrying := r.attempt(ctx, req, attempt)
+		if retrying {
+			return nil, retry.RetryableError(err)
+		}
+
+		return res, err
 	}
 
 	backoff := retry.WithJitterPercent(config.DefaultJitterPercent, retry.NewConstant(r.backoff))
 	backoff = retry.WithMaxRetries(r.maxRetries, backoff)
-	res, err := retry.DoValue(req.Context(), backoff, operation)
-	return res, err, false
+	return retry.DoValue(ctx, backoff, operation)
 }
 
-func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *roundTripAttempt) (*http.Response, error) {
+func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *roundTripAttempt) (*http.Response, error, bool) {
 	attemptReq, err := request(req, ctx, attempt.attempt)
 	if err != nil {
-		return nil, err
+		return nil, err, false
 	}
 
 	res, err := r.RoundTripper.RoundTrip(attemptReq)
 	if retryErr := attempt.retry(ctx, req, res, err, r.backoff, r.maxRetries); retryErr != nil {
-		return nil, retryErr
+		return nil, retryErr, true
 	}
 
-	return res, err
+	return res, err, false
 }
 
 type roundTripAttempt struct {
@@ -191,7 +211,7 @@ func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *ht
 	retryErr = statusError(retryErr, err)
 	if res == nil {
 		a.attempt++
-		return retry.RetryableError(retryErr)
+		return retryErr
 	}
 	if a.attempt >= maxRetries {
 		return nil
@@ -202,7 +222,7 @@ func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *ht
 
 	closeResponse(res)
 	a.attempt++
-	return retry.RetryableError(retryErr)
+	return retryErr
 }
 
 func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Request, error) {
@@ -226,6 +246,10 @@ func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Requ
 
 func shouldRetryAttempt(ctx context.Context, res *http.Response, err error) (bool, error) {
 	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	if errors.Is(err, http.ErrUseLastResponse) {
 		return false, err
 	}
 

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -511,6 +511,21 @@ func TestRoundTripperDoesNotRetryLocalStatusError(t *testing.T) {
 	require.Equal(t, 1, rt.Calls)
 }
 
+func TestRoundTripperDoesNotRetryUseLastResponse(t *testing.T) {
+	rt := &test.ErrorRoundTripper{Err: http.ErrUseLastResponse}
+	retrying := retry.NewRoundTripper(&retry.Config{
+		Attempts: 2,
+		Backoff:  time.Millisecond,
+	}, rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, http.ErrUseLastResponse)
+	require.Equal(t, 1, rt.Calls)
+}
+
 func TestRoundTripperPreservesRecoverableTransportError(t *testing.T) {
 	wantErr := io.ErrUnexpectedEOF
 	rt := &test.ErrorRoundTripper{Err: wantErr}


### PR DESCRIPTION
## What

- HTTP retry now executes the first attempt directly after its initial request-context cancellation check.
- The retry/backoff helper is used only after a first retryable result, so non-canceled request bodies are handed to the inner `RoundTripper` before retry scheduling can observe cancellation.
- `net/http.ErrUseLastResponse` is treated as a terminal retry outcome, and the retry tests cover that it is not retried.
- `AGENTS.md` documents the direct-first-attempt ownership decision and the terminal redirect sentinel behavior for future reviews.

## Why

- Running the first attempt through the retry helper made request-body ownership depend on whether the helper observed cancellation before invoking the operation.
- Executing the first attempt directly keeps the ownership rule simple: already canceled requests are closed locally, while all other request bodies are owned by the inner transport from attempt one.
- Cross-origin redirect rejections are local terminal decisions, not transient transport failures that another retry can fix.

## Testing

- `make package=transport/http/retry specs` - passed; covers retry behavior, body closure for already canceled requests, and terminal `ErrUseLastResponse` classification.
- `make package=transport/http specs` - passed; covers the supported HTTP client stack using retry with token, limiter, and breaker behavior.
- `make package=transport/http/retry lint` - passed; covers linting for the changed retry package.
