### PR TITLE
feat(http): recover request panics safely

### DIFF
--- a/transport/http/recovery.go
+++ b/transport/http/recovery.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
+	snoop "github.com/felixge/httpsnoop"
+)
+
+type recoveryHandler struct{}
+
+func (*recoveryHandler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	committed := false
+	hooks := snoop.Hooks{
+		WriteHeader: func(writeHeader snoop.WriteHeaderFunc) snoop.WriteHeaderFunc {
+			return func(code int) {
+				committed = true
+				writeHeader(code)
+			}
+		},
+		Write: func(write snoop.WriteFunc) snoop.WriteFunc {
+			return func(bytes []byte) (int, error) {
+				committed = true
+				return write(bytes)
+			}
+		},
+		ReadFrom: func(readFrom snoop.ReadFromFunc) snoop.ReadFromFunc {
+			return func(reader io.Reader) (int64, error) {
+				committed = true
+				return readFrom(reader)
+			}
+		},
+		WriteString: func(writeString snoop.WriteStringFunc) snoop.WriteStringFunc {
+			return func(value string) (int, error) {
+				committed = true
+				return writeString(value)
+			}
+		},
+		Flush: func(flush snoop.FlushFunc) snoop.FlushFunc {
+			return func() {
+				committed = true
+				flush()
+			}
+		},
+		FlushError: func(flushError snoop.FlushErrorFunc) snoop.FlushErrorFunc {
+			return func() error {
+				committed = true
+				return flushError()
+			}
+		},
+	}
+	defer func() {
+		if value := recover(); value != nil {
+			if committed {
+				// The response is already on the wire, so writing a safe 500 would mix
+				// response states. Let net/http abort the broken in-flight response.
+				panic(value)
+			}
+
+			err := status.SafeError(http.StatusInternalServerError, runtime.ConvertRecover(value))
+			_ = status.WriteError(res, err)
+		}
+	}()
+
+	next(snoop.Wrap(res, hooks), req)
+}

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -133,6 +133,8 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(logger.NewHandler(params.Name, params.Logger))
 	}
 
+	neg.Use(&recoveryHandler{})
+
 	if params.Verifier != nil {
 		neg.Use(token.NewHandler(params.Name, params.UserID, params.Verifier))
 	}

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -98,3 +98,22 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 	require.Equal(t, "http: request entity too large", body)
 }
+
+func TestServerRecoversPanic(t *testing.T) {
+	world := test.NewWorld(t, test.WithWorldHTTP())
+	http.HandleFunc(world.ServeMux, "GET /panic", func(http.ResponseWriter, *http.Request) {
+		panic("test panic")
+	})
+	world.HandleHello()
+	world.Start()
+
+	res, body, err := world.GetBody(t.Context(), world.PathServerURL("http", "panic"), http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "http: internal server error", body)
+
+	res, body, err = world.GetBody(t.Context(), world.PathServerURL("http", "hello"), http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "hello!", body)
+}


### PR DESCRIPTION
## What

- Return safe 500 responses when server handlers panic before a response is committed.
- Preserve normal abort behavior after a response is already committed, avoiding a second mixed error payload.
- Add an integration test covering panic recovery and a subsequent successful request.

## Why

- Handler panics previously surfaced as EOF or connection resets even when no response had been written.
- A controlled internal-error response makes failures more consistent for clients and lets the existing request logger observe the recovered 500 outcome.

## Testing

- `go test -count=1 ./transport/http ./net/http ./net/server` - passed
- `go test -count=1 ./transport/grpc -run 'TestServerRecovers(Unary|Stream)Panic'` - passed on rerun after one transient `DeadlineExceeded` failure
- `make lint` - passed
