### PR TITLE
feat(config): include source context in startup errors

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/cli"
+	"github.com/alexfalkowski/go-service/v2/config"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -53,6 +54,22 @@ func TestApplicationServerRunWithInvalidFlag(t *testing.T) {
 	)
 
 	require.Error(t, app.Run(t.Context()))
+}
+
+func TestApplicationServerRunWithMissingEnvConfig(t *testing.T) {
+	t.Setenv("MISSING_CONFIG", "")
+	test.SetupCLI("server", "-config", "env:MISSING_CONFIG")
+
+	app := cli.NewApplication(
+		func(c cli.Commander) {
+			cmd := c.AddServer("server", "Start the server.", test.Options()...)
+			cmd.AddConfig(strings.Empty)
+		},
+	)
+
+	err := app.Run(t.Context())
+	require.ErrorIs(t, err, config.ErrEnvMissing)
+	require.ErrorContains(t, err, "env MISSING_CONFIG")
 }
 
 func TestApplicationServerRunWithConfigFlag(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,6 +116,7 @@ func TestInvalidEnvMissingConfig(t *testing.T) {
 
 	_, err := config.NewConfig[config.Config](decoder, test.Validator)
 	require.ErrorIs(t, err, config.ErrEnvMissing)
+	require.ErrorContains(t, err, "env CONFIG")
 }
 
 func TestInvalidEnvKindConfig(t *testing.T) {
@@ -131,6 +132,20 @@ func TestInvalidEnvKindConfig(t *testing.T) {
 
 	_, err = config.NewConfig[config.Config](decoder, test.Validator)
 	require.ErrorIs(t, err, config.ErrNoEncoder)
+	require.ErrorContains(t, err, "env CONFIG")
+	require.ErrorContains(t, err, "kind what")
+}
+
+func TestInvalidFileKindConfig(t *testing.T) {
+	set := flag.NewFlagSet("test")
+	set.AddConfig("file:config.go")
+
+	decoder := test.NewDecoder(set)
+
+	_, err := config.NewConfig[config.Config](decoder, test.Validator)
+	require.ErrorIs(t, err, config.ErrNoEncoder)
+	require.ErrorContains(t, err, "file config.go")
+	require.ErrorContains(t, err, "extension go")
 }
 
 func TestInvalidEnvDataConfig(t *testing.T) {
@@ -187,13 +202,19 @@ func TestValidCommonConfig(t *testing.T) {
 }
 
 func TestInvalidCommonConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", test.FS.Join(home, ".config"))
+
 	set := flag.NewFlagSet("test")
 	set.AddConfig(strings.Empty)
 
 	decoder := test.NewDecoder(set)
 
 	_, err := config.NewConfig[config.Config](decoder, test.Validator)
-	require.Error(t, err)
+	require.ErrorIs(t, err, config.ErrLocationMissing)
+	require.ErrorContains(t, err, "default config "+test.Name.String())
+	require.ErrorContains(t, err, "/etc/"+test.Name.String()+"/"+test.Name.String()+".yaml")
 }
 
 func TestInvalidKindConfig(t *testing.T) {
@@ -218,6 +239,7 @@ func TestInvalidKindConfig(t *testing.T) {
 
 	_, err = config.NewConfig[config.Config](decoder, test.Validator)
 	require.ErrorIs(t, err, config.ErrInvalidSource)
+	require.ErrorContains(t, err, "source test:test")
 }
 
 func TestNewConfigRejectsEmptyDecodedConfig(t *testing.T) {

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -57,7 +57,7 @@ func NewDecoder(params DecoderParams) Decoder {
 	case "env":
 		return NewENV(location, params.Encoder)
 	default:
-		return invalidSourceDecoder{}
+		return invalidSourceDecoder{source: params.Flags.GetConfig()}
 	}
 }
 

--- a/config/default.go
+++ b/config/default.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -73,12 +74,14 @@ func (c *Default) find() (string, io.ReadCloser, error) {
 		"/etc/" + name,
 	}
 	extensions := []string{".yaml", ".yml", ".hjson", ".toml", ".json"}
+	var paths []string
 
 	for _, extension := range extensions {
 		file := name + extension
 
 		for _, dir := range dirs {
 			path := c.fs.Join(dir, file)
+			paths = append(paths, path)
 			if !c.fs.PathExists(path) {
 				continue
 			}
@@ -89,5 +92,8 @@ func (c *Default) find() (string, io.ReadCloser, error) {
 		}
 	}
 
-	return strings.Empty, nil, ErrLocationMissing
+	searched := strings.Join(", ", paths...)
+	context := strings.Join(strings.Space, "default config", name, "searched", searched)
+
+	return strings.Empty, nil, errors.Prefix(context, ErrLocationMissing)
 }

--- a/config/env.go
+++ b/config/env.go
@@ -4,6 +4,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
@@ -29,16 +30,17 @@ import (
 // NewENV reads the environment variable once at construction time and stores the parsed kind and data.
 func NewENV(location string, enc *encoding.Map) *ENV {
 	kind, data, _ := strings.CutColon(os.Getenv(location))
-	return &ENV{kind: kind, data: data, enc: enc}
+	return &ENV{location: location, kind: kind, data: data, enc: enc}
 }
 
 // ENV decodes configuration from an environment variable.
 //
 // It expects the variable value to be formatted as "<kind>:<base64-content>" (see NewENV).
 type ENV struct {
-	enc  *encoding.Map
-	kind string
-	data string
+	enc      *encoding.Map
+	location string
+	kind     string
+	data     string
 }
 
 // Decode decodes the configuration into v.
@@ -52,7 +54,7 @@ type ENV struct {
 //   - Any decode/unmarshal error returned by the selected encoder.
 func (e *ENV) Decode(v any) error {
 	if strings.IsEmpty(e.kind) || strings.IsEmpty(e.data) {
-		return ErrEnvMissing
+		return errors.Prefix("env "+e.location, ErrEnvMissing)
 	}
 
 	data, err := base64.Decode(e.data)
@@ -62,7 +64,7 @@ func (e *ENV) Decode(v any) error {
 
 	enc := e.enc.Get(e.kind)
 	if enc == nil {
-		return ErrNoEncoder
+		return errors.Prefix(strings.Join(strings.Space, "env", e.location, "kind", e.kind), ErrNoEncoder)
 	}
 
 	return enc.Decode(bytes.NewBuffer(data), v)

--- a/config/file.go
+++ b/config/file.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // NewFile constructs a file-based Decoder that loads configuration from a specific file path.
@@ -46,9 +48,10 @@ func (f *File) Decode(v any) error {
 	}
 	defer file.Close()
 
-	enc := f.enc.Get(f.fs.PathExtension(location))
+	extension := f.fs.PathExtension(location)
+	enc := f.enc.Get(extension)
 	if enc == nil {
-		return ErrNoEncoder
+		return errors.Prefix(strings.Join(strings.Space, "file", location, "extension", extension), ErrNoEncoder)
 	}
 
 	return enc.Decode(file, v)

--- a/config/invalid.go
+++ b/config/invalid.go
@@ -1,7 +1,11 @@
 package config
 
-type invalidSourceDecoder struct{}
+import "github.com/alexfalkowski/go-service/v2/errors"
 
-func (invalidSourceDecoder) Decode(any) error {
-	return ErrInvalidSource
+type invalidSourceDecoder struct {
+	source string
+}
+
+func (d invalidSourceDecoder) Decode(any) error {
+	return errors.Prefix("source "+d.source, ErrInvalidSource)
 }


### PR DESCRIPTION
## What

- Add source context to startup configuration errors while preserving existing sentinel matching.
- Cover missing environment config, unknown environment payload kinds, unknown file extensions, default lookup misses, invalid explicit sources, and the supported CLI server startup path.
- Keep the change scoped to error reporting; config source formats, flags, and validation behavior are unchanged.

## Why

- Generic startup errors made failed rollouts harder to diagnose because operators had to reconstruct which config source, environment variable, file extension, or default lookup path failed.
- Including the failing source in the error chain makes config startup failures more actionable without breaking callers that use `errors.Is` against existing config sentinels.

## Testing

- `go test -count=1 ./config ./cli` - passed
- `go test -count=1 ./config/...` - passed
- `make lint` - passed
