### PR TITLE
feat(sql): support role-specific pool settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 - `cli.RunCode` returns `os.ExitCodeSuccess` on success, preserves non-zero
   shutdown exit codes requested through `di.ExitCode(...)`, and otherwise
   returns `os.ExitCodeFailure`.
+- `cli.Application.AddClient` intentionally models short-lived client command
+  work as DI/Fx startup work. Client commands may perform their main action
+  from constructors or lifecycle `OnStart` hooks, then stop the graph
+  immediately after startup completes. Do not flag the absence of a separate
+  post-DI command-task API solely because command work lives in `OnStart`; this
+  is the supported pattern, as used by downstream client templates. Report only
+  concrete broken behavior such as incorrect error propagation, ignored
+  shutdown exit codes, lifecycle ordering bugs, or a documented command
+  contract that cannot be expressed with the DI lifecycle.
 - `cli.Application.Run` intentionally sanitizes Go test harness `-test.*`
   arguments before handing `os.Args` to the command runner because this
   repository commonly exercises CLI applications through Go test binaries. Do
@@ -202,6 +211,12 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   `go-units.FromHumanSize` does not parse; that is accepted upstream behavior
   unless this repository adds a strict round-trip promise for those values.
 - Redis cache config intentionally expects `cache.options.url` to exist and be a string.
+- Redis cache isolation should use Redis URL database selection, such as
+  `/0` through `/15`, a dedicated endpoint, or deployment-level isolation. Do
+  not flag missing service-name key namespacing or prefix-scoped Redis
+  `Cache.Flush`; implementing that cleanup requires client-side key iteration,
+  while the supported Redis flush behavior is `FLUSHDB` against the selected
+  database.
 - PostgreSQL DSN security options, including TLS/`sslmode`, are intentionally
   part of the DSN supplied by the service configuration. `database/sql/pg`
   passes resolved DSNs through to pgx and does not impose repository-level DSN
@@ -388,6 +403,14 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   local validation logic or a public contract beyond upstream library behavior.
 - `telemetry/header.Map.MustSecrets` can panic if secret resolution fails during config projection.
 - Health registration helpers require `*net/http.ServeMux`.
+- Health checks intentionally use go-health registration and observer mapping
+  directly. Service code may colocate `server.Register` and `server.Observe`
+  calls in one DI function for `healthz`, `livez`, `readyz`, and `grpc`
+  observers. Do not flag the absence of a standard health probe composition
+  helper solely because observer names are hand-mapped; report only concrete
+  broken behavior such as missing documented endpoints, ignored observer
+  errors, wrong probe names, or a public API promise that standard probes are
+  auto-composed.
 - Shared metadata, header, and string helpers live under `net/...`, not `transport/...`.
 - `vendor/` is gitignored and regenerated via `make dep`.
 - HTTP webhook verification buffers `req.Body` intentionally for signature checks.

--- a/README.md
+++ b/README.md
@@ -421,11 +421,11 @@ Server commands created through `cli.Application.AddServer` include `runtime.Mod
 
 SQL root config is `database/sql.Config`, with Postgres under `sql.pg`.
 
-Postgres config embeds common pool + DSN config (`database/sql/config.Config`), including writer/reader DSNs and pool sizes. Enabled SQL configs must set positive `max_open_conns` and `max_idle_conns`; `max_idle_conns` must not exceed `max_open_conns`.
+Postgres config embeds common pool + DSN config (`database/sql/config.Config`), including writer/reader pools. Each role pool owns its `dsns` and `settings`. Enabled SQL pool settings must set positive `max_open_conns` and `max_idle_conns`; `max_idle_conns` must not exceed `max_open_conns`.
 
 `module.Server` and `module.Client` both include `sql.Module`, which currently wires PostgreSQL support via `database/sql/pg.Module`.
 
-Enablement is presence-based: a nil `sql` block or a nil `sql.pg` block disables SQL wiring. When enabled, the pgx stdlib driver is registered under the name `pg`, and writer/reader DSNs are resolved using the source-string rules described above. Enabled PostgreSQL config must provide at least one non-empty `writers[].url` or `readers[].url`. Driver instrumentation is installed when tracing or metrics are enabled, OpenTelemetry `database/sql` stats metrics are registered when metrics are enabled, and the resulting pools are closed on lifecycle stop.
+Enablement is presence-based: a nil `sql` block or a nil `sql.pg` block disables SQL wiring. When enabled, the pgx stdlib driver is registered under the name `pg`, and reader/writer DSNs are resolved using the source-string rules described above. Enabled PostgreSQL config must provide at least one non-empty `reader.dsns[].url` or `writer.dsns[].url`. Driver instrumentation is installed when tracing or metrics are enabled, OpenTelemetry `database/sql` stats metrics are registered when metrics are enabled, and the resulting pools are closed on lifecycle stop.
 
 SQL wiring creates `database/sql` pool handles and applies pool settings, but it
 does not ping PostgreSQL during construction. Call `DBs.Ping`,
@@ -437,14 +437,22 @@ Example (with source strings for DSNs):
 ```yaml
 sql:
   pg:
-    writers:
-      - url: env:PG_WRITER_DSN
-    readers:
-      - url: env:PG_READER_DSN
-    max_open_conns: 5
-    max_idle_conns: 5
-    conn_max_idle_time: 30m
-    conn_max_lifetime: 1h
+    reader:
+      dsns:
+        - url: env:PG_READER_DSN
+      settings:
+        max_open_conns: 20
+        max_idle_conns: 10
+        conn_max_idle_time: 30m
+        conn_max_lifetime: 1h
+    writer:
+      dsns:
+        - url: env:PG_WRITER_DSN
+      settings:
+        max_open_conns: 3
+        max_idle_conns: 2
+        conn_max_idle_time: 10m
+        conn_max_lifetime: 30m
 ```
 
 Example (literal DSN; not recommended for production secrets):
@@ -452,9 +460,12 @@ Example (literal DSN; not recommended for production secrets):
 ```yaml
 sql:
   pg:
-    writers:
-      - url: postgres://user:pass@localhost:5432/dbname?sslmode=disable
-    max_open_conns: 10
+    writer:
+      dsns:
+        - url: postgres://user:pass@localhost:5432/dbname?sslmode=disable
+      settings:
+        max_open_conns: 10
+        max_idle_conns: 5
 ```
 
 ### Dependencies

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -364,14 +364,18 @@ func verifyHooksConfig(t *testing.T, cfg *config.Config) {
 func verifySQLConfig(t *testing.T, cfg *config.Config) {
 	t.Helper()
 
-	require.Len(t, cfg.SQL.PG.Writers, 1)
-	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Writers[0].URL)
-	require.Len(t, cfg.SQL.PG.Readers, 1)
-	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Readers[0].URL)
-	require.Equal(t, 5, cfg.SQL.PG.MaxIdleConns)
-	require.Equal(t, 5, cfg.SQL.PG.MaxOpenConns)
-	require.Equal(t, 30*time.Minute, cfg.SQL.PG.ConnMaxIdleTime)
-	require.Equal(t, time.Hour, cfg.SQL.PG.ConnMaxLifetime)
+	require.Len(t, cfg.SQL.PG.Reader.DSNs, 1)
+	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Reader.DSNs[0].URL)
+	require.Equal(t, 4, cfg.SQL.PG.Reader.Settings.MaxIdleConns)
+	require.Equal(t, 8, cfg.SQL.PG.Reader.Settings.MaxOpenConns)
+	require.Equal(t, 20*time.Minute, cfg.SQL.PG.Reader.Settings.ConnMaxIdleTime)
+	require.Equal(t, time.Hour, cfg.SQL.PG.Reader.Settings.ConnMaxLifetime)
+	require.Len(t, cfg.SQL.PG.Writer.DSNs, 1)
+	require.Equal(t, "file:../test/secrets/pg", cfg.SQL.PG.Writer.DSNs[0].URL)
+	require.Equal(t, 2, cfg.SQL.PG.Writer.Settings.MaxIdleConns)
+	require.Equal(t, 3, cfg.SQL.PG.Writer.Settings.MaxOpenConns)
+	require.Equal(t, 10*time.Minute, cfg.SQL.PG.Writer.Settings.ConnMaxIdleTime)
+	require.Equal(t, 30*time.Minute, cfg.SQL.PG.Writer.Settings.ConnMaxLifetime)
 }
 
 func verifyTelemetryConfig(t *testing.T, cfg *config.Config) {

--- a/database/sql/config.go
+++ b/database/sql/config.go
@@ -14,7 +14,7 @@ import "github.com/alexfalkowski/go-service/v2/database/sql/pg"
 // *[Config] is treated as "SQL disabled". Driver-specific sub-configs are also pointers and are treated
 // as optional; downstream constructors typically return (nil, nil) when a required sub-config is nil.
 type Config struct {
-	// PG configures PostgreSQL support (writer/reader DSNs and shared pool settings).
+	// PG configures PostgreSQL support (reader/writer DSNs and pool settings).
 	//
 	// PostgreSQL is the only SQL backend wired by this repository today.
 	PG *pg.Config `yaml:"pg,omitempty" json:"pg,omitempty" toml:"pg,omitempty"`

--- a/database/sql/config/config.go
+++ b/database/sql/config/config.go
@@ -5,28 +5,48 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-// Config contains shared [github.com/alexfalkowski/go-service/v2/database/sql] connection pool configuration.
+// Config contains shared [github.com/alexfalkowski/go-service/v2/database/sql] connection pool settings.
 //
 // It is intended to be embedded by driver-specific configuration types (for example PostgreSQL)
 // and consumed by the SQL wiring in this repository.
 //
-// [Config.Writers] and [Config.Readers] contain DSNs (connection strings) expressed as go-service "source strings"
-// (literal values, `file:` paths, or `env:` references) that are resolved by [os.FS.ReadSource].
-// Enabled SQL configurations must provide at least one writer or reader DSN, and each resolved DSN must be non-empty.
+// [Config.Reader] and [Config.Writer] contain role-specific pools. Each pool
+// owns its DSNs and its pool settings. DSNs are connection strings
+// expressed as go-service "source strings" (literal values, `file:` paths, or
+// `env:` references) that are resolved by [os.FS.ReadSource]. Enabled SQL
+// configurations must provide at least one writer or reader DSN, and each
+// resolved DSN must be non-empty.
 type Config struct {
-	// Writers is the set of primary (read-write) datasource DSNs.
+	// Reader is the replica (read-only) datasource pool.
+	Reader *Pool `yaml:"reader,omitempty" json:"reader,omitempty" toml:"reader,omitempty" validate:"omitempty"`
+
+	// Writer is the primary (read-write) datasource pool.
+	Writer *Pool `yaml:"writer,omitempty" json:"writer,omitempty" toml:"writer,omitempty" validate:"omitempty"`
+}
+
+// IsEnabled reports whether SQL configuration is present.
+//
+// By convention, a nil *[Config] is treated as "SQL disabled".
+func (c *Config) IsEnabled() bool {
+	return c != nil
+}
+
+// Pool contains DSNs and connection pool settings for a SQL role.
+type Pool struct {
+	// Settings configures connection pool behavior for this role.
+	Settings *PoolSettings `yaml:"settings,omitempty" json:"settings,omitempty" toml:"settings,omitempty" validate:"required"`
+
+	// DSNs is the set of datasource names for this role.
 	//
 	// Each DSN URL is a "source string" resolved via [os.FS.ReadSource], so it can be:
 	//   - "env:NAME" to read the DSN from an environment variable,
 	//   - "file:/path/to/dsn" to read the DSN from a file, or
 	//   - any other value treated as a literal DSN string.
-	Writers []DSN `yaml:"writers,omitempty" json:"writers,omitempty" toml:"writers,omitempty"`
+	DSNs []DSN `yaml:"dsns,omitempty" json:"dsns,omitempty" toml:"dsns,omitempty"`
+}
 
-	// Readers is the set of replica (read-only) datasource DSNs.
-	//
-	// Each DSN URL is a "source string" resolved via [os.FS.ReadSource] (see [Config.Writers] for the supported formats).
-	Readers []DSN `yaml:"readers,omitempty" json:"readers,omitempty" toml:"readers,omitempty"`
-
+// PoolSettings contains SQL connection pool settings for a role.
+type PoolSettings struct {
 	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
 	//
 	// In config files it is encoded as a Go duration string (for example "30s", "5m", "1h").
@@ -42,13 +62,6 @@ type Config struct {
 
 	// MaxIdleConns is the maximum number of connections in the idle connection pool.
 	MaxIdleConns int `yaml:"max_idle_conns" json:"max_idle_conns" toml:"max_idle_conns" validate:"gt=0,ltefield=MaxOpenConns"`
-}
-
-// IsEnabled reports whether SQL configuration is present.
-//
-// By convention, a nil *[Config] is treated as "SQL disabled".
-func (c *Config) IsEnabled() bool {
-	return c != nil
 }
 
 // DSN is a SQL datasource name (connection string) configuration.

--- a/database/sql/config/config_test.go
+++ b/database/sql/config/config_test.go
@@ -17,54 +17,66 @@ func TestConfigValidation(t *testing.T) {
 	}{
 		{
 			name: "valid",
-			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: 1},
-		},
-		{
-			name: "negative conn max lifetime",
-			cfg:  &config.Config{ConnMaxLifetime: -time.Second, MaxOpenConns: 1, MaxIdleConns: 1},
-			err:  true,
-		},
-		{
-			name: "negative conn max idle time",
-			cfg:  &config.Config{ConnMaxIdleTime: -time.Second, MaxOpenConns: 1, MaxIdleConns: 1},
-			err:  true,
-		},
-		{
-			name: "negative max open conns",
-			cfg:  &config.Config{MaxOpenConns: -1, MaxIdleConns: 1},
-			err:  true,
-		},
-		{
-			name: "zero max open conns",
-			cfg:  &config.Config{MaxOpenConns: 0, MaxIdleConns: 1},
-			err:  true,
-		},
-		{
-			name: "negative max idle conns",
-			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: -1},
-			err:  true,
-		},
-		{
-			name: "zero max idle conns",
-			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: 0},
-			err:  true,
-		},
-		{
-			name: "max idle conns greater than max open conns",
-			cfg:  &config.Config{MaxOpenConns: 1, MaxIdleConns: 2},
-			err:  true,
+			cfg: &config.Config{
+				Reader: &config.Pool{Settings: &config.PoolSettings{
+					ConnMaxLifetime: time.Second,
+					ConnMaxIdleTime: time.Second,
+					MaxOpenConns:    2,
+					MaxIdleConns:    1,
+				}},
+				Writer: &config.Pool{Settings: &config.PoolSettings{MaxOpenConns: 1, MaxIdleConns: 1}},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := test.Validator.Struct(tt.cfg)
-			if tt.err {
-				require.Error(t, err)
-				return
-			}
+			requireConfigValidation(t, tt.cfg, tt.err)
+		})
+	}
+}
 
-			require.NoError(t, err)
+func TestPoolValidation(t *testing.T) {
+	tests := []struct {
+		cfg  *config.Config
+		name string
+		err  bool
+	}{
+		{
+			name: "missing reader pool settings",
+			cfg: &config.Config{
+				Reader: &config.Pool{},
+			},
+			err: true,
+		},
+		{
+			name: "reader pool negative conn max lifetime",
+			cfg: &config.Config{
+				Reader: &config.Pool{
+					Settings: &config.PoolSettings{ConnMaxLifetime: -time.Second, MaxOpenConns: 1, MaxIdleConns: 1},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "writer pool max idle conns greater than max open conns",
+			cfg: &config.Config{
+				Writer: &config.Pool{Settings: &config.PoolSettings{MaxOpenConns: 1, MaxIdleConns: 2}},
+			},
+			err: true,
+		},
+		{
+			name: "writer pool zero max open conns",
+			cfg: &config.Config{
+				Writer: &config.Pool{Settings: &config.PoolSettings{MaxOpenConns: 0, MaxIdleConns: 1}},
+			},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireConfigValidation(t, tt.cfg, tt.err)
 		})
 	}
 }
@@ -72,4 +84,16 @@ func TestConfigValidation(t *testing.T) {
 func TestConfigIsEnabled(t *testing.T) {
 	require.False(t, (*config.Config)(nil).IsEnabled())
 	require.True(t, (&config.Config{}).IsEnabled())
+}
+
+func requireConfigValidation(t *testing.T, cfg *config.Config, wantErr bool) {
+	t.Helper()
+
+	err := test.Validator.Struct(cfg)
+	if wantErr {
+		require.Error(t, err)
+		return
+	}
+
+	require.NoError(t, err)
 }

--- a/database/sql/config/doc.go
+++ b/database/sql/config/doc.go
@@ -5,14 +5,15 @@
 //
 // # Pool configuration
 //
-// The top-level [Config] models common connection pool settings such as:
+// [Config] models reader and writer [Pool] values. Each pool owns both its
+// datasource names and its complete [PoolSettings], including:
 //   - maximum connection lifetime,
 //   - max open connections, and
 //   - max idle connections.
 //
 // # DSNs and source strings
 //
-// Writer and replica (reader) DSNs are configured via [DSN] entries. Each DSN URL is expressed as a
+// Reader and writer DSNs are configured through [Pool.DSNs]. Each DSN URL is expressed as a
 // go-service "source string" (resolved via [github.com/alexfalkowski/go-service/v2/os.FS.ReadSource]), so it can be:
 //   - "env:NAME" to read from an environment variable,
 //   - "file:/path/to/dsn" to read from a file, or
@@ -20,5 +21,5 @@
 //
 // Enabled SQL configurations must provide at least one writer or reader DSN, and each resolved DSN must be non-empty.
 //
-// Start with [Config] and [DSN].
+// Start with [Config], [Pool], [PoolSettings], and [DSN].
 package config

--- a/database/sql/doc.go
+++ b/database/sql/doc.go
@@ -25,8 +25,9 @@
 //
 // # Writer/reader pools and telemetry
 //
-// Driver integrations typically open writer/reader connection pools, configure pool limits/lifetimes,
-// wrap drivers with OpenTelemetry instrumentation when tracing or metrics are enabled, and register
+// Driver integrations typically open writer/reader connection pools, configure
+// role-specific pool limits/lifetimes, wrap drivers with OpenTelemetry
+// instrumentation when tracing or metrics are enabled, and register
 // [database/sql] stats metrics when metrics are enabled.
 //
 // Start with [Module] and [Config].

--- a/database/sql/driver/connect.go
+++ b/database/sql/driver/connect.go
@@ -19,8 +19,7 @@ import (
 // It resolves DSNs from cfg using the provided filesystem (DSNs are configured
 // as go-service "source strings"), opens writer and reader pools, registers
 // OpenTelemetry DB stats metrics for each pool when metrics are enabled, and
-// then applies pool settings (connection lifetime, max idle, and max open
-// connections).
+// then applies each role's pool settings.
 //
 // Like [database/sql.Open], this creates pool handles but does not ping the
 // database or verify network reachability. Call [DBs.Ping], [DBs.PingWriter],
@@ -33,7 +32,7 @@ import (
 // Failure behavior:
 //   - returns errors encountered while resolving DSNs or creating pool handles,
 //   - returns [ErrEmptyDSN] when any configured DSN source resolves to empty bytes, and
-//   - returns [ErrNoDSNs] when neither writers nor readers are configured.
+//   - returns [ErrNoDSNs] when neither writer nor reader DSNs are configured.
 //
 // The returned DBs owns repository lifecycle cleanup such as DB stats metric
 // unregistration.
@@ -94,12 +93,12 @@ func ConnectWritersReaders(name string, writerDSNs, readerDSNs []string) (*DBs, 
 }
 
 func connect(name string, fs *os.FS, cfg *config.Config, opts ...telemetry.Option) (*DBs, error) {
-	writers, err := resolveDSNs(fs, cfg.Writers)
+	readers, err := resolveDSNs(fs, cfg.Reader)
 	if err != nil {
 		return nil, err
 	}
 
-	readers, err := resolveDSNs(fs, cfg.Readers)
+	writers, err := resolveDSNs(fs, cfg.Writer)
 	if err != nil {
 		return nil, err
 	}
@@ -109,18 +108,33 @@ func connect(name string, fs *os.FS, cfg *config.Config, opts ...telemetry.Optio
 		return nil, err
 	}
 
-	db.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
-	db.SetConnMaxLifetime(cfg.ConnMaxLifetime)
-	db.SetMaxIdleConns(cfg.MaxIdleConns)
-	db.SetMaxOpenConns(cfg.MaxOpenConns)
+	applyPoolSettings(db.Readers(), cfg.Reader)
+	applyPoolSettings(db.Writers(), cfg.Writer)
 
 	return db, nil
 }
 
-func resolveDSNs(fs *os.FS, dsns []config.DSN) ([]string, error) {
-	resolved := make([]string, len(dsns))
+func applyPoolSettings(databases []*sql.DB, pool *config.Pool) {
+	if pool == nil || pool.Settings == nil {
+		return
+	}
 
-	for i, dsn := range dsns {
+	for _, db := range databases {
+		db.SetConnMaxIdleTime(pool.Settings.ConnMaxIdleTime.Duration())
+		db.SetConnMaxLifetime(pool.Settings.ConnMaxLifetime.Duration())
+		db.SetMaxIdleConns(pool.Settings.MaxIdleConns)
+		db.SetMaxOpenConns(pool.Settings.MaxOpenConns)
+	}
+}
+
+func resolveDSNs(fs *os.FS, pool *config.Pool) ([]string, error) {
+	if pool == nil {
+		return nil, nil
+	}
+
+	resolved := make([]string, len(pool.DSNs))
+
+	for i, dsn := range pool.DSNs {
 		url, err := dsn.GetURL(fs)
 		if err != nil {
 			return nil, err

--- a/database/sql/driver/db.go
+++ b/database/sql/driver/db.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
-	"github.com/alexfalkowski/go-service/v2/time"
 )
 
 // DBs contains writer and reader SQL connection pools.
@@ -84,36 +83,6 @@ func (d *DBs) Destroy() error {
 	errs = append(errs, closeAll(d.databases())...)
 
 	return errors.Join(errs...)
-}
-
-// SetConnMaxLifetime sets the maximum amount of time a connection may be reused
-// across all pools.
-func (d *DBs) SetConnMaxLifetime(v time.Duration) {
-	for _, db := range d.databases() {
-		db.SetConnMaxLifetime(v.Duration())
-	}
-}
-
-// SetConnMaxIdleTime sets the maximum amount of time a connection may remain idle
-// across all pools.
-func (d *DBs) SetConnMaxIdleTime(v time.Duration) {
-	for _, db := range d.databases() {
-		db.SetConnMaxIdleTime(v.Duration())
-	}
-}
-
-// SetMaxIdleConns sets the maximum number of idle connections across all pools.
-func (d *DBs) SetMaxIdleConns(v int) {
-	for _, db := range d.databases() {
-		db.SetMaxIdleConns(v)
-	}
-}
-
-// SetMaxOpenConns sets the maximum number of open connections across all pools.
-func (d *DBs) SetMaxOpenConns(v int) {
-	for _, db := range d.databases() {
-		db.SetMaxOpenConns(v)
-	}
 }
 
 func (d *DBs) databases() []*sql.DB {

--- a/database/sql/driver/doc.go
+++ b/database/sql/driver/doc.go
@@ -7,7 +7,7 @@
 //   - [Register], which wraps a concrete [database/sql/driver.Driver] with OpenTelemetry
 //     instrumentation and installs it in the global [database/sql] driver registry.
 //   - [Open], which resolves DSNs from go-service source strings, creates writer/reader pools,
-//     applies pool settings, registers DB stats metrics, and closes those pools on lifecycle stop.
+//     applies each role's pool settings, registers DB stats metrics, and closes those pools on lifecycle stop.
 //
 // Pool creation follows the [database/sql.Open] contract: it may not establish a
 // network connection immediately. Use [github.com/alexfalkowski/go-service/v2/database/sql/driver.DBs.Ping],

--- a/database/sql/driver/driver_test.go
+++ b/database/sql/driver/driver_test.go
@@ -20,7 +20,7 @@ func TestOpenUnregistersDBStatsMetrics(t *testing.T) {
 
 	lc := fxtest.NewLifecycle(t)
 	db, err := driver.Open(lc, driverName, test.FS, &config.Config{
-		Writers: []config.DSN{{URL: "benchmark"}},
+		Writer: newPool(1),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
@@ -48,7 +48,7 @@ func TestConnectDestroyUnregistersDBStatsMetrics(t *testing.T) {
 	driverName := test.RegisterBenchmarkSQLDriver(t, "test-sql-")
 
 	db, err := driver.Connect(driverName, test.FS, &config.Config{
-		Writers: []config.DSN{{URL: "benchmark"}},
+		Writer: newPool(1),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
@@ -65,7 +65,7 @@ func TestConnectUsesTelemetryOptionsForDBStatsMetrics(t *testing.T) {
 	driverName := test.RegisterBenchmarkSQLDriver(t, "test-sql-")
 
 	db, err := driver.Connect(driverName, test.FS, &config.Config{
-		Writers: []config.DSN{{URL: "benchmark"}},
+		Writer: newPool(1),
 	}, telemetry.WithAttributes(attributes.DBSystemNamePostgreSQL))
 	require.NoError(t, err)
 	require.NotNil(t, db)
@@ -110,7 +110,7 @@ func TestConnectUnregistersReaderDBStatsMetrics(t *testing.T) {
 	driverName := test.RegisterBenchmarkSQLDriver(t, "test-sql-")
 
 	db, err := driver.Connect(driverName, test.FS, &config.Config{
-		Readers: []config.DSN{{URL: "benchmark"}},
+		Reader: newPool(1),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
@@ -126,9 +126,8 @@ func TestConnectAppliesPoolSettings(t *testing.T) {
 	driverName := test.RegisterBenchmarkSQLDriver(t, "test-sql-")
 
 	db, err := driver.Connect(driverName, test.FS, &config.Config{
-		Writers:      []config.DSN{{URL: "benchmark"}},
-		Readers:      []config.DSN{{URL: "benchmark"}},
-		MaxOpenConns: 3,
+		Reader: newPool(3),
+		Writer: newPool(3),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
@@ -145,9 +144,41 @@ func TestConnectAppliesPoolSettings(t *testing.T) {
 	require.Equal(t, 3, readers[0].Stats().MaxOpenConnections)
 }
 
+func TestConnectAppliesRolePoolSettings(t *testing.T) {
+	driverName := test.RegisterBenchmarkSQLDriver(t, "test-sql-")
+
+	db, err := driver.Connect(driverName, test.FS, &config.Config{
+		Reader: newPool(7),
+		Writer: newPool(5),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer func() {
+		require.NoError(t, db.Destroy())
+	}()
+
+	writers := db.Writers()
+	require.Len(t, writers, 1)
+	require.Equal(t, 5, writers[0].Stats().MaxOpenConnections)
+
+	readers := db.Readers()
+	require.Len(t, readers, 1)
+	require.Equal(t, 7, readers[0].Stats().MaxOpenConnections)
+}
+
 func TestConnectWritersReadersReturnsErrors(t *testing.T) {
 	db, errs := driver.ConnectWritersReaders("missing-driver", []string{"benchmark"}, nil)
 
 	require.Nil(t, db)
 	require.Error(t, errors.Join(errs...))
+}
+
+func newPool(maxOpenConns int) *config.Pool {
+	return &config.Pool{
+		DSNs: []config.DSN{{URL: "benchmark"}},
+		Settings: &config.PoolSettings{
+			MaxOpenConns: maxOpenConns,
+			MaxIdleConns: maxOpenConns,
+		},
+	}
 }

--- a/database/sql/pg/config.go
+++ b/database/sql/pg/config.go
@@ -5,7 +5,7 @@ import "github.com/alexfalkowski/go-service/v2/database/sql/config"
 // Config contains PostgreSQL SQL database configuration.
 //
 // It embeds [github.com/alexfalkowski/go-service/v2/database/sql/config.Config] to reuse common
-// [github.com/alexfalkowski/go-service/v2/database/sql] pool settings and DSN configuration.
+// [github.com/alexfalkowski/go-service/v2/database/sql] writer and reader pool settings.
 // PostgreSQL connection options, including TLS and sslmode settings, belong in the configured DSNs
 // and are passed through to pgx unchanged.
 //

--- a/database/sql/pg/doc.go
+++ b/database/sql/pg/doc.go
@@ -18,9 +18,9 @@
 //
 // [Open] resolves writer and replica DSNs from configuration (DSNs are
 // expressed as go-service "source strings"), creates pool handles using the
-// shared writer/reader pool abstraction used by the repository, applies pool
-// settings (max lifetime/open/idle), and registers OpenTelemetry DB stats
-// metrics when metrics are enabled.
+// shared writer/reader pool abstraction used by the repository, applies each
+// role's pool settings, and registers OpenTelemetry DB stats metrics when
+// metrics are enabled.
 //
 // Pool creation follows the [database/sql.Open] contract and does not ping the
 // database or prove network reachability. Use the returned DBs Ping helpers or

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -69,18 +69,18 @@ func TestInvalidOpen(t *testing.T) {
 		name    string
 	}{
 		{
-			name: "invalid writers",
+			name: "invalid writer",
 			config: test.NewPGConfigWithDSNs(
-				[]config.DSN{{URL: test.FilePath("secrets/none")}},
 				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
+				[]config.DSN{{URL: test.FilePath("secrets/none")}},
 			),
 			wantErr: fs.ErrNotExist,
 		},
 		{
-			name: "invalid readers",
+			name: "invalid reader",
 			config: test.NewPGConfigWithDSNs(
-				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
 				[]config.DSN{{URL: test.FilePath("secrets/none")}},
+				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
 			),
 			wantErr: fs.ErrNotExist,
 		},
@@ -92,16 +92,16 @@ func TestInvalidOpen(t *testing.T) {
 		{
 			name: "empty writer dsn",
 			config: test.NewPGConfigWithDSNs(
-				[]config.DSN{{}},
 				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
+				[]config.DSN{{}},
 			),
 			wantErr: driver.ErrEmptyDSN,
 		},
 		{
 			name: "empty reader dsn",
 			config: test.NewPGConfigWithDSNs(
-				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
 				[]config.DSN{{URL: "env:PG_EMPTY_DSN"}},
+				[]config.DSN{{URL: test.FilePath("secrets/pg")}},
 			),
 			wantErr: driver.ErrEmptyDSN,
 		},
@@ -356,12 +356,8 @@ func TestInvalidStatementQuery(t *testing.T) {
 
 func TestInvalidSQLPort(t *testing.T) {
 	cfg := &pg.Config{Config: &config.Config{
-		Writers:         []config.DSN{{URL: test.FilePath("secrets/pg_invalid")}},
-		Readers:         []config.DSN{{URL: test.FilePath("secrets/pg_invalid")}},
-		MaxOpenConns:    5,
-		MaxIdleConns:    5,
-		ConnMaxIdleTime: 30 * time.Minute,
-		ConnMaxLifetime: time.Hour,
+		Reader: newPool(test.FilePath("secrets/pg_invalid")),
+		Writer: newPool(test.FilePath("secrets/pg_invalid")),
 	}}
 
 	lc := fxtest.NewLifecycle(t)
@@ -378,4 +374,16 @@ func TestInvalidSQLPort(t *testing.T) {
 	lc.RequireStart()
 	require.Error(t, db.Ping())
 	lc.RequireStop()
+}
+
+func newPool(url string) *config.Pool {
+	return &config.Pool{
+		DSNs: []config.DSN{{URL: url}},
+		Settings: &config.PoolSettings{
+			MaxOpenConns:    5,
+			MaxIdleConns:    5,
+			ConnMaxIdleTime: 30 * time.Minute,
+			ConnMaxLifetime: time.Hour,
+		},
+	}
 }

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -331,11 +331,19 @@ func NewPGConfig() *pg.Config {
 }
 
 // NewPGConfigWithDSNs returns the Postgres config used by database-backed integration tests with explicit DSNs.
-func NewPGConfigWithDSNs(writers, readers []sql.DSN) *pg.Config {
+func NewPGConfigWithDSNs(readers, writers []sql.DSN) *pg.Config {
 	return &pg.Config{
 		Config: &sql.Config{
-			Writers:         writers,
-			Readers:         readers,
+			Reader: newSQLPool(readers),
+			Writer: newSQLPool(writers),
+		},
+	}
+}
+
+func newSQLPool(dsns []sql.DSN) *sql.Pool {
+	return &sql.Pool{
+		DSNs: dsns,
+		Settings: &sql.PoolSettings{
 			MaxOpenConns:    5,
 			MaxIdleConns:    5,
 			ConnMaxIdleTime: 30 * time.Minute,

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -62,20 +62,32 @@
   }
   sql: {
     pg: {
-      writers: [
-        {
-          url: "file:../test/secrets/pg"
+      reader: {
+        dsns: [
+          {
+            url: "file:../test/secrets/pg"
+          }
+        ]
+        settings: {
+          max_open_conns: 8
+          max_idle_conns: 4
+          conn_max_idle_time: "20m"
+          conn_max_lifetime: "1h"
         }
-      ]
-      readers: [
-        {
-          url: "file:../test/secrets/pg"
+      }
+      writer: {
+        dsns: [
+          {
+            url: "file:../test/secrets/pg"
+          }
+        ]
+        settings: {
+          max_open_conns: 3
+          max_idle_conns: 2
+          conn_max_idle_time: "10m"
+          conn_max_lifetime: "30m"
         }
-      ]
-      max_open_conns: 5
-      max_idle_conns: 5
-      conn_max_idle_time: "30m"
-      conn_max_lifetime: "1h"
+      }
     }
   }
   telemetry: {

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -56,16 +56,22 @@ previous = "file:../test/secrets/hooks_previous"
 [id]
 kind = "uuid"
 
-[sql.pg]
-max_open_conns = 5
-max_idle_conns = 5
-conn_max_idle_time = "30m"
+[sql.pg.reader.settings]
+max_open_conns = 8
+max_idle_conns = 4
+conn_max_idle_time = "20m"
 conn_max_lifetime = "1h"
 
-[[sql.pg.writers]]
+[[sql.pg.reader.dsns]]
 url = "file:../test/secrets/pg"
 
-[[sql.pg.readers]]
+[sql.pg.writer.settings]
+max_open_conns = 3
+max_idle_conns = 2
+conn_max_idle_time = "10m"
+conn_max_lifetime = "30m"
+
+[[sql.pg.writer.dsns]]
 url = "file:../test/secrets/pg"
 
 [telemetry.logger]

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -45,14 +45,22 @@ id:
   kind: uuid
 sql:
   pg:
-    writers:
-      - url: file:../test/secrets/pg
-    readers:
-      - url: file:../test/secrets/pg
-    max_open_conns: 5
-    max_idle_conns: 5
-    conn_max_idle_time: 30m
-    conn_max_lifetime: 1h
+    reader:
+      dsns:
+        - url: file:../test/secrets/pg
+      settings:
+        max_open_conns: 8
+        max_idle_conns: 4
+        conn_max_idle_time: 20m
+        conn_max_lifetime: 1h
+    writer:
+      dsns:
+        - url: file:../test/secrets/pg
+      settings:
+        max_open_conns: 3
+        max_idle_conns: 2
+        conn_max_idle_time: 10m
+        conn_max_lifetime: 30m
 telemetry:
   attributes:
     k8s.namespace.name: payments

--- a/test/configs/invalid_trace.yml
+++ b/test/configs/invalid_trace.yml
@@ -38,13 +38,20 @@ id:
   kind: uuid
 sql:
   pg:
-    writers:
-      - url: file:../test/secrets/pg
-    readers:
-      - url: file:../test/secrets/pg
-    max_open_conns: 5
-    max_idle_conns: 5
-    conn_max_lifetime: 1h
+    reader:
+      dsns:
+        - url: file:../test/secrets/pg
+      settings:
+        max_open_conns: 5
+        max_idle_conns: 5
+        conn_max_lifetime: 1h
+    writer:
+      dsns:
+        - url: file:../test/secrets/pg
+      settings:
+        max_open_conns: 5
+        max_idle_conns: 5
+        conn_max_lifetime: 1h
 telemetry:
   logger:
     kind: text


### PR DESCRIPTION
## What

- Replace the PostgreSQL SQL config shape with role-specific writer and reader pools where each role owns its `dsns` and `settings`.
- Apply each configured role's pool settings when opening writer and reader database pools.
- Update SQL README examples, package docs, config fixtures, and validation tests for the breaking `writers.dsns` / `writers.settings` and `readers.dsns` / `readers.settings` schema.
- Add durable AGENTS guidance for client command lifecycle work, Redis cache DB isolation, and direct health registration/observer mapping.

## Why

- Operators need to size primary and replica database pools independently instead of sharing one global connection-pool block across all writer and reader DSNs.
- Making writers and readers first-class pools keeps DSNs and pool settings together and avoids a compatibility layer of global defaults plus role overrides.

## Testing

- `make package=database/sql/config specs` - passed
- `make package=database/sql/driver specs` - passed
- `make package=database/sql/pg specs` - passed
- `make package=database/sql specs` - passed
- `make package=config specs` - passed
- `make package=database/sql lint` - passed
- `make package=config lint` - passed
- `git diff --check` - passed
