### PR TITLE
feat(grpc): recover handler panics

### DIFF
--- a/internal/test/service.go
+++ b/internal/test/service.go
@@ -16,15 +16,26 @@ type Service struct {
 }
 
 // SayHello returns a greeting for the requested name.
+//
+// The name "panic" is reserved for transport recovery tests.
 func (s *Service) SayHello(ctx context.Context, req *v1.SayHelloRequest) (*v1.SayHelloResponse, error) {
+	if req.GetName() == "panic" {
+		panic("test panic")
+	}
+
 	return &v1.SayHelloResponse{Message: "Hello " + req.GetName()}, nil
 }
 
 // SayStreamHello reads a single request from the bidi stream and replies with one greeting message.
+//
+// The name "panic" is reserved for transport recovery tests.
 func (s *Service) SayStreamHello(stream v1.GreeterService_SayStreamHelloServer) error {
 	req, err := stream.Recv()
 	if err != nil {
 		return err
+	}
+	if req.GetName() == "panic" {
+		panic("test panic")
 	}
 
 	return stream.Send(&v1.SayStreamHelloResponse{Message: "Hello " + req.GetName()})

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -78,6 +78,45 @@ func TestStream(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
+func TestServerRecoversUnaryPanic(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldGRPC())
+	conn := test.RequireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	_, err := client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "panic"})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+	assertSafePanicStatus(t, err)
+
+	resp, err := client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "Hello test", resp.GetMessage())
+}
+
+func TestServerRecoversStreamPanic(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldGRPC())
+	conn := test.RequireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	_, err = test.SendStreamHello(t, stream, "panic")
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+	assertSafePanicStatus(t, err)
+
+	stream, err = client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+	resp, err := test.SendStreamHello(t, stream, "test")
+	require.NoError(t, err)
+	require.Equal(t, "Hello test", resp.GetMessage())
+}
+
 func TestUnaryMaxReceiveSize(t *testing.T) {
 	world := newStartedGRPCWorld(t, 64)
 	conn := test.RequireGRPCConn(t, world)
@@ -151,4 +190,14 @@ func newStartedGRPCWorldWithOptions(t *testing.T, maxReceiveSize bytes.Size, opt
 	}
 
 	return test.NewStartedWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldGRPC())
+}
+
+func assertSafePanicStatus(t *testing.T, err error) {
+	t.Helper()
+
+	stat, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, "grpc: internal", stat.Message())
+	require.NotContains(t, stat.Message(), "test panic")
+	require.NotContains(t, stat.Message(), "recovered")
 }

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -11,17 +11,21 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	grpcserver "github.com/alexfalkowski/go-service/v2/net/grpc/server"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/telemetry"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 )
 
 // ServerParams defines dependencies for constructing a gRPC transport [Server].
@@ -173,6 +177,8 @@ func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInte
 		uis = append(uis, logger.UnaryServerInterceptor(params.Logger))
 	}
 
+	uis = append(uis, recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)))
+
 	if params.Verifier != nil {
 		uis = append(uis, token.UnaryServerInterceptor(params.UserID, params.Verifier))
 	}
@@ -197,6 +203,8 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 		sis = append(sis, logger.StreamServerInterceptor(params.Logger))
 	}
 
+	sis = append(sis, recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)))
+
 	if params.Verifier != nil {
 		sis = append(sis, token.StreamServerInterceptor(params.UserID, params.Verifier))
 	}
@@ -212,6 +220,10 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 	sis = append(sis, interceptors...)
 
 	return grpc.ChainStreamInterceptor(sis...)
+}
+
+func recoveryHandler(value any) error {
+	return status.SafeError(codes.Internal, runtime.ConvertRecover(value))
 }
 
 func maxReceiveSizeOption(cfg *Config) grpc.ServerOption {


### PR DESCRIPTION
## What

- Recover unary and stream server handler panics in the standard transport chain and return a safe internal status.
- Keep the recovered panic as the internal cause through runtime.ConvertRecover without exposing panic text to clients.
- Add test fixture coverage for unary and stream panic recovery through the existing Greeter test world.

## Why

- Prevent one bad RPC handler or appended server interceptor panic from escaping the request path and taking down the process.
- Preserve client-safe status behavior while allowing the standard server logger to observe the recovered Internal outcome.

## Testing

- `make dep` - passed
- `make package=transport/grpc specs` - passed
- `make lint` - passed
