### PR TITLE
build(make): propagate recursive command runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,43 +6,43 @@ include bin/build/make/git.mak
 diagrams: crypto-diagram database-diagram telemetry-diagram transport-diagram
 
 crypto-diagram:
-	@make package=crypto create-diagram
+	@$(MAKE) package=crypto create-diagram
 
 database-diagram:
-	@make package=database create-diagram
+	@$(MAKE) package=database create-diagram
 
 telemetry-diagram:
-	@make package=telemetry create-diagram
+	@$(MAKE) package=telemetry create-diagram
 
 transport-diagram:
-	@make package=transport create-diagram
+	@$(MAKE) package=transport create-diagram
 
 # Run all the benchmarks.
 benchmarks: http-benchmarks grpc-benchmarks sql-benchmarks cache-benchmarks bytes-benchmarks strings-benchmarks id-benchmarks http-content-benchmarks
 
 http-benchmarks:
-	@make package=transport/http benchtime=100x benchmark
+	@$(MAKE) package=transport/http benchtime=100x benchmark
 
 grpc-benchmarks:
-	@make package=transport/grpc benchtime=100x benchmark
+	@$(MAKE) package=transport/grpc benchtime=100x benchmark
 
 sql-benchmarks:
-	@make package=database/sql/driver benchtime=100x benchmark
+	@$(MAKE) package=database/sql/driver benchtime=100x benchmark
 
 cache-benchmarks:
-	@make package=cache/driver benchtime=100x benchmark
+	@$(MAKE) package=cache/driver benchtime=100x benchmark
 
 bytes-benchmarks:
-	@make package=bytes benchtime=100x benchmark
+	@$(MAKE) package=bytes benchtime=100x benchmark
 
 strings-benchmarks:
-	@make package=strings benchtime=100x benchmark
+	@$(MAKE) package=strings benchtime=100x benchmark
 
 id-benchmarks:
-	@make package=id benchtime=100x benchmark
+	@$(MAKE) package=id benchtime=100x benchmark
 
 http-content-benchmarks:
-	@make package=net/http/content benchtime=100x benchmark
+	@$(MAKE) package=net/http/content benchtime=100x benchmark
 
 # Generate for tests.
 generate:


### PR DESCRIPTION
## What

- Recursive diagram and benchmark targets now propagate the selected command runner into child invocations.
- Removed the resolved temporary issue ledger after confirming `ISSUE-1` was fixed.

## Why

- Users invoking `gmake` on macOS should not fall back to the system BSD make implementation inside nested targets.
- This keeps the documented diagram and benchmark workflows usable when GNU Make is required for the shared Makefile fragments.

## Testing

- `env PATH=/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/gmake -n diagrams` - passed
- `env PATH=/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/gmake -n benchmarks` - passed
- `git diff --check` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
