### PR TITLE
feat(cache): report hits from get

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -59,11 +59,11 @@ func NewCache(params CacheParams) *Cache {
 	}
 
 	return &Cache{
-		cm:     params.Compressor,
-		em:     params.Encoder,
-		cfg:    params.Config,
-		pool:   params.Pool,
-		driver: params.Driver,
+		compress: params.Compressor,
+		encoding: params.Encoder,
+		config:   params.Config,
+		pool:     params.Pool,
+		driver:   params.Driver,
 	}
 }
 
@@ -80,42 +80,11 @@ func NewCache(params CacheParams) *Cache {
 //
 // Compression is selected from configuration, falling back to "none" when unknown/unavailable.
 type Cache struct {
-	cm     *compress.Map
-	em     *encoding.Map
-	cfg    *config.Config
-	pool   *sync.BufferPool
-	driver driver.Driver
-}
-
-// maxSizeWriter enforces the cache encoded-size limit at the writer boundary.
-// It prevents encoders from growing the intermediate buffer past max_size before
-// compression gets its own chance to validate the payload.
-type maxSizeWriter struct {
-	writer  io.Writer
-	max     int64
-	written int64
-}
-
-func (w *maxSizeWriter) Write(data []byte) (int, error) {
-	remaining := w.max - w.written
-	if int64(len(data)) > remaining {
-		if remaining <= 0 {
-			return 0, compresserrors.ErrTooLarge
-		}
-
-		n, err := w.writer.Write(data[:int(remaining)])
-		w.written += int64(n)
-		if err != nil {
-			return n, err
-		}
-
-		return n, compresserrors.ErrTooLarge
-	}
-
-	n, err := w.writer.Write(data)
-	w.written += int64(n)
-
-	return n, err
+	compress *compress.Map
+	encoding *encoding.Map
+	config   *config.Config
+	pool     *sync.BufferPool
+	driver   driver.Driver
 }
 
 // Flush removes cached data according to the underlying driver's flush semantics.
@@ -135,23 +104,27 @@ func (c *Cache) Remove(ctx context.Context, key string) error {
 	return c.driver.Delete(ctx, c.driverKey(key))
 }
 
-// Get loads a cached value for key into value.
+// Get loads a cached value for key into value and reports whether a value was found.
 //
-// Cache misses are not treated as errors: if the entry is missing or expired, Get returns nil and
-// leaves value unchanged.
+// Cache misses are not treated as errors: if the entry is missing or expired, Get returns
+// false, nil and leaves value unchanged.
 //
 // The value parameter should be a pointer to the destination value (for example *MyStruct).
-func (c *Cache) Get(ctx context.Context, key string, value any) error {
+func (c *Cache) Get(ctx context.Context, key string, value any) (bool, error) {
 	val, err := c.driver.Fetch(ctx, c.driverKey(key))
 	if err != nil {
 		if drivererrors.IsMissingError(err) || drivererrors.IsExpiredError(err) {
-			return nil
+			return false, nil
 		}
 
-		return err
+		return false, err
 	}
 
-	return c.decode(val, value)
+	if err := c.decode(val, value); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // Persist stores value under key with the provided TTL.
@@ -178,7 +151,7 @@ func (c *Cache) encode(value any) (string, error) {
 	buf := c.pool.Get()
 	defer c.pool.Put(buf)
 
-	maxSize := c.cfg.GetMaxSize()
+	maxSize := c.config.GetMaxSize()
 	writer := &maxSizeWriter{writer: buf, max: maxSize.Bytes()}
 	if err := c.writeEncoder(value).Encode(writer, value); err != nil {
 		return strings.Empty, err
@@ -199,7 +172,7 @@ func (c *Cache) encode(value any) (string, error) {
 }
 
 func (c *Cache) decode(value string, field any) error {
-	maxSize := c.cfg.GetMaxSize()
+	maxSize := c.config.GetMaxSize()
 	if maxSize.Bytes() <= maxBase64EncodedLenInput && int64(len(value)) > base64.EncodedLen(maxSize) {
 		return compresserrors.ErrTooLarge
 	}
@@ -219,12 +192,12 @@ func (c *Cache) decode(value string, field any) error {
 }
 
 func (c *Cache) compressor() compress.Compressor {
-	return c.cm.Get(c.compressorKind())
+	return c.compress.Get(c.compressorKind())
 }
 
 func (c *Cache) compressorKind() string {
-	if cmp := c.cm.Get(c.cfg.Compressor); cmp != nil {
-		return c.cfg.Compressor
+	if cmp := c.compress.Get(c.config.Compressor); cmp != nil {
+		return c.config.Compressor
 	}
 
 	return "none"
@@ -233,9 +206,9 @@ func (c *Cache) compressorKind() string {
 func (c *Cache) readEncoder(value any) encoding.Encoder {
 	switch value.(type) {
 	case io.ReaderFrom:
-		return c.em.Get("plain")
+		return c.encoding.Get("plain")
 	case proto.Message:
-		return c.em.Get("proto")
+		return c.encoding.Get("proto")
 	default:
 		return c.configuredEncoder()
 	}
@@ -244,21 +217,21 @@ func (c *Cache) readEncoder(value any) encoding.Encoder {
 func (c *Cache) writeEncoder(value any) encoding.Encoder {
 	switch value.(type) {
 	case io.WriterTo:
-		return c.em.Get("plain")
+		return c.encoding.Get("plain")
 	case proto.Message:
-		return c.em.Get("proto")
+		return c.encoding.Get("proto")
 	default:
 		return c.configuredEncoder()
 	}
 }
 
 func (c *Cache) configuredEncoder() encoding.Encoder {
-	return c.em.Get(c.encoderKind())
+	return c.encoding.Get(c.encoderKind())
 }
 
 func (c *Cache) encoderKind() string {
-	if enc := c.em.Get(c.cfg.Encoder); enc != nil {
-		return c.cfg.Encoder
+	if enc := c.encoding.Get(c.config.Encoder); enc != nil {
+		return c.config.Encoder
 	}
 
 	return "json"

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -39,8 +39,9 @@ func TestGenericValidCache(t *testing.T) {
 
 	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
-	value, err := cache.Get[string](t.Context(), "test")
+	value, ok, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, "hello?", *value)
 
 	require.NoError(t, world.Remove(t.Context(), "test"))
@@ -73,8 +74,9 @@ func TestModuleRegistersGenericCache(t *testing.T) {
 
 	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
-	value, err := cache.Get[string](t.Context(), "test")
+	value, ok, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, "hello?", *value)
 }
 
@@ -83,9 +85,50 @@ func TestGenericDisabledCache(t *testing.T) {
 
 	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
 
-	value, err := cache.Get[string](t.Context(), "test")
+	value, ok, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, value)
+}
+
+func TestGenericGetValidEmptyCache(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	require.NoError(t, cache.Persist(t.Context(), "test", new(""), time.Minute))
+
+	value, ok, err := cache.Get[string](t.Context(), "test")
+	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, strings.Empty, *value)
+
+	require.NoError(t, world.Remove(t.Context(), "test"))
+}
+
+func TestGenericGetMissingCache(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	value, ok, err := cache.Get[string](t.Context(), "missing")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, strings.Empty, *value)
+
+	require.NoError(t, world.Remove(t.Context(), "missing"))
+}
+
+func TestGenericGetDisabledCache(t *testing.T) {
+	cache.Register(nil)
+	t.Cleanup(func() {
+		cache.Register(nil)
+	})
+
+	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
+
+	value, ok, err := cache.Get[string](t.Context(), "test")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, value)
 }
 
 func TestMaxSizeOnPersist(t *testing.T) {
@@ -125,7 +168,7 @@ func TestMaxSizeOnGet(t *testing.T) {
 
 	cfg.MaxSize = 4
 
-	err := world.Get(t.Context(), "test", ptr.Zero[string]())
+	_, err := world.Get(t.Context(), "test", ptr.Zero[string]())
 	require.ErrorIs(t, err, compresserrors.ErrTooLarge)
 }
 
@@ -138,7 +181,9 @@ func TestMaxSizeOnGetAllowsEncodedValueLargerThanLimit(t *testing.T) {
 	)
 
 	value := ptr.Zero[string]()
-	require.NoError(t, world.Get(t.Context(), "test", value))
+	ok, err := world.Get(t.Context(), "test", value)
+	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, "ok", *value)
 }
 
@@ -150,7 +195,7 @@ func TestMaxSizeOnGetRejectsEncodedValueTooLarge(t *testing.T) {
 		test.WithWorldCacheDriver(&test.Cache{Value: base64.Encode(make([]byte, 7))}),
 	)
 
-	err := world.Get(t.Context(), "test", ptr.Zero[string]())
+	_, err := world.Get(t.Context(), "test", ptr.Zero[string]())
 	require.ErrorIs(t, err, compresserrors.ErrTooLarge)
 }
 
@@ -163,7 +208,9 @@ func TestMaxSizeOnGetAllowsHugeConfiguredLimit(t *testing.T) {
 	)
 
 	value := ptr.Zero[string]()
-	require.NoError(t, world.Get(t.Context(), "test", value))
+	ok, err := world.Get(t.Context(), "test", value)
+	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, "ok", *value)
 }
 
@@ -201,7 +248,9 @@ func TestGetMissesAfterCacheFormatChange(t *testing.T) {
 				test.WithWorldCacheDriver(drv),
 			)
 			value := "unchanged"
-			require.NoError(t, reader.Get(t.Context(), "test", &value))
+			ok, err := reader.Get(t.Context(), "test", &value)
+			require.NoError(t, err)
+			require.False(t, ok)
 			require.Equal(t, "unchanged", value)
 		})
 	}
@@ -215,8 +264,9 @@ func TestExpiredCache(t *testing.T) {
 	// Simulate expiry.
 	time.Sleep(time.Second)
 
-	_, err := cache.Get[string](t.Context(), "test")
+	_, ok, err := cache.Get[string](t.Context(), "test")
 	require.NoError(t, err)
+	require.False(t, ok)
 
 	require.NoError(t, world.Remove(t.Context(), "test"))
 }
@@ -272,7 +322,9 @@ func TestErroneousSave(t *testing.T) {
 		require.NoError(t, world.Persist(t.Context(), "test", &test.ReadFromOnly{Name: "hello?"}, time.Minute))
 
 		var get test.Request
-		require.NoError(t, world.Get(t.Context(), "test", &get))
+		ok, err := world.Get(t.Context(), "test", &get)
+		require.NoError(t, err)
+		require.True(t, ok)
 		require.Equal(t, "hello?", get.Name)
 	})
 }
@@ -296,7 +348,8 @@ func TestErroneousGet(t *testing.T) {
 				test.WithWorldCacheDriver(tt.driver),
 			)
 
-			require.Error(t, world.Get(t.Context(), "test", ptr.Zero[string]()))
+			_, err := world.Get(t.Context(), "test", ptr.Zero[string]())
+			require.Error(t, err)
 		})
 	}
 }
@@ -307,11 +360,39 @@ func TestWriteToOnlyUsesConfiguredEncoderOnGet(t *testing.T) {
 	require.NoError(t, world.Persist(t.Context(), "test", &test.Request{Name: "hello?"}, time.Minute))
 
 	get := &test.WriteToOnly{}
-	require.NoError(t, world.Get(t.Context(), "test", get))
+	ok, err := world.Get(t.Context(), "test", get)
+	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, "hello?", get.Name)
 }
 
-func TestMissingCache(t *testing.T) {
+func TestGetValidEmptyStringCache(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg))
+
+	require.NoError(t, world.Persist(t.Context(), "test", new(""), time.Minute))
+
+	value := "existing"
+	ok, err := world.Get(t.Context(), "test", &value)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, strings.Empty, value)
+}
+
+func TestGetValidEmptyBufferCache(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg))
+
+	require.NoError(t, world.Persist(t.Context(), "test", bytes.NewBufferString(strings.Empty), time.Minute))
+
+	value := bytes.NewBufferString("existing")
+	ok, err := world.Get(t.Context(), "test", value)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, value.Bytes())
+}
+
+func TestGetMissingCache(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &config.Config{Kind: "ttlcache", MaxEntries: config.DefaultMaxEntries}
 
@@ -335,11 +416,13 @@ func TestMissingCache(t *testing.T) {
 	})
 	value := "existing"
 
-	require.NoError(t, c.Get(t.Context(), "missing", &value))
+	ok, err := c.Get(t.Context(), "missing", &value)
+	require.NoError(t, err)
+	require.False(t, ok)
 	require.Equal(t, "existing", value)
 }
 
-func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
+func TestGetExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
 	cfg := &config.Config{Kind: "ttlcache", MaxEntries: config.DefaultMaxEntries}
 	c := cache.NewCache(cache.CacheParams{
 		Config:     cfg,
@@ -350,7 +433,9 @@ func TestExpiredCacheLeavesDestinationUnchanged(t *testing.T) {
 	})
 	value := "existing"
 
-	require.NoError(t, c.Get(t.Context(), "expired", &value))
+	ok, err := c.Get(t.Context(), "expired", &value)
+	require.NoError(t, err)
+	require.False(t, ok)
 	require.Equal(t, "existing", value)
 }
 

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -9,8 +9,8 @@
 //
 // In addition to the instance API on *[Cache], this package exposes package-level generic helpers
 // ([Get] and [Persist]). Those helpers are nil-safe after [Register] has been called (via DI wiring in
-// [Module]), and they become no-ops / return zero values when caching is disabled. In the standard
-// service composition this registration is performed for you by the module graph.
+// [Module]). When caching is disabled, [Persist] is a no-op and [Get] returns nil, false, nil. In the
+// standard service composition this registration is performed for you by the module graph.
 //
 // # Value encoding
 //

--- a/cache/generic.go
+++ b/cache/generic.go
@@ -14,27 +14,28 @@ var cache *Cache
 // Once registered, package-level helpers like [Get] and [Persist] will delegate to the registered
 // *[Cache] instance.
 //
-// If c is nil, the helpers behave as if caching is disabled (they return zero values / act as no-ops).
+// If c is nil, the helpers behave as if caching is disabled: [Get] returns nil, false, nil and
+// [Persist] is a no-op.
 func Register(c *Cache) {
 	cache = c
 }
 
-// Get loads a cached value for key into a newly allocated value of type T and returns it.
+// Get loads a cached value for key into a newly allocated value of type T and reports whether a value was found.
 //
 // Semantics:
-//   - If caching is disabled (no cache registered), [Get] returns a zero-value *T and a nil error.
-//   - If the cache driver reports a miss/expired entry, [Get] returns a zero-value *T and a nil error.
+//   - If caching is disabled (no cache registered), [Get] returns nil, false, and a nil error.
+//   - If the cache driver reports a miss/expired entry, [Get] returns a zero-value *T, false, and a nil error.
 //   - If a non-miss error occurs (for example decode failure or driver error), [Get] returns the
-//     zero-value *T along with that error.
-//
-// The returned pointer is always non-nil.
-func Get[T any](ctx context.Context, key string) (*T, error) {
-	value := ptr.Zero[T]()
+//     zero-value *T, false, along with that error.
+func Get[T any](ctx context.Context, key string) (*T, bool, error) {
 	if cache == nil {
-		return value, nil
+		return nil, false, nil
 	}
 
-	return value, cache.Get(ctx, key, value)
+	value := ptr.Zero[T]()
+	ok, err := cache.Get(ctx, key, value)
+
+	return value, ok, err
 }
 
 // Persist stores value under key with the provided TTL.

--- a/cache/writer.go
+++ b/cache/writer.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"github.com/alexfalkowski/go-service/v2/compress/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+)
+
+// maxSizeWriter enforces the cache encoded-size limit at the writer boundary.
+// It prevents encoders from growing the intermediate buffer past max_size before
+// compression gets its own chance to validate the payload.
+type maxSizeWriter struct {
+	writer  io.Writer
+	max     int64
+	written int64
+}
+
+func (w *maxSizeWriter) Write(data []byte) (int, error) {
+	remaining := w.max - w.written
+	if int64(len(data)) > remaining {
+		if remaining <= 0 {
+			return 0, errors.ErrTooLarge
+		}
+
+		n, err := w.writer.Write(data[:int(remaining)])
+		w.written += int64(n)
+		if err != nil {
+			return n, err
+		}
+
+		return n, errors.ErrTooLarge
+	}
+
+	n, err := w.writer.Write(data)
+	w.written += int64(n)
+
+	return n, err
+}

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -73,7 +73,9 @@ func RequireCacheRoundTrip(tb testing.TB, cfg *config.Config, persist, get any) 
 	world := NewStartedWorld(tb, WithWorldCacheConfig(cfg))
 
 	require.NoError(tb, world.Persist(tb.Context(), "test", persist, time.Minute))
-	require.NoError(tb, world.Get(tb.Context(), "test", get))
+	ok, err := world.Get(tb.Context(), "test", get)
+	require.NoError(tb, err)
+	require.True(tb, ok)
 	RequireCacheValue(tb, get)
 	require.NoError(tb, world.Remove(tb.Context(), "test"))
 }


### PR DESCRIPTION
## What

- Changed the cache read APIs so `Cache.Get` returns `(bool, error)` and generic `Get[T]` returns `(*T, bool, error)`.
- Kept misses and expired entries as non-error cache-aside outcomes while exposing `false` for the hit signal.
- Documented disabled generic-cache behavior as `nil, false, nil`, added coverage for missing, expired, disabled, and empty-value hits, and moved the max-size writer into its own file.

## Why

- Service authors need to distinguish cache misses from cached zero or empty values without sentinel values or bypassing the cache facade.
- Breaking the existing `Get` signature keeps hit reporting on the primary read API instead of adding a parallel lookup API.

## Testing

- `go test -count=1 ./...` - passed
- `go test -count=1 ./cache` - passed
- `make package=cache specs` - passed
- `make lint` - passed
