### PR TITLE
feat(events): allow binary outbound encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,9 +974,11 @@ Supported stacks include:
 CloudEvents HTTP wiring lives under `transport/http/events`: use
 `NewReceiver(...).Register(...)` to receive events on a POST route and
 `NewSender(...).Send(...)` with `net/http/events.ContextWithTarget(...)` to
-send events. The sender uses structured HTTP encoding. Webhook-protected
-receivers also require structured encoding and reject binary-mode CloudEvents
-with `ce-*` headers before signature verification.
+send events. The sender uses structured HTTP encoding by default; configure
+`WithSenderEncoding(SenderEncodingBinary)` for outbound integrations that
+require binary-mode CloudEvents. Webhook-protected receivers require structured
+encoding and reject binary-mode CloudEvents with `ce-*` headers before
+signature verification.
 
 ### HTTP content types
 

--- a/net/http/events/events.go
+++ b/net/http/events/events.go
@@ -62,6 +62,11 @@ func SendStructured(ctx context.Context, client Client, event Event) Result {
 	return client.Send(binding.WithForceStructured(ctx), event)
 }
 
+// SendBinary sends event using binary CloudEvents encoding.
+func SendBinary(ctx context.Context, client Client, event Event) Result {
+	return client.Send(binding.WithForceBinary(ctx), event)
+}
+
 // ContextWithTarget returns a context with the CloudEvents target set.
 func ContextWithTarget(ctx context.Context, target string) context.Context {
 	return cloudevents.ContextWithTarget(ctx, target)

--- a/transport/http/events/doc.go
+++ b/transport/http/events/doc.go
@@ -3,7 +3,7 @@
 // This package integrates go-service CloudEvents HTTP helpers with transport wiring.
 // It provides helpers to:
 //   - register HTTP handlers that receive CloudEvents and dispatch to a ReceiverFunc, and
-//   - create CloudEvents HTTP clients that send events using an HTTP RoundTripper.
+//   - create CloudEvents HTTP clients that send events using an HTTP RoundTripper and configured encoding.
 //
 // Start with [NewReceiver] / [Receiver.Register] for receiving and [NewSender] for sending.
 package events

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -191,6 +191,48 @@ func TestSenderUsesStructuredEncoding(t *testing.T) {
 	require.Contains(t, body, `"type":"example.type"`)
 }
 
+func TestSenderUsesBinaryEncoding(t *testing.T) {
+	contentTypes := make(chan string, 1)
+	specVersions := make(chan string, 1)
+	ids := make(chan string, 1)
+	sources := make(chan string, 1)
+	types := make(chan string, 1)
+	bodies := make(chan string, 1)
+	readErrors := make(chan error, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		data, _, err := io.ReadAll(req.Body)
+		contentTypes <- req.Header.Get("Content-Type")
+		specVersions <- req.Header.Get("Ce-Specversion")
+		ids <- req.Header.Get("Ce-Id")
+		sources <- req.Header.Get("Ce-Source")
+		types <- req.Header.Get("Ce-Type")
+		bodies <- bytes.String(data)
+		readErrors <- err
+
+		res.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	sender := transportevents.NewSender(nil, transportevents.WithSenderEncoding(transportevents.SenderEncodingBinary))
+
+	e := events.NewEvent()
+	e.SetID("event-1")
+	e.SetSource("example/uri")
+	e.SetType("example.type")
+	require.NoError(t, e.SetData(events.TextPlain, "test"))
+
+	result := sender.Send(events.ContextWithTarget(t.Context(), server.URL+"/events"), e)
+	require.NoError(t, <-readErrors)
+	test.RequireACK(t, result)
+	require.Equal(t, events.TextPlain, <-contentTypes)
+	require.Equal(t, "1.0", <-specVersions)
+	require.Equal(t, "event-1", <-ids)
+	require.Equal(t, "example/uri", <-sources)
+	require.Equal(t, "example.type", <-types)
+	require.Equal(t, "test", <-bodies)
+}
+
 func TestSenderUsesDefaultTimeout(t *testing.T) {
 	start, deadline := sendWithDeadline(t)
 	remaining := time.Duration(deadline.Sub(start))

--- a/transport/http/events/options.go
+++ b/transport/http/events/options.go
@@ -5,10 +5,19 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
+// SenderEncoding selects the CloudEvents HTTP encoding used by a sender.
+type SenderEncoding uint8
+
+// SenderEncodingStructured sends CloudEvents using structured HTTP encoding.
+const SenderEncodingStructured SenderEncoding = 0
+
+// SenderEncodingBinary sends CloudEvents using binary HTTP encoding.
+const SenderEncodingBinary SenderEncoding = 1
+
 // SenderOption configures a CloudEvents HTTP sender.
 //
-// Sender options control how the CloudEvents client is constructed, primarily by selecting the underlying
-// HTTP transport used to send events.
+// Sender options control how the CloudEvents client sends events, including the underlying HTTP transport and
+// CloudEvents HTTP encoding.
 type SenderOption interface {
 	apply(opts *senderOptions)
 }
@@ -16,6 +25,7 @@ type SenderOption interface {
 type senderOptions struct {
 	roundTripper http.RoundTripper
 	timeout      time.Duration
+	encoding     SenderEncoding
 }
 
 type senderOptionFunc func(*senderOptions)
@@ -40,6 +50,16 @@ func WithSenderRoundTripper(rt http.RoundTripper) SenderOption {
 func WithSenderTimeout(timeout time.Duration) SenderOption {
 	return senderOptionFunc(func(o *senderOptions) {
 		o.timeout = timeout
+	})
+}
+
+// WithSenderEncoding configures the CloudEvents HTTP encoding used when sending events.
+//
+// The default is [SenderEncodingStructured].
+// Webhook-protected go-service receivers require structured encoding and reject binary-mode CloudEvents.
+func WithSenderEncoding(encoding SenderEncoding) SenderOption {
+	return senderOptionFunc(func(o *senderOptions) {
+		o.encoding = encoding
 	})
 }
 

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -16,6 +16,9 @@ import (
 //
 // If no round tripper is configured via [WithSenderRoundTripper], it uses the default HTTP transport.
 //
+// The sender uses structured CloudEvents HTTP encoding by default. Use [WithSenderEncoding] to select binary
+// encoding for outbound integrations that require it.
+//
 // The sender follows only same-origin redirects. Cross-origin redirects are returned to the caller instead
 // of being followed so webhook signatures are not minted for redirected origins.
 //
@@ -28,15 +31,20 @@ func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {
 	httpClient.CheckRedirect = http.SameOriginRedirect
 
 	sender := events.NewClient(*httpClient)
-	return &Sender{client: sender}
+	return &Sender{client: sender, encoding: resolved.encoding}
 }
 
-// Sender wraps a CloudEvents client and forces structured HTTP encoding for outbound events.
+// Sender wraps a CloudEvents client and sends outbound events using its configured HTTP encoding.
 type Sender struct {
-	client events.Client
+	client   events.Client
+	encoding SenderEncoding
 }
 
-// Send transmits event using structured CloudEvents encoding.
+// Send transmits event using the configured CloudEvents HTTP encoding.
 func (s *Sender) Send(ctx context.Context, event events.Event) events.Result {
+	if s.encoding == SenderEncodingBinary {
+		return events.SendBinary(ctx, s.client, event)
+	}
+
 	return events.SendStructured(ctx, s.client, event)
 }


### PR DESCRIPTION
## What

- Add a CloudEvents sender encoding option so outbound senders keep structured HTTP encoding by default and can opt into binary HTTP encoding.
- Add the lower-level binary send helper used by the transport sender.
- Update README and GoDoc to describe the binary opt-in and keep the structured-only webhook receiver boundary explicit.

## Why

- Service authors can interoperate with consumers that require binary-mode CloudEvents without bypassing the go-service sender wrapper, timeout handling, redirect policy, round tripper injection, or webhook signing path.
- The change is additive and preserves existing sender behavior for current callers.

## Testing

- `make package=transport/http/events specs` - passed
- `make package=net/http/events specs` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning
- `make specs` - failed because unrelated `transport/grpc` auth/limiter tests timed out or returned unexpected status codes; the changed `transport/http/events` package passed in that run
- `make package=transport/grpc specs` - failed on unrelated `TestMissingClientAuthUnary`; no `transport/grpc` files changed
- `go test ./transport/grpc -run TestMissingClientAuthUnary -count=1` - passed
- `go test ./transport/grpc -run 'TestValidAuthUnary|TestClientLimiterUnary' -count=1` - failed on unrelated `TestValidAuthUnary` deadline errors; no `transport/grpc` files changed

AI-assisted-by: [Codex](https://openai.com/codex/)
