### PR TITLE
test(test): honor canceled retry contexts

### DIFF
--- a/internal/test/connect.go
+++ b/internal/test/connect.go
@@ -22,7 +22,11 @@ func Connect(ctx context.Context, address string) (net.Conn, error) {
 		}
 
 		err = dialErr
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 
 	return nil, err


### PR DESCRIPTION
## What

- Make the shared connection retry helper return when its caller context is canceled during retry backoff.
- Keep the existing retry loop, one-second deadline, and 10ms backoff behavior unchanged for non-canceled callers.

## Why

- Canceled readiness probes should not keep waiting for the helper's full retry deadline.
- This keeps cancellation-path server checks responsive while preserving the current successful-start behavior.

## Testing

- `go test -count=1 ./net/http/server ./net/grpc/server` - passed
- `make lint` - passed
