### PR TITLE
feat(time): reject negative provider timeout

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -78,6 +78,16 @@ func TestInvalidFileConfig(t *testing.T) {
 	}
 }
 
+func TestInvalidTimeTimeoutConfig(t *testing.T) {
+	set := flag.NewFlagSet("test")
+	set.AddConfig(test.FilePath("configs/invalid_time.config.yml"))
+
+	decoder := test.NewDecoder(set)
+
+	_, err := config.NewConfig[config.Config](decoder, test.Validator)
+	require.Error(t, err)
+}
+
 func TestValidEnvConfig(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/configs/invalid_time.config.yml
+++ b/test/configs/invalid_time.config.yml
@@ -1,0 +1,7 @@
+environment: production
+id:
+  kind: uuid
+time:
+  kind: ntp
+  address: pool.ntp.org
+  timeout: -1s

--- a/time/config.go
+++ b/time/config.go
@@ -32,7 +32,7 @@ package time
 // # Timeout
 //
 // Timeout bounds network operations performed by the selected provider. A zero
-// value uses the upstream client's default timeout.
+// value uses the upstream client's default timeout. Negative values are invalid.
 type Config struct {
 	// Kind selects the network time provider implementation (for example "ntp" or "nts").
 	//
@@ -48,7 +48,8 @@ type Config struct {
 	// Timeout bounds network operations performed by the selected provider.
 	//
 	// A zero value uses the upstream client's default timeout.
-	Timeout Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	// Negative values are invalid.
+	Timeout Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether network time configuration is present.


### PR DESCRIPTION
## What

- Reject negative network provider timeout values during top-level configuration validation.
- Add regression coverage for `time.timeout: -1s` through `config.NewConfig`.
- Document the negative timeout constraint on `time.Config`.

## Why

- Services should fail startup on invalid network provider timeout configuration instead of passing negative durations into upstream NTP/NTS operations.
- This aligns the network provider timeout with the repository's other non-negative timeout configuration fields.

## Testing

- `make package=config specs` - passed
- `make package=time specs` - passed
- `make lint` - passed
- Added config coverage for negative `time.timeout` values.

AI-assisted-by: [Codex](https://openai.com/codex/)
