### PR TITLE
feat(cache): allow default entry limits

### DIFF
--- a/cache/config/config.go
+++ b/cache/config/config.go
@@ -34,7 +34,9 @@ type Config struct {
 	MaxSize bytes.Size `yaml:"max_size" json:"max_size" toml:"max_size" validate:"config_size"`
 
 	// MaxEntries limits the number of entries retained by bounded in-memory cache drivers.
-	MaxEntries int `yaml:"max_entries" json:"max_entries" toml:"max_entries" validate:"gt=0"`
+	//
+	// A zero value applies [DefaultMaxEntries].
+	MaxEntries int `yaml:"max_entries" json:"max_entries" toml:"max_entries" validate:"gte=0"`
 }
 
 // IsEnabled reports whether caching is enabled.

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -57,6 +57,14 @@ func TestConfigValidation(t *testing.T) {
 			cfg:  &config.Config{MaxEntries: 1},
 		},
 		{
+			name: "valid default max entries",
+			cfg:  &config.Config{MaxEntries: 0},
+		},
+		{
+			name: "valid redis without max entries",
+			cfg:  &config.Config{Kind: "redis", Options: map[string]any{"url": "redis://localhost:6379"}},
+		},
+		{
 			name: "negative max size",
 			cfg:  &config.Config{MaxSize: -1, MaxEntries: config.DefaultMaxEntries},
 			err:  true,
@@ -64,11 +72,6 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "oversized max size",
 			cfg:  &config.Config{MaxSize: bytes.MaxConfigSize + 1, MaxEntries: config.DefaultMaxEntries},
-			err:  true,
-		},
-		{
-			name: "zero max entries",
-			cfg:  &config.Config{MaxEntries: 0},
 			err:  true,
 		},
 		{


### PR DESCRIPTION
## What

- Allow cache `max_entries` to be omitted by accepting zero during config validation.
- Document zero as the defaulted value for cache entry limits.
- Cover the defaulted value and a Redis cache config without `max_entries`.

## Why

- Redis does not consume the in-memory entry limit, so valid Redis cache configs should not have to provide an unrelated `max_entries` setting.
- This keeps validation aligned with `GetMaxEntries`, where zero already falls back to `DefaultMaxEntries`.

## Testing

- `go test -count=1 ./cache/...` - passed
- `go test -count=1 ./health/checker ./transport/http/health` - passed
- `make lint` - passed
- `make package=cache specs` - passed
- `make package=cache/config specs` - passed
