### PR TITLE
feat(telemetry): add configurable resource labels and export controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,10 +486,18 @@ Telemetry config root is `telemetry.Config`:
 
 ```yaml
 telemetry:
+  attributes:
+    k8s.namespace.name: payments
+    service.instance.id: instance-1
   logger: ...
   metrics: ...
   tracer: ...
 ```
+
+`attributes` are plain OpenTelemetry resource labels attached to logs, metrics,
+and traces. They are not source strings. Fixed go-service identity attributes
+such as `host.id`, `service.name`, `service.version`, and
+`deployment.environment.name` take precedence if the same key is configured.
 
 ### Logging
 
@@ -568,9 +576,14 @@ telemetry:
   metrics:
     kind: otlp
     url: http://localhost:9009/otlp/v1/metrics
+    interval: 30s
+    timeout: 5s
     headers:
       Authorization: env:OTLP_METRICS_AUTH
 ```
+
+`interval` and `timeout` apply only to OTLP push metrics. When either value is
+unset or zero, the OpenTelemetry SDK default is used.
 
 ### Tracing
 
@@ -581,12 +594,27 @@ telemetry:
   tracer:
     kind: otlp
     url: http://localhost:4318/v1/traces
+    sampler:
+      kind: ratio
+      ratio: 0.25
     headers:
       Authorization: env:OTLP_TRACES_AUTH
 ```
 
 > [!NOTE]
 > Current tracer wiring exports via OTLP/HTTP when `telemetry.tracer.kind` is `otlp` and `url` is configured.
+>
+> Supported sampler kinds:
+>
+> - `always_on`: record every trace.
+> - `always_off`: drop every trace.
+> - `ratio`: follow an incoming parent span's sampled decision when the request
+>   already has trace context; otherwise record the configured fraction of new
+>   root traces. Set `ratio` between `0` and `1`, where `0` drops new root
+>   traces and `1` records all new root traces.
+>
+> When `sampler` is omitted, go-service preserves the OpenTelemetry SDK default
+> sampler and SDK sampler environment handling.
 
 ### Telemetry libraries used
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,6 +57,7 @@ func TestValidHomeFileConfig(t *testing.T) {
 func TestInvalidFileConfig(t *testing.T) {
 	files := []string{
 		test.FilePath("configs/invalid.yml"),
+		test.FilePath("configs/invalid_telemetry.config.yml"),
 		test.FilePath("configs/invalid_trace.yml"),
 		test.FilePath("configs/missing.yml"),
 		test.FilePath("configs/script.sh"),
@@ -367,9 +368,15 @@ func verifyTelemetryConfig(t *testing.T, cfg *config.Config) {
 
 	require.Equal(t, "text", cfg.Telemetry.Logger.Kind)
 	require.Equal(t, "info", cfg.Telemetry.Logger.Level)
+	require.Equal(t, "payments", cfg.Telemetry.Attributes["k8s.namespace.name"])
+	require.Equal(t, "instance-1", cfg.Telemetry.Attributes["service.instance.id"])
 	require.Equal(t, "prometheus", cfg.Telemetry.Metrics.Kind)
+	require.Equal(t, 30*time.Second, cfg.Telemetry.Metrics.Interval)
+	require.Equal(t, 5*time.Second, cfg.Telemetry.Metrics.Timeout)
 	require.Equal(t, "http://localhost:4318/v1/traces", cfg.Telemetry.Tracer.URL)
 	require.Equal(t, "otlp", cfg.Telemetry.Tracer.Kind)
+	require.Equal(t, "ratio", cfg.Telemetry.Tracer.Sampler.Kind)
+	require.InDelta(t, 0.25, cfg.Telemetry.Tracer.Sampler.Ratio, 0.001)
 }
 
 func verifyTimeConfig(t *testing.T, cfg *config.Config) {

--- a/config/module.go
+++ b/config/module.go
@@ -26,6 +26,7 @@ var Module = di.Module(
 	di.Constructor(environmentConfig), di.Constructor(cacheConfig),
 	di.Constructor(debugConfig), di.Constructor(idConfig), di.Constructor(timeConfig),
 	di.Constructor(pgConfig), di.Constructor(featureConfig), di.Constructor(hooksConfig),
+	di.Constructor(attributeMap),
 	di.Constructor(loggerConfig), di.Constructor(tracerConfig), di.Constructor(metricsConfig),
 	di.Constructor(accessConfig), di.Constructor(grpcConfig), di.Constructor(httpConfig),
 )

--- a/config/telemetry.go
+++ b/config/telemetry.go
@@ -2,10 +2,18 @@ package config
 
 import (
 	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 )
+
+func attributeMap(cfg *Config) attributes.Map {
+	if cfg.Telemetry.IsEnabled() {
+		return cfg.Telemetry.Attributes
+	}
+	return nil
+}
 
 func loggerConfig(cfg *Config, fs *os.FS) *logger.Config {
 	if cfg.Telemetry.IsEnabled() && cfg.Telemetry.Logger.IsEnabled() {

--- a/telemetry/attributes/attributes.go
+++ b/telemetry/attributes/attributes.go
@@ -2,14 +2,15 @@ package attributes
 
 import (
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 // SchemaURL is the OpenTelemetry semantic conventions schema URL used by this package.
 //
 // It is an alias of [semconv.SchemaURL] and is typically passed to
-// [go.opentelemetry.io/otel/sdk/resource.NewWithAttributes] to declare which semantic-convention schema version
-// the provided attributes follow.
+// [resource.NewWithAttributes] to declare which semantic-convention schema
+// version the provided attributes follow.
 const SchemaURL = semconv.SchemaURL
 
 // Key aliases [attribute.Key] for callers that want to work with OpenTelemetry
@@ -25,6 +26,18 @@ type Key = attribute.Key
 //
 // Functions in this package return KeyValue-compatible values.
 type KeyValue = attribute.KeyValue
+
+// Resource aliases [resource.Resource] for callers that want to exchange
+// OpenTelemetry resources through this package without importing the SDK
+// resource package directly.
+type Resource = resource.Resource
+
+// Map contains configured OpenTelemetry resource attributes.
+//
+// Values are plain labels, not go-service source strings. Provider identity
+// attributes added by [NewResource] take precedence over duplicate configured
+// keys.
+type Map map[string]string
 
 // DBSystemNamePostgreSQL identifies PostgreSQL as the value of the
 // db.system.name semantic-convention attribute.
@@ -122,4 +135,24 @@ func DeploymentEnvironmentName(env string) attribute.KeyValue {
 	}
 
 	return semconv.DeploymentEnvironmentNameDevelopment
+}
+
+// NewResource constructs the OpenTelemetry resource used by go-service providers.
+//
+// Configured resource attributes are added first, then the fixed go-service
+// identity attributes are appended so they win on duplicate keys.
+func NewResource(attrs Map, id, name, version, environment string) *Resource {
+	resourceAttrs := make([]attribute.KeyValue, 0, len(attrs)+4)
+	for key, value := range attrs {
+		resourceAttrs = append(resourceAttrs, attribute.String(key, value))
+	}
+
+	resourceAttrs = append(resourceAttrs,
+		HostID(id),
+		ServiceName(name),
+		ServiceVersion(version),
+		DeploymentEnvironmentName(environment),
+	)
+
+	return resource.NewWithAttributes(SchemaURL, resourceAttrs...)
 }

--- a/telemetry/attributes/attributes_test.go
+++ b/telemetry/attributes/attributes_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResourceMergesConfiguredAttributesWithIdentity(t *testing.T) {
+	t.Parallel()
+
+	resource := attributes.NewResource(
+		attributes.Map{
+			"k8s.namespace.name":                                 "payments",
+			string(attributes.HostID("").Key):                    "configured",
+			string(attributes.ServiceName("").Key):               "configured",
+			string(attributes.ServiceVersion("").Key):            "configured",
+			string(attributes.DeploymentEnvironmentName("").Key): "configured",
+		},
+		"host-id",
+		"service-name",
+		"service-version",
+		"prod",
+	)
+	attrs := resourceAttributes(resource.Attributes())
+
+	require.Equal(t, "payments", attrs["k8s.namespace.name"])
+	require.Equal(t, "host-id", attrs["host.id"])
+	require.Equal(t, "service-name", attrs["service.name"])
+	require.Equal(t, "service-version", attrs["service.version"])
+	require.Equal(t, "production", attrs["deployment.environment.name"])
+}
+
 func TestDeploymentEnvironmentName(t *testing.T) {
 	t.Parallel()
 
@@ -38,4 +63,12 @@ func TestDeploymentEnvironmentName(t *testing.T) {
 			require.Equal(t, tt.expected, attribute.Value.AsString())
 		})
 	}
+}
+
+func resourceAttributes(attrs []attributes.KeyValue) map[string]string {
+	values := make(map[string]string)
+	for _, attr := range attrs {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	return values
 }

--- a/telemetry/attributes/doc.go
+++ b/telemetry/attributes/doc.go
@@ -19,7 +19,7 @@
 //   - [DeploymentEnvironmentName]
 //
 // These helpers return attribute.KeyValue values that can be passed to
-// [go.opentelemetry.io/otel/sdk/resource.NewWithAttributes].
+// [NewResource].
 //
 // # Schema URL
 //

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
@@ -21,6 +22,14 @@ import (
 // own enable/disable semantics based on their specific config (for example nil
 // config or an empty kind).
 type Config struct {
+	// Attributes are OpenTelemetry resource attributes attached to all configured
+	// telemetry providers.
+	//
+	// Values are plain resource labels, not source strings. Fixed service identity
+	// attributes such as service.name and service.version take precedence over
+	// duplicate keys.
+	Attributes attributes.Map `yaml:"attributes,omitempty" json:"attributes,omitempty" toml:"attributes,omitempty"`
+
 	// Logger configures application/system logging output and exporters.
 	Logger *logger.Config `yaml:"logger,omitempty" json:"logger,omitempty" toml:"logger,omitempty"`
 

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -36,6 +36,11 @@
 // subpackages may also support their own enable/disable semantics (for example
 // nil config or empty kind).
 //
+// [Config.Attributes] attaches plain OpenTelemetry resource labels to configured
+// logs, metrics, and traces. These values are not source strings. Fixed
+// go-service identity attributes such as service.name and service.version take
+// precedence over duplicate configured keys.
+//
 // # OTLP endpoint security
 //
 // Logger, metrics, and tracer OTLP exporters may send per-signal Headers fields as outbound request

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 )
 
 const (
@@ -96,6 +97,10 @@ type LoggerParams struct {
 	//
 	// A nil Config disables logging and causes NewLogger to return (nil, nil).
 	Config *Config
+
+	// Attributes are optional OpenTelemetry resource attributes attached to
+	// exporter-backed logs.
+	Attributes attributes.Map `optional:"true"`
 
 	// ID identifies the host or instance emitting logs.
 	//

--- a/telemetry/logger/otlp.go
+++ b/telemetry/logger/otlp.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/sdk/log"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
@@ -30,12 +29,12 @@ func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
 		return nil, err
 	}
 
-	attrs := resource.NewWithAttributes(
-		attributes.SchemaURL,
-		attributes.HostID(params.ID.String()),
-		attributes.ServiceName(params.Name.String()),
-		attributes.ServiceVersion(params.Version.String()),
-		attributes.DeploymentEnvironmentName(params.Environment.String()),
+	attrs := attributes.NewResource(
+		params.Attributes,
+		params.ID.String(),
+		params.Name.String(),
+		params.Version.String(),
+		params.Environment.String(),
 	)
 
 	provider := log.NewLoggerProvider(log.WithProcessor(log.NewBatchProcessor(exporter)), log.WithResource(attrs))

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "github.com/alexfalkowski/go-service/v2/telemetry/header"
+import (
+	"github.com/alexfalkowski/go-service/v2/telemetry/header"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
 
 // Config configures OpenTelemetry metrics export.
 type Config struct {
@@ -34,6 +37,18 @@ type Config struct {
 	//
 	// For "prometheus", URL is typically ignored by the exporter/reader implementation.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty" validate:"omitempty,http_url"`
+
+	// Interval is the OTLP periodic export interval.
+	//
+	// A zero value keeps the OpenTelemetry SDK default. Negative values are
+	// invalid. This field only applies when Kind is "otlp".
+	Interval time.Duration `yaml:"interval,omitempty" json:"interval,omitempty" toml:"interval,omitempty" validate:"gte=0"`
+
+	// Timeout is the OTLP periodic export timeout.
+	//
+	// A zero value keeps the OpenTelemetry SDK default. Negative values are
+	// invalid. This field only applies when Kind is "otlp".
+	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gte=0"`
 }
 
 // IsEnabled reports whether metrics configuration is present.

--- a/telemetry/metrics/doc.go
+++ b/telemetry/metrics/doc.go
@@ -37,6 +37,9 @@
 //
 // If [Config.Kind] is unknown, NewReader returns [ErrNotFound].
 //
+// For "otlp", [Config.Interval] and [Config.Timeout] configure the periodic
+// reader export cadence. Zero values preserve the OpenTelemetry SDK defaults.
+//
 // # OTLP endpoint security
 //
 // When [Config.Headers] is non-empty, non-loopback "http://" OTLP endpoints are
@@ -64,6 +67,8 @@
 //   - deployment.environment.name
 //
 // These values come from go-service env types provided via DI.
+// Additional configured resource attributes are also attached, with the fixed
+// identity attributes taking precedence on duplicate keys.
 //
 // # Lifecycle behavior
 //

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/host"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 var (
@@ -29,12 +28,15 @@ type MeterProviderParams struct {
 	// meter provider with the application.
 	Lifecycle di.Lifecycle
 
-	// Config enables metrics when non-nil and supplies exporter settings.
-	Config *Config
-
 	// Reader is the SDK reader/exporter that NewMeterProvider will attach to the provider.
 	// A nil reader disables metrics even when Config is set.
 	Reader sdk.Reader
+
+	// Config enables metrics when non-nil and supplies exporter settings.
+	Config *Config
+
+	// Attributes are optional OpenTelemetry resource attributes attached to metrics.
+	Attributes attributes.Map `optional:"true"`
 
 	// ID is the host identifier used for the resource's host.id attribute.
 	ID env.ID
@@ -71,12 +73,12 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		return noopProvider
 	}
 
-	attrs := resource.NewWithAttributes(
-		attributes.SchemaURL,
-		attributes.HostID(params.ID.String()),
-		attributes.ServiceName(params.Name.String()),
-		attributes.ServiceVersion(params.Version.String()),
-		attributes.DeploymentEnvironmentName(params.Environment.String()),
+	attrs := attributes.NewResource(
+		params.Attributes,
+		params.ID.String(),
+		params.Name.String(),
+		params.Version.String(),
+		params.Environment.String(),
 	)
 	provider := sdk.NewMeterProvider(sdk.WithReader(params.Reader), sdk.WithResource(attrs))
 	setMeterProvider(provider, true)

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -1,11 +1,15 @@
 package metrics_test
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/time"
+	sync "github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -85,16 +89,21 @@ func TestMeterProviderStopResetsGlobalState(t *testing.T) {
 	require.NotEqual(t, provider, metrics.GetMeterProvider())
 }
 
-func TestMeterProviderResourceAttributes(t *testing.T) {
+func TestMeterProviderAttributes(t *testing.T) {
 	t.Cleanup(func() {
 		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	})
 
 	reader := metrics.NewManualReader()
 	provider := metrics.NewMeterProvider(metrics.MeterProviderParams{
-		Lifecycle:   fxtest.NewLifecycle(t),
-		Config:      &metrics.Config{},
-		Reader:      reader,
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config:    &metrics.Config{},
+		Reader:    reader,
+		Attributes: attributes.Map{
+			"k8s.namespace.name":                      "payments",
+			string(attributes.ServiceName("").Key):    "configured",
+			string(attributes.ServiceVersion("").Key): "configured",
+		},
 		ID:          test.ID,
 		Name:        test.Name,
 		Version:     test.Version,
@@ -112,6 +121,50 @@ func TestMeterProviderResourceAttributes(t *testing.T) {
 	require.Equal(t, test.Name.String(), attrs[attributes.ServiceName("").Key])
 	require.Equal(t, test.Version.String(), attrs[attributes.ServiceVersion("").Key])
 	require.Equal(t, "development", attrs[attributes.DeploymentEnvironmentName("").Key])
+	require.Equal(t, "payments", attrs[attributes.Key("k8s.namespace.name")])
+}
+
+func TestOTLPReaderUsesConfiguredInterval(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	var exports sync.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		exports.Add(1)
+		res.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	lc := fxtest.NewLifecycle(t)
+	cfg := &metrics.Config{
+		Kind:     "otlp",
+		URL:      server.URL,
+		Interval: 20 * time.Millisecond,
+		Timeout:  time.Second,
+	}
+	reader, err := metrics.NewReader(lc, test.Name, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = reader.Shutdown(t.Context())
+	})
+
+	provider := metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   lc,
+		Config:      cfg,
+		Reader:      reader,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+	counter, err := provider.Meter(test.Name.String()).Int64Counter("requests")
+	require.NoError(t, err)
+	counter.Add(t.Context(), 1)
+
+	require.Eventually(t, func() bool {
+		return exports.Load() > 0
+	}, (2 * time.Second).Duration(), (20 * time.Millisecond).Duration())
 }
 
 func resourceAttributes(rm metrics.ResourceMetrics) map[attributes.Key]string {

--- a/telemetry/metrics/reader.go
+++ b/telemetry/metrics/reader.go
@@ -62,7 +62,7 @@ func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
 		if err != nil {
 			return nil, prefix(err)
 		}
-		return metric.NewPeriodicReader(exporter), nil
+		return metric.NewPeriodicReader(exporter, periodicReaderOptions(cfg)...), nil
 	case "prometheus":
 		exporter, err := prometheus.New(prometheus.WithNamespace(name.String()))
 		if err != nil {
@@ -72,4 +72,16 @@ func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
 	default:
 		return nil, ErrNotFound
 	}
+}
+
+func periodicReaderOptions(cfg *Config) []metric.PeriodicReaderOption {
+	opts := make([]metric.PeriodicReaderOption, 0, 2)
+	if cfg.Interval > 0 {
+		opts = append(opts, metric.WithInterval(cfg.Interval.Duration()))
+	}
+	if cfg.Timeout > 0 {
+		opts = append(opts, metric.WithTimeout(cfg.Timeout.Duration()))
+	}
+
+	return opts
 }

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -15,6 +15,12 @@ type Config struct {
 	// exporter (for example via header.Map.Secrets or header.Map.MustSecrets).
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
 
+	// Sampler configures trace head sampling.
+	//
+	// A nil or empty sampler preserves the OpenTelemetry SDK default sampler and
+	// SDK environment handling. When set, it overrides those defaults.
+	Sampler *SamplerConfig `yaml:"sampler,omitempty" json:"sampler,omitempty" toml:"sampler,omitempty"`
+
 	// Kind selects the tracer/exporter implementation.
 	//
 	// An empty kind means tracing is not configured. This package supports "otlp" and
@@ -33,5 +39,25 @@ type Config struct {
 //
 // A nil *[Config] or empty Kind indicates tracing is disabled.
 func (c *Config) IsEnabled() bool {
+	return c != nil && c.Kind != ""
+}
+
+// SamplerConfig configures trace head sampling.
+type SamplerConfig struct {
+	// Kind selects the sampler implementation.
+	//
+	// Supported values are "always_on", "always_off", and "ratio".
+	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty" validate:"omitempty,oneof=always_on always_off ratio"`
+
+	// Ratio is the fraction used by the ratio sampler when starting root traces.
+	//
+	// Values must be between 0 and 1, inclusive. A zero ratio drops new root
+	// traces and a ratio of 1 samples every new root trace. Incoming parent
+	// sampling decisions are preserved.
+	Ratio float64 `yaml:"ratio,omitempty" json:"ratio,omitempty" toml:"ratio,omitempty" validate:"gte=0,lte=1"`
+}
+
+// IsEnabled reports whether sampler configuration is present.
+func (c *SamplerConfig) IsEnabled() bool {
 	return c != nil && c.Kind != ""
 }

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -8,7 +8,8 @@
 //
 // The provider is configured with a Resource describing the running service instance,
 // including standard service identity attributes (host ID, service name, service version,
-// and deployment environment name).
+// and deployment environment name) plus any configured resource attributes. Fixed
+// service identity attributes take precedence on duplicate keys.
 //
 // # Enablement model
 //
@@ -39,6 +40,10 @@
 //
 // The supported kind is "otlp". Unknown non-empty kinds cause Register to return
 // ErrNotFound.
+//
+// [Config.Sampler] optionally configures head sampling. When omitted, Register
+// preserves the OpenTelemetry SDK default sampler and SDK sampler environment
+// handling. When set, it overrides those defaults.
 //
 // The exporter request headers are provided by [Config.Headers]. Header values may be
 // configured as go-service "source strings" (for example "env:NAME", "file:/path", or a

--- a/telemetry/tracer/errors.go
+++ b/telemetry/tracer/errors.go
@@ -5,6 +5,9 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // ErrNotFound is returned when the configured tracer kind is unknown.
 var ErrNotFound = errors.New("tracer: not found")
 
+// ErrInvalidSampler is returned when sampler configuration is invalid.
+var ErrInvalidSampler = errors.New("tracer: invalid sampler")
+
 func prefix(err error) error {
 	return errors.Prefix("tracer", err)
 }

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alexfalkowski/go-sync"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -30,11 +29,40 @@ type SpanExporter = sdk.SpanExporter
 // Provider is an alias for [trace.TracerProvider].
 type Provider = trace.TracerProvider
 
+// SpanContext is an alias for [trace.SpanContext].
+type SpanContext = trace.SpanContext
+
+// SpanContextConfig is an alias for [trace.SpanContextConfig].
+type SpanContextConfig = trace.SpanContextConfig
+
+// SpanID is an alias for [trace.SpanID].
+type SpanID = trace.SpanID
+
 // SDKProvider is an alias for [go.opentelemetry.io/otel/sdk/trace.TracerProvider].
 type SDKProvider = sdk.TracerProvider
 
+// TraceFlags is an alias for [trace.TraceFlags].
+type TraceFlags = trace.TraceFlags
+
+// TraceID is an alias for [trace.TraceID].
+type TraceID = trace.TraceID
+
 // ProviderOption is an alias for [go.opentelemetry.io/otel/sdk/trace.TracerProviderOption].
 type ProviderOption = sdk.TracerProviderOption
+
+// FlagsSampled is an alias for [trace.FlagsSampled].
+const FlagsSampled = trace.FlagsSampled
+
+// ContextWithRemoteSpanContext returns a copy of parent with sc set as the
+// current remote span context.
+func ContextWithRemoteSpanContext(parent context.Context, sc SpanContext) context.Context {
+	return trace.ContextWithRemoteSpanContext(parent, sc)
+}
+
+// NewSpanContext constructs a SpanContext from config.
+func NewSpanContext(config SpanContextConfig) SpanContext {
+	return trace.NewSpanContext(config)
+}
 
 // NewProvider constructs an OpenTelemetry SDK tracer provider.
 func NewProvider(opts ...ProviderOption) *SDKProvider {
@@ -63,6 +91,9 @@ type TracerParams struct {
 
 	// Config enables tracing when non-nil and supplies exporter settings.
 	Config *Config
+
+	// Attributes are optional OpenTelemetry resource attributes attached to traces.
+	Attributes attributes.Map `optional:"true"`
 
 	// ID is the host identifier used for the resource's host.id attribute.
 	ID env.ID
@@ -111,15 +142,24 @@ func Register(params TracerParams) error {
 
 		client := otlptracehttp.NewClient(opts...)
 		exporter := otlptrace.NewUnstarted(client)
-		attrs := resource.NewWithAttributes(
-			attributes.SchemaURL,
-			attributes.HostID(params.ID.String()),
-			attributes.ServiceName(params.Name.String()),
-			attributes.ServiceVersion(params.Version.String()),
-			attributes.DeploymentEnvironmentName(params.Environment.String()),
+		attrs := attributes.NewResource(
+			params.Attributes,
+			params.ID.String(),
+			params.Name.String(),
+			params.Version.String(),
+			params.Environment.String(),
 		)
 
-		provider := sdk.NewTracerProvider(sdk.WithResource(attrs), sdk.WithBatcher(exporter))
+		providerOpts := []sdk.TracerProviderOption{sdk.WithResource(attrs), sdk.WithBatcher(exporter)}
+		sampler, err := newSampler(params.Config.Sampler)
+		if err != nil {
+			return prefix(err)
+		}
+		if sampler != nil {
+			providerOpts = append(providerOpts, sdk.WithSampler(sampler))
+		}
+
+		provider := sdk.NewTracerProvider(providerOpts...)
 		setProvider(provider, true)
 
 		params.Lifecycle.Append(di.Hook{
@@ -145,4 +185,24 @@ func Register(params TracerParams) error {
 // IsEnabled reports whether this package has registered tracing as enabled.
 func IsEnabled() bool {
 	return enabled.Load()
+}
+
+func newSampler(cfg *SamplerConfig) (sdk.Sampler, error) {
+	if !cfg.IsEnabled() {
+		return nil, nil
+	}
+	if cfg.Ratio < 0 || cfg.Ratio > 1 {
+		return nil, ErrInvalidSampler
+	}
+
+	switch cfg.Kind {
+	case "always_on":
+		return sdk.AlwaysSample(), nil
+	case "always_off":
+		return sdk.NeverSample(), nil
+	case "ratio":
+		return sdk.ParentBased(sdk.TraceIDRatioBased(cfg.Ratio)), nil
+	default:
+		return nil, ErrInvalidSampler
+	}
 }

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -3,6 +3,7 @@ package tracer_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
@@ -80,6 +81,90 @@ func TestRegisterStopResetsGlobalProvider(t *testing.T) {
 	require.NoError(t, lc.Stop(t.Context()))
 
 	require.False(t, tracer.IsEnabled())
+}
+
+func TestRegisterSampler(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
+	})
+
+	tests := []struct {
+		sampler       *tracer.SamplerConfig
+		ctx           func(context.Context) context.Context
+		name          string
+		wantRecording bool
+	}{
+		{
+			name:          "always on",
+			sampler:       &tracer.SamplerConfig{Kind: "always_on"},
+			wantRecording: true,
+		},
+		{
+			name:    "always off",
+			sampler: &tracer.SamplerConfig{Kind: "always_off"},
+		},
+		{
+			name:    "ratio zero",
+			sampler: &tracer.SamplerConfig{Kind: "ratio", Ratio: 0},
+		},
+		{
+			name:          "ratio one",
+			sampler:       &tracer.SamplerConfig{Kind: "ratio", Ratio: 1},
+			wantRecording: true,
+		},
+		{
+			name:          "ratio keeps sampled parent",
+			sampler:       &tracer.SamplerConfig{Kind: "ratio", Ratio: 0},
+			ctx:           withSampledRemoteParent,
+			wantRecording: true,
+		},
+		{
+			name:    "ratio keeps unsampled parent",
+			sampler: &tracer.SamplerConfig{Kind: "ratio", Ratio: 1},
+			ctx:     withUnsampledRemoteParent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.ctx != nil {
+				ctx = tt.ctx(ctx)
+			}
+
+			requireSamplerRecording(t, tt.sampler, ctx, tt.wantRecording)
+		})
+	}
+}
+
+func TestRegisterInvalidSampler(t *testing.T) {
+	tests := []struct {
+		sampler *tracer.SamplerConfig
+		name    string
+	}{
+		{name: "invalid kind", sampler: &tracer.SamplerConfig{Kind: "wrong"}},
+		{name: "negative ratio", sampler: &tracer.SamplerConfig{Kind: "ratio", Ratio: -0.1}},
+		{name: "ratio above one", sampler: &tracer.SamplerConfig{Kind: "ratio", Ratio: 1.1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tracer.Register(tracer.TracerParams{
+				Lifecycle: fxtest.NewLifecycle(t),
+				Config: &tracer.Config{
+					Kind:    "otlp",
+					URL:     "https://localhost:4318/v1/traces",
+					Sampler: tt.sampler,
+				},
+				ID:          test.ID,
+				Name:        test.Name,
+				Version:     test.Version,
+				Environment: test.Environment,
+			})
+
+			require.ErrorIs(t, err, tracer.ErrInvalidSampler)
+		})
+	}
 }
 
 func TestRegisterInvalidKind(t *testing.T) {
@@ -160,4 +245,43 @@ func TestRegisterMissingOTLPEndpointIgnoresEnv(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
+}
+
+func withSampledRemoteParent(ctx context.Context) context.Context {
+	return tracer.ContextWithRemoteSpanContext(ctx, tracer.NewSpanContext(tracer.SpanContextConfig{
+		TraceID:    tracer.TraceID{1},
+		SpanID:     tracer.SpanID{1},
+		TraceFlags: tracer.FlagsSampled,
+		Remote:     true,
+	}))
+}
+
+func requireSamplerRecording(t *testing.T, sampler *tracer.SamplerConfig, ctx context.Context, want bool) {
+	t.Helper()
+
+	require.NoError(t, tracer.Register(tracer.TracerParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config: &tracer.Config{
+			Kind:    "otlp",
+			URL:     "https://localhost:4318/v1/traces",
+			Sampler: sampler,
+		},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}))
+
+	_, span := tracer.GetProvider().Tracer(test.Name.String()).Start(ctx, "request")
+	defer span.End()
+
+	require.Equal(t, want, span.IsRecording())
+}
+
+func withUnsampledRemoteParent(ctx context.Context) context.Context {
+	return tracer.ContextWithRemoteSpanContext(ctx, tracer.NewSpanContext(tracer.SpanContextConfig{
+		TraceID: tracer.TraceID{1},
+		SpanID:  tracer.SpanID{1},
+		Remote:  true,
+	}))
 }

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -69,16 +69,26 @@
     }
   }
   telemetry: {
+    attributes: {
+      "k8s.namespace.name": payments
+      "service.instance.id": "instance-1"
+    }
     logger: {
       kind: text
       level: info
     }
     metrics: {
       kind: prometheus
+      interval: "30s"
+      timeout: "5s"
     }
     tracer: {
       kind: otlp
       url: "http://localhost:4318/v1/traces"
+      sampler: {
+        kind: ratio
+        ratio: 0.25
+      }
       headers: {
         Authorization: "file:../test/secrets/telemetry"
       }

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -62,12 +62,22 @@ url = "file:../test/secrets/pg"
 kind = "text"
 level = "info"
 
+[telemetry.attributes]
+"k8s.namespace.name" = "payments"
+"service.instance.id" = "instance-1"
+
 [telemetry.metrics]
 kind = "prometheus"
+interval = "30s"
+timeout = "5s"
 
 [telemetry.tracer]
 kind = "otlp"
 url = "http://localhost:4318/v1/traces"
+
+[telemetry.tracer.sampler]
+kind = "ratio"
+ratio = 0.25
 
 [telemetry.tracer.headers]
 Authorization = "file:../test/secrets/telemetry"

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -46,14 +46,22 @@ sql:
     conn_max_idle_time: 30m
     conn_max_lifetime: 1h
 telemetry:
+  attributes:
+    k8s.namespace.name: payments
+    service.instance.id: instance-1
   logger:
     kind: text
     level: info
   metrics:
     kind: prometheus
+    interval: 30s
+    timeout: 5s
   tracer:
     kind: otlp
     url: http://localhost:4318/v1/traces
+    sampler:
+      kind: ratio
+      ratio: 0.25
     headers:
       Authorization: file:../test/secrets/telemetry
 time:

--- a/test/configs/invalid_telemetry.config.yml
+++ b/test/configs/invalid_telemetry.config.yml
@@ -1,0 +1,10 @@
+telemetry:
+  metrics:
+    kind: otlp
+    interval: -1s
+    timeout: -1s
+  tracer:
+    kind: otlp
+    sampler:
+      kind: ratio
+      ratio: 1.1


### PR DESCRIPTION
## What

- Add `telemetry.attributes` so operators can attach configured OpenTelemetry resource labels to logs, metrics, and traces while fixed service identity attributes keep precedence.
- Add optional trace sampler config for always-on, always-off, ratio, and parent-based ratio sampling while preserving SDK defaults when omitted.
- Add OTLP metrics `interval` and `timeout` config, update docs and fixtures, and cover the new behavior with focused config and provider tests.

## Why

- Operators can now add deployment dimensions, control trace volume, and tune push metrics cadence through the standard config path instead of replacing repository-owned telemetry wiring.

## Testing

- `make specs package=config` - passed
- `make specs package=telemetry/attributes` - passed
- `make specs package=telemetry/logger` - passed
- `make specs package=telemetry/metrics` - passed
- `make specs package=telemetry/tracer` - passed
- `make lint` - passed
- `git diff --check` - passed
