### PR TITLE
feat(http): normalize redirect origins and status messages

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -268,7 +268,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	}
 
 	if isErrorStatus(response.StatusCode) {
-		return status.Error(response.StatusCode, strings.ToLower(http.StatusText(response.StatusCode)))
+		return status.Error(response.StatusCode, defaultErrorMessage(response.StatusCode))
 	}
 
 	if opts.HasResponse() {
@@ -282,6 +282,14 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 
 func isErrorStatus(code int) bool {
 	return code >= 400 && code <= 599
+}
+
+func defaultErrorMessage(code int) string {
+	if message := http.StatusText(code); !strings.IsEmpty(message) {
+		return strings.ToLower(message)
+	}
+
+	return status.DefaultMessage(code)
 }
 
 func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -76,6 +76,21 @@ func TestDoPreservesErrorMediaStatusCode(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, status.Code(err))
 }
 
+func TestDoUsesDefaultMessageForNonstandardErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.Text)
+		res.WriteHeader(http.StatusClientClosedRequest)
+	}))
+	defer server.Close()
+
+	c := client.NewClient(test.Content, test.Pool)
+
+	err := c.Get(t.Context(), server.URL, client.Options{})
+	require.Error(t, err)
+	require.EqualError(t, err, "http: client closed request")
+	require.Equal(t, http.StatusClientClosedRequest, status.Code(err))
+}
+
 func TestDoNormalizesErrorMediaSuccessStatusCode(t *testing.T) {
 	tests := []struct {
 		name string

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -162,13 +162,30 @@ func IgnoreRedirect(_ *Request, _ []*Request) error {
 	return ErrUseLastResponse
 }
 
-// SameOrigin reports whether prev and next use the same URL scheme and host.
+// SameOrigin reports whether prev and next use the same URL origin.
 func SameOrigin(prev, next *url.URL) bool {
 	if prev == nil || next == nil {
 		return false
 	}
 
-	return prev.Scheme == next.Scheme && prev.Host == next.Host
+	return strings.ToLower(prev.Scheme) == strings.ToLower(next.Scheme) &&
+		strings.ToLower(prev.Hostname()) == strings.ToLower(next.Hostname()) &&
+		originPort(prev) == originPort(next)
+}
+
+func originPort(u *url.URL) string {
+	if port := u.Port(); !strings.IsEmpty(port) {
+		return port
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return strings.Empty
+	}
 }
 
 // IsCrossOriginRedirect reports whether req is a redirected request whose previous request used a different origin.

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -102,8 +102,11 @@ func TestSameOriginRedirect(t *testing.T) {
 		next string
 	}{
 		{name: "same origin", next: "https://example.com/next", want: nil},
+		{name: "same origin host case", next: "https://EXAMPLE.com/next", want: nil},
+		{name: "same origin default port", next: "https://example.com:443/next", want: nil},
 		{name: "different host", next: "https://other.example.com/next", want: http.ErrUseLastResponse},
 		{name: "different scheme", next: "http://example.com/next", want: http.ErrUseLastResponse},
+		{name: "different port", next: "https://example.com:444/next", want: http.ErrUseLastResponse},
 	}
 
 	prev, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/start", http.NoBody)
@@ -125,18 +128,40 @@ func TestSameOriginRedirect(t *testing.T) {
 }
 
 func TestSameOrigin(t *testing.T) {
+	tests := []struct {
+		name string
+		prev string
+		next string
+		want bool
+	}{
+		{name: "same origin", prev: "https://example.com/start", next: "https://example.com/next", want: true},
+		{name: "same origin host case", prev: "https://example.com/start", next: "https://EXAMPLE.com/next", want: true},
+		{name: "same origin https default port", prev: "https://example.com/start", next: "https://example.com:443/next", want: true},
+		{name: "same origin http default port", prev: "http://example.com/start", next: "http://example.com:80/next", want: true},
+		{name: "different host", prev: "https://example.com/start", next: "https://other.example.com/next", want: false},
+		{name: "different scheme", prev: "https://example.com/start", next: "http://example.com/next", want: false},
+		{name: "different port", prev: "https://example.com/start", next: "https://example.com:444/next", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev, err := url.Parse(tt.prev)
+			require.NoError(t, err)
+
+			next, err := url.Parse(tt.next)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, http.SameOrigin(prev, next))
+		})
+	}
+
 	prev, err := url.Parse("https://example.com/start")
 	require.NoError(t, err)
 
-	same, err := url.Parse("https://example.com/next")
+	next, err := url.Parse("https://example.com/next")
 	require.NoError(t, err)
 
-	different, err := url.Parse("https://other.example.com/next")
-	require.NoError(t, err)
-
-	require.True(t, http.SameOrigin(prev, same))
-	require.False(t, http.SameOrigin(prev, different))
-	require.False(t, http.SameOrigin(nil, same))
+	require.False(t, http.SameOrigin(nil, next))
 	require.False(t, http.SameOrigin(prev, nil))
 }
 


### PR DESCRIPTION
## What

- Same-origin redirect checks now compare canonical URL origins by lower-casing scheme and hostname and treating explicit default ports as the same origin.
- Generic client error responses now fall back to repository default messages for nonstandard statuses such as 499 when the standard library has no status text.
- Added focused tests for canonical same-origin redirects and nonstandard client error messages.

## Why

- Credentialed clients using the default same-origin redirect policy should not reject redirects that only differ by URL spelling.
- Callers should get useful diagnostics for repository-supported nonstandard error statuses instead of empty error strings.

## Testing

- `go test -count=1 ./net/http/...` - passed
- `make lint` - passed with an existing gomodguard deprecation warning and 0 issues.
