### PR TITLE
feat(retry): adapt shared client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,16 +1061,12 @@ When manually constructing HTTP or gRPC clients, pass a transport-specific retry
 shared retry mechanics and add protocol-specific failure classification:
 
 ```go
-httpRetry := &httpretry.Config{
-	Config:      sharedRetry,
-	StatusCodes: []int{429, 502, 503},
-}
-
-grpcRetry := &grpcretry.Config{
-	Config: sharedRetry,
-	Codes:  []codes.Code{codes.Unavailable, codes.ResourceExhausted},
-}
+httpRetry := httpretry.NewConfig(sharedRetry, 429, 502, 503)
+grpcRetry := grpcretry.NewConfig(sharedRetry, codes.Unavailable, codes.ResourceExhausted)
 ```
+
+`NewConfig` returns `nil` when the shared retry config is `nil`, preserving client-option wiring that
+disables retries by omitting retry config.
 
 `attempts` is the total number of attempts, including the initial call. A value
 of `0` or `1` means no retry beyond the first attempt; values above `10` are

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -14,9 +14,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
 	grpcbreaker "github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
 	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
+	grpcretry "github.com/alexfalkowski/go-service/v2/transport/grpc/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/http"
 	httpbreaker "github.com/alexfalkowski/go-service/v2/transport/http/breaker"
 	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
+	httpretry "github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/retry"
 )
 
@@ -58,7 +60,7 @@ func (c *Client) NewHTTP(os ...httpbreaker.Option) (*http.Client, error) {
 		http.WithClientLogger(c.Logger),
 		http.WithClientRoundTripper(c.RoundTripper),
 		http.WithClientBreaker(os...),
-		http.WithClientRetry(NewHTTPClientRetryConfig(c.Retry)),
+		http.WithClientRetry(httpretry.NewConfig(c.Retry)),
 		http.WithClientUserAgent(UserAgent),
 		http.WithClientTokenGenerator(UserID, c.Generator),
 		http.WithClientTimeout(time.Minute),
@@ -82,7 +84,7 @@ func (c *Client) NewGRPC(os ...grpcbreaker.Option) (*grpc.ClientConn, error) {
 		grpc.WithClientStreamInterceptors(),
 		grpc.WithClientLogger(c.Logger),
 		grpc.WithClientBreaker(os...),
-		grpc.WithClientRetry(NewGRPCClientRetryConfig(c.Retry)),
+		grpc.WithClientRetry(grpcretry.NewConfig(c.Retry)),
 		grpc.WithClientUserAgent(UserAgent),
 		grpc.WithClientTokenGenerator(UserID, c.Generator),
 		grpc.WithClientTimeout(time.Minute),

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -163,32 +163,12 @@ func NewRetry() *retry.Config {
 
 // NewHTTPRetryConfig returns an HTTP retry config with shared retry mechanics.
 func NewHTTPRetryConfig(attempts uint64, backoff time.Duration, statusCodes ...int) *httpretry.Config {
-	return &httpretry.Config{
-		Config:      &retry.Config{Attempts: attempts, Backoff: backoff},
-		StatusCodes: statusCodes,
-	}
+	return httpretry.NewConfig(&retry.Config{Attempts: attempts, Backoff: backoff}, statusCodes...)
 }
 
 // NewGRPCRetryConfig returns a gRPC retry config with shared retry mechanics and a per-attempt timeout.
-func NewGRPCRetryConfig(attempts uint64, backoff time.Duration, cs ...codes.Code) *grpcretry.Config {
-	return &grpcretry.Config{
-		Config: &retry.Config{
-			Attempts: attempts,
-			Timeout:  time.Second,
-			Backoff:  backoff,
-		},
-		Codes: cs,
-	}
-}
-
-// NewHTTPClientRetryConfig returns an HTTP retry config from shared client retry config.
-func NewHTTPClientRetryConfig(cfg *retry.Config) *httpretry.Config {
-	return &httpretry.Config{Config: cfg}
-}
-
-// NewGRPCClientRetryConfig returns a gRPC retry config from shared client retry config.
-func NewGRPCClientRetryConfig(cfg *retry.Config) *grpcretry.Config {
-	return &grpcretry.Config{Config: cfg}
+func NewGRPCRetryConfig(attempts uint64, backoff time.Duration, codes ...codes.Code) *grpcretry.Config {
+	return grpcretry.NewConfig(&retry.Config{Attempts: attempts, Timeout: time.Second, Backoff: backoff}, codes...)
 }
 
 // NewTLSClientConfig returns the client certificate fixture used by secure transport tests.

--- a/transport/grpc/retry/config.go
+++ b/transport/grpc/retry/config.go
@@ -5,6 +5,20 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/retry"
 )
 
+// NewConfig returns a gRPC retry config from shared retry mechanics.
+//
+// If cfg is nil, NewConfig returns nil so client option wiring can preserve disabled retries.
+func NewConfig(cfg *retry.Config, codes ...codes.Code) *Config {
+	if cfg == nil {
+		return nil
+	}
+
+	return &Config{
+		Config: cfg,
+		Codes:  codes,
+	}
+}
+
 // Config configures retry behavior for gRPC unary client calls.
 //
 // It embeds shared retry mechanics and adds gRPC-specific failure classification.

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -21,6 +21,15 @@ func TestConfigRejectsInvalidCodes(t *testing.T) {
 	require.Error(t, test.Validator.Struct(test.NewGRPCRetryConfig(0, 0, codes.Code(17))))
 }
 
+func TestNewConfigReturnsGRPCConfig(t *testing.T) {
+	cfg := &config.Config{Attempts: 2, Backoff: time.Millisecond}
+	retrying := retry.NewConfig(cfg, codes.ResourceExhausted)
+
+	require.Same(t, cfg, retrying.Config)
+	require.Equal(t, []codes.Code{codes.ResourceExhausted}, retrying.Codes)
+	require.Nil(t, retry.NewConfig(nil))
+}
+
 func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(1, time.Millisecond))
 

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -13,6 +13,7 @@ import (
 	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
 	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
+	httpretry "github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
 )
@@ -111,7 +112,7 @@ func TestRoundTripperRetriesThroughClientLimiter(t *testing.T) {
 	rt, err := transporthttp.NewRoundTripper(
 		transporthttp.WithClientRoundTripper(base),
 		transporthttp.WithClientLimiter(clientLimiter),
-		transporthttp.WithClientRetry(test.NewHTTPClientRetryConfig(test.FastRetryConfig)),
+		transporthttp.WithClientRetry(httpretry.NewConfig(test.FastRetryConfig)),
 		transporthttp.WithClientUserAgent(test.UserAgent),
 	)
 	require.NoError(t, err)
@@ -131,7 +132,7 @@ func TestRoundTripperRetriesThroughClientBreaker(t *testing.T) {
 	base := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusServiceUnavailable, http.StatusOK}}
 	rt, err := transporthttp.NewRoundTripper(
 		transporthttp.WithClientRoundTripper(base),
-		transporthttp.WithClientRetry(test.NewHTTPClientRetryConfig(test.FastRetryConfig)),
+		transporthttp.WithClientRetry(httpretry.NewConfig(test.FastRetryConfig)),
 		transporthttp.WithClientBreaker(
 			breaker.WithSettings(breaker.Settings{
 				ReadyToTrip: func(counts breaker.Counts) bool {

--- a/transport/http/retry/config.go
+++ b/transport/http/retry/config.go
@@ -2,6 +2,20 @@ package retry
 
 import "github.com/alexfalkowski/go-service/v2/transport/retry"
 
+// NewConfig returns an HTTP retry config from shared retry mechanics.
+//
+// If cfg is nil, NewConfig returns nil so client option wiring can preserve disabled retries.
+func NewConfig(cfg *retry.Config, statusCodes ...int) *Config {
+	if cfg == nil {
+		return nil
+	}
+
+	return &Config{
+		Config:      cfg,
+		StatusCodes: statusCodes,
+	}
+}
+
 // Config configures retry behavior for outbound HTTP requests.
 //
 // It embeds shared retry mechanics and adds HTTP-specific failure classification.

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -25,6 +25,15 @@ func TestConfigRejectsInvalidStatusCodes(t *testing.T) {
 	require.Error(t, test.Validator.Struct(&retry.Config{StatusCodes: []int{600}}))
 }
 
+func TestNewConfigReturnsHTTPConfig(t *testing.T) {
+	cfg := &config.Config{Attempts: 2, Backoff: time.Millisecond}
+	retrying := retry.NewConfig(cfg, http.StatusBadGateway)
+
+	require.Same(t, cfg, retrying.Config)
+	require.Equal(t, []int{http.StatusBadGateway}, retrying.StatusCodes)
+	require.Nil(t, retry.NewConfig(nil))
+}
+
 func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/transport/retry/doc.go
+++ b/transport/retry/doc.go
@@ -46,9 +46,10 @@
 // # Usage
 //
 // Embed Config into larger service configuration when callers need shared retry mechanics.
-// Transport-specific retry configuration, such as HTTP or gRPC client retry config, embeds
-// Config and adds protocol-specific failure classification before it is passed to transport
-// wiring.
+// Transport-specific helpers, such as [github.com/alexfalkowski/go-service/v2/transport/http/retry.NewConfig]
+// and [github.com/alexfalkowski/go-service/v2/transport/grpc/retry.NewConfig], adapt Config into
+// transport-specific retry configuration with protocol-specific failure classification before it is passed to
+// transport wiring.
 //
 // Start with Config in config.go.
 package retry


### PR DESCRIPTION
## What

- Add HTTP and gRPC retry config constructors that adapt shared retry mechanics into transport-specific retry configs.
- Preserve disabled retry wiring by returning nil when the shared retry config is nil.
- Update internal test constructors, README guidance, and retry package docs to use the transport-specific constructors.
- Cover the new constructors with HTTP and gRPC retry package tests.

## Why

- Downstream clients can pass shared client retry config through transport-specific helpers without repeating struct literals or accidentally enabling retry when config is omitted.
- Transport-specific failure classification stays owned by the HTTP and gRPC retry packages while shared retry mechanics remain reusable.

## Testing

- `make package=transport/http/retry specs` - passed
- `make package=transport/grpc/retry specs` - passed
- `make lint` - passed
- `git diff --check` - passed
