### PR TITLE
test(specs): add fuzz coverage and safe parallelism

### DIFF
--- a/bytes/fuzz_test.go
+++ b/bytes/fuzz_test.go
@@ -1,0 +1,67 @@
+package bytes_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzSizeTextRoundTrip(f *testing.F) {
+	f.Add("0B")
+	f.Add("64B")
+	f.Add("4MB")
+	f.Add("1048576B")
+	f.Add("not-a-size")
+
+	f.Fuzz(func(t *testing.T, text string) {
+		if len(text) > 128 {
+			t.Skip()
+		}
+
+		var size bytes.Size
+		if err := size.UnmarshalText([]byte(text)); err != nil {
+			return
+		}
+		if size < 0 || size > bytes.PB {
+			t.Skip()
+		}
+
+		encoded, err := size.MarshalText()
+		require.NoError(t, err)
+
+		var decoded bytes.Size
+		require.NoError(t, decoded.UnmarshalText(encoded))
+		require.Equal(t, size, decoded)
+	})
+}
+
+func FuzzSizeJSONRoundTrip(f *testing.F) {
+	f.Add([]byte(`"0B"`))
+	f.Add([]byte(`"64B"`))
+	f.Add([]byte(`"4MB"`))
+	f.Add([]byte(`1048576`))
+	f.Add([]byte(`"not-a-size"`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1024 {
+			t.Skip()
+		}
+
+		var size bytes.Size
+		if err := json.Unmarshal(data, &size); err != nil {
+			return
+		}
+		if size < 0 || size > bytes.PB {
+			t.Skip()
+		}
+
+		encoded, err := json.Marshal(size)
+		require.NoError(t, err)
+
+		var decoded bytes.Size
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.Equal(t, size, decoded)
+	})
+}

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -9,14 +9,20 @@ import (
 )
 
 func TestMustParseSize(t *testing.T) {
+	t.Parallel()
+
 	require.Panics(t, func() { bytes.MustParseSize("test") })
 }
 
 func TestDefaultSize(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, 4*bytes.MB, bytes.DefaultSize)
 }
 
 func TestSizeTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		text string
@@ -31,6 +37,8 @@ func TestSizeTextRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			text, err := tt.size.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.text, string(text))
@@ -43,6 +51,8 @@ func TestSizeTextRoundTrip(t *testing.T) {
 }
 
 func TestSizeJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		text string
@@ -54,6 +64,8 @@ func TestSizeJSONRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			data, err := json.Marshal(tt.size)
 			require.NoError(t, err)
 			require.Equal(t, tt.text, string(data))
@@ -66,6 +78,8 @@ func TestSizeJSONRoundTrip(t *testing.T) {
 }
 
 func TestSizeUnmarshalTextInvalid(t *testing.T) {
+	t.Parallel()
+
 	var size bytes.Size
 
 	err := size.UnmarshalText([]byte("not-a-size"))
@@ -73,6 +87,8 @@ func TestSizeUnmarshalTextInvalid(t *testing.T) {
 }
 
 func TestSizeUnmarshalJSONInvalid(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input string
@@ -87,6 +103,8 @@ func TestSizeUnmarshalJSONInvalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var size bytes.Size
 
 			err := json.Unmarshal([]byte(tt.input), &size)
@@ -96,6 +114,8 @@ func TestSizeUnmarshalJSONInvalid(t *testing.T) {
 }
 
 func TestSizeUnmarshalJSONWithWhitespace(t *testing.T) {
+	t.Parallel()
+
 	var size bytes.Size
 
 	err := json.Unmarshal([]byte(" \n\t\"64B\" \n\t"), &size)
@@ -104,6 +124,8 @@ func TestSizeUnmarshalJSONWithWhitespace(t *testing.T) {
 }
 
 func TestSizeZeroValueEncoding(t *testing.T) {
+	t.Parallel()
+
 	var size bytes.Size
 
 	text, err := size.MarshalText()

--- a/compress/none/fuzz_test.go
+++ b/compress/none/fuzz_test.go
@@ -1,0 +1,37 @@
+package none_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/none"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzCompressor(f *testing.F) {
+	f.Add([]byte(""), uint16(0))
+	f.Add([]byte("hello"), uint16(5))
+	f.Add([]byte("hello"), uint16(4))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		cmp := none.NewCompressor()
+		size := bytes.Size(limit)
+
+		compressed, err := cmp.Compress(data, size)
+		if int64(len(data)) > size.Bytes() {
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+			return
+		}
+		require.NoError(t, err)
+		require.Equal(t, data, compressed)
+
+		decompressed, err := cmp.Decompress(compressed, size)
+		require.NoError(t, err)
+		require.Equal(t, data, decompressed)
+	})
+}

--- a/compress/none/none_test.go
+++ b/compress/none/none_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestCompressorReturnsDataUnchanged(t *testing.T) {
+	t.Parallel()
+
 	cmp := none.NewCompressor()
 	data := strings.Bytes("hello")
 
@@ -24,6 +26,8 @@ func TestCompressorReturnsDataUnchanged(t *testing.T) {
 }
 
 func TestCompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := none.NewCompressor()
 
 	_, err := cmp.Compress(strings.Bytes("hello"), 4)
@@ -31,6 +35,8 @@ func TestCompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := none.NewCompressor()
 
 	_, err := cmp.Decompress(strings.Bytes("hello"), 4)

--- a/compress/s2/fuzz_test.go
+++ b/compress/s2/fuzz_test.go
@@ -1,0 +1,59 @@
+package s2_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/s2"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzCompressor(f *testing.F) {
+	f.Add([]byte(""), uint16(0))
+	f.Add([]byte("hello"), uint16(5))
+	f.Add([]byte("hello"), uint16(4))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		cmp := s2.NewCompressor()
+		size := bytes.Size(limit)
+
+		compressed, err := cmp.Compress(data, size)
+		if int64(len(data)) > size.Bytes() {
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+			return
+		}
+		require.NoError(t, err)
+
+		decompressed, err := cmp.Decompress(compressed, size)
+		require.NoError(t, err)
+		require.Equal(t, string(data), string(decompressed))
+	})
+}
+
+func FuzzDecompress(f *testing.F) {
+	cmp := s2.NewCompressor()
+	encoded, err := cmp.Compress([]byte("hello"), bytes.KB)
+	require.NoError(f, err)
+
+	f.Add(encoded, uint16(5))
+	f.Add([]byte("invalid"), uint16(1024))
+	f.Add([]byte{0x80}, uint16(1024))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		decoded, err := s2.NewCompressor().Decompress(data, bytes.Size(limit))
+		if err != nil {
+			return
+		}
+
+		require.LessOrEqual(t, int64(len(decoded)), int64(limit))
+	})
+}

--- a/compress/s2/s2_test.go
+++ b/compress/s2/s2_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestCompressor(t *testing.T) {
+	t.Parallel()
+
 	cmp := s2.NewCompressor()
 	data := strings.Bytes("hello")
 	size := bytes.Size(len(data))
@@ -24,6 +26,8 @@ func TestCompressor(t *testing.T) {
 }
 
 func TestCompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := s2.NewCompressor()
 
 	_, err := cmp.Compress(strings.Bytes("hello"), 4)
@@ -31,6 +35,8 @@ func TestCompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := s2.NewCompressor()
 	data := strings.Bytes("hello")
 	compressed, err := cmp.Compress(data, bytes.KB)
@@ -41,6 +47,8 @@ func TestDecompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsInvalidData(t *testing.T) {
+	t.Parallel()
+
 	cmp := s2.NewCompressor()
 
 	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
@@ -49,6 +57,8 @@ func TestDecompressRejectsInvalidData(t *testing.T) {
 }
 
 func TestDecompressReturnsDecodedLenError(t *testing.T) {
+	t.Parallel()
+
 	cmp := s2.NewCompressor()
 
 	_, err := cmp.Decompress([]byte{0x80}, bytes.KB)

--- a/compress/snappy/fuzz_test.go
+++ b/compress/snappy/fuzz_test.go
@@ -1,0 +1,59 @@
+package snappy_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/snappy"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzCompressor(f *testing.F) {
+	f.Add([]byte(""), uint16(0))
+	f.Add([]byte("hello"), uint16(5))
+	f.Add([]byte("hello"), uint16(4))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		cmp := snappy.NewCompressor()
+		size := bytes.Size(limit)
+
+		compressed, err := cmp.Compress(data, size)
+		if int64(len(data)) > size.Bytes() {
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+			return
+		}
+		require.NoError(t, err)
+
+		decompressed, err := cmp.Decompress(compressed, size)
+		require.NoError(t, err)
+		require.Equal(t, string(data), string(decompressed))
+	})
+}
+
+func FuzzDecompress(f *testing.F) {
+	cmp := snappy.NewCompressor()
+	encoded, err := cmp.Compress([]byte("hello"), bytes.KB)
+	require.NoError(f, err)
+
+	f.Add(encoded, uint16(5))
+	f.Add([]byte("invalid"), uint16(1024))
+	f.Add([]byte{0x80}, uint16(1024))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		decoded, err := snappy.NewCompressor().Decompress(data, bytes.Size(limit))
+		if err != nil {
+			return
+		}
+
+		require.LessOrEqual(t, int64(len(decoded)), int64(limit))
+	})
+}

--- a/compress/snappy/snappy_test.go
+++ b/compress/snappy/snappy_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestCompressor(t *testing.T) {
+	t.Parallel()
+
 	cmp := snappy.NewCompressor()
 	data := strings.Bytes("hello")
 	size := bytes.Size(len(data))
@@ -24,6 +26,8 @@ func TestCompressor(t *testing.T) {
 }
 
 func TestCompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := snappy.NewCompressor()
 
 	_, err := cmp.Compress(strings.Bytes("hello"), 4)
@@ -31,6 +35,8 @@ func TestCompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := snappy.NewCompressor()
 	data := strings.Bytes("hello")
 	compressed, err := cmp.Compress(data, bytes.KB)
@@ -41,6 +47,8 @@ func TestDecompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsInvalidData(t *testing.T) {
+	t.Parallel()
+
 	cmp := snappy.NewCompressor()
 
 	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
@@ -49,6 +57,8 @@ func TestDecompressRejectsInvalidData(t *testing.T) {
 }
 
 func TestDecompressReturnsDecodedLenError(t *testing.T) {
+	t.Parallel()
+
 	cmp := snappy.NewCompressor()
 
 	_, err := cmp.Decompress([]byte{0x80}, bytes.KB)

--- a/compress/zstd/fuzz_test.go
+++ b/compress/zstd/fuzz_test.go
@@ -1,0 +1,59 @@
+package zstd_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzCompressor(f *testing.F) {
+	f.Add([]byte(""), uint16(0))
+	f.Add([]byte("hello"), uint16(5))
+	f.Add([]byte("hello"), uint16(4))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		cmp := zstd.NewCompressor()
+		size := bytes.Size(limit)
+
+		compressed, err := cmp.Compress(data, size)
+		if int64(len(data)) > size.Bytes() {
+			require.ErrorIs(t, err, errors.ErrTooLarge)
+			return
+		}
+		require.NoError(t, err)
+
+		decompressed, err := cmp.Decompress(compressed, size)
+		require.NoError(t, err)
+		require.Equal(t, string(data), string(decompressed))
+	})
+}
+
+func FuzzDecompress(f *testing.F) {
+	cmp := zstd.NewCompressor()
+	encoded, err := cmp.Compress([]byte("hello"), bytes.KB)
+	require.NoError(f, err)
+
+	f.Add(encoded, uint16(5))
+	f.Add([]byte("invalid"), uint16(1024))
+	f.Add([]byte{0x28, 0xb5, 0x2f, 0xfd}, uint16(1024))
+
+	f.Fuzz(func(t *testing.T, data []byte, limit uint16) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		decoded, err := zstd.NewCompressor().Decompress(data, bytes.Size(limit))
+		if err != nil {
+			return
+		}
+
+		require.LessOrEqual(t, int64(len(decoded)), int64(limit))
+	})
+}

--- a/compress/zstd/zstd_test.go
+++ b/compress/zstd/zstd_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestCompressor(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 	data := strings.Bytes("hello")
 	size := bytes.Size(len(data))
@@ -26,6 +28,8 @@ func TestCompressor(t *testing.T) {
 }
 
 func TestCompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 
 	_, err := cmp.Compress(strings.Bytes("hello"), 4)
@@ -33,6 +37,8 @@ func TestCompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsTooLarge(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 	data := strings.Bytes("hello")
 	compressed, err := cmp.Compress(data, bytes.KB)
@@ -43,6 +49,8 @@ func TestDecompressRejectsTooLarge(t *testing.T) {
 }
 
 func TestDecompressRejectsInvalidData(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 
 	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
@@ -51,6 +59,8 @@ func TestDecompressRejectsInvalidData(t *testing.T) {
 }
 
 func TestDecompressPreservesDecoderSizeError(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 
 	data := make([]byte, zstd.MinWindowSize+1)
@@ -63,6 +73,8 @@ func TestDecompressPreservesDecoderSizeError(t *testing.T) {
 }
 
 func TestDecompressAllowsWindowLargerThanOutputLimit(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 	data := make([]byte, 64<<10)
 	encoder, err := compress.NewWriter(nil, compress.WithWindowSize(128<<10), compress.WithSingleSegment(false))
@@ -76,6 +88,8 @@ func TestDecompressAllowsWindowLargerThanOutputLimit(t *testing.T) {
 }
 
 func TestDecompressRejectsInvalidLimits(t *testing.T) {
+	t.Parallel()
+
 	cmp := zstd.NewCompressor()
 	data := strings.Bytes("hello")
 	encoded, err := cmp.Compress(data, bytes.KB)
@@ -89,6 +103,8 @@ func TestDecompressRejectsInvalidLimits(t *testing.T) {
 		{name: "max int64", size: math.MaxInt64},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			decoded, err := cmp.Decompress(encoded, tt.size)
 			require.ErrorIs(t, err, errors.ErrTooLarge)
 			require.Nil(t, decoded)

--- a/encoding/base64/base64_test.go
+++ b/encoding/base64/base64_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestEncodeUsesStandardPaddedBase64(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		expected string
 		name     string
@@ -23,12 +25,16 @@ func TestEncodeUsesStandardPaddedBase64(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, tt.expected, base64.Encode(tt.src))
 		})
 	}
 }
 
 func TestDecodeUsesStandardPaddedBase64(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		encoded  string
@@ -43,6 +49,8 @@ func TestDecodeUsesStandardPaddedBase64(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual, err := base64.Decode(tt.encoded)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, actual)
@@ -51,6 +59,8 @@ func TestDecodeUsesStandardPaddedBase64(t *testing.T) {
 }
 
 func TestEncodedLenUsesStandardPadding(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		size     bytes.Size
@@ -65,6 +75,8 @@ func TestEncodedLenUsesStandardPadding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, tt.expected, base64.EncodedLen(tt.size))
 		})
 	}

--- a/encoding/bytes/bytes_test.go
+++ b/encoding/bytes/bytes_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestEncoder(t *testing.T) {
+	t.Parallel()
+
 	encoder := encoding.NewEncoder()
 
 	buffer := test.Pool.Get()
@@ -34,6 +36,8 @@ func TestEncoder(t *testing.T) {
 }
 
 func TestDecodeResetsDestination(t *testing.T) {
+	t.Parallel()
+
 	encoder := encoding.NewEncoder()
 
 	buffer := test.Pool.Get()
@@ -46,6 +50,8 @@ func TestDecodeResetsDestination(t *testing.T) {
 }
 
 func TestInvalidTypedNilEncode(t *testing.T) {
+	t.Parallel()
+
 	encoder := encoding.NewEncoder()
 
 	err := encoder.Encode(io.Discard, (*bytes.Buffer)(nil))
@@ -53,18 +59,24 @@ func TestInvalidTypedNilEncode(t *testing.T) {
 }
 
 func TestEncodeReturnsWriteToError(t *testing.T) {
+	t.Parallel()
+
 	encoder := encoding.NewEncoder()
 
 	require.ErrorIs(t, encoder.Encode(io.Discard, test.ErrWriterTo{}), test.ErrFailed)
 }
 
 func TestDecodeReturnsReadFromError(t *testing.T) {
+	t.Parallel()
+
 	encoder := encoding.NewEncoder()
 
 	require.ErrorIs(t, encoder.Decode(bytes.NewBufferString("test"), errReaderFrom{}), test.ErrFailed)
 }
 
 func TestInvalidTypedNilDecode(t *testing.T) {
+	t.Parallel()
+
 	encoder := encoding.NewEncoder()
 
 	err := encoder.Decode(bytes.NewBufferString("test"), (*bytes.Buffer)(nil))

--- a/encoding/bytes/fuzz_test.go
+++ b/encoding/bytes/fuzz_test.go
@@ -1,0 +1,29 @@
+package bytes_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	encoding "github.com/alexfalkowski/go-service/v2/encoding/bytes"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzEncoder(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("test"))
+	f.Add([]byte("line\nbreak"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		encoder := encoding.NewEncoder()
+		encoded := &bytes.Buffer{}
+		require.NoError(t, encoder.Encode(encoded, bytes.NewBuffer(data)))
+
+		decoded := &bytes.Buffer{}
+		require.NoError(t, encoder.Decode(encoded, decoded))
+		require.Equal(t, data, decoded.Bytes())
+	})
+}

--- a/encoding/gob/fuzz_test.go
+++ b/encoding/gob/fuzz_test.go
@@ -1,0 +1,42 @@
+package gob_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/gob"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzUnmarshal(f *testing.F) {
+	for _, msg := range []map[string]string{
+		{},
+		{"test": "test"},
+		{"test": ""},
+	} {
+		data, err := gob.Marshal(msg)
+		require.NoError(f, err)
+		f.Add(data)
+	}
+	f.Add([]byte("junk"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		var msg map[string]string
+		if err := gob.Unmarshal(data, &msg); err != nil {
+			return
+		}
+
+		encoded, err := gob.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, gob.Unmarshal(encoded, &decoded))
+		require.Len(t, decoded, len(msg))
+		for key, value := range msg {
+			require.Equal(t, value, decoded[key])
+		}
+	})
+}

--- a/encoding/gob/gob_test.go
+++ b/encoding/gob/gob_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
 	encoder := gob.NewEncoder()
 
 	buffer := test.Pool.Get()
@@ -23,6 +25,8 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	msg := map[string]string{"test": "test"}
 
 	data, err := gob.Marshal(msg)
@@ -34,12 +38,16 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestMarshalReturnsError(t *testing.T) {
+	t.Parallel()
+
 	_, err := gob.Marshal(func() {})
 
 	require.Error(t, err)
 }
 
 func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	encoder := gob.NewEncoder()
 
 	buffer := test.Pool.Get()
@@ -49,6 +57,8 @@ func TestEncodeReturnsError(t *testing.T) {
 }
 
 func TestDecodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	encoder := gob.NewEncoder()
 
 	var msg map[string]string
@@ -56,6 +66,8 @@ func TestDecodeReturnsError(t *testing.T) {
 }
 
 func TestDecodeRejectsTrailingValue(t *testing.T) {
+	t.Parallel()
+
 	encoder := gob.NewEncoder()
 
 	buffer := test.Pool.Get()
@@ -71,6 +83,8 @@ func TestDecodeRejectsTrailingValue(t *testing.T) {
 }
 
 func TestUnmarshalRejectsTrailingValue(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -84,6 +98,8 @@ func TestUnmarshalRejectsTrailingValue(t *testing.T) {
 }
 
 func TestDecodeRejectsMalformedTrailingData(t *testing.T) {
+	t.Parallel()
+
 	encoder := gob.NewEncoder()
 
 	buffer := test.Pool.Get()

--- a/encoding/hjson/fuzz_test.go
+++ b/encoding/hjson/fuzz_test.go
@@ -1,0 +1,37 @@
+package hjson_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzUnmarshal(f *testing.F) {
+	f.Add([]byte("{test: test}"))
+	f.Add([]byte("{test: ''}"))
+	f.Add([]byte("{}"))
+	f.Add([]byte("{test: first, test: second}"))
+	f.Add([]byte("{"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		var msg map[string]string
+		if err := hjson.Unmarshal(data, &msg); err != nil {
+			return
+		}
+
+		encoded, err := hjson.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, hjson.Unmarshal(encoded, &decoded))
+		require.Len(t, decoded, len(msg))
+		for key, value := range msg {
+			require.Equal(t, value, decoded[key])
+		}
+	})
+}

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestEncode(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 	buf := &bytes.Buffer{}
 
@@ -19,6 +21,8 @@ func TestEncode(t *testing.T) {
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	data, err := hjson.Marshal(&message{Test: "test"})
 	require.NoError(t, err)
 	require.Contains(t, string(data), "test")
@@ -29,12 +33,16 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestMarshalReturnsError(t *testing.T) {
+	t.Parallel()
+
 	_, err := hjson.Marshal(func() {})
 
 	require.Error(t, err)
 }
 
 func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 	buf := &bytes.Buffer{}
 
@@ -42,12 +50,16 @@ func TestEncodeReturnsError(t *testing.T) {
 }
 
 func TestEncodeReturnsWriteError(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 
 	require.ErrorIs(t, encoder.Encode(test.ErrWriter{}, &message{Test: "test"}), test.ErrFailed)
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 	msg := &message{}
 
@@ -56,6 +68,8 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecodeRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 	msg := &message{}
 
@@ -66,6 +80,8 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 }
 
 func TestDecodeReturnsReadError(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 	msg := &message{}
 
@@ -73,6 +89,8 @@ func TestDecodeReturnsReadError(t *testing.T) {
 }
 
 func TestDecodeRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
 	encoder := hjson.NewEncoder()
 	msg := &message{}
 
@@ -82,6 +100,8 @@ func TestDecodeRejectsDuplicateKeys(t *testing.T) {
 }
 
 func TestUnmarshalRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
 	msg := &message{}
 
 	err := hjson.Unmarshal([]byte("{\n  test: first\n  test: second\n}\n"), msg)

--- a/encoding/json/fuzz_test.go
+++ b/encoding/json/fuzz_test.go
@@ -1,0 +1,37 @@
+package json_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzUnmarshal(f *testing.F) {
+	f.Add([]byte(`{"test":"test"}`))
+	f.Add([]byte(`{"test":""}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"test":"test"}{"extra":"value"}`))
+	f.Add([]byte(`{`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		var msg map[string]string
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+
+		encoded, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.Len(t, decoded, len(msg))
+		for key, value := range msg {
+			require.Equal(t, value, decoded[key])
+		}
+	})
+}

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestEncode(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -22,6 +24,8 @@ func TestEncode(t *testing.T) {
 }
 
 func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -31,6 +35,8 @@ func TestEncodeReturnsError(t *testing.T) {
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
+
 	encoder := json.NewEncoder()
 	var msg map[string]string
 
@@ -39,6 +45,8 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecodeAcceptsTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+
 	encoder := json.NewEncoder()
 	var msg map[string]string
 
@@ -47,6 +55,8 @@ func TestDecodeAcceptsTrailingWhitespace(t *testing.T) {
 }
 
 func TestDecodeRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
 	encoder := json.NewEncoder()
 	msg := &message{}
 
@@ -57,11 +67,15 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 }
 
 func TestDecodeRejectsTrailingData(t *testing.T) {
+	t.Parallel()
+
 	for _, input := range []string{
 		`{"test":"test"} garbage`,
 		`{"test":"test"}{"test":"other"}`,
 	} {
 		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
 			encoder := json.NewEncoder()
 			var msg map[string]string
 
@@ -73,6 +87,8 @@ func TestDecodeRejectsTrailingData(t *testing.T) {
 }
 
 func TestMarshal(t *testing.T) {
+	t.Parallel()
+
 	msg := map[string]string{"test": "test"}
 
 	data, err := json.Marshal(msg)
@@ -82,12 +98,16 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestMarshalReturnsError(t *testing.T) {
+	t.Parallel()
+
 	_, err := json.Marshal(func() {})
 
 	require.Error(t, err)
 }
 
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	var msg map[string]string
 
 	require.NoError(t, json.Unmarshal([]byte("{\"test\":\"test\"}"), &msg))
@@ -95,6 +115,8 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestUnmarshalRejectsTrailingData(t *testing.T) {
+	t.Parallel()
+
 	var msg map[string]string
 
 	err := json.Unmarshal([]byte("{\"test\":\"test\"}{\"extra\":\"value\"}"), &msg)

--- a/encoding/msgpack/fuzz_test.go
+++ b/encoding/msgpack/fuzz_test.go
@@ -1,0 +1,42 @@
+package msgpack_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/msgpack"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzUnmarshal(f *testing.F) {
+	for _, msg := range []map[string]string{
+		{},
+		{"test": "test"},
+		{"test": ""},
+	} {
+		data, err := msgpack.Marshal(msg)
+		require.NoError(f, err)
+		f.Add(data)
+	}
+	f.Add([]byte("junk"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		var msg map[string]string
+		if err := msgpack.Unmarshal(data, &msg); err != nil {
+			return
+		}
+
+		encoded, err := msgpack.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, msgpack.Unmarshal(encoded, &decoded))
+		require.Len(t, decoded, len(msg))
+		for key, value := range msg {
+			require.Equal(t, value, decoded[key])
+		}
+	})
+}

--- a/encoding/msgpack/msgpack_test.go
+++ b/encoding/msgpack/msgpack_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -24,6 +26,8 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -33,6 +37,8 @@ func TestEncodeReturnsError(t *testing.T) {
 }
 
 func TestDecodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	encoder := msgpack.NewEncoder()
 
 	var actual map[string]string
@@ -40,6 +46,8 @@ func TestDecodeReturnsError(t *testing.T) {
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	msg := map[string]string{"test": "test"}
 
 	data, err := msgpack.Marshal(msg)
@@ -51,12 +59,16 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestMarshalReturnsError(t *testing.T) {
+	t.Parallel()
+
 	_, err := msgpack.Marshal(func() {})
 
 	require.Error(t, err)
 }
 
 func TestDecodeRejectsTrailingValue(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -71,6 +83,8 @@ func TestDecodeRejectsTrailingValue(t *testing.T) {
 }
 
 func TestDecodeRejectsMalformedTrailingData(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -86,6 +100,8 @@ func TestDecodeRejectsMalformedTrailingData(t *testing.T) {
 }
 
 func TestUnmarshalRejectsTrailingValue(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -100,6 +116,8 @@ func TestUnmarshalRejectsTrailingValue(t *testing.T) {
 }
 
 func TestUnmarshalRejectsLargeTrailingHeader(t *testing.T) {
+	t.Parallel()
+
 	data, err := msgpack.Marshal(map[string]string{"test": "test"})
 	require.NoError(t, err)
 	data = append(data, 0xdd, 0xff, 0xff, 0xff, 0xff)
@@ -111,12 +129,16 @@ func TestUnmarshalRejectsLargeTrailingHeader(t *testing.T) {
 }
 
 func TestUnmarshalReturnsDecodeError(t *testing.T) {
+	t.Parallel()
+
 	var actual map[string]string
 
 	require.Error(t, msgpack.Unmarshal([]byte("junk"), &actual))
 }
 
 func TestUnmarshalRejectsMalformedTrailingData(t *testing.T) {
+	t.Parallel()
+
 	data, err := msgpack.Marshal(map[string]string{"test": "test"})
 	require.NoError(t, err)
 	data = append(data, []byte("junk")...)

--- a/encoding/toml/fuzz_test.go
+++ b/encoding/toml/fuzz_test.go
@@ -1,0 +1,37 @@
+package toml_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/toml"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzUnmarshal(f *testing.F) {
+	f.Add([]byte(`test = "test"`))
+	f.Add([]byte(`test = ""`))
+	f.Add([]byte(""))
+	f.Add([]byte("test = \"test\"\nextra = \"value\""))
+	f.Add([]byte("="))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		var msg map[string]string
+		if err := toml.Unmarshal(data, &msg); err != nil {
+			return
+		}
+
+		encoded, err := toml.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, toml.Unmarshal(encoded, &decoded))
+		require.Len(t, decoded, len(msg))
+		for key, value := range msg {
+			require.Equal(t, value, decoded[key])
+		}
+	})
+}

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestEncode(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -22,6 +24,8 @@ func TestEncode(t *testing.T) {
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	msg := map[string]string{"test": "test"}
 
 	data, err := toml.Marshal(msg)
@@ -34,12 +38,16 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestMarshalReturnsError(t *testing.T) {
+	t.Parallel()
+
 	_, err := toml.Marshal(func() {})
 
 	require.Error(t, err)
 }
 
 func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -49,6 +57,8 @@ func TestEncodeReturnsError(t *testing.T) {
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
+
 	encoder := toml.NewEncoder()
 	var msg map[string]string
 
@@ -57,6 +67,8 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecodeRejectsUndecodedMetadata(t *testing.T) {
+	t.Parallel()
+
 	encoder := toml.NewEncoder()
 	msg := &message{}
 

--- a/encoding/yaml/fuzz_test.go
+++ b/encoding/yaml/fuzz_test.go
@@ -1,0 +1,37 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzUnmarshal(f *testing.F) {
+	f.Add([]byte("test: test"))
+	f.Add([]byte("test: ''"))
+	f.Add([]byte("{}"))
+	f.Add([]byte("test: test\n---\ntest: other"))
+	f.Add([]byte(": invalid"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		var msg map[string]string
+		if err := yaml.Unmarshal(data, &msg); err != nil {
+			return
+		}
+
+		encoded, err := yaml.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, yaml.Unmarshal(encoded, &decoded))
+		require.Len(t, decoded, len(msg))
+		for key, value := range msg {
+			require.Equal(t, value, decoded[key])
+		}
+	})
+}

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestEncode(t *testing.T) {
+	t.Parallel()
+
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 
@@ -23,6 +25,8 @@ func TestEncode(t *testing.T) {
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	msg := map[string]string{"test": "test"}
 
 	data, err := yaml.Marshal(msg)
@@ -35,18 +39,24 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestMarshalReturnsError(t *testing.T) {
+	t.Parallel()
+
 	_, err := yaml.Marshal(marshalError{})
 
 	require.ErrorIs(t, err, test.ErrFailed)
 }
 
 func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
 	encoder := yaml.NewEncoder()
 
 	require.Error(t, encoder.Encode(test.ErrWriter{}, map[string]string{"test": "test"}))
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
+
 	encoder := yaml.NewEncoder()
 	var msg map[string]string
 
@@ -55,6 +65,8 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecodeRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
 	encoder := yaml.NewEncoder()
 	msg := &message{}
 
@@ -65,11 +77,15 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 }
 
 func TestDecodeRejectsTrailingDocument(t *testing.T) {
+	t.Parallel()
+
 	for _, input := range []string{
 		"test: test\n---\ntest: other",
 		"test: test\n---\n: invalid",
 	} {
 		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
 			encoder := yaml.NewEncoder()
 			var msg map[string]string
 
@@ -81,6 +97,8 @@ func TestDecodeRejectsTrailingDocument(t *testing.T) {
 }
 
 func TestUnmarshalRejectsTrailingDocument(t *testing.T) {
+	t.Parallel()
+
 	var msg map[string]string
 
 	err := yaml.Unmarshal([]byte("test: test\n---\ntest: other"), &msg)

--- a/net/grpc/fuzz_test.go
+++ b/net/grpc/fuzz_test.go
@@ -1,0 +1,35 @@
+package grpc_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/url"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzParseServiceMethod(f *testing.F) {
+	for _, full := range []string{
+		"/greet.v1.Greeter/SayHello",
+		"greet.v1.Greeter/SayHello",
+		"/greet.v1.Greeter",
+		"/greet.v1.Greeter/",
+		"//SayHello",
+		"",
+	} {
+		f.Add(full)
+	}
+
+	f.Fuzz(func(t *testing.T, full string) {
+		service, method := grpc.ParseServiceMethod(full)
+		splitService, splitMethod, ok := url.SplitPath(full)
+		if !ok {
+			require.Equal(t, "root", service)
+			require.Equal(t, "root", method)
+			return
+		}
+
+		require.Equal(t, splitService, service)
+		require.Equal(t, splitMethod, method)
+	})
+}

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -11,10 +11,14 @@ import (
 )
 
 func TestStatusText(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, codes.Unauthenticated.String(), grpc.StatusText(codes.Unauthenticated))
 }
 
 func TestParseServiceMethod(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		full    string
@@ -29,6 +33,8 @@ func TestParseServiceMethod(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			service, method := grpc.ParseServiceMethod(test.full)
 			require.Equal(t, test.service, service)
 			require.Equal(t, test.method, method)
@@ -37,10 +43,14 @@ func TestParseServiceMethod(t *testing.T) {
 }
 
 func TestSetTrailer(t *testing.T) {
+	t.Parallel()
+
 	require.NoError(t, grpc.SetTrailer(t.Context(), nil))
 }
 
 func TestNewServerWithAdvancedOptions(t *testing.T) {
+	t.Parallel()
+
 	opts := options.Map{
 		"max_concurrent_streams":   "7",
 		"connection_timeout":       "250ms",
@@ -57,6 +67,8 @@ func TestNewServerWithAdvancedOptions(t *testing.T) {
 }
 
 func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
+	t.Parallel()
+
 	keys := []string{
 		"keepalive_enforcement_policy_ping_min_time",
 		"keepalive_max_connection_idle",
@@ -68,6 +80,8 @@ func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
 
 	for _, key := range keys {
 		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
 			require.Panics(t, func() {
 				grpc.NewServer(options.Map{key: "-1s"}, time.Second)
 			})
@@ -76,6 +90,8 @@ func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
 }
 
 func TestNewServerWithOverflowingAdvancedOptions(t *testing.T) {
+	t.Parallel()
+
 	require.Panics(t, func() {
 		grpc.NewServer(options.Map{"initial_window_size": "3GB"}, time.Second)
 	})

--- a/net/header/fuzz_test.go
+++ b/net/header/fuzz_test.go
@@ -1,0 +1,41 @@
+package header_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/header"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzParseBearer(f *testing.F) {
+	for _, value := range []string{
+		"Bearer token",
+		"bearer token",
+		strings.Empty,
+		"Bearer ",
+		"Bearer \t",
+		"Bob token",
+		"Basic token",
+		"Bearer token extra",
+	} {
+		f.Add(value)
+	}
+
+	f.Fuzz(func(t *testing.T, value string) {
+		token, err := header.ParseBearer(value)
+		if err == nil {
+			require.NotEmpty(t, token)
+			return
+		}
+
+		require.Empty(t, token)
+		require.True(
+			t,
+			errors.Is(err, header.ErrInvalidAuthorization) || errors.Is(err, header.ErrNotSupportedAuthorization),
+			"unexpected error: %v",
+			err,
+		)
+	})
+}

--- a/net/header/header_test.go
+++ b/net/header/header_test.go
@@ -9,12 +9,16 @@ import (
 )
 
 func TestValidParseBearer(t *testing.T) {
+	t.Parallel()
+
 	value, err := header.ParseBearer("Bearer token")
 	require.NoError(t, err)
 	require.Equal(t, "token", value)
 }
 
 func TestForwardedIPs(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, [...]header.ForwardedIP{
 		{HTTP: "X-Real-Ip", GRPC: "x-real-ip"},
 		{HTTP: "CF-Connecting-Ip", GRPC: "cf-connecting-ip"},
@@ -24,17 +28,23 @@ func TestForwardedIPs(t *testing.T) {
 }
 
 func TestValidParseBearerWithLowercaseScheme(t *testing.T) {
+	t.Parallel()
+
 	value, err := header.ParseBearer("bearer token")
 	require.NoError(t, err)
 	require.Equal(t, "token", value)
 }
 
 func TestMissingParseBearer(t *testing.T) {
+	t.Parallel()
+
 	_, err := header.ParseBearer(strings.Empty)
 	require.ErrorIs(t, err, header.ErrInvalidAuthorization)
 }
 
 func TestParseBearerRejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		header string
 		name   string
@@ -45,6 +55,8 @@ func TestParseBearerRejectsEmptyToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := header.ParseBearer(tt.header)
 			require.ErrorIs(t, err, header.ErrInvalidAuthorization)
 		})
@@ -52,11 +64,15 @@ func TestParseBearerRejectsEmptyToken(t *testing.T) {
 }
 
 func TestNotSupportedParseBearer(t *testing.T) {
+	t.Parallel()
+
 	_, err := header.ParseBearer("Bob token")
 	require.ErrorIs(t, err, header.ErrNotSupportedAuthorization)
 }
 
 func TestParseBearerRejectsBasic(t *testing.T) {
+	t.Parallel()
+
 	_, err := header.ParseBearer("Basic token")
 	require.ErrorIs(t, err, header.ErrNotSupportedAuthorization)
 }

--- a/net/http/fuzz_test.go
+++ b/net/http/fuzz_test.go
@@ -1,0 +1,51 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/url"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzParseServiceMethod(f *testing.F) {
+	for _, seed := range []struct {
+		path   string
+		method string
+	}{
+		{path: "/test/hello", method: http.MethodGet},
+		{path: "/test/users/123", method: http.MethodPost},
+		{path: "/", method: http.MethodGet},
+		{path: "/health", method: http.MethodPost},
+		{path: "", method: http.MethodGet},
+		{path: "//hello", method: http.MethodPost},
+		{path: "/test/", method: http.MethodPut},
+	} {
+		f.Add(seed.path, seed.method)
+	}
+
+	f.Fuzz(func(t *testing.T, path, method string) {
+		if len(path) > 1024 || len(method) > 128 {
+			t.Skip()
+		}
+
+		req := &http.Request{Method: method, URL: &url.URL{Path: path}}
+		service, action := http.ParseServiceMethod(req)
+		splitService, splitMethod, ok := url.SplitPath(path)
+		if ok {
+			require.Equal(t, splitService, service)
+			require.Equal(t, splitMethod, action)
+			return
+		}
+
+		require.Equal(t, strings.ToLower(method), action)
+		if strings.IsEmpty(path) || path == "/" {
+			require.Equal(t, "root", service)
+			return
+		}
+		if path[0] == '/' {
+			require.Equal(t, path[1:], service)
+		}
+	})
+}

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestMaxBytesHandler(t *testing.T) {
+	t.Parallel()
+
 	handler := http.MaxBytesHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		_, _, err := io.ReadAll(req.Body)
 		var maxBytesError *http.MaxBytesError
@@ -34,10 +36,14 @@ func TestMaxBytesHandler(t *testing.T) {
 }
 
 func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
+	t.Parallel()
+
 	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 
 	for _, key := range []string{"read_timeout", "write_timeout", "idle_timeout", "read_header_timeout"} {
 		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
 			require.Panics(t, func() {
 				http.NewServer(options.Map{key: "-1s"}, time.Second, handler)
 			})
@@ -46,6 +52,8 @@ func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
 }
 
 func TestProtocols(t *testing.T) {
+	t.Parallel()
+
 	protocols := http.Protocols()
 
 	require.True(t, protocols.HTTP1())
@@ -54,6 +62,8 @@ func TestProtocols(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC()
 	value := now.Format(http.TimeFormat)
 
@@ -64,6 +74,8 @@ func TestParseTime(t *testing.T) {
 }
 
 func TestTransport(t *testing.T) {
+	t.Parallel()
+
 	cfg := &tls.Config{}
 
 	transport := http.Transport(cfg)
@@ -85,6 +97,8 @@ func TestTransport(t *testing.T) {
 }
 
 func TestNewServerSetsProtocols(t *testing.T) {
+	t.Parallel()
+
 	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 
 	server := http.NewServer(options.Map{}, time.Second, handler)
@@ -96,6 +110,8 @@ func TestNewServerSetsProtocols(t *testing.T) {
 }
 
 func TestSameOriginRedirect(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		want error
 		name string
@@ -114,6 +130,8 @@ func TestSameOriginRedirect(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			next, err := http.NewRequestWithContext(t.Context(), http.MethodGet, tt.next, http.NoBody)
 			require.NoError(t, err)
 			err = http.SameOriginRedirect(next, []*http.Request{prev})
@@ -128,6 +146,8 @@ func TestSameOriginRedirect(t *testing.T) {
 }
 
 func TestSameOrigin(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		prev string
@@ -145,6 +165,8 @@ func TestSameOrigin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			prev, err := url.Parse(tt.prev)
 			require.NoError(t, err)
 
@@ -166,6 +188,8 @@ func TestSameOrigin(t *testing.T) {
 }
 
 func TestIsCrossOriginRedirect(t *testing.T) {
+	t.Parallel()
+
 	prev, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/start", http.NoBody)
 	require.NoError(t, err)
 
@@ -184,6 +208,8 @@ func TestIsCrossOriginRedirect(t *testing.T) {
 }
 
 func TestClosingRoundTripperClosesBodyWhenRequested(t *testing.T) {
+	t.Parallel()
+
 	rt := http.ClosingRoundTripper(func(*http.Request) (*http.Response, error, bool) {
 		return nil, io.ErrUnexpectedEOF, true
 	})
@@ -198,6 +224,8 @@ func TestClosingRoundTripperClosesBodyWhenRequested(t *testing.T) {
 }
 
 func TestClosingRoundTripperLeavesDelegatedBodyOpen(t *testing.T) {
+	t.Parallel()
+
 	rt := http.ClosingRoundTripper(func(*http.Request) (*http.Response, error, bool) {
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil, false
 	})
@@ -212,11 +240,15 @@ func TestClosingRoundTripperLeavesDelegatedBodyOpen(t *testing.T) {
 }
 
 func TestIgnoreRedirect(t *testing.T) {
+	t.Parallel()
+
 	err := http.IgnoreRedirect(nil, nil)
 	require.ErrorIs(t, err, http.ErrUseLastResponse)
 }
 
 func TestParseServiceMethod(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		url     string
@@ -232,6 +264,8 @@ func TestParseServiceMethod(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := httptest.NewRequestWithContext(t.Context(), test.method, test.url, http.NoBody)
 			service, action := http.ParseServiceMethod(req)
 			require.Equal(t, test.service, service)

--- a/net/http/media/fuzz_test.go
+++ b/net/http/media/fuzz_test.go
@@ -1,0 +1,41 @@
+package media_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzParse(f *testing.F) {
+	for _, value := range []string{
+		"json",
+		"text/plain; charset",
+		"Application/YAML; profile=test",
+		media.MessagePack,
+		"TEXT/PLAIN; Charset=utf-8",
+		media.Text,
+		media.HTML,
+		"text/plain; profile=test",
+		media.JSON,
+	} {
+		f.Add(value)
+	}
+
+	f.Fuzz(func(t *testing.T, value string) {
+		if len(value) > 512 {
+			t.Skip()
+		}
+
+		mediaType, err := media.Parse(value)
+		if err != nil {
+			require.ErrorIs(t, err, media.ErrInvalidType)
+			return
+		}
+
+		require.False(t, mediaType.IsZero())
+		require.NotEmpty(t, mediaType.String())
+		require.NotEmpty(t, mediaType.Subtype())
+		require.NotEmpty(t, mediaType.WithUTF8())
+	})
+}

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -8,16 +8,22 @@ import (
 )
 
 func TestParseInvalidMediaType(t *testing.T) {
+	t.Parallel()
+
 	_, err := media.Parse("json")
 	require.ErrorIs(t, err, media.ErrInvalidType)
 }
 
 func TestParseInvalidMediaTypeParameter(t *testing.T) {
+	t.Parallel()
+
 	_, err := media.Parse("text/plain; charset")
 	require.ErrorIs(t, err, media.ErrInvalidType)
 }
 
 func TestParseNormalizesMediaTypeCase(t *testing.T) {
+	t.Parallel()
+
 	mediaType, err := media.Parse("Application/YAML; profile=test")
 
 	require.NoError(t, err)
@@ -27,6 +33,8 @@ func TestParseNormalizesMediaTypeCase(t *testing.T) {
 }
 
 func TestParseStripsVendorSubtypePrefix(t *testing.T) {
+	t.Parallel()
+
 	mediaType, err := media.Parse(media.MessagePack)
 
 	require.NoError(t, err)
@@ -35,6 +43,8 @@ func TestParseStripsVendorSubtypePrefix(t *testing.T) {
 }
 
 func TestTypeWithUTF8(t *testing.T) {
+	t.Parallel()
+
 	mediaType, err := media.Parse("TEXT/PLAIN; Charset=utf-8")
 
 	require.NoError(t, err)
@@ -42,10 +52,14 @@ func TestTypeWithUTF8(t *testing.T) {
 }
 
 func TestTypeByExtension(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "image/svg+xml", media.TypeByExtension(".svg"))
 }
 
 func TestTypeWithUTF8Values(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name      string
 		mediaType string
@@ -60,6 +74,8 @@ func TestTypeWithUTF8Values(t *testing.T) {
 		{name: "msgpack", mediaType: media.MessagePack, expected: media.MessagePack},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			mediaType, err := media.Parse(tc.mediaType)
 
 			require.NoError(t, err)

--- a/net/url/fuzz_test.go
+++ b/net/url/fuzz_test.go
@@ -1,0 +1,36 @@
+package url_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/url"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzSplitPath(f *testing.F) {
+	for _, path := range []string{
+		"/service/method",
+		"/service/users/123",
+		"service/method",
+		"/service",
+		"//method",
+		"/service/",
+		"/",
+		"",
+	} {
+		f.Add(path)
+	}
+
+	f.Fuzz(func(t *testing.T, path string) {
+		first, rest, ok := url.SplitPath(path)
+		if !ok {
+			require.Empty(t, first)
+			require.Empty(t, rest)
+			return
+		}
+
+		require.NotEmpty(t, first)
+		require.NotEmpty(t, rest)
+		require.Equal(t, "/"+first+"/"+rest, path)
+	})
+}

--- a/net/url/url_test.go
+++ b/net/url/url_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestSplitPath(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		path  string
@@ -27,6 +29,8 @@ func TestSplitPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			first, rest, ok := url.SplitPath(tt.path)
 			require.Equal(t, tt.first, first)
 			require.Equal(t, tt.rest, rest)

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAppendEmpty(t *testing.T) {
+	t.Parallel()
+
 	var writer *test.ErrWriter
 	var elem io.Writer = writer
 	var nilSlice []string
@@ -27,12 +29,16 @@ func TestAppendEmpty(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Empty(t, test.append())
 		})
 	}
 }
 
 func TestAppendNotZero(t *testing.T) {
+	t.Parallel()
+
 	integer := 2
 
 	tests := []struct {
@@ -48,12 +54,16 @@ func TestAppendNotZero(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.NotEmpty(t, test.append())
 		})
 	}
 }
 
 func TestBackward(t *testing.T) {
+	t.Parallel()
+
 	values := []string{}
 	for _, value := range slices.Backward([]string{"first", "second"}) {
 		values = append(values, value)
@@ -63,6 +73,8 @@ func TestBackward(t *testing.T) {
 }
 
 func TestElemFunc(t *testing.T) {
+	t.Parallel()
+
 	elems := []*string{new("test")}
 
 	tests := []struct {
@@ -76,6 +88,8 @@ func TestElemFunc(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			elem, ok := slices.ElemFunc(elems, func(value *string) bool { return *value == test.value })
 
 			require.Equal(t, test.found, ok)
@@ -91,6 +105,8 @@ func TestElemFunc(t *testing.T) {
 }
 
 func TestClip(t *testing.T) {
+	t.Parallel()
+
 	values := [...]string{"first", "second"}
 	first := slices.Clip(values[0:1])
 	second := values[1:2]
@@ -102,17 +118,25 @@ func TestClip(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
+	t.Parallel()
+
 	type names []string
 
 	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+
 		require.True(t, slices.Contains(names{"alice", "bob"}, "bob"))
 	})
 
 	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+
 		require.False(t, slices.Contains(names{"alice", "bob"}, "eve"))
 	})
 
 	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
 		require.False(t, slices.Contains(names{}, "alice"))
 	})
 }

--- a/strings/strcase_test.go
+++ b/strings/strcase_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestCaseConversion(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		convert func() string
 		name    string
@@ -20,6 +22,8 @@ func TestCaseConversion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, test.convert())
 		})
 	}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -11,6 +11,8 @@ import (
 var testBytesSink []byte
 
 func TestBytes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		s    string
@@ -21,6 +23,8 @@ func TestBytes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := strings.Bytes(test.s)
 
 			require.Len(t, got, len(test.s))
@@ -43,6 +47,8 @@ func TestBytesDoesNotAllocate(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		s    string
@@ -55,12 +61,16 @@ func TestIsEmpty(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.IsEmpty(test.s))
 		})
 	}
 }
 
 func TestIsAnyEmpty(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		ss   []string
@@ -74,12 +84,16 @@ func TestIsAnyEmpty(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.IsAnyEmpty(test.ss...))
 		})
 	}
 }
 
 func TestJoin(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		sep  string
@@ -93,12 +107,16 @@ func TestJoin(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.Join(test.sep, test.ss...))
 		})
 	}
 }
 
 func TestConcat(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		want string
@@ -111,12 +129,16 @@ func TestConcat(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.Concat(test.ss...))
 		})
 	}
 }
 
 func TestCutColon(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		s          string
@@ -133,6 +155,8 @@ func TestCutColon(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			before, after, found := strings.CutColon(test.s)
 
 			require.Equal(t, test.wantBefore, before)
@@ -143,6 +167,8 @@ func TestCutColon(t *testing.T) {
 }
 
 func TestLastIndex(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		s      string
@@ -156,12 +182,16 @@ func TestLastIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.LastIndex(test.s, test.substr))
 		})
 	}
 }
 
 func TestCount(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		s      string
@@ -175,12 +205,16 @@ func TestCount(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.Count(test.s, test.substr))
 		})
 	}
 }
 
 func TestReplaceAll(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		s    string
@@ -195,12 +229,16 @@ func TestReplaceAll(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.ReplaceAll(test.s, test.old, test.new))
 		})
 	}
 }
 
 func TestTrim(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		s      string
@@ -214,6 +252,8 @@ func TestTrim(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.want, strings.Trim(test.s, test.cutset))
 		})
 	}

--- a/time/duration_test.go
+++ b/time/duration_test.go
@@ -9,14 +9,20 @@ import (
 )
 
 func TestMustParseDuration(t *testing.T) {
+	t.Parallel()
+
 	require.Panics(t, func() { time.MustParseDuration("test") })
 }
 
 func TestDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, 30*time.Second, time.DefaultTimeout)
 }
 
 func TestDurationTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	duration := 5*time.Second + 250*time.Millisecond
 
 	text, err := duration.MarshalText()
@@ -29,6 +35,8 @@ func TestDurationTextRoundTrip(t *testing.T) {
 }
 
 func TestDurationJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	duration := 3*time.Minute + 15*time.Second
 
 	data, err := json.Marshal(duration)
@@ -41,6 +49,8 @@ func TestDurationJSONRoundTrip(t *testing.T) {
 }
 
 func TestDurationUnmarshalTextInvalid(t *testing.T) {
+	t.Parallel()
+
 	var duration time.Duration
 
 	err := duration.UnmarshalText([]byte("not-a-duration"))
@@ -48,6 +58,8 @@ func TestDurationUnmarshalTextInvalid(t *testing.T) {
 }
 
 func TestDurationUnmarshalJSONInvalid(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input string
@@ -61,6 +73,8 @@ func TestDurationUnmarshalJSONInvalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var duration time.Duration
 
 			err := json.Unmarshal([]byte(tt.input), &duration)
@@ -70,6 +84,8 @@ func TestDurationUnmarshalJSONInvalid(t *testing.T) {
 }
 
 func TestDurationZeroValueEncoding(t *testing.T) {
+	t.Parallel()
+
 	var duration time.Duration
 
 	text, err := duration.MarshalText()

--- a/time/fuzz_test.go
+++ b/time/fuzz_test.go
@@ -1,0 +1,61 @@
+package time_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzDurationTextRoundTrip(f *testing.F) {
+	f.Add("0s")
+	f.Add("250ms")
+	f.Add("5.25s")
+	f.Add("3m15s")
+	f.Add("not-a-duration")
+
+	f.Fuzz(func(t *testing.T, text string) {
+		if len(text) > 128 {
+			t.Skip()
+		}
+
+		var duration time.Duration
+		if err := duration.UnmarshalText([]byte(text)); err != nil {
+			return
+		}
+
+		encoded, err := duration.MarshalText()
+		require.NoError(t, err)
+
+		var decoded time.Duration
+		require.NoError(t, decoded.UnmarshalText(encoded))
+		require.Equal(t, duration, decoded)
+	})
+}
+
+func FuzzDurationJSONRoundTrip(f *testing.F) {
+	f.Add([]byte(`"0s"`))
+	f.Add([]byte(`"250ms"`))
+	f.Add([]byte(`"5.25s"`))
+	f.Add([]byte(`"3m15s"`))
+	f.Add([]byte(`"not-a-duration"`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1024 {
+			t.Skip()
+		}
+
+		var duration time.Duration
+		if err := json.Unmarshal(data, &duration); err != nil {
+			return
+		}
+
+		encoded, err := json.Marshal(duration)
+		require.NoError(t, err)
+
+		var decoded time.Duration
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.Equal(t, duration, decoded)
+	})
+}


### PR DESCRIPTION
## What

- Add dedicated fuzz targets for repository-owned parsing, encoding, scalar, and compression contracts.
- Enable safe parallel execution for pure helper, parser, codec, and wrapper tests.
- Keep fuzz coverage scoped away from straight alias-only surfaces while still parallelizing safe alias tests.

## Why

- Broadens mutation coverage for malformed inputs, size limits, round-trip contracts, and parser fallbacks.
- Reduces local and CI spec wall time by allowing independent pure tests to run concurrently.
- Keeps the fuzz suite focused on behavior this repository owns rather than re-testing upstream libraries.

## Testing

- `make specs` - passed; ran the full Go spec suite with fuzz seed targets included.
- `make lint` - passed; ran repository lint after fixing the error sentinel check in `net/header/fuzz_test.go`.
- `make fuzz package=<package> name=<target> fuzztime=1s` - passed for every remaining fuzz target added in this change.
- `git diff --check` - passed; checked tracked diff whitespace.
