### PR TITLE
test(internal): surface fuzz and benchmark entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ transport-diagram:
 	@$(MAKE) package=transport create-diagram
 
 # Run all the benchmarks.
-benchmarks: http-benchmarks grpc-benchmarks sql-benchmarks cache-benchmarks bytes-benchmarks strings-benchmarks id-benchmarks http-content-benchmarks
+benchmarks: http-benchmarks grpc-benchmarks sql-benchmarks cache-benchmarks bytes-benchmarks \
+	strings-benchmarks id-benchmarks net-http-benchmarks http-content-benchmarks
 
 http-benchmarks:
 	@$(MAKE) package=transport/http benchtime=100x benchmark
@@ -41,8 +42,47 @@ strings-benchmarks:
 id-benchmarks:
 	@$(MAKE) package=id benchtime=100x benchmark
 
+net-http-benchmarks:
+	@$(MAKE) package=net/http benchtime=100x benchmark
+
 http-content-benchmarks:
 	@$(MAKE) package=net/http/content benchtime=100x benchmark
+
+# Run bounded fuzz smoke tests. Set fuzztime=<duration> to override the default 1s per target.
+fuzz-smoke: bytes-fuzz time-fuzz encoding-fuzz compress-fuzz net-fuzz
+
+bytes-fuzz:
+	@$(MAKE) package=bytes name=FuzzSizeTextRoundTrip fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=bytes name=FuzzSizeJSONRoundTrip fuzztime=$(or $(fuzztime),1s) fuzz
+
+time-fuzz:
+	@$(MAKE) package=time name=FuzzDurationTextRoundTrip fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=time name=FuzzDurationJSONRoundTrip fuzztime=$(or $(fuzztime),1s) fuzz
+
+encoding-fuzz:
+	@$(MAKE) package=encoding/bytes name=FuzzEncoder fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=encoding/gob name=FuzzUnmarshal fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=encoding/hjson name=FuzzUnmarshal fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=encoding/json name=FuzzUnmarshal fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=encoding/msgpack name=FuzzUnmarshal fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=encoding/toml name=FuzzUnmarshal fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=encoding/yaml name=FuzzUnmarshal fuzztime=$(or $(fuzztime),1s) fuzz
+
+compress-fuzz:
+	@$(MAKE) package=compress/none name=FuzzCompressor fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=compress/s2 name=FuzzCompressor fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=compress/s2 name=FuzzDecompress fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=compress/snappy name=FuzzCompressor fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=compress/snappy name=FuzzDecompress fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=compress/zstd name=FuzzCompressor fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=compress/zstd name=FuzzDecompress fuzztime=$(or $(fuzztime),1s) fuzz
+
+net-fuzz:
+	@$(MAKE) package=net/grpc name=FuzzParseServiceMethod fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=net/header name=FuzzParseBearer fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=net/http name=FuzzParseServiceMethod fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=net/http/media name=FuzzParse fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=net/url name=FuzzSplitPath fuzztime=$(or $(fuzztime),1s) fuzz
 
 # Generate for tests.
 generate:

--- a/README.md
+++ b/README.md
@@ -1302,7 +1302,20 @@ make cache-benchmarks
 make bytes-benchmarks
 make strings-benchmarks
 make id-benchmarks
+make net-http-benchmarks
 make http-content-benchmarks
+```
+
+### Fuzz smoke tests
+
+```sh
+make fuzz-smoke
+make bytes-fuzz
+make time-fuzz
+make encoding-fuzz
+make compress-fuzz
+make net-fuzz
+make package=encoding/json name=FuzzUnmarshal fuzztime=10s fuzz
 ```
 
 ### Coverage reports

--- a/bytes/benchmark_test.go
+++ b/bytes/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 // benchmarkStringSink keeps conversion results observable so benchmarks report real allocation costs.
 var benchmarkStringSink string
 
+// BenchmarkBytes measures the allocation difference between ordinary byte-to-string copies and the unsafe helper.
 func BenchmarkBytes(b *testing.B) {
 	b.ReportAllocs()
 

--- a/bytes/fuzz_test.go
+++ b/bytes/fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzSizeTextRoundTrip explores human-readable size parsing and text marshaling used by config values.
 func FuzzSizeTextRoundTrip(f *testing.F) {
 	f.Add("0B")
 	f.Add("64B")
@@ -37,6 +38,7 @@ func FuzzSizeTextRoundTrip(f *testing.F) {
 	})
 }
 
+// FuzzSizeJSONRoundTrip explores JSON size parsing while preserving the text round-trip invariant.
 func FuzzSizeJSONRoundTrip(f *testing.F) {
 	f.Add([]byte(`"0B"`))
 	f.Add([]byte(`"64B"`))

--- a/cache/driver/benchmark_test.go
+++ b/cache/driver/benchmark_test.go
@@ -11,6 +11,8 @@ import (
 
 var driverSink driver.Driver
 
+// BenchmarkRedisTelemetry measures Redis driver construction overhead with telemetry disabled, partial,
+// and fully enabled.
 func BenchmarkRedisTelemetry(b *testing.B) {
 	bench := func(name string, setup func(testing.TB)) {
 		b.Run(name, func(b *testing.B) {

--- a/compress/none/fuzz_test.go
+++ b/compress/none/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzCompressor explores the common compression size-limit invariant for the no-op codec.
 func FuzzCompressor(f *testing.F) {
 	f.Add([]byte(""), uint16(0))
 	f.Add([]byte("hello"), uint16(5))

--- a/compress/s2/fuzz_test.go
+++ b/compress/s2/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzCompressor explores S2 compression round trips while preserving repository size-limit behavior.
 func FuzzCompressor(f *testing.F) {
 	f.Add([]byte(""), uint16(0))
 	f.Add([]byte("hello"), uint16(5))
@@ -35,6 +36,7 @@ func FuzzCompressor(f *testing.F) {
 	})
 }
 
+// FuzzDecompress explores malformed S2 input and the decoded-size limit invariant.
 func FuzzDecompress(f *testing.F) {
 	cmp := s2.NewCompressor()
 	encoded, err := cmp.Compress([]byte("hello"), bytes.KB)

--- a/compress/snappy/fuzz_test.go
+++ b/compress/snappy/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzCompressor explores Snappy compression round trips while preserving repository size-limit behavior.
 func FuzzCompressor(f *testing.F) {
 	f.Add([]byte(""), uint16(0))
 	f.Add([]byte("hello"), uint16(5))
@@ -35,6 +36,7 @@ func FuzzCompressor(f *testing.F) {
 	})
 }
 
+// FuzzDecompress explores malformed Snappy input and the decoded-size limit invariant.
 func FuzzDecompress(f *testing.F) {
 	cmp := snappy.NewCompressor()
 	encoded, err := cmp.Compress([]byte("hello"), bytes.KB)

--- a/compress/zstd/fuzz_test.go
+++ b/compress/zstd/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzCompressor explores zstd compression round trips while preserving repository size-limit behavior.
 func FuzzCompressor(f *testing.F) {
 	f.Add([]byte(""), uint16(0))
 	f.Add([]byte("hello"), uint16(5))
@@ -35,6 +36,7 @@ func FuzzCompressor(f *testing.F) {
 	})
 }
 
+// FuzzDecompress explores malformed zstd input and the decoded-size limit invariant.
 func FuzzDecompress(f *testing.F) {
 	cmp := zstd.NewCompressor()
 	encoded, err := cmp.Compress([]byte("hello"), bytes.KB)

--- a/database/sql/driver/benchmark_test.go
+++ b/database/sql/driver/benchmark_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// BenchmarkSQLTelemetry measures database/sql wrapper overhead with telemetry disabled, partial, and fully enabled.
 func BenchmarkSQLTelemetry(b *testing.B) {
 	bench := func(name string, setup func(testing.TB)) {
 		b.Run(name, func(b *testing.B) {

--- a/encoding/bytes/fuzz_test.go
+++ b/encoding/bytes/fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzEncoder explores arbitrary byte streams through the repository's encode/decode byte-copy invariant.
 func FuzzEncoder(f *testing.F) {
 	f.Add([]byte(""))
 	f.Add([]byte("test"))

--- a/encoding/gob/fuzz_test.go
+++ b/encoding/gob/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzUnmarshal explores gob decoder input space and verifies accepted map payloads round-trip.
 func FuzzUnmarshal(f *testing.F) {
 	for _, msg := range []map[string]string{
 		{},

--- a/encoding/hjson/fuzz_test.go
+++ b/encoding/hjson/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzUnmarshal explores the HJSON decoder surface, including duplicate-key handling, for accepted map payloads.
 func FuzzUnmarshal(f *testing.F) {
 	f.Add([]byte("{test: test}"))
 	f.Add([]byte("{test: ''}"))

--- a/encoding/json/fuzz_test.go
+++ b/encoding/json/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzUnmarshal explores the strict JSON decoder surface and verifies accepted map payloads round-trip.
 func FuzzUnmarshal(f *testing.F) {
 	f.Add([]byte(`{"test":"test"}`))
 	f.Add([]byte(`{"test":""}`))

--- a/encoding/msgpack/fuzz_test.go
+++ b/encoding/msgpack/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzUnmarshal explores MessagePack decoder input space and verifies accepted map payloads round-trip.
 func FuzzUnmarshal(f *testing.F) {
 	for _, msg := range []map[string]string{
 		{},

--- a/encoding/toml/fuzz_test.go
+++ b/encoding/toml/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzUnmarshal explores TOML decoder input space and verifies accepted map payloads round-trip.
 func FuzzUnmarshal(f *testing.F) {
 	f.Add([]byte(`test = "test"`))
 	f.Add([]byte(`test = ""`))

--- a/encoding/yaml/fuzz_test.go
+++ b/encoding/yaml/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzUnmarshal explores the strict YAML decoder surface and verifies accepted map payloads round-trip.
 func FuzzUnmarshal(f *testing.F) {
 	f.Add([]byte("test: test"))
 	f.Add([]byte("test: ''"))

--- a/id/benchmark_test.go
+++ b/id/benchmark_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// BenchmarkGenerators tracks generator cost for the ID kinds supported by configuration.
 func BenchmarkGenerators(b *testing.B) {
 	kinds := []string{
 		"ksuid",

--- a/net/grpc/fuzz_test.go
+++ b/net/grpc/fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzParseServiceMethod explores gRPC telemetry service/method derivation for arbitrary full-method strings.
 func FuzzParseServiceMethod(f *testing.F) {
 	for _, full := range []string{
 		"/greet.v1.Greeter/SayHello",

--- a/net/header/fuzz_test.go
+++ b/net/header/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzParseBearer explores Authorization header parsing while preserving supported error classification.
 func FuzzParseBearer(f *testing.F) {
 	for _, value := range []string{
 		"Bearer token",

--- a/net/http/benchmark_test.go
+++ b/net/http/benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// BenchmarkClientTelemetry measures client request overhead with telemetry disabled, metrics-only, and tracing enabled.
 func BenchmarkClientTelemetry(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	defer server.Close()

--- a/net/http/content/benchmark_test.go
+++ b/net/http/content/benchmark_test.go
@@ -12,6 +12,7 @@ import (
 // benchmarkMedia prevents the compiler from eliminating media negotiation work.
 var benchmarkMedia content.Media
 
+// BenchmarkNewFromMediaJSON tracks the exact media-type fast path used on hot request paths.
 func BenchmarkNewFromMediaJSON(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
@@ -19,6 +20,7 @@ func BenchmarkNewFromMediaJSON(b *testing.B) {
 	}
 }
 
+// BenchmarkNewFromRequestJSON tracks request header media negotiation overhead for a common JSON body.
 func BenchmarkNewFromRequestJSON(b *testing.B) {
 	req := httptest.NewRequestWithContext(b.Context(), "POST", "/hello", nil)
 	req.Header.Set(content.TypeKey, media.JSON)
@@ -29,6 +31,7 @@ func BenchmarkNewFromRequestJSON(b *testing.B) {
 	}
 }
 
+// BenchmarkNewFromMediaWithParameters tracks the parser path needed for parameterized media types.
 func BenchmarkNewFromMediaWithParameters(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {

--- a/net/http/fuzz_test.go
+++ b/net/http/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzParseServiceMethod explores HTTP telemetry service/method derivation for arbitrary paths and methods.
 func FuzzParseServiceMethod(f *testing.F) {
 	for _, seed := range []struct {
 		path   string

--- a/net/http/media/fuzz_test.go
+++ b/net/http/media/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzParse explores media type parsing and normalization for request content negotiation.
 func FuzzParse(f *testing.F) {
 	for _, value := range []string{
 		"json",

--- a/net/url/fuzz_test.go
+++ b/net/url/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzSplitPath explores slash-prefixed service/method path parsing used by HTTP and gRPC telemetry.
 func FuzzSplitPath(f *testing.F) {
 	for _, path := range []string{
 		"/service/method",

--- a/strings/benchmark_test.go
+++ b/strings/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 // benchmarkBytesSink keeps conversion results observable so benchmarks report real allocation costs.
 var benchmarkBytesSink []byte
 
+// BenchmarkStrings measures the allocation difference between ordinary string-to-byte copies and the unsafe helper.
 func BenchmarkStrings(b *testing.B) {
 	b.ReportAllocs()
 

--- a/time/fuzz_test.go
+++ b/time/fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzDurationTextRoundTrip explores duration parsing and text marshaling used by config values.
 func FuzzDurationTextRoundTrip(f *testing.F) {
 	f.Add("0s")
 	f.Add("250ms")
@@ -34,6 +35,7 @@ func FuzzDurationTextRoundTrip(f *testing.F) {
 	})
 }
 
+// FuzzDurationJSONRoundTrip explores JSON duration parsing while preserving the text round-trip invariant.
 func FuzzDurationJSONRoundTrip(f *testing.F) {
 	f.Add([]byte(`"0s"`))
 	f.Add([]byte(`"250ms"`))

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -20,6 +20,8 @@ func init() {
 	transportgrpc.Register(test.FS)
 }
 
+// BenchmarkGRPC compares the standard gRPC stack with the supported go-service server stack and telemetry layers.
+//
 //nolint:funlen
 func BenchmarkGRPC(b *testing.B) {
 	b.Run("std", func(b *testing.B) {

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -25,6 +25,8 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
+// BenchmarkHTTP compares the standard HTTP stack with the supported go-service server stack and telemetry layers.
+//
 //nolint:funlen
 func BenchmarkHTTP(b *testing.B) {
 	b.Run("std", func(b *testing.B) {
@@ -218,6 +220,7 @@ func BenchmarkHTTP(b *testing.B) {
 	})
 }
 
+// BenchmarkMVC measures the supported MVC HTML rendering path through the HTTP transport stack.
 func BenchmarkMVC(b *testing.B) {
 	b.Run("html", func(b *testing.B) {
 		b.ReportAllocs()
@@ -250,6 +253,7 @@ func BenchmarkMVC(b *testing.B) {
 			closeResponse(b, resp)
 		}
 
+		b.StopTimer()
 		client.CloseIdleConnections()
 		world.RequireStop()
 	})
@@ -281,6 +285,8 @@ func startHTTPBenchmarkWorld(b *testing.B, world *test.World) {
 	require.NoError(b, conn.Close())
 }
 
+// BenchmarkRPC measures RPC client/server body encoding overhead across supported HTTP media types.
+//
 //nolint:funlen
 func BenchmarkRPC(b *testing.B) {
 	b.Run("text", func(b *testing.B) {
@@ -353,6 +359,8 @@ func BenchmarkRPC(b *testing.B) {
 	})
 }
 
+// BenchmarkRest measures REST client/server body encoding and static response overhead across supported media types.
+//
 //nolint:funlen
 func BenchmarkRest(b *testing.B) {
 	b.Run("text", func(b *testing.B) {


### PR DESCRIPTION
## What

- Added `net-http-benchmarks` and included it in the aggregate `make benchmarks` target.
- Added grouped fuzz smoke targets and documented benchmark/fuzz commands in the README.
- Added explicit rationale comments to benchmark and fuzz entrypoints, and excluded MVC benchmark teardown from measured time.

## Why

- Aligns the repository with the updated shared Go benchmark and fuzz guidance from `bin`.
- Makes fuzz smoke coverage discoverable through repository Make targets instead of requiring manual target lookup.
- Ensures the existing `net/http` telemetry benchmark is exercised by the normal benchmark aggregate.

## Testing

- `make benchmarks` - passed
- `make fuzz-smoke` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning and 0 issues
- `make -n benchmarks` - passed
- `make -n fuzz-smoke` - passed
- `git diff --check` - passed
- `make specs`, `make sec`, and `make coverage` were not run locally for this scoped benchmark/fuzz workflow change.

AI-assisted-by: [Codex](https://openai.com/codex/)
