### PR TITLE
feat(token): tolerate service clock skew

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ transport:
       jwt:
         iss: my-service
         exp: 1h
+        leeway: 30s
         key: active
         keys:
           active:
@@ -696,11 +697,12 @@ Important behavior:
 
 - JWT generation signs with `jwt.key`; verification requires the token `kid` header to select an entry in `jwt.keys`.
 - `exp` is parsed as a Go duration string; invalid values can fail fast.
+- `leeway` is optional clock-skew tolerance for verification; keep it small because it extends acceptance around `iat`/`nbf` and `exp`.
 
 > [!IMPORTANT]
 > JWT generation and verification use Ed25519 key material from `jwt.keys`. Keep private key material only on services that mint tokens; verifiers only need public keys.
 
-All token `exp` values are Go duration strings and must be positive whole-second durations. Values such
+All token `exp` and non-zero `leeway` values are Go duration strings and must be positive whole-second durations. Values such
 as `1s`, `15m`, and `24h` validate; sub-second values such as `500ms` do not.
 
 ### Paseto
@@ -715,6 +717,7 @@ transport:
       paseto:
         iss: my-service
         exp: 1h
+        leeway: 30s
         key: active
         keys:
           active:
@@ -725,7 +728,7 @@ transport:
 ```
 
 > [!NOTE]
-> The PASETO implementation issues **v4 public** tokens. Generation signs with `paseto.key`, writes that id as footer `kid`, and verification selects the public key from `paseto.keys`.
+> The PASETO implementation issues **v4 public** tokens. Generation signs with `paseto.key`, writes that id as footer `kid`, and verification selects the public key from `paseto.keys`. `paseto.leeway` is optional clock-skew tolerance for verification.
 
 ### SSH tokens
 
@@ -740,6 +743,7 @@ transport:
       kind: ssh
       ssh:
         exp: 5m
+        leeway: 30s
         keys:
           active:
             public: file:/keys/active.pub
@@ -754,6 +758,7 @@ transport:
       kind: ssh
       ssh:
         exp: 5m
+        leeway: 30s
         key: active
         keys:
           active:
@@ -767,6 +772,7 @@ transport:
 > - `ssh.key` is the active key id used for minting tokens (the matching `ssh.keys` entry requires private key material).
 > - `ssh.keys` is the trusted key map used for verification (public keys).
 > - `ssh.exp` sets the token validity window; SSH keys remain long-lived, while generated tokens are short-lived.
+> - `ssh.leeway` is optional clock-skew tolerance for verification; keep it small because it extends acceptance around `iat` and `exp`.
 > - SSH tokens carry `sub` equal to `kid`, so the verified subject is the trusted peer key id.
 
 ---

--- a/token/jwt/config.go
+++ b/token/jwt/config.go
@@ -56,6 +56,13 @@ type Config struct {
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
 	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"duration_second_precision"`
+
+	// Leeway is the optional clock-skew tolerance applied during verification.
+	//
+	// A zero value keeps strict time validation. Non-zero values allow iat/nbf to
+	// be slightly in the future and exp to be slightly in the past while preserving
+	// the signed lifetime cap enforced from iat to exp.
+	Leeway time.Duration `yaml:"leeway,omitempty" json:"leeway,omitempty" toml:"leeway,omitempty" validate:"omitempty,duration_second_precision"`
 }
 
 // IsEnabled reports whether JWT configuration is present.

--- a/token/jwt/doc.go
+++ b/token/jwt/doc.go
@@ -53,10 +53,12 @@
 //   - The "kid" header exists and selects a configured verification key.
 //   - The issuer claim matches the configured Issuer.
 //   - The audience claim contains the expected audience.
-//   - Registered claim validity (exp/nbf/iat) using [github.com/golang-jwt/jwt/v4.RegisteredClaims.Valid].
+//   - Registered claim time validity (exp/nbf/iat) using [Config.Leeway] as
+//     optional clock-skew tolerance.
+//   - The signed lifetime from iat to exp does not exceed [Config.Expiration].
 //
-// Upstream parsing, signature validation, and registered-claim validation can fail before
-// later go-service issuer, audience, and lifetime checks run.
+// Upstream parsing and signature validation can fail before later go-service
+// issuer, audience, time-validity, and lifetime checks run.
 //
 // On failures, this package may return sentinel errors from token/errors for common
 // classes of validation issues (for example ErrInvalidAlgorithm, ErrInvalidKeyID,
@@ -68,8 +70,8 @@
 //
 // # Configuration and enablement
 //
-// Config provides the issuer, active key id, named key set, and expiration settings
-// used for issuance and verification. A nil *[Config] is treated as disabled:
+// Config provides the issuer, active key id, named key set, expiration, and optional
+// leeway settings used for issuance and verification. A nil *[Config] is treated as disabled:
 // NewToken returns nil.
 //
 // Expiration is a typed duration. In config files it is encoded using the standard

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -107,14 +107,14 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 //   - The JWT header "kid" exists, is non-empty, and selects a configured verification key.
 //   - The issuer claim ("iss") matches cfg.Issuer.
 //   - The audience claim ("aud") contains the expected aud.
-//   - Registered claim time validity using [github.com/golang-jwt/jwt/v4.RegisteredClaims.Valid] (exp/nbf/iat).
+//   - Registered claim time validity with cfg.Leeway clock-skew tolerance (exp/nbf/iat).
 //   - The signed lifetime (exp - iat) does not exceed cfg.Expiration.
 //
 // This method returns sentinel errors from token/errors for some common classes of
 // failures (issuer/audience mismatches and validate-time algorithm/kid mismatches).
 // Parse/validation errors produced by the upstream JWT library may be returned as-is.
-// Upstream parse, signature, or registered-claim validation errors can be returned
-// before the local issuer, audience, required-claim, and lifetime checks run.
+// Upstream parse and signature errors can be returned before the local issuer,
+// audience, required-claim, time-validity, and lifetime checks run.
 func (t *Token) Verify(token, aud string) (string, error) {
 	if strings.IsEmpty(t.cfg.Issuer) || t.cfg.Expiration <= 0 {
 		return strings.Empty, errors.ErrInvalidConfig
@@ -122,7 +122,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 
 	claims := &RegisteredClaims{}
 
-	_, err := jwt.ParseWithClaims(token, claims, t.validate)
+	_, err := jwt.ParseWithClaims(token, claims, t.validate, jwt.WithoutClaimsValidation())
 	if err != nil {
 		return strings.Empty, err
 	}
@@ -135,14 +135,10 @@ func (t *Token) Verify(token, aud string) (string, error) {
 		return strings.Empty, errors.ErrInvalidAudience
 	}
 
-	if err := claims.Valid(); err != nil {
-		return strings.Empty, err
-	}
-
 	if err := validateRequiredClaims(claims); err != nil {
 		return strings.Empty, err
 	}
-	if err := validateLifetime(claims, t.cfg.Expiration); err != nil {
+	if err := validateTime(claims, t.cfg.Expiration, t.cfg.Leeway); err != nil {
 		return strings.Empty, err
 	}
 
@@ -182,6 +178,20 @@ func validateRequiredClaims(claims *RegisteredClaims) error {
 	}
 
 	return nil
+}
+
+func validateTime(claims *RegisteredClaims, maxLifetime, leeway time.Duration) error {
+	now := time.Now()
+	allowedFuture := now.Add(leeway.Duration())
+	if claims.IssuedAt.After(allowedFuture) || claims.NotBefore.After(allowedFuture) {
+		return errors.ErrInvalidTime
+	}
+
+	if !claims.ExpiresAt.Time.Add(leeway.Duration()).After(now) {
+		return errors.ErrInvalidTime
+	}
+
+	return validateLifetime(claims, maxLifetime)
 }
 
 func validateLifetime(claims *RegisteredClaims, maxLifetime time.Duration) error {

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -44,6 +44,16 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 				Expiration: time.Hour,
 			},
 		},
+		{
+			name: "invalid leeway precision",
+			config: &jwt.Config{
+				Issuer:     "iss",
+				Key:        valid.Key,
+				Keys:       valid.Keys,
+				Expiration: time.Hour,
+				Leeway:     time.Millisecond,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -66,6 +76,67 @@ func TestValid(t *testing.T) {
 	sub, err := token.Verify(tkn, "hello")
 	require.NoError(t, err)
 	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestVerifyWithLeeway(t *testing.T) {
+	cfg := test.NewToken("jwt")
+	cfg.JWT.Leeway = time.Minute
+	token := jwt.NewToken(cfg.JWT, test.FS, uuid.NewGenerator())
+	now := time.Now()
+
+	t.Run("issuer clock ahead within leeway", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, nil, func(claims *jwt.RegisteredClaims) {
+			issuedAt := now.Add((30 * time.Second).Duration())
+			claims.IssuedAt = &jwt.NumericDate{Time: issuedAt}
+			claims.NotBefore = &jwt.NumericDate{Time: issuedAt}
+			claims.ExpiresAt = &jwt.NumericDate{Time: issuedAt.Add(cfg.JWT.Expiration.Duration())}
+		})
+
+		sub, err := token.Verify(tkn, "hello")
+		require.NoError(t, err)
+		require.Equal(t, test.UserID.String(), sub)
+	})
+
+	t.Run("issuer clock ahead beyond leeway", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, nil, func(claims *jwt.RegisteredClaims) {
+			issuedAt := now.Add((2 * time.Minute).Duration())
+			claims.IssuedAt = &jwt.NumericDate{Time: issuedAt}
+			claims.NotBefore = &jwt.NumericDate{Time: issuedAt}
+			claims.ExpiresAt = &jwt.NumericDate{Time: issuedAt.Add(cfg.JWT.Expiration.Duration())}
+		})
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidTime)
+	})
+
+	t.Run("expired within leeway", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, nil, func(claims *jwt.RegisteredClaims) {
+			expiresAt := now.Add(-(30 * time.Second).Duration())
+			issuedAt := expiresAt.Add(-cfg.JWT.Expiration.Duration())
+			claims.IssuedAt = &jwt.NumericDate{Time: issuedAt}
+			claims.NotBefore = &jwt.NumericDate{Time: issuedAt}
+			claims.ExpiresAt = &jwt.NumericDate{Time: expiresAt}
+		})
+
+		sub, err := token.Verify(tkn, "hello")
+		require.NoError(t, err)
+		require.Equal(t, test.UserID.String(), sub)
+	})
+
+	t.Run("expired beyond leeway", func(t *testing.T) {
+		tkn := signedJWT(t, cfg.JWT, nil, func(claims *jwt.RegisteredClaims) {
+			expiresAt := now.Add(-(2 * time.Minute).Duration())
+			issuedAt := expiresAt.Add(-cfg.JWT.Expiration.Duration())
+			claims.IssuedAt = &jwt.NumericDate{Time: issuedAt}
+			claims.NotBefore = &jwt.NumericDate{Time: issuedAt}
+			claims.ExpiresAt = &jwt.NumericDate{Time: expiresAt}
+		})
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidTime)
+	})
 }
 
 func TestInvalid(t *testing.T) {
@@ -428,5 +499,6 @@ func cloneConfig(cfg *jwt.Config) *jwt.Config {
 		Key:        cfg.Key,
 		Keys:       cfg.Keys,
 		Expiration: cfg.Expiration,
+		Leeway:     cfg.Leeway,
 	}
 }

--- a/token/paseto/config.go
+++ b/token/paseto/config.go
@@ -44,6 +44,13 @@ type Config struct {
 	//
 	// In config files it is encoded as a Go duration string, for example "15m" or "24h".
 	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"duration_second_precision"`
+
+	// Leeway is the optional clock-skew tolerance applied during verification.
+	//
+	// A zero value keeps strict time validation. Non-zero values allow iat/nbf to
+	// be slightly in the future and exp to be slightly in the past while preserving
+	// the signed lifetime cap enforced from iat to exp.
+	Leeway time.Duration `yaml:"leeway,omitempty" json:"leeway,omitempty" toml:"leeway,omitempty" validate:"omitempty,duration_second_precision"`
 }
 
 // IsEnabled reports whether PASETO configuration is present.

--- a/token/paseto/doc.go
+++ b/token/paseto/doc.go
@@ -50,13 +50,13 @@
 // set of rules that typically include:
 //
 //   - issued by the configured issuer (iss),
-//   - not expired at the time of verification,
-//   - valid at the current time (iat/nbf window semantics as defined by the
-//     upstream library),
 //   - for the expected audience (aud).
 //
 // The signature is verified using the Ed25519 public key selected by the footer
 // "kid" value.
+// After parsing and signature verification, go-service validates exp/nbf/iat
+// using [Config.Leeway] as optional clock-skew tolerance and checks that the
+// signed lifetime from iat to exp does not exceed [Config.Expiration].
 //
 // On failure, parser, rule, signature, and key-construction errors may come
 // from the upstream PASETO library. Local config, subject, and signed-lifetime
@@ -64,8 +64,8 @@
 //
 // # Configuration and enablement
 //
-// Config provides issuer, active key id, named key set, and expiration settings.
-// A nil *[Config] is treated as disabled: NewToken returns nil.
+// Config provides issuer, active key id, named key set, expiration, and optional
+// leeway settings. A nil *[Config] is treated as disabled: NewToken returns nil.
 //
 // Expiration is a typed duration. In config files it is encoded using the standard
 // Go duration string format (such as "15m" or "24h"), so invalid values fail during

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -92,8 +92,7 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 //
 // The rules enforced include:
 //   - issuer matches cfg.Issuer (iss)
-//   - token is not expired
-//   - token is valid at the current time (iat/nbf semantics as defined by the upstream library)
+//   - token is valid at the current time with cfg.Leeway clock-skew tolerance (iat/nbf/exp)
 //   - audience matches aud (aud)
 //   - the signed lifetime (exp - iat) does not exceed cfg.Expiration
 //
@@ -105,10 +104,8 @@ func (t *Token) Verify(token, aud string) (string, error) {
 		return strings.Empty, errors.ErrInvalidConfig
 	}
 
-	parser := paseto.NewParser()
+	parser := paseto.NewParserWithoutExpiryCheck()
 	parser.AddRule(paseto.IssuedBy(t.cfg.Issuer))
-	parser.AddRule(paseto.NotExpired())
-	parser.AddRule(paseto.ValidAt(time.Now()))
 	parser.AddRule(paseto.ForAudience(aud))
 
 	key, err := t.publicKey(token, parser)
@@ -126,7 +123,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 		return strings.Empty, err
 	}
 
-	if err := validateLifetime(parsed, t.cfg.Expiration); err != nil {
+	if err := validateTime(parsed, t.cfg.Expiration, t.cfg.Leeway); err != nil {
 		return strings.Empty, err
 	}
 
@@ -169,15 +166,33 @@ func subject(token *paseto.Token) (string, error) {
 	return sub, nil
 }
 
-func validateLifetime(token *paseto.Token, maxLifetime time.Duration) error {
+func validateTime(token *paseto.Token, maxLifetime, leeway time.Duration) error {
 	issuedAt, err := token.GetIssuedAt()
 	if err != nil {
-		return err
+		return errors.ErrInvalidTime
+	}
+	notBefore, err := token.GetNotBefore()
+	if err != nil {
+		return errors.ErrInvalidTime
 	}
 	expiresAt, err := token.GetExpiration()
 	if err != nil {
-		return err
+		return errors.ErrInvalidTime
 	}
+
+	now := time.Now()
+	allowedFuture := now.Add(leeway.Duration())
+	if issuedAt.After(allowedFuture) || notBefore.After(allowedFuture) {
+		return errors.ErrInvalidTime
+	}
+	if !expiresAt.Add(leeway.Duration()).After(now) {
+		return errors.ErrInvalidTime
+	}
+
+	return validateLifetimeRange(issuedAt, expiresAt, maxLifetime)
+}
+
+func validateLifetimeRange(issuedAt, expiresAt time.Time, maxLifetime time.Duration) error {
 	if !expiresAt.After(issuedAt) || expiresAt.Sub(issuedAt) > maxLifetime.Duration() {
 		return errors.ErrInvalidTime
 	}

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -3,7 +3,9 @@ package paseto_test
 import (
 	"testing"
 
+	pasetotest "aidanwoods.dev/go-paseto"
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -44,6 +46,16 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 				Expiration: time.Hour,
 			},
 		},
+		{
+			name: "invalid leeway precision",
+			config: &paseto.Config{
+				Issuer:     "iss",
+				Key:        valid.Key,
+				Keys:       valid.Keys,
+				Expiration: time.Hour,
+				Leeway:     time.Millisecond,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -66,6 +78,51 @@ func TestValid(t *testing.T) {
 	sub, err := token.Verify(tkn, "hello")
 	require.NoError(t, err)
 	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestVerifyWithLeeway(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	cfg.Paseto.Leeway = time.Minute
+	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
+	now := time.Now()
+
+	t.Run("issuer clock ahead within leeway", func(t *testing.T) {
+		issuedAt := now.Add((30 * time.Second).Duration())
+		tkn := signedPaseto(t, cfg.Paseto, issuedAt, issuedAt, issuedAt.Add(cfg.Paseto.Expiration.Duration()))
+
+		sub, err := token.Verify(tkn, "hello")
+		require.NoError(t, err)
+		require.Equal(t, test.UserID.String(), sub)
+	})
+
+	t.Run("issuer clock ahead beyond leeway", func(t *testing.T) {
+		issuedAt := now.Add((2 * time.Minute).Duration())
+		tkn := signedPaseto(t, cfg.Paseto, issuedAt, issuedAt, issuedAt.Add(cfg.Paseto.Expiration.Duration()))
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidTime)
+	})
+
+	t.Run("expired within leeway", func(t *testing.T) {
+		expiresAt := now.Add(-(30 * time.Second).Duration())
+		issuedAt := expiresAt.Add(-cfg.Paseto.Expiration.Duration())
+		tkn := signedPaseto(t, cfg.Paseto, issuedAt, issuedAt, expiresAt)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.NoError(t, err)
+		require.Equal(t, test.UserID.String(), sub)
+	})
+
+	t.Run("expired beyond leeway", func(t *testing.T) {
+		expiresAt := now.Add(-(2 * time.Minute).Duration())
+		issuedAt := expiresAt.Add(-cfg.Paseto.Expiration.Duration())
+		tkn := signedPaseto(t, cfg.Paseto, issuedAt, issuedAt, expiresAt)
+
+		sub, err := token.Verify(tkn, "hello")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidTime)
+	})
 }
 
 func TestInvalidEmptySubject(t *testing.T) {
@@ -337,5 +394,31 @@ func cloneConfig(cfg *paseto.Config) *paseto.Config {
 		Key:        cfg.Key,
 		Keys:       cfg.Keys,
 		Expiration: cfg.Expiration,
+		Leeway:     cfg.Leeway,
 	}
+}
+
+func signedPaseto(t *testing.T, cfg *paseto.Config, issuedAt, notBefore, expiresAt time.Time) string {
+	t.Helper()
+
+	key, err := cfg.Keys.Get(cfg.Key).Signer(test.PEM)
+	require.NoError(t, err)
+
+	token := pasetotest.NewToken()
+	token.SetJti("test-id")
+	token.SetIssuedAt(issuedAt)
+	token.SetNotBefore(notBefore)
+	token.SetExpiration(expiresAt)
+	token.SetIssuer(cfg.Issuer)
+	token.SetAudience("hello")
+	token.SetSubject(test.UserID.String())
+
+	footer, err := json.Marshal(map[string]string{"kid": cfg.Key})
+	require.NoError(t, err)
+	token.SetFooter(footer)
+
+	s, err := pasetotest.NewV4AsymmetricSecretKeyFromBytes(key.PrivateKey)
+	require.NoError(t, err)
+
+	return token.V4Sign(s, nil)
 }

--- a/token/ssh/claims.go
+++ b/token/ssh/claims.go
@@ -54,7 +54,7 @@ func decodeClaims(raw []byte) (*claims, error) {
 	return c, nil
 }
 
-func validateClaims(c *claims, aud string, now int64, maxLifetime time.Duration) error {
+func validateClaims(c *claims, aud string, now time.Time, maxLifetime, leeway time.Duration) error {
 	if c.Audience != aud {
 		return token.ErrInvalidAudience
 	}
@@ -64,8 +64,8 @@ func validateClaims(c *claims, aud string, now int64, maxLifetime time.Duration)
 	if c.Subject != c.KeyID {
 		return crypto.ErrInvalidMatch
 	}
-	invalidIssuedAt := c.IssuedAt <= 0 || c.IssuedAt > now
-	invalidExpiration := c.ExpiresAt <= now || c.ExpiresAt <= c.IssuedAt
+	invalidIssuedAt := c.IssuedAt <= 0 || c.IssuedAt > now.Add(leeway.Duration()).UnixNano()
+	invalidExpiration := c.ExpiresAt <= 0 || c.ExpiresAt <= now.Add(-leeway.Duration()).UnixNano() || c.ExpiresAt <= c.IssuedAt
 	if invalidIssuedAt || invalidExpiration {
 		return token.ErrInvalidTime
 	}

--- a/token/ssh/config.go
+++ b/token/ssh/config.go
@@ -55,6 +55,13 @@ type Config struct {
 	// In config files it is encoded as a Go duration string, for example "15m" or "1h".
 	// It must use whole-second precision.
 	Expiration time.Duration `yaml:"exp,omitempty" json:"exp,omitempty" toml:"exp,omitempty" validate:"duration_second_precision"`
+
+	// Leeway is the optional clock-skew tolerance applied during verification.
+	//
+	// A zero value keeps strict time validation. Non-zero values allow iat to be
+	// slightly in the future and exp to be slightly in the past while preserving
+	// the signed lifetime cap enforced from iat to exp.
+	Leeway time.Duration `yaml:"leeway,omitempty" json:"leeway,omitempty" toml:"leeway,omitempty" validate:"omitempty,duration_second_precision"`
 }
 
 // IsEnabled reports whether SSH token configuration is enabled.

--- a/token/ssh/doc.go
+++ b/token/ssh/doc.go
@@ -29,6 +29,8 @@
 //   - [Config.Key] is the active signing key id used for Generate.
 //   - [Config.Keys] is a named key set used for Generate and Verify.
 //   - [Config.Expiration] controls how long generated tokens remain valid.
+//   - [Config.Leeway] optionally tolerates small verifier/issuer clock skew
+//     around iat and exp while preserving the signed lifetime cap.
 //
 // Verification is id-based: Verify extracts kid from the signed claims and
 // then looks up a matching public key configuration in [Config.Keys] (via

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -184,7 +184,7 @@ func (t *Token) Verify(tkn, aud string) (string, error) {
 		return strings.Empty, err
 	}
 
-	if err := validateClaims(claims, aud, time.Now().UnixNano(), t.cfg.Expiration); err != nil {
+	if err := validateClaims(claims, aud, time.Now(), t.cfg.Expiration, t.cfg.Leeway); err != nil {
 		return strings.Empty, err
 	}
 

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -35,6 +35,32 @@ func TestConfigIsEnabled(t *testing.T) {
 	}
 }
 
+func TestConfigRejectsInvalidValues(t *testing.T) {
+	valid := test.NewToken("ssh").SSH
+	tests := []struct {
+		config *ssh.Config
+		name   string
+	}{
+		{
+			name: "invalid leeway precision",
+			config: &ssh.Config{
+				Key:        valid.Key,
+				Keys:       valid.Keys,
+				Expiration: valid.Expiration,
+				Leeway:     time.Millisecond,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, test.Validator.Struct(tt.config))
+		})
+	}
+
+	require.NoError(t, test.Validator.Struct(valid))
+}
+
 func TestValid(t *testing.T) {
 	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 
@@ -60,6 +86,58 @@ func TestValidForAudience(t *testing.T) {
 	sub, err := token.Verify(tkn, "/service.Method")
 	require.NoError(t, err)
 	require.Equal(t, test.UserID.String(), sub)
+}
+
+func TestVerifyWithLeeway(t *testing.T) {
+	cfg := test.NewToken("ssh").SSH
+	cfg.Leeway = time.Minute
+	token := ssh.NewToken(cfg, test.FS)
+	now := time.Now()
+
+	tests := []struct {
+		err       error
+		issuedAt  time.Time
+		expiresAt time.Time
+		name      string
+	}{
+		{
+			name:      "issuer clock ahead within leeway",
+			issuedAt:  now.Add((30 * time.Second).Duration()),
+			expiresAt: now.Add((30 * time.Second).Duration()).Add(cfg.Expiration.Duration()),
+		},
+		{
+			name:      "issuer clock ahead beyond leeway",
+			issuedAt:  now.Add((2 * time.Minute).Duration()),
+			expiresAt: now.Add((2 * time.Minute).Duration()).Add(cfg.Expiration.Duration()),
+			err:       errors.ErrInvalidTime,
+		},
+		{
+			name:      "expired within leeway",
+			issuedAt:  now.Add(-(30 * time.Second).Duration()).Add(-cfg.Expiration.Duration()),
+			expiresAt: now.Add(-(30 * time.Second).Duration()),
+		},
+		{
+			name:      "expired beyond leeway",
+			issuedAt:  now.Add(-(2 * time.Minute).Duration()).Add(-cfg.Expiration.Duration()),
+			expiresAt: now.Add(-(2 * time.Minute).Duration()),
+			err:       errors.ErrInvalidTime,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tkn := signedSSHToken(t, cfg, sshClaims(cfg, tt.issuedAt, tt.expiresAt))
+			sub, err := token.Verify(tkn, "/service.Method")
+			if tt.err != nil {
+				require.Empty(t, sub)
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.UserID.String(), sub)
+		})
+	}
 }
 
 func TestInvalidAudience(t *testing.T) {
@@ -482,6 +560,17 @@ func TestKeysGet(t *testing.T) {
 	require.Nil(t, keys.Get("missing"))
 	require.Nil(t, ssh.Keys{}.Get("missing"))
 	require.Nil(t, ssh.Keys(nil).Get("missing"))
+}
+
+func sshClaims(cfg *ssh.Config, issuedAt, expiresAt time.Time) map[string]any {
+	return map[string]any{
+		"ver": "v1",
+		"kid": cfg.Key,
+		"sub": cfg.Key,
+		"aud": "/service.Method",
+		"iat": issuedAt.UnixNano(),
+		"exp": expiresAt.UnixNano(),
+	}
 }
 
 func signedSSHToken(t *testing.T, cfg *ssh.Config, claims map[string]any) string {


### PR DESCRIPTION
## What

- Add optional `leeway` verification config for JWT, PASETO, and SSH.
- Apply leeway to issued-at/not-before future checks and expiration past checks while preserving the signed lifetime cap from issued-at to expiration.
- Document the new config key and security tradeoff in README and package docs.

## Why

- Small wall-clock drift between service hosts can otherwise reject freshly issued service-to-service credentials or credentials near expiry.
- A zero `leeway` keeps strict validation, while configured leeway gives operators a bounded way to avoid intermittent authentication failures.

## Testing

- `make package=token/jwt specs` - passed
- `make package=token/paseto specs` - passed
- `make package=token/ssh specs` - passed
- `make package=token specs` - passed
- `make package=config specs` - passed
- `make package=transport/http/token specs` - passed
- `make package=transport/grpc/token specs` - passed
- `make package=token/jwt lint` - passed
- `make package=token/paseto lint` - passed
- `make package=token/ssh lint` - passed
- `make package=token lint` - passed
