### PR TITLE
test(fuzz): use count-based bounded runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ net-http-benchmarks:
 http-content-benchmarks:
 	@$(MAKE) package=net/http/content benchtime=100x benchmark
 
-fuzztime_default := 5s
+fuzztime_default := 10000x
 
-# Run bounded fuzz tests. Set fuzztime=<duration> to override the default 5s per target.
+# Run bounded fuzz tests. Set fuzztime=<duration-or-count> to override the default 10000 executions per target.
 fuzzes: bytes-fuzz time-fuzz encoding-fuzz compress-fuzz net-fuzz
 
 bytes-fuzz:


### PR DESCRIPTION
## What

- Switch the repo-level bounded fuzz targets to a count-based default of 10000 executions per target.
- Keep the existing fuzztime override path so callers can still choose a duration or a different execution count.
- Leave the shared bin helper unchanged; the consuming repo Makefile passes the explicit default for aggregate fuzz targets.

## Why

- Avoid Go fuzz coordinator deadline failures where a wall-clock fuzz budget can report context deadline exceeded when new interesting inputs arrive at the timeout boundary.
- Keep CI fuzz coverage bounded while preventing timeout expiry itself from failing the target.

## Testing

- `make help` - passed
- `make -n fuzzes` - passed
- `make fuzzes` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
