### PR TITLE
feat(sql): tune idle pool aging

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ sql:
       - url: env:PG_READER_DSN
     max_open_conns: 5
     max_idle_conns: 5
+    conn_max_idle_time: 30m
     conn_max_lifetime: 1h
 ```
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -358,6 +358,7 @@ func verifySQLConfig(t *testing.T, cfg *config.Config) {
 	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Readers[0].URL)
 	require.Equal(t, 5, cfg.SQL.PG.MaxIdleConns)
 	require.Equal(t, 5, cfg.SQL.PG.MaxOpenConns)
+	require.Equal(t, 30*time.Minute, cfg.SQL.PG.ConnMaxIdleTime)
 	require.Equal(t, time.Hour, cfg.SQL.PG.ConnMaxLifetime)
 }
 

--- a/database/sql/config/config.go
+++ b/database/sql/config/config.go
@@ -32,6 +32,11 @@ type Config struct {
 	// In config files it is encoded as a Go duration string (for example "30s", "5m", "1h").
 	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime,omitempty" json:"conn_max_lifetime,omitempty" toml:"conn_max_lifetime,omitempty" validate:"gte=0"`
 
+	// ConnMaxIdleTime is the maximum amount of time a connection may remain idle.
+	//
+	// In config files it is encoded as a Go duration string (for example "30s", "5m", "1h").
+	ConnMaxIdleTime time.Duration `yaml:"conn_max_idle_time,omitempty" json:"conn_max_idle_time,omitempty" toml:"conn_max_idle_time,omitempty" validate:"gte=0"`
+
 	// MaxOpenConns is the maximum number of open connections to the database.
 	MaxOpenConns int `yaml:"max_open_conns" json:"max_open_conns" toml:"max_open_conns" validate:"gt=0"`
 

--- a/database/sql/config/config_test.go
+++ b/database/sql/config/config_test.go
@@ -25,6 +25,11 @@ func TestConfigValidation(t *testing.T) {
 			err:  true,
 		},
 		{
+			name: "negative conn max idle time",
+			cfg:  &config.Config{ConnMaxIdleTime: -time.Second, MaxOpenConns: 1, MaxIdleConns: 1},
+			err:  true,
+		},
+		{
 			name: "negative max open conns",
 			cfg:  &config.Config{MaxOpenConns: -1, MaxIdleConns: 1},
 			err:  true,

--- a/database/sql/driver/connect.go
+++ b/database/sql/driver/connect.go
@@ -109,6 +109,7 @@ func connect(name string, fs *os.FS, cfg *config.Config, opts ...telemetry.Optio
 		return nil, err
 	}
 
+	db.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
 	db.SetConnMaxLifetime(cfg.ConnMaxLifetime)
 	db.SetMaxIdleConns(cfg.MaxIdleConns)
 	db.SetMaxOpenConns(cfg.MaxOpenConns)

--- a/database/sql/driver/db.go
+++ b/database/sql/driver/db.go
@@ -94,6 +94,14 @@ func (d *DBs) SetConnMaxLifetime(v time.Duration) {
 	}
 }
 
+// SetConnMaxIdleTime sets the maximum amount of time a connection may remain idle
+// across all pools.
+func (d *DBs) SetConnMaxIdleTime(v time.Duration) {
+	for _, db := range d.databases() {
+		db.SetConnMaxIdleTime(v.Duration())
+	}
+}
+
 // SetMaxIdleConns sets the maximum number of idle connections across all pools.
 func (d *DBs) SetMaxIdleConns(v int) {
 	for _, db := range d.databases() {

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -360,6 +360,7 @@ func TestInvalidSQLPort(t *testing.T) {
 		Readers:         []config.DSN{{URL: test.FilePath("secrets/pg_invalid")}},
 		MaxOpenConns:    5,
 		MaxIdleConns:    5,
+		ConnMaxIdleTime: 30 * time.Minute,
 		ConnMaxLifetime: time.Hour,
 	}}
 

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -329,6 +329,7 @@ func NewPGConfigWithDSNs(writers, readers []sql.DSN) *pg.Config {
 			Readers:         readers,
 			MaxOpenConns:    5,
 			MaxIdleConns:    5,
+			ConnMaxIdleTime: 30 * time.Minute,
 			ConnMaxLifetime: time.Hour,
 		},
 	}

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -64,6 +64,7 @@
       ]
       max_open_conns: 5
       max_idle_conns: 5
+      conn_max_idle_time: "30m"
       conn_max_lifetime: "1h"
     }
   }

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -49,6 +49,7 @@ kind = "uuid"
 [sql.pg]
 max_open_conns = 5
 max_idle_conns = 5
+conn_max_idle_time = "30m"
 conn_max_lifetime = "1h"
 
 [[sql.pg.writers]]

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -43,6 +43,7 @@ sql:
       - url: file:../test/secrets/pg
     max_open_conns: 5
     max_idle_conns: 5
+    conn_max_idle_time: 30m
     conn_max_lifetime: 1h
 telemetry:
   logger:


### PR DESCRIPTION
## What

- Add `conn_max_idle_time` to shared SQL pool configuration.
- Apply the configured idle-age limit to every writer and reader database pool.
- Update README, shared test fixtures, config fixtures, and validation coverage for the new field.

## Why

- Operators can align client-side SQL idle connection aging with database, proxy, or infrastructure idle timeout policies without custom wiring.
- The new field fits alongside the existing pool controls for open connections, idle connections, and maximum connection lifetime while preserving zero-value database/sql defaults.

## Testing

- `make package=database/sql/config specs` - passed
- `make package=database/sql/driver specs` - passed
- `make package=database/sql/pg specs` - passed
- `make package=config specs` - passed
- `make lint` - passed
- `git diff --check` - passed
