### PR TITLE
build(make): run renamed fuzz aggregate in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
       - run: make generate-stale
       - run: make sec
       - run: make specs
+      - run: make fuzzes
       - run: make benchmarks
       - save_cache:
           name: save go build cache

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ net-http-benchmarks:
 http-content-benchmarks:
 	@$(MAKE) package=net/http/content benchtime=100x benchmark
 
-# Run bounded fuzz smoke tests. Set fuzztime=<duration> to override the default 1s per target.
-fuzz-smoke: bytes-fuzz time-fuzz encoding-fuzz compress-fuzz net-fuzz
+# Run bounded fuzz tests. Set fuzztime=<duration> to override the default 1s per target.
+fuzzes: bytes-fuzz time-fuzz encoding-fuzz compress-fuzz net-fuzz
 
 bytes-fuzz:
 	@$(MAKE) package=bytes name=FuzzSizeTextRoundTrip fuzztime=$(or $(fuzztime),1s) fuzz

--- a/README.md
+++ b/README.md
@@ -1306,10 +1306,10 @@ make net-http-benchmarks
 make http-content-benchmarks
 ```
 
-### Fuzz smoke tests
+### Fuzz tests
 
 ```sh
-make fuzz-smoke
+make fuzzes
 make bytes-fuzz
 make time-fuzz
 make encoding-fuzz


### PR DESCRIPTION
## What

- Rename the bounded fuzz aggregate from `fuzz-smoke` to `fuzzes`.
- Add `make fuzzes` to the CircleCI quality path before benchmarks.
- Update README fuzz command documentation to use the new aggregate name.

## Why

- Keeps the fuzz command naming aligned with the existing aggregate target style while making fuzz coverage part of CI.
- Intentionally breaks callers of `make fuzz-smoke`; the replacement command is `make fuzzes`.

## Testing

- `make fuzzes` - passed
- `make help` - passed
- `git diff --check` - passed
