### PR TITLE
feat(cache): bound encoded values before compression

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -87,6 +87,37 @@ type Cache struct {
 	driver driver.Driver
 }
 
+// maxSizeWriter enforces the cache encoded-size limit at the writer boundary.
+// It prevents encoders from growing the intermediate buffer past max_size before
+// compression gets its own chance to validate the payload.
+type maxSizeWriter struct {
+	writer  io.Writer
+	max     int64
+	written int64
+}
+
+func (w *maxSizeWriter) Write(data []byte) (int, error) {
+	remaining := w.max - w.written
+	if int64(len(data)) > remaining {
+		if remaining <= 0 {
+			return 0, compresserrors.ErrTooLarge
+		}
+
+		n, err := w.writer.Write(data[:int(remaining)])
+		w.written += int64(n)
+		if err != nil {
+			return n, err
+		}
+
+		return n, compresserrors.ErrTooLarge
+	}
+
+	n, err := w.writer.Write(data)
+	w.written += int64(n)
+
+	return n, err
+}
+
 // Flush removes cached data according to the underlying driver's flush semantics.
 //
 // For persistent backends such as Redis this can be a destructive operation:
@@ -147,16 +178,18 @@ func (c *Cache) encode(value any) (string, error) {
 	buf := c.pool.Get()
 	defer c.pool.Put(buf)
 
-	if err := c.writeEncoder(value).Encode(buf, value); err != nil {
+	maxSize := c.cfg.GetMaxSize()
+	writer := &maxSizeWriter{writer: buf, max: maxSize.Bytes()}
+	if err := c.writeEncoder(value).Encode(writer, value); err != nil {
 		return strings.Empty, err
 	}
 
 	data := buf.Bytes()
-	compressed, err := c.compressor().Compress(data, c.cfg.GetMaxSize())
+	compressed, err := c.compressor().Compress(data, maxSize)
 	if err != nil {
 		return strings.Empty, err
 	}
-	if int64(len(compressed)) > c.cfg.GetMaxSize().Bytes() {
+	if int64(len(compressed)) > maxSize.Bytes() {
 		return strings.Empty, compresserrors.ErrTooLarge
 	}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
@@ -103,6 +104,17 @@ func TestMaxSizeOnPersistCompressedValue(t *testing.T) {
 
 	err := world.Persist(t.Context(), "test", new("a"), time.Minute)
 	require.ErrorIs(t, err, compresserrors.ErrTooLarge)
+}
+
+func TestMaxSizeOnPersistStopsOversizedEncodedValue(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	cfg.MaxSize = 4
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+	value := &oversizedWriterTo{size: cfg.MaxSize.Bytes() + 1}
+
+	err := world.Persist(t.Context(), "test", value, time.Minute)
+	require.ErrorIs(t, err, compresserrors.ErrTooLarge)
+	require.Equal(t, cfg.MaxSize.Bytes(), value.written)
 }
 
 func TestMaxSizeOnGet(t *testing.T) {
@@ -400,6 +412,18 @@ type cacheRoundTripCase struct {
 	get     func() any
 	config  *config.Config
 	name    string
+}
+
+type oversizedWriterTo struct {
+	size    int64
+	written int64
+}
+
+func (w *oversizedWriterTo) WriteTo(dst io.Writer) (int64, error) {
+	n, err := dst.Write(make([]byte, w.size))
+	w.written = int64(n)
+
+	return w.written, err
 }
 
 type expiredCacheDriver struct{}


### PR DESCRIPTION
## What

- Enforce the configured max_size while cache values are encoded, before encoded bytes are accepted into the intermediate buffer.
- Keep the existing compressed-value and read-side size checks in place.
- Add regression coverage for io.WriterTo payloads that attempt to write one byte past the configured limit.

## Why

- The cache configuration promises that max_size applies before compression, after compression, and after decompression.
- Enforcing the pre-compression bound at the writer boundary avoids buffering oversized encoded payloads before returning compress/errors.ErrTooLarge.

## Testing

- `make package=cache specs` - passed
- `make package=cache lint` - passed; reported the existing gomodguard deprecation warning and 0 issues.
