### PR TITLE
feat(compress): classify zstd window limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,16 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   source references, not raw passwords or credentials.
 - Nil pointer sub-configs usually mean "disabled".
 - Standard module wiring is the supported path. Do not flag hypothetical failures that require hand-wiring an incomplete DI graph unless the public API explicitly promises that custom construction mode.
+- Recommend Fx `optional:"true"` dependency tags only with concrete evidence
+  that a supported DI graph may omit that dependency. A nil check, "optional"
+  prose, or guarded hook installation is a lead, not enough by itself; verify
+  standard `module.Server`/`module.Client` wiring, CLI/server application
+  wiring, a config-disabled path, or existing supported test/user wiring where
+  the dependency can genuinely be absent. Directly composing an exported
+  lower-level module is not enough evidence unless a public contract explicitly
+  promises that module works standalone without the standard bundle. If the
+  standard module bundle always resolves the dependency and no such lower-level
+  contract exists, do not flag the missing optional tag.
 - `*os.FS` dependencies are provided by the supported DI wiring path and are
   expected to be non-nil there. Do not flag nil-`*os.FS` panics in token,
   crypto, config, or source-string loading paths based solely on manually
@@ -354,10 +364,14 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   by the runtime `Generate` and `Verify` paths. Do not flag missing startup
   warmup/validation for token key sources solely because bad, missing,
   unreadable, or malformed administrator-supplied key material can surface
-  during token issuance or verification. Report only concrete bugs such as
-  panics, accepted weak or wrong key types/sizes, secret leakage, ignored
-  documented token config validation, or a public API promise that token key
-  material is fully resolved before runtime token operations.
+  during token issuance or verification. Do not recommend duplicating runtime
+  token checks at startup merely to reject an empty or incomplete trusted key
+  set, including SSH `keys`, unless a supported config contract explicitly
+  promises that structural key usability is validated before runtime token
+  operations. Report only concrete bugs such as panics, accepted weak or wrong
+  key types/sizes, secret leakage, ignored documented token config validation,
+  or a public API promise that token key material is fully resolved before
+  runtime token operations.
 - Token tests should focus on repository-owned wrapper behavior. Do not flag or
   add tests that require hand-crafting upstream JWT/PASETO internals solely to
   prove library-owned parsing, signature, expiration, not-before, or

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -19,6 +19,9 @@ const decoderMaxMemory = bytes.MaxConfigSize
 // ErrDecoderSizeExceeded is returned by the underlying Zstandard decoder when decoded size exceeds its limit.
 var ErrDecoderSizeExceeded = zstd.ErrDecoderSizeExceeded
 
+// ErrWindowSizeExceeded is returned by the underlying Zstandard decoder when a frame window exceeds its limit.
+var ErrWindowSizeExceeded = zstd.ErrWindowSizeExceeded
+
 // NewCompressor constructs a Zstandard (zstd) compressor implementation.
 //
 // The returned value implements [github.com/alexfalkowski/go-service/v2/compress.Compressor].
@@ -55,7 +58,8 @@ func (c *Compressor) Compress(data []byte, size bytes.Size) ([]byte, error) {
 // An error is returned if data is not valid zstd-encoded content or the
 // decompressed data exceeds size. This implementation also returns
 // [github.com/alexfalkowski/go-service/v2/compress/errors.ErrTooLarge] for
-// negative limits, math.MaxInt64 limits, and zstd decoder-size limit errors.
+// negative limits, math.MaxInt64 limits, and zstd decoder size/window limit
+// errors.
 func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 	limit := size.Bytes()
 	if limit < 0 || limit == math.MaxInt64 {
@@ -73,7 +77,7 @@ func (c *Compressor) Decompress(data []byte, size bytes.Size) ([]byte, error) {
 
 	decoded, _, err := io.ReadAll(io.LimitReader(decoder, limit+1))
 	if err != nil {
-		if errors.Is(err, ErrDecoderSizeExceeded) {
+		if errors.Is(err, ErrDecoderSizeExceeded) || errors.Is(err, ErrWindowSizeExceeded) {
 			return nil, fmt.Errorf("%w: %w", compress.ErrTooLarge, err)
 		}
 


### PR DESCRIPTION
## What

- Classify zstd decoder window-limit failures as `compress/errors.ErrTooLarge` while preserving the upstream `ErrWindowSizeExceeded` error in the chain.
- Add reviewer guidance for Fx optional dependency tags and token startup-validation recommendations.

## Why

- Keeps zstd memory/window-limit rejections aligned with the common compressor size-limit sentinel.
- Records repository-specific review boundaries so agents do not report unsupported lower-level module composition or duplicated startup token validation as findings.

## Testing

- `make specs package=compress/zstd` - passed
- `make lint` - passed
- `git diff --check` - passed
- No crafted zstd header regression test was added by request; existing zstd package coverage was rerun after the implementation change.

AI-assisted-by: [Codex](https://openai.com/codex/)
