### PR TITLE
feat(time): bound live network checks with provider fallbacks

### DIFF
--- a/time/config.go
+++ b/time/config.go
@@ -28,6 +28,11 @@ package time
 // The expected format is implementation-specific (for example a hostname or
 // pool name). If Address is empty or invalid, the provider will typically return
 // an error when Now is called.
+//
+// # Timeout
+//
+// Timeout bounds network operations performed by the selected provider. A zero
+// value uses the upstream client's default timeout.
 type Config struct {
 	// Kind selects the network time provider implementation (for example "ntp" or "nts").
 	//
@@ -39,6 +44,11 @@ type Config struct {
 	// The expected format is implementation-specific. For example, NTP may accept
 	// pool hostnames, and NTS may accept hostnames of NTS-enabled servers.
 	Address string `yaml:"address,omitempty" json:"address,omitempty" toml:"address,omitempty"`
+
+	// Timeout bounds network operations performed by the selected provider.
+	//
+	// A zero value uses the upstream client's default timeout.
+	Timeout Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
 }
 
 // IsEnabled reports whether network time configuration is present.

--- a/time/net.go
+++ b/time/net.go
@@ -30,9 +30,9 @@ func NewNetwork(cfg *Config) (Network, error) {
 
 	switch cfg.Kind {
 	case "ntp":
-		return NewNTPNetwork(cfg.Address), nil
+		return NewNTPNetwork(cfg.Address, cfg.Timeout), nil
 	case "nts":
-		return NewNTSNetwork(cfg.Address), nil
+		return NewNTSNetwork(cfg.Address, cfg.Timeout), nil
 	default:
 		return nil, ErrNotFound
 	}

--- a/time/net_test.go
+++ b/time/net_test.go
@@ -3,6 +3,7 @@ package time_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
@@ -18,14 +19,24 @@ func TestNewNetworkInvalidKind(t *testing.T) {
 	require.Error(t, err)
 }
 
-func requireNetworkNow(t *testing.T, cfg *time.Config) {
+func requireAnyNetworkNow(t *testing.T, configs ...*time.Config) {
 	t.Helper()
 
-	n, err := time.NewNetwork(cfg)
-	require.NoError(t, err)
+	var errs []error
+	for _, cfg := range configs {
+		n, err := time.NewNetwork(cfg)
+		require.NoError(t, err)
 
-	_, err = n.Now()
-	require.NoError(t, err)
+		_, err = n.Now()
+		if err == nil {
+			return
+		}
+
+		t.Logf("%s %q failed: %v", cfg.Kind, cfg.Address, err)
+		errs = append(errs, err)
+	}
+
+	require.NoError(t, errors.Join(errs...))
 }
 
 func requireNetworkNowError(t *testing.T, cfg *time.Config) {

--- a/time/ntp.go
+++ b/time/ntp.go
@@ -13,8 +13,10 @@ import (
 // The address argument is passed through to the upstream NTP client implementation and is
 // typically a hostname (for example an NTP pool name) or host:port depending on the client
 // library behavior. If address is empty or invalid, calls to Now will typically return an error.
-func NewNTPNetwork(address string) *NTPNetwork {
-	return &NTPNetwork{address: address}
+//
+// If timeout is zero, the upstream client's default timeout is used.
+func NewNTPNetwork(address string, timeout Duration) *NTPNetwork {
+	return &NTPNetwork{address: address, timeout: timeout}
 }
 
 // NTPNetwork implements Network by querying an NTP server for the current time.
@@ -23,6 +25,7 @@ func NewNTPNetwork(address string) *NTPNetwork {
 // with "ntp" to make failures easier to attribute when multiple time sources are possible.
 type NTPNetwork struct {
 	address string
+	timeout Duration
 }
 
 // Now returns the current time as reported by the configured NTP server.
@@ -30,6 +33,14 @@ type NTPNetwork struct {
 // This method performs network I/O. Any error returned by the underlying NTP library is
 // wrapped/prefixed with "ntp" for context.
 func (n *NTPNetwork) Now() (Time, error) {
-	t, err := ntp.Time(n.address)
-	return t, errors.Prefix("ntp", err)
+	res, err := ntp.QueryWithOptions(n.address, ntp.QueryOptions{Timeout: n.timeout.Duration()})
+	if err != nil {
+		return Time{}, errors.Prefix("ntp", err)
+	}
+
+	if err := res.Validate(); err != nil {
+		return Time{}, errors.Prefix("ntp", err)
+	}
+
+	return Now().Add(res.ClockOffset), nil
 }

--- a/time/ntp_test.go
+++ b/time/ntp_test.go
@@ -7,7 +7,11 @@ import (
 )
 
 func TestValidNTP(t *testing.T) {
-	requireNetworkNow(t, &time.Config{Kind: "ntp", Address: "0.beevik-ntp.pool.ntp.org"})
+	requireAnyNetworkNow(t,
+		&time.Config{Kind: "ntp", Address: "0.beevik-ntp.pool.ntp.org", Timeout: 2 * time.Second},
+		&time.Config{Kind: "ntp", Address: "1.beevik-ntp.pool.ntp.org", Timeout: 2 * time.Second},
+		&time.Config{Kind: "ntp", Address: "time.cloudflare.com", Timeout: 2 * time.Second},
+	)
 }
 
 func TestInvalidNTP(t *testing.T) {

--- a/time/nts.go
+++ b/time/nts.go
@@ -2,6 +2,7 @@ package time
 
 import (
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/beevik/ntp"
 	"github.com/beevik/nts"
 )
 
@@ -14,8 +15,10 @@ import (
 // The address argument is passed through to the upstream NTS client implementation and is
 // typically a hostname (and possibly port) of an NTS-enabled server. If address is empty or
 // invalid, calls to Now will typically return an error.
-func NewNTSNetwork(address string) *NTSNetwork {
-	return &NTSNetwork{address: address}
+//
+// If timeout is zero, the upstream client's default timeout is used.
+func NewNTSNetwork(address string, timeout Duration) *NTSNetwork {
+	return &NTSNetwork{address: address, timeout: timeout}
 }
 
 // NTSNetwork implements Network by querying an NTS server and validating the response.
@@ -28,6 +31,7 @@ func NewNTSNetwork(address string) *NTSNetwork {
 // by the authenticated offset.
 type NTSNetwork struct {
 	address string
+	timeout Duration
 }
 
 // Now returns the current time as reported by the configured NTS server.
@@ -35,19 +39,20 @@ type NTSNetwork struct {
 // This method performs network I/O and validates the NTS response before returning.
 //
 // The algorithm is:
-//   - Establish a session ([nts.NewSession]).
-//   - Query the server (session.Query).
+//   - Establish a session ([nts.NewSessionWithOptions]).
+//   - Query the server (session.QueryWithOptions).
 //   - Validate the response (res.Validate).
 //   - Apply the server-provided clock offset to the local time.
 //
 // Any error returned by the underlying NTS library is wrapped/prefixed with "nts" for context.
 func (n *NTSNetwork) Now() (Time, error) {
-	session, err := nts.NewSession(n.address)
+	timeout := n.timeout.Duration()
+	session, err := nts.NewSessionWithOptions(n.address, &nts.SessionOptions{Timeout: timeout})
 	if err != nil {
 		return Time{}, n.prefix(err)
 	}
 
-	res, err := session.Query()
+	res, err := session.QueryWithOptions(&ntp.QueryOptions{Timeout: timeout})
 	if err != nil {
 		return Time{}, n.prefix(err)
 	}

--- a/time/nts_test.go
+++ b/time/nts_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestValidNTS(t *testing.T) {
-	requireNetworkNow(t, &time.Config{Kind: "nts", Address: "time.cloudflare.com"})
+	requireAnyNetworkNow(t,
+		&time.Config{Kind: "nts", Address: "time.cloudflare.com", Timeout: 2 * time.Second},
+		&time.Config{Kind: "nts", Address: "nts.netnod.se", Timeout: 2 * time.Second},
+	)
 }
 
 func TestInvalidNTS(t *testing.T) {


### PR DESCRIPTION
## What

- Add configurable timeout support for network time providers.
- Keep live NTP/NTS tests in the default test suite while trying multiple real providers before failing.
- Use explicit two-second timeouts in the live network time tests.

## Why

- Reduces transient failures from DNS, network, or individual public time-service availability without replacing the tests with fakes.
- Gives service configuration a direct way to bound network time calls while preserving upstream default timeout behavior for zero values.

## Testing

- `go test -count=1 ./time ./config/...` - passed
- `make package=time specs` - passed
- `make lint` - passed
