### PR TITLE
feat(header): validate http field names and values

### DIFF
--- a/net/header/doc.go
+++ b/net/header/doc.go
@@ -1,11 +1,11 @@
 // Package header provides shared helpers for working with network protocol headers in go-service.
 //
-// This package currently focuses on Bearer Authorization header parsing and shared forwarding header names so
-// HTTP and gRPC integrations can use the same metadata semantics.
+// This package focuses on Bearer Authorization header parsing, HTTP header field validation, and shared
+// forwarding header names so HTTP and gRPC integrations can use the same metadata semantics.
 //
 // Forwarded IP headers are accepted as trusted inputs by transport metadata extraction. Services that rely on
 // extracted IPs for access logs, policy, or rate limiting should only receive traffic through trusted edge
 // infrastructure that strips or overwrites client-supplied forwarding headers.
 //
-// Start with [ParseBearer] and [ForwardedIPs].
+// Start with [ParseBearer], [ValidFieldName], [ValidFieldValue], and [ForwardedIPs].
 package header

--- a/net/header/header.go
+++ b/net/header/header.go
@@ -3,6 +3,7 @@ package header
 import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"golang.org/x/net/http/httpguts"
 )
 
 // BearerAuthorization is the HTTP Authorization scheme name for Bearer token authentication.
@@ -14,20 +15,20 @@ import (
 // where <token> is an opaque access token (for example, a JWT).
 const BearerAuthorization = "Bearer"
 
-var (
-	// ForwardedIPs lists the forwarding headers used to derive a client IP address.
-	//
-	// Metadata extraction accepts these as trusted inputs, so callers should only rely on derived IPs behind
-	// trusted edge infrastructure that strips or overwrites client-supplied forwarding headers.
-	//
-	// The order reflects the preferred source when multiple headers are present.
-	ForwardedIPs = [...]ForwardedIP{
-		{HTTP: "X-Real-Ip", GRPC: "x-real-ip"},
-		{HTTP: "CF-Connecting-Ip", GRPC: "cf-connecting-ip"},
-		{HTTP: "True-Client-Ip", GRPC: "true-client-ip"},
-		{HTTP: "X-Forwarded-For", GRPC: "x-forwarded-for"},
-	}
+// ForwardedIPs lists the forwarding headers used to derive a client IP address.
+//
+// Metadata extraction accepts these as trusted inputs, so callers should only rely on derived IPs behind
+// trusted edge infrastructure that strips or overwrites client-supplied forwarding headers.
+//
+// The order reflects the preferred source when multiple headers are present.
+var ForwardedIPs = [...]ForwardedIP{
+	{HTTP: "X-Real-Ip", GRPC: "x-real-ip"},
+	{HTTP: "CF-Connecting-Ip", GRPC: "cf-connecting-ip"},
+	{HTTP: "True-Client-Ip", GRPC: "true-client-ip"},
+	{HTTP: "X-Forwarded-For", GRPC: "x-forwarded-for"},
+}
 
+var (
 	// ErrInvalidAuthorization is returned when an Authorization header cannot be parsed.
 	//
 	// This is returned when the header does not contain a scheme and value separated by a single ASCII space
@@ -52,6 +53,16 @@ type ForwardedIP struct {
 	// gRPC metadata is normalized to lowercase, so lowercase keys hit the direct
 	// metadata lookup path instead of falling back to case-insensitive scanning.
 	GRPC string
+}
+
+// ValidFieldName reports whether name is a valid HTTP header field name.
+func ValidFieldName(name string) bool {
+	return httpguts.ValidHeaderFieldName(name)
+}
+
+// ValidFieldValue reports whether value is a valid HTTP header field value.
+func ValidFieldValue(value string) bool {
+	return httpguts.ValidHeaderFieldValue(value)
 }
 
 // ParseBearer parses an HTTP Authorization header and returns its bearer token value.

--- a/net/header/header_test.go
+++ b/net/header/header_test.go
@@ -27,6 +27,54 @@ func TestForwardedIPs(t *testing.T) {
 	}, header.ForwardedIPs)
 }
 
+func TestValidFieldName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "standard", value: "X-Request-Id", valid: true},
+		{name: "http token symbols", value: "X-Rate_Limit~Policy", valid: true},
+		{name: "empty", value: strings.Empty},
+		{name: "space", value: "Bad Header"},
+		{name: "unicode", value: "Café"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.valid, header.ValidFieldName(tt.value))
+		})
+	}
+}
+
+func TestValidFieldValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "plain", value: "Bearer token", valid: true},
+		{name: "empty", value: strings.Empty, valid: true},
+		{name: "tab", value: "a\tb", valid: true},
+		{name: "newline", value: "a\nb"},
+		{name: "nul", value: "a\x00b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.valid, header.ValidFieldValue(tt.value))
+		})
+	}
+}
+
 func TestValidParseBearerWithLowercaseScheme(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

- Added `net/header` helpers for validating HTTP field names and values.
- Updated package documentation so the new validation API is discoverable alongside bearer parsing and forwarding header names.
- Added table coverage for accepted and rejected field names and values.

## Why

- Downstream services can validate user-controlled response headers through the go-service header package instead of importing lower-level HTTP internals directly.
- Keeping this in `net/header` gives HTTP callers a neutral package home without expanding the API into gRPC metadata validation.

## Testing

- `gmake package=net/header specs` - passed; covered the new public validation helpers plus existing bearer and forwarding header behavior.
- `gmake lint` - passed; reported the existing gomodguard deprecation warning and 0 issues.
- `git diff --check` - passed.
- Broader CI checks such as `gmake specs`, `gmake sec`, `gmake fuzzes`, `gmake benchmarks`, and `gmake coverage` were not run locally.
