### PR TITLE
feat(telemetry): support authenticated remote collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,9 +602,28 @@ telemetry:
 > [!WARNING]
 > OTLP exporters reject non-loopback `http://` endpoints when headers are configured. Use HTTPS for remote collectors that require authorization headers; cleartext with headers is accepted only for local loopback endpoints.
 >
-> OTLP/gRPC exporters use `protocol: grpc` and a `host:port` endpoint such as `localhost:4317`. Header-bearing remote gRPC endpoints are rejected until TLS configuration is supported for OTLP/gRPC exporters.
+> OTLP/gRPC exporters use `protocol: grpc` and a `host:port` endpoint such as `localhost:4317`. Header-bearing remote gRPC endpoints require the signal's `tls` config; loopback gRPC endpoints may still use cleartext.
 >
 > OTLP exporter endpoints must be set in go-service config fields such as `telemetry.logger.url`, `telemetry.metrics.url`, and `telemetry.tracer.url`. Standard OpenTelemetry endpoint environment variables such as `OTEL_EXPORTER_OTLP_ENDPOINT` are not used as fallback sources.
+
+Remote OTLP/gRPC exporters can use the same TLS source-string model as other go-service clients:
+
+```yaml
+telemetry:
+  tracer:
+    kind: otlp
+    protocol: grpc
+    url: collector.example.com:4317
+    tls:
+      ca: file:/etc/otel/ca.pem
+      cert: file:/etc/otel/client.crt
+      key: file:/etc/otel/client.key
+      server_name: collector.example.com
+    headers:
+      Authorization: env:OTLP_TRACES_AUTH
+```
+
+Use the same `tls` shape under `telemetry.logger` or `telemetry.metrics` when those signals export through OTLP/gRPC.
 
 ### Metrics
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -388,6 +388,10 @@ func verifyTelemetryConfig(t *testing.T, cfg *config.Config) {
 	require.Equal(t, "http://localhost:4318/v1/traces", cfg.Telemetry.Tracer.URL)
 	require.Equal(t, "otlp", cfg.Telemetry.Tracer.Kind)
 	require.Equal(t, "http", cfg.Telemetry.Tracer.Protocol)
+	require.Equal(t, "file:../test/certs/rootCA.pem", cfg.Telemetry.Tracer.TLS.CA)
+	require.Equal(t, "file:../test/certs/client-cert.pem", cfg.Telemetry.Tracer.TLS.Cert)
+	require.Equal(t, "file:../test/certs/client-key.pem", cfg.Telemetry.Tracer.TLS.Key)
+	require.Equal(t, "collector.example.com", cfg.Telemetry.Tracer.TLS.ServerName)
 	require.Equal(t, "ratio", cfg.Telemetry.Tracer.Sampler.Kind)
 	require.InDelta(t, 0.25, cfg.Telemetry.Tracer.Sampler.Ratio, 0.001)
 }

--- a/internal/test/metrics.go
+++ b/internal/test/metrics.go
@@ -123,7 +123,7 @@ func NewPrometheusMeterProvider(lc di.Lifecycle) (metrics.MeterProvider, error) 
 
 // NewMeterProvider creates a meter provider with a reader registered on the supplied lifecycle.
 func NewMeterProvider(lc di.Lifecycle, config *metrics.Config) (metrics.MeterProvider, error) {
-	r, err := metrics.NewReader(lc, Name, config)
+	r, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: config, FS: FS, Name: Name})
 	if err != nil {
 		return nil, err
 	}

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -49,8 +49,8 @@
 // headers. When headers are configured, non-loopback "http://" endpoints are rejected to avoid sending
 // credential-bearing headers over cleartext transport. Use "https://" for external collectors. Local
 // development collectors on "localhost" or loopback IP addresses may use "http://".
-// OTLP/gRPC exporters use host:port endpoints. Header-bearing remote gRPC endpoints are rejected until
-// TLS configuration is supported for OTLP/gRPC exporters.
+// OTLP/gRPC exporters use host:port endpoints. Header-bearing remote gRPC endpoints
+// require the signal's TLS config; loopback gRPC endpoints may still use cleartext.
 //
 // OTLP endpoints must be supplied through go-service config fields such as telemetry.logger.url,
 // telemetry.metrics.url, and telemetry.tracer.url. Standard OpenTelemetry endpoint environment variables

--- a/telemetry/internal/otlp/endpoint.go
+++ b/telemetry/internal/otlp/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"net/netip"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/url"
@@ -30,24 +31,41 @@ var ErrInvalidProtocol = errors.New("otlp: invalid protocol")
 // non-local cleartext endpoint.
 var ErrInsecureEndpoint = errors.New("otlp: insecure endpoint")
 
+// Endpoint describes an explicitly configured OTLP endpoint.
+type Endpoint struct {
+	// TLS configures TLS for gRPC exporters.
+	TLS *tls.Config
+
+	// Headers contains metadata sent to the OTLP collector.
+	Headers map[string]string
+
+	// Protocol selects the OTLP exporter protocol.
+	Protocol string
+
+	// Address is the configured OTLP destination.
+	//
+	// HTTP exporters expect a URL. gRPC exporters expect host:port.
+	Address string
+}
+
 // ValidateEndpoint validates an explicitly configured OTLP endpoint.
-func ValidateEndpoint(protocol, endpoint string, headers map[string]string) error {
-	if strings.IsEmpty(endpoint) {
+func ValidateEndpoint(endpoint Endpoint) error {
+	if strings.IsEmpty(endpoint.Address) {
 		return ErrMissingEndpoint
 	}
 
-	switch protocol {
+	switch endpoint.Protocol {
 	case ProtocolHTTP:
-		return validateHTTP(endpoint, headers)
+		return validateHTTP(endpoint)
 	case ProtocolGRPC:
-		return validateGRPC(endpoint, headers)
+		return validateGRPC(endpoint)
 	default:
 		return ErrInvalidProtocol
 	}
 }
 
-func validateHTTP(rawURL string, headers map[string]string) error {
-	u, err := url.Parse(rawURL)
+func validateHTTP(endpoint Endpoint) error {
+	u, err := url.Parse(endpoint.Address)
 	if err != nil {
 		return err
 	}
@@ -56,15 +74,15 @@ func validateHTTP(rawURL string, headers map[string]string) error {
 		return ErrInvalidEndpoint
 	}
 
-	if u.Scheme != "http" || len(headers) == 0 || isLoopback(u.Hostname()) {
+	if u.Scheme != "http" || len(endpoint.Headers) == 0 || isLoopback(u.Hostname()) {
 		return nil
 	}
 
 	return ErrInsecureEndpoint
 }
 
-func validateGRPC(endpoint string, headers map[string]string) error {
-	host, port, err := net.SplitHostPort(endpoint)
+func validateGRPC(endpoint Endpoint) error {
+	host, port, err := net.SplitHostPort(endpoint.Address)
 	if err != nil || strings.IsEmpty(host) {
 		return ErrInvalidEndpoint
 	}
@@ -72,7 +90,7 @@ func validateGRPC(endpoint string, headers map[string]string) error {
 		return ErrInvalidEndpoint
 	}
 
-	if len(headers) == 0 || isLoopback(host) {
+	if len(endpoint.Headers) == 0 || endpoint.TLS != nil || isLoopback(host) {
 		return nil
 	}
 

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -3,6 +3,7 @@ package otlp_test
 import (
 	"testing"
 
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/stretchr/testify/require"
 )
@@ -10,22 +11,27 @@ import (
 func TestValidateEndpoint(t *testing.T) {
 	headers := map[string]string{"Authorization": "Bearer token"}
 
-	require.NoError(t, otlp.ValidateEndpoint("http", "https://collector.example.com/v1/traces", headers))
-	require.NoError(t, otlp.ValidateEndpoint("http", "http://localhost:4318/v1/traces", headers))
-	require.NoError(t, otlp.ValidateEndpoint("http", "http://127.0.0.1:4318/v1/traces", headers))
-	require.NoError(t, otlp.ValidateEndpoint("http", "http://collector.example.com/v1/traces", nil))
-	require.NoError(t, otlp.ValidateEndpoint("grpc", "localhost:4317", headers))
-	require.NoError(t, otlp.ValidateEndpoint("grpc", "collector.example.com:4317", nil))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "https://collector.example.com/v1/traces", Headers: headers}))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://localhost:4318/v1/traces", Headers: headers}))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://127.0.0.1:4318/v1/traces", Headers: headers}))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces"}))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "localhost:4317", Headers: headers}))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317"}))
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers, TLS: &tls.Config{}}))
 
-	err := otlp.ValidateEndpoint("http", "http://collector.example.com/v1/traces", headers)
+	err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces", Headers: headers})
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 
-	err = otlp.ValidateEndpoint("grpc", "collector.example.com:4317", headers)
+	err = otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers})
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
 func TestValidateEndpointInvalidURL(t *testing.T) {
-	err := otlp.ValidateEndpoint("http", "http://%", map[string]string{"Authorization": "Bearer token"})
+	err := otlp.ValidateEndpoint(otlp.Endpoint{
+		Protocol: "http",
+		Address:  "http://%",
+		Headers:  map[string]string{"Authorization": "Bearer token"},
+	})
 
 	require.Error(t, err)
 	require.NotErrorIs(t, err, otlp.ErrInsecureEndpoint)
@@ -37,19 +43,19 @@ func TestValidateEndpointRejectsInvalidEndpoint(t *testing.T) {
 		"https:///v1/traces",
 	} {
 		t.Run(rawURL, func(t *testing.T) {
-			err := otlp.ValidateEndpoint("http", rawURL, nil)
+			err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: rawURL})
 
 			require.ErrorIs(t, err, otlp.ErrInvalidEndpoint)
 		})
 	}
 
-	for _, endpoint := range []string{
+	for _, address := range []string{
 		"https://collector.example.com:4317",
 		"collector.example.com",
 		"collector.example.com:4317/v1/traces",
 	} {
-		t.Run(endpoint, func(t *testing.T) {
-			err := otlp.ValidateEndpoint("grpc", endpoint, nil)
+		t.Run(address, func(t *testing.T) {
+			err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: address})
 
 			require.ErrorIs(t, err, otlp.ErrInvalidEndpoint)
 		})
@@ -59,15 +65,15 @@ func TestValidateEndpointRejectsInvalidEndpoint(t *testing.T) {
 func TestValidateEndpointRequiresEndpoint(t *testing.T) {
 	headers := map[string]string{"Authorization": "Bearer token"}
 
-	require.ErrorIs(t, otlp.ValidateEndpoint("http", "", headers), otlp.ErrMissingEndpoint)
-	require.NoError(t, otlp.ValidateEndpoint("http", "https://collector.example.com/v1/traces", headers))
+	require.ErrorIs(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Headers: headers}), otlp.ErrMissingEndpoint)
+	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "https://collector.example.com/v1/traces", Headers: headers}))
 
-	err := otlp.ValidateEndpoint("http", "http://collector.example.com/v1/traces", headers)
+	err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces", Headers: headers})
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
 func TestValidateEndpointRejectsInvalidProtocol(t *testing.T) {
-	err := otlp.ValidateEndpoint("wrong", "collector.example.com:4317", nil)
+	err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "wrong", Address: "collector.example.com:4317"})
 
 	require.ErrorIs(t, err, otlp.ErrInvalidProtocol)
 }
@@ -76,6 +82,9 @@ func TestValidateEndpointIgnoresEnv(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector.example.com/v1/traces")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
 
-	err := otlp.ValidateEndpoint("http", "", map[string]string{"Authorization": "Bearer token"})
+	err := otlp.ValidateEndpoint(otlp.Endpoint{
+		Protocol: "http",
+		Headers:  map[string]string{"Authorization": "Bearer token"},
+	})
 	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
 }

--- a/telemetry/logger/config.go
+++ b/telemetry/logger/config.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 )
@@ -24,6 +25,12 @@ type Config struct {
 	// "file:/path", or a literal value). Resolution is performed by the consumer that
 	// prepares configuration for use by the logger/exporter.
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
+
+	// TLS configures OTLP/gRPC client transport security.
+	//
+	// This only applies when Kind is "otlp" and Protocol is "grpc". A non-nil
+	// config enables TLS; Cert, Key, and CA values use go-service source strings.
+	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Kind selects the logger implementation.
 	//

--- a/telemetry/logger/doc.go
+++ b/telemetry/logger/doc.go
@@ -56,8 +56,8 @@
 // rejected to avoid sending credential-bearing headers over cleartext transport.
 // Use "https://" for external collectors. Local development collectors on
 // "localhost" or loopback IP addresses may use "http://".
-// Header-bearing remote OTLP/gRPC endpoints are rejected until TLS configuration
-// is supported for OTLP/gRPC exporters.
+// Header-bearing remote OTLP/gRPC endpoints require [Config.TLS]; loopback gRPC
+// endpoints may still use cleartext.
 //
 // # Notes
 //

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 )
 
@@ -97,6 +98,9 @@ type LoggerParams struct {
 	//
 	// A nil Config disables logging and causes NewLogger to return (nil, nil).
 	Config *Config
+
+	// FS resolves TLS source strings for OTLP/gRPC exporters.
+	FS *os.FS
 
 	// Attributes are optional OpenTelemetry resource attributes attached to
 	// exporter-backed logs.

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -231,6 +232,33 @@ func TestInvalidOTLPGRPCEndpoint(t *testing.T) {
 
 	_, err := logger.NewLogger(params)
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestOTLPGRPCLoggerWithTLSHeaders(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := &logger.Config{
+		Kind:     "otlp",
+		Protocol: "grpc",
+		URL:      "collector.example.com:4317",
+		TLS:      &tls.Config{ServerName: "collector.example.com"},
+		Headers: header.Map{
+			"Authorization": "Bearer token",
+		},
+	}
+	params := logger.LoggerParams{
+		Lifecycle:   lc,
+		Config:      cfg,
+		FS:          test.FS,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}
+
+	log, err := logger.NewLogger(params)
+	require.NoError(t, err)
+	require.NotNil(t, log)
+	require.NoError(t, lc.Stop(t.Context()))
 }
 
 func TestMissingOTLPEndpointIgnoresEnv(t *testing.T) {

--- a/telemetry/logger/otlp.go
+++ b/telemetry/logger/otlp.go
@@ -3,8 +3,10 @@ package logger
 import (
 	"log/slog"
 
+	"github.com/alexfalkowski/go-service/v2/config/client"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
@@ -16,11 +18,16 @@ import (
 )
 
 func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
-	if err := otlp.ValidateEndpoint(params.Config.GetProtocol(), params.Config.URL, params.Config.Headers); err != nil {
+	if err := otlp.ValidateEndpoint(otlp.Endpoint{
+		Protocol: params.Config.GetProtocol(),
+		Address:  params.Config.URL,
+		Headers:  params.Config.Headers,
+		TLS:      params.Config.TLS,
+	}); err != nil {
 		return nil, err
 	}
 
-	exporter, err := newOtlpExporter(params.Config)
+	exporter, err := newOtlpExporter(params)
 	if err != nil {
 		return nil, err
 	}
@@ -51,18 +58,27 @@ func newOtlpLogger(params LoggerParams) (*slog.Logger, error) {
 	return slog.New(&levelHandler{handler: handler, level: level(params.Config)}), nil
 }
 
-func newOtlpExporter(cfg *Config) (log.Exporter, error) {
-	switch cfg.GetProtocol() {
+func newOtlpExporter(params LoggerParams) (log.Exporter, error) {
+	switch params.Config.GetProtocol() {
 	case otlp.ProtocolGRPC:
-		opts := []otlploggrpc.Option{otlploggrpc.WithHeaders(cfg.Headers), otlploggrpc.WithInsecure()}
-		if !strings.IsEmpty(cfg.URL) {
-			opts = append(opts, otlploggrpc.WithEndpoint(cfg.URL))
+		opts := []otlploggrpc.Option{otlploggrpc.WithHeaders(params.Config.Headers)}
+		if params.Config.TLS == nil {
+			opts = append(opts, otlploggrpc.WithInsecure())
+		} else {
+			conf, err := client.NewConfig(params.FS, params.Config.TLS)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, otlploggrpc.WithTLSCredentials(grpc.NewTLS(conf)))
+		}
+		if !strings.IsEmpty(params.Config.URL) {
+			opts = append(opts, otlploggrpc.WithEndpoint(params.Config.URL))
 		}
 		return otlploggrpc.New(context.Background(), opts...)
 	default:
-		opts := []otlploghttp.Option{otlploghttp.WithHeaders(cfg.Headers)}
-		if !strings.IsEmpty(cfg.URL) {
-			opts = append(opts, otlploghttp.WithEndpointURL(cfg.URL))
+		opts := []otlploghttp.Option{otlploghttp.WithHeaders(params.Config.Headers)}
+		if !strings.IsEmpty(params.Config.URL) {
+			opts = append(opts, otlploghttp.WithEndpointURL(params.Config.URL))
 		}
 		return otlploghttp.New(context.Background(), opts...)
 	}

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -18,6 +19,12 @@ type Config struct {
 	// prepares configuration for use by the exporter (for example via header.Map.Secrets
 	// or header.Map.MustSecrets).
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
+
+	// TLS configures OTLP/gRPC client transport security.
+	//
+	// This only applies when Kind is "otlp" and Protocol is "grpc". A non-nil
+	// config enables TLS; Cert, Key, and CA values use go-service source strings.
+	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Kind selects the metrics reader/exporter implementation.
 	//

--- a/telemetry/metrics/doc.go
+++ b/telemetry/metrics/doc.go
@@ -48,8 +48,8 @@
 // rejected to avoid sending credential-bearing headers over cleartext transport.
 // Use "https://" for external collectors. Local development collectors on
 // "localhost" or loopback IP addresses may use "http://".
-// Header-bearing remote OTLP/gRPC endpoints are rejected until TLS configuration
-// is supported for OTLP/gRPC exporters.
+// Header-bearing remote OTLP/gRPC endpoints require [Config.TLS]; loopback gRPC
+// endpoints may still use cleartext.
 //
 // # Global provider installation
 //

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -143,7 +143,7 @@ func TestOTLPReaderUsesConfiguredInterval(t *testing.T) {
 		Interval: 20 * time.Millisecond,
 		Timeout:  time.Second,
 	}
-	reader, err := metrics.NewReader(lc, test.Name, cfg)
+	reader, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = reader.Shutdown(t.Context())

--- a/telemetry/metrics/reader.go
+++ b/telemetry/metrics/reader.go
@@ -1,10 +1,13 @@
 package metrics
 
 import (
+	"github.com/alexfalkowski/go-service/v2/config/client"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -16,23 +19,42 @@ import (
 // ErrNotFound is returned when the configured metrics reader kind is unknown.
 var ErrNotFound = errors.New("metrics: reader not found")
 
-// NewReader constructs an OpenTelemetry SDK metric reader based on cfg.
+// ReaderParams declares the dependencies required by NewReader.
 //
-// If metrics are disabled (`cfg == nil`), it returns (nil, nil).
+// It is intended for Fx/Dig injection. OTLP/gRPC readers use FS to resolve TLS
+// source strings when TLS is configured.
+type ReaderParams struct {
+	di.In
+
+	// Lifecycle is used to shut down the reader with the application.
+	Lifecycle di.Lifecycle
+
+	// Config enables metrics when non-nil and selects the reader/exporter kind.
+	Config *Config
+
+	// FS resolves TLS source strings for OTLP/gRPC exporters.
+	FS *os.FS
+
+	// Name identifies the service emitting metrics.
+	Name env.Name
+}
+
+// NewReader constructs an OpenTelemetry SDK metric reader based on Config.
 //
-// The constructed reader is registered with the provided lifecycle and is shut down on stop.
-// If the reader was already shut down, the shutdown error is ignored.
-func NewReader(lc di.Lifecycle, name env.Name, cfg *Config) (metric.Reader, error) {
-	if !cfg.IsEnabled() {
+// If metrics are disabled, it returns (nil, nil). The constructed reader is
+// registered with the provided lifecycle and is shut down on stop. If the
+// reader was already shut down, the shutdown error is ignored.
+func NewReader(params ReaderParams) (metric.Reader, error) {
+	if !params.Config.IsEnabled() {
 		return nil, nil
 	}
 
-	reader, err := newReader(name, cfg)
+	reader, err := newMetricReader(params.Name, params.FS, params.Config)
 	if err != nil {
 		return nil, err
 	}
 
-	lc.Append(di.Hook{
+	params.Lifecycle.Append(di.Hook{
 		OnStop: func(ctx context.Context) error {
 			if err := reader.Shutdown(ctx); err != nil {
 				if errors.Is(err, metric.ErrReaderShutdown) {
@@ -47,14 +69,19 @@ func NewReader(lc di.Lifecycle, name env.Name, cfg *Config) (metric.Reader, erro
 	return reader, nil
 }
 
-func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
+func newMetricReader(name env.Name, fs *os.FS, cfg *Config) (metric.Reader, error) {
 	switch cfg.Kind {
 	case "otlp":
-		if err := otlp.ValidateEndpoint(cfg.GetProtocol(), cfg.URL, cfg.Headers); err != nil {
+		if err := otlp.ValidateEndpoint(otlp.Endpoint{
+			Protocol: cfg.GetProtocol(),
+			Address:  cfg.URL,
+			Headers:  cfg.Headers,
+			TLS:      cfg.TLS,
+		}); err != nil {
 			return nil, prefix(err)
 		}
 
-		exporter, err := newOTLPExporter(cfg)
+		exporter, err := newOTLPExporter(fs, cfg)
 		if err != nil {
 			return nil, prefix(err)
 		}
@@ -70,10 +97,19 @@ func newReader(name env.Name, cfg *Config) (metric.Reader, error) {
 	}
 }
 
-func newOTLPExporter(cfg *Config) (metric.Exporter, error) {
+func newOTLPExporter(fs *os.FS, cfg *Config) (metric.Exporter, error) {
 	switch cfg.GetProtocol() {
 	case otlp.ProtocolGRPC:
-		opts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithHeaders(cfg.Headers), otlpmetricgrpc.WithInsecure()}
+		opts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithHeaders(cfg.Headers)}
+		if cfg.TLS == nil {
+			opts = append(opts, otlpmetricgrpc.WithInsecure())
+		} else {
+			conf, err := client.NewConfig(fs, cfg.TLS)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, otlpmetricgrpc.WithTLSCredentials(grpc.NewTLS(conf)))
+		}
 		if !strings.IsEmpty(cfg.URL) {
 			opts = append(opts, otlpmetricgrpc.WithEndpoint(cfg.URL))
 		}

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -3,6 +3,7 @@ package metrics_test
 import (
 	"testing"
 
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
@@ -15,7 +16,7 @@ func TestInvalidReader(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{Kind: "wrong"}
 
-	_, err := metrics.NewReader(lc, test.Name, cfg)
+	_, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
 	require.Error(t, err)
 }
 
@@ -27,7 +28,12 @@ func TestConfigGetProtocol(t *testing.T) {
 
 func TestReaderShutdownIgnoresAlreadyShutdownReader(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
-	reader, err := metrics.NewReader(lc, test.Name, &metrics.Config{Kind: "prometheus"})
+	reader, err := metrics.NewReader(metrics.ReaderParams{
+		Lifecycle: lc,
+		Config:    &metrics.Config{Kind: "prometheus"},
+		FS:        test.FS,
+		Name:      test.Name,
+	})
 	require.NoError(t, err)
 
 	lc.RequireStart()
@@ -46,7 +52,7 @@ func TestInvalidOTLPEndpoint(t *testing.T) {
 		},
 	}
 
-	_, err := metrics.NewReader(lc, test.Name, cfg)
+	_, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
@@ -58,7 +64,7 @@ func TestOTLPGRPCReader(t *testing.T) {
 		URL:      "localhost:4317",
 	}
 
-	reader, err := metrics.NewReader(lc, test.Name, cfg)
+	reader, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 	require.NoError(t, reader.Shutdown(t.Context()))
@@ -75,8 +81,26 @@ func TestInvalidOTLPGRPCEndpoint(t *testing.T) {
 		},
 	}
 
-	_, err := metrics.NewReader(lc, test.Name, cfg)
+	_, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestOTLPGRPCReaderWithTLSHeaders(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := &metrics.Config{
+		Kind:     "otlp",
+		Protocol: "grpc",
+		URL:      "collector.example.com:4317",
+		TLS:      &tls.Config{ServerName: "collector.example.com"},
+		Headers: header.Map{
+			"Authorization": "Bearer token",
+		},
+	}
+
+	reader, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.NoError(t, reader.Shutdown(t.Context()))
 }
 
 func TestMissingOTLPEndpointIgnoresEnv(t *testing.T) {
@@ -91,6 +115,6 @@ func TestMissingOTLPEndpointIgnoresEnv(t *testing.T) {
 		},
 	}
 
-	_, err := metrics.NewReader(lc, test.Name, cfg)
+	_, err := metrics.NewReader(metrics.ReaderParams{Lifecycle: lc, Config: cfg, FS: test.FS, Name: test.Name})
 	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
 }

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 )
@@ -17,6 +18,12 @@ type Config struct {
 	// resolution is performed by the consumer that prepares configuration for use by the
 	// exporter (for example via header.Map.Secrets or header.Map.MustSecrets).
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
+
+	// TLS configures OTLP/gRPC client transport security.
+	//
+	// This only applies when Kind is "otlp" and Protocol is "grpc". A non-nil
+	// config enables TLS; Cert, Key, and CA values use go-service source strings.
+	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Sampler configures trace head sampling.
 	//

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -58,6 +58,6 @@
 // rejected to avoid sending credential-bearing headers over cleartext transport.
 // Use "https://" for external collectors. Local development collectors on
 // "localhost" or loopback IP addresses may use "http://".
-// Header-bearing remote OTLP/gRPC endpoints are rejected until TLS configuration
-// is supported for OTLP/gRPC exporters.
+// Header-bearing remote OTLP/gRPC endpoints require [Config.TLS]; loopback gRPC
+// endpoints may still use cleartext.
 package tracer

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -1,9 +1,12 @@
 package tracer
 
 import (
+	"github.com/alexfalkowski/go-service/v2/config/client"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
@@ -93,6 +96,9 @@ type TracerParams struct {
 	// Config enables tracing when non-nil and supplies exporter settings.
 	Config *Config
 
+	// FS resolves TLS source strings for OTLP/gRPC exporters.
+	FS *os.FS
+
 	// Attributes are optional OpenTelemetry resource attributes attached to traces.
 	Attributes attributes.Map `optional:"true"`
 
@@ -132,11 +138,19 @@ func Register(params TracerParams) error {
 
 	switch params.Config.Kind {
 	case "otlp":
-		if err := otlp.ValidateEndpoint(params.Config.GetProtocol(), params.Config.URL, params.Config.Headers); err != nil {
+		if err := otlp.ValidateEndpoint(otlp.Endpoint{
+			Protocol: params.Config.GetProtocol(),
+			Address:  params.Config.URL,
+			Headers:  params.Config.Headers,
+			TLS:      params.Config.TLS,
+		}); err != nil {
 			return prefix(err)
 		}
 
-		exporter := newOTLPExporter(params.Config)
+		exporter, err := newOTLPExporter(params)
+		if err != nil {
+			return prefix(err)
+		}
 		attrs := attributes.NewResource(
 			params.Attributes,
 			params.ID.String(),
@@ -177,20 +191,29 @@ func Register(params TracerParams) error {
 	}
 }
 
-func newOTLPExporter(cfg *Config) *otlptrace.Exporter {
-	switch cfg.GetProtocol() {
+func newOTLPExporter(params TracerParams) (*otlptrace.Exporter, error) {
+	switch params.Config.GetProtocol() {
 	case otlp.ProtocolGRPC:
-		opts := []otlptracegrpc.Option{otlptracegrpc.WithHeaders(cfg.Headers), otlptracegrpc.WithInsecure()}
-		if !strings.IsEmpty(cfg.URL) {
-			opts = append(opts, otlptracegrpc.WithEndpoint(cfg.URL))
+		opts := []otlptracegrpc.Option{otlptracegrpc.WithHeaders(params.Config.Headers)}
+		if params.Config.TLS == nil {
+			opts = append(opts, otlptracegrpc.WithInsecure())
+		} else {
+			conf, err := client.NewConfig(params.FS, params.Config.TLS)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, otlptracegrpc.WithTLSCredentials(grpc.NewTLS(conf)))
 		}
-		return otlptrace.NewUnstarted(otlptracegrpc.NewClient(opts...))
+		if !strings.IsEmpty(params.Config.URL) {
+			opts = append(opts, otlptracegrpc.WithEndpoint(params.Config.URL))
+		}
+		return otlptrace.NewUnstarted(otlptracegrpc.NewClient(opts...)), nil
 	default:
-		opts := []otlptracehttp.Option{otlptracehttp.WithHeaders(cfg.Headers)}
-		if !strings.IsEmpty(cfg.URL) {
-			opts = append(opts, otlptracehttp.WithEndpointURL(cfg.URL))
+		opts := []otlptracehttp.Option{otlptracehttp.WithHeaders(params.Config.Headers)}
+		if !strings.IsEmpty(params.Config.URL) {
+			opts = append(opts, otlptracehttp.WithEndpointURL(params.Config.URL))
 		}
-		return otlptrace.NewUnstarted(otlptracehttp.NewClient(opts...))
+		return otlptrace.NewUnstarted(otlptracehttp.NewClient(opts...)), nil
 	}
 }
 

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
@@ -233,6 +234,33 @@ func TestRegisterInvalidOTLPGRPCEndpoint(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestRegisterOTLPGRPCExporterWithTLSHeaders(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
+	})
+
+	err := tracer.Register(tracer.TracerParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Config: &tracer.Config{
+			Kind:     "otlp",
+			Protocol: "grpc",
+			URL:      "collector.example.com:4317",
+			TLS:      &tls.Config{ServerName: "collector.example.com"},
+			Headers: header.Map{
+				"Authorization": "Bearer token",
+			},
+		},
+		FS:          test.FS,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+
+	require.NoError(t, err)
+	require.True(t, tracer.IsEnabled())
 }
 
 func TestRegisterOTLPEndpointLoopbackIPs(t *testing.T) {

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -103,6 +103,12 @@
       kind: otlp
       protocol: http
       url: "http://localhost:4318/v1/traces"
+      tls: {
+        ca: "file:../test/certs/rootCA.pem"
+        cert: "file:../test/certs/client-cert.pem"
+        key: "file:../test/certs/client-key.pem"
+        server_name: "collector.example.com"
+      }
       sampler: {
         kind: ratio
         ratio: 0.25

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -89,6 +89,12 @@ kind = "otlp"
 protocol = "http"
 url = "http://localhost:4318/v1/traces"
 
+[telemetry.tracer.tls]
+ca = "file:../test/certs/rootCA.pem"
+cert = "file:../test/certs/client-cert.pem"
+key = "file:../test/certs/client-key.pem"
+server_name = "collector.example.com"
+
 [telemetry.tracer.sampler]
 kind = "ratio"
 ratio = 0.25

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -73,6 +73,11 @@ telemetry:
     kind: otlp
     protocol: http
     url: http://localhost:4318/v1/traces
+    tls:
+      ca: file:../test/certs/rootCA.pem
+      cert: file:../test/certs/client-cert.pem
+      key: file:../test/certs/client-key.pem
+      server_name: collector.example.com
     sampler:
       kind: ratio
       ratio: 0.25


### PR DESCRIPTION
## What

- Add per-signal `tls` configuration for OTLP/gRPC logger, metrics, and tracer exporters.
- Use TLS credentials for remote OTLP/gRPC exporters when `tls` is configured, while preserving cleartext behavior for loopback and no-TLS paths.
- Update endpoint validation, config fixtures, tests, and README/package docs for authenticated remote collectors.

## Why

- Operators and service authors can now send logs, metrics, and traces to authenticated remote OTLP/gRPC collectors without switching protocols, dropping headers, or replacing the standard telemetry wiring.
- The change keeps the existing insecure defaults for local development and only permits header-bearing remote gRPC endpoints when TLS is explicitly configured.

## Testing

- `make lint` - passed
- `make specs` - passed, including OTLP endpoint validation and logger/metrics/tracer TLS-header coverage.
- `make sec` - passed, with govulncheck and Trivy reporting no vulnerabilities.
