### PR TITLE
docs(agents): clarify browser policy boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,14 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   external edge, gateway, ingress, load balancer, or service mesh limiter when
   those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
+- go-service is a microservices framework; browser-facing concerns such as
+  CORS are expected to live at a BFF, API gateway, ingress, CDN, or other edge
+  layer. Do not flag missing built-in CORS/preflight support solely because
+  browser clients cannot call authenticated service endpoints cross-origin
+  through the standard HTTP stack. Report only concrete bugs where a public API
+  promises browser-direct support, an existing edge/BFF integration is broken,
+  or the repo adds first-class CORS/pre-auth middleware semantics and violates
+  them.
 - Transport limiter `max_keys` intentionally caps the number of
   caller-derived keys that get independent in-memory buckets. Additional
   distinct keys share one overflow bucket; do not flag this as accidental key


### PR DESCRIPTION
## What

- Document that browser-facing concerns such as CORS belong at a BFF, gateway, ingress, CDN, or other edge layer.
- Tell future audits not to treat missing built-in CORS/preflight handling as a go-service feature gap unless the repository starts promising browser-direct support or first-class CORS semantics.

## Why

- go-service is a microservices framework, so CORS policy ownership should remain outside the core service transport stack.
- The guidance prevents future feature-gap passes from rediscovering direct browser preflight handling as a high-priority framework feature.

## Testing

- `git diff --check` - passed
- `make lint` - passed
- Broader specs were not run because this change only updates contributor/audit guidance.
