### PR TITLE
feat(content): split http media negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ signature verification.
 
 ### HTTP content types
 
-The HTTP REST and RPC helpers decode request bodies from the request `Content-Type`, falling back to JSON when `Content-Type` is absent or unknown. Response encoding uses the negotiated media type, falling back to the first `Accept` media type when `Content-Type` is absent.
+The HTTP REST and RPC helpers decode request bodies from the request `Content-Type`, falling back to JSON when `Content-Type` is absent or unknown. Response encoding uses the first `Accept` media type when present, falling back to the request `Content-Type` when `Accept` is absent. Client helpers can set `ContentType` for the request body and `Accept` for an independent response format.
 
 Built-in text/object payload media types include:
 

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"cmp"
-
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -117,10 +115,11 @@ func NewClient(content *content.Content, pool *sync.BufferPool, opts ...ClientOp
 	return &Client{client: client, content: content, pool: pool, maxResponseSize: clientOptions.maxResponseSize.Bytes()}
 }
 
-// Options describes the request/response payloads and content type for a single call.
+// Options describes the request/response payloads and media types for a single call.
 //
-// ContentType is used to select an encoder/decoder via net/http/content. Typical values are media
-// types like "application/json" or go-service specific protobuf media types.
+// ContentType is used to select the request encoder via net/http/content. Accept is used to request
+// a distinct response media type.
+// Typical values are media types like "application/json" or go-service specific protobuf media types.
 //
 // Request and Response are optional:
 //   - If Request is non-nil, it is encoded into the request body.
@@ -135,8 +134,11 @@ type Options struct {
 	Response any
 
 	// ContentType is the request Content-Type used for encoding and the fallback decoder selection
-	// when the response does not provide a Content-Type header.
+	// when Accept and the response Content-Type header are not set.
 	ContentType string
+
+	// Accept is the response Accept media type sent on the request.
+	Accept string
 }
 
 // HasRequest reports whether a request payload is set.
@@ -203,6 +205,7 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 //
 // Request headers:
 //   - The request Content-Type header is set to the negotiated media type.
+//   - The request Accept header is set when opts.Accept is non-empty.
 //
 // Response handling:
 //   - The response body is read into an internal buffer up to the configured response size limit.
@@ -210,7 +213,7 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 //     error message and returned as a net/http/status error.
 //   - Otherwise, if the status code is in the 4xx/5xx range, a generic status error is returned.
 //   - Otherwise, if opts.Response is non-nil, the response body is decoded into it using the encoder
-//     selected by the response Content-Type (falling back to opts.ContentType if absent).
+//     selected by the response Content-Type (falling back to opts.ContentType).
 //
 // Notes:
 //   - Callers may pass the zero Options value when no request/response bodies are needed.
@@ -238,6 +241,9 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	}
 
 	request.Header.Set(content.TypeKey, requestMedia.String())
+	if !strings.IsEmpty(opts.Accept) {
+		request.Header.Set(content.AcceptKey, opts.Accept)
+	}
 
 	response, err := c.client.Do(request)
 	if err != nil {
@@ -253,11 +259,8 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 		return err
 	}
 
-	// If for some reason the server does not return it, default to opts.
-	contentType := cmp.Or(response.Header.Get(content.TypeKey), opts.ContentType)
-
 	// The server handlers return text/error to indicate an error.
-	responseMedia := c.content.NewFromMedia(contentType)
+	responseMedia := c.content.NewFromMedia(responseContentType(response.Header, opts))
 	if responseMedia.IsError() {
 		code := response.StatusCode
 		if !isErrorStatus(code) {
@@ -290,6 +293,14 @@ func defaultErrorMessage(code int) string {
 	}
 
 	return status.DefaultMessage(code)
+}
+
+func responseContentType(header http.Header, opts Options) string {
+	if contentType := header.Get(content.TypeKey); !strings.IsEmpty(contentType) {
+		return contentType
+	}
+
+	return opts.ContentType
 }
 
 func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -155,6 +155,33 @@ func TestDoUsesMsgPack(t *testing.T) {
 	require.Equal(t, "Hello Bob", response.Greeting)
 }
 
+func TestDoSendsAccept(t *testing.T) {
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var request test.Request
+		require.Equal(t, media.JSON, req.Header.Get(content.TypeKey))
+		require.Equal(t, media.YAML, req.Header.Get(content.AcceptKey))
+		require.NoError(t, test.Encoder.Get("json").Decode(req.Body, &request))
+		body := bytes.NewBuffer(nil)
+		require.NoError(t, test.Encoder.Get("yaml").Encode(body, &test.Response{Greeting: "Hello " + request.Name}))
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{content.TypeKey: []string{media.YAML}},
+			Body:       io.NopCloser(body),
+		}, nil
+	})))
+
+	var response test.Response
+	err := c.Post(t.Context(), "http://example.com", client.Options{
+		ContentType: media.JSON,
+		Accept:      media.YAML,
+		Request:     &test.Request{Name: "Bob"},
+		Response:    &response,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Hello Bob", response.Greeting)
+}
+
 func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	var body io.ReadCloser
 	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/net/http/client/doc.go
+++ b/net/http/client/doc.go
@@ -4,8 +4,8 @@
 //   - request/response body encoding/decoding via [github.com/alexfalkowski/go-service/v2/net/http/content.Content], and
 //   - consistent error handling via [github.com/alexfalkowski/go-service/v2/net/http/status].
 //
-// The wrapper is intended for service-to-service HTTP calls where the payload format is negotiated
-// explicitly via Content-Type (for example application/json or application/hjson).
+// The wrapper is intended for service-to-service HTTP calls where request payload format is selected
+// explicitly via Content-Type and response payload format can be requested separately via Accept.
 //
 // # Options and behavior
 //
@@ -20,7 +20,8 @@
 // Each call uses an [Options] value describing:
 //   - Request: request payload model (optional)
 //   - Response: response payload model (optional)
-//   - ContentType: media type used to select an encoder/decoder
+//   - ContentType: request media type used to select the request encoder
+//   - Accept: response media type used for the Accept header
 //
 // If Request is set, it is encoded into the request body.
 // If Response is set, it is decoded from the response body on non-error responses.

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -53,6 +53,21 @@ func (c *Content) NewFromRequest(req *http.Request) Media {
 	return c.newRequestMedia(mediaType)
 }
 
+// NewFromAccept parses the first request Accept media type and returns a matching Media.
+//
+// If Accept is not set, it falls back to Content-Type.
+//
+// If parsing fails, it falls back to JSON.
+// If the internal error media type is selected, it falls back to plain text.
+func (c *Content) NewFromAccept(req *http.Request) Media {
+	mediaType := firstMediaType(req.Header.Get(AcceptKey))
+	if strings.IsEmpty(mediaType) {
+		mediaType = req.Header.Get(TypeKey)
+	}
+
+	return c.newRequestMedia(mediaType)
+}
+
 // NewFromContentType parses the request Content-Type header and returns a matching Media.
 //
 // If parsing fails, it falls back to JSON.

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -47,6 +47,27 @@ func TestNewFromRequestPrefersContentType(t *testing.T) {
 	require.Same(t, test.Encoder.Get("toml"), media.Encoder)
 }
 
+func TestNewFromAcceptPrefersAccept(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.TypeKey, media.TOML)
+	req.Header.Set(content.AcceptKey, media.YAML)
+
+	media := test.Content.NewFromAccept(req)
+
+	require.Equal(t, "yaml", media.Subtype())
+	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
+}
+
+func TestNewFromAcceptFallsBackToContentType(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.TypeKey, media.TOML)
+
+	media := test.Content.NewFromAccept(req)
+
+	require.Equal(t, "toml", media.Subtype())
+	require.Same(t, test.Encoder.Get("toml"), media.Encoder)
+}
+
 func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 	req.Header.Set(content.AcceptKey, "application/yaml, application/toml")

--- a/net/http/content/doc.go
+++ b/net/http/content/doc.go
@@ -9,9 +9,10 @@
 // media subtype (e.g. "json", "hjson", "yaml", "toml", "proto").
 //
 // [Content] can derive a [Media] from either:
-//   - an incoming HTTP request's Content-Type header, falling back to Accept ([NewFromRequest]),
-//   - an incoming HTTP request's Content-Type header ([NewFromContentType]), or
-//   - a raw media type string ([NewFromMedia]).
+//   - an incoming HTTP request's Content-Type header, falling back to Accept ([Content.NewFromRequest]),
+//   - an incoming HTTP request's Accept header, falling back to Content-Type ([Content.NewFromAccept]),
+//   - an incoming HTTP request's Content-Type header ([Content.NewFromContentType]), or
+//   - a raw media type string ([Content.NewFromMedia]).
 //
 // # Error payloads
 //

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -21,7 +21,8 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 //
 // Content negotiation:
 // Request-body decoding uses the request Content-Type, falling back to JSON when Content-Type is absent or
-// unknown. The response Content-Type header is set to the negotiated media type.
+// unknown. Response encoding uses the request Accept header, falling back to Content-Type when Accept is
+// absent. The response Content-Type header is set to the negotiated response media type.
 //
 // Errors:
 // If request decoding fails, NewRequestHandler converts the decode error into a 400 Bad Request using
@@ -81,7 +82,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		mediaType := cont.NewFromRequest(req)
+		mediaType := cont.NewFromAccept(req)
 		ctx = meta.WithContent(ctx, req, res, mediaType.Encoder)
 		res.Header().Set(TypeKey, mediaType.WithUTF8())
 

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewRequestHandlerPrefersContentType(t *testing.T) {
+func TestNewRequestHandlerUsesAcceptForResponse(t *testing.T) {
 	handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "Hello " + req.Name}, nil
 	})
@@ -28,8 +28,10 @@ func TestNewRequestHandlerPrefersContentType(t *testing.T) {
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.JSON, res.Header().Get(content.TypeKey))
-	require.JSONEq(t, `{"Greeting":"Hello Bob","Meta":null}`, res.Body.String())
+	require.Equal(t, media.YAML, res.Header().Get(content.TypeKey))
+	var response test.Response
+	require.NoError(t, test.Encoder.Get("yaml").Decode(res.Body, &response))
+	require.Equal(t, "Hello Bob", response.Greeting)
 }
 
 func TestNewRequestHandlerRejectsUnsafeBinaryRequestBody(t *testing.T) {

--- a/net/http/rest/doc.go
+++ b/net/http/rest/doc.go
@@ -16,8 +16,8 @@
 // and [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
 //   - decode request bodies (where applicable) from Content-Type, falling back to JSON when
 //     Content-Type is absent or unknown, and
-//   - encode responses using the negotiated media type, falling back to the first Accept media type
-//     when Content-Type is absent.
+//   - encode responses using the first Accept media type, falling back to Content-Type when
+//     Accept is absent.
 //
 // Errors are written using net/http/status helpers.
 //

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -70,8 +70,8 @@ func RouteRequest[Req any, Res any](pattern string, handler content.RequestHandl
 // Route registers a handler under pattern that encodes a response.
 //
 // The handler is built using [github.com/alexfalkowski/go-service/v2/net/http/content.NewHandler], which:
-//   - selects an encoder based on the request Content-Type, falling back to the first Accept media type when
-//     Content-Type is absent, and
+//   - selects an encoder based on the first Accept media type, falling back to Content-Type when
+//     Accept is absent, and
 //   - encodes the returned response model using the negotiated media type.
 //
 // Registration:

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -28,6 +28,7 @@ type ClientOption interface {
 type clientOpts struct {
 	roundTripper http.RoundTripper
 	contentType  string
+	accept       string
 	timeout      time.Duration
 }
 
@@ -50,11 +51,21 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 // WithClientContentType sets the Content-Type used for requests made by the RPC client.
 //
 // This value is passed through to the underlying content-aware HTTP client and is used to select the
-// encoder/decoder for request/response bodies. Typical values include "application/json",
-// "application/hjson", or go-service protobuf media types.
+// request encoder. Typical values include "application/json", "application/hjson", or go-service
+// protobuf media types.
 func WithClientContentType(ct string) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.contentType = ct
+	})
+}
+
+// WithClientAccept sets the Accept media type used for responses from the RPC client.
+//
+// This value is passed through to the underlying content-aware HTTP client and sent as the request
+// Accept header.
+func WithClientAccept(accept string) ClientOption {
+	return clientOptionFunc(func(o *clientOpts) {
+		o.accept = accept
 	})
 }
 
@@ -85,13 +96,14 @@ func NewClient(url string, opts ...ClientOption) *Client {
 		client.WithRedirect(client.RedirectIgnore),
 	)
 
-	return &Client{client: client, url: url, contentType: os.contentType}
+	return &Client{client: client, url: url, contentType: os.contentType, accept: os.accept}
 }
 
 // Client is an RPC client that issues POST requests using the configured content codecs.
 type Client struct {
 	client      *client.Client
 	contentType string
+	accept      string
 	url         string
 }
 
@@ -103,7 +115,8 @@ type Client struct {
 //
 // Content-Type behavior:
 // The request Content-Type is set to c.contentType and is used to select encoders/decoders via
-// the underlying content-aware client.
+// the underlying content-aware client. When configured, Accept is sent as the response media
+// preference and fallback decoder selection.
 //
 // The res parameter is typically a pointer to the destination value (for example *MyResponse).
 func (c *Client) Post(ctx context.Context, path string, req, res any) error {
@@ -114,7 +127,7 @@ func (c *Client) Post(ctx context.Context, path string, req, res any) error {
 		return ErrInvalidResponse
 	}
 
-	opts := client.Options{ContentType: c.contentType, Request: req, Response: res}
+	opts := client.Options{ContentType: c.contentType, Accept: c.accept, Request: req, Response: res}
 	return c.client.Post(ctx, c.url+path, opts)
 }
 

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -1,9 +1,12 @@
 package rpc_test
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -36,4 +39,28 @@ func TestPostRequiresNonNilTypedResponse(t *testing.T) {
 	req := &test.Request{Name: "Bob"}
 	var res *test.Response
 	require.ErrorIs(t, client.Post(t.Context(), "/hello", req, res), rpc.ErrInvalidResponse)
+}
+
+func TestPostUsesAccept(t *testing.T) {
+	mux := http.NewServeMux()
+	rpc.Register(rpc.RegisterParams{
+		Mux:     mux,
+		Content: test.Content,
+		Pool:    test.Pool,
+	})
+	rpc.Route("/hello", test.SuccessSayHello)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := rpc.NewClient(server.URL,
+		rpc.WithClientContentType(media.JSON),
+		rpc.WithClientAccept(media.YAML),
+	)
+	var res test.Response
+
+	err := client.Post(t.Context(), "/hello", &test.Request{Name: "Bob"}, &res)
+
+	require.NoError(t, err)
+	require.Equal(t, "Hello Bob", res.Greeting)
 }

--- a/net/http/rpc/doc.go
+++ b/net/http/rpc/doc.go
@@ -15,8 +15,8 @@
 // Handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
 //   - decodes the request body into a request model from Content-Type, falling back to JSON when
 //     Content-Type is absent or unknown, and
-//   - encodes the response model using the negotiated media type, falling back to the first Accept media type
-//     when Content-Type is absent.
+//   - encodes the response model using the first Accept media type, falling back to Content-Type when
+//     Accept is absent.
 //
 // Errors are written using net/http/status helpers.
 //

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -19,7 +19,7 @@ import (
 // The handler is constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
 //   - decodes the request body using Content-Type, falling back to JSON when Content-Type is absent or unknown,
 //   - decodes the request body into a newly allocated request model, and
-//   - encodes the returned response model using the negotiated media type.
+//   - encodes the returned response model using Accept, falling back to Content-Type when Accept is absent.
 //
 // Registration:
 // The resulting handler is registered on the package-level mux configured via [Register].

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
@@ -129,6 +130,33 @@ func TestRestRequestWithContent(t *testing.T) {
 			require.Equal(t, "Hello test", resp.Greeting)
 		})
 	}
+}
+
+func TestRestRequestUsesAcceptForResponse(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+
+	test.RegisterRequestHandlers("/hello", test.RestRequestContent)
+
+	body := test.Pool.Get()
+	defer test.Pool.Put(body)
+	require.NoError(t, test.Encoder.Get("json").Encode(body, &test.Request{Name: "Bob"}))
+	header := http.Header{}
+	header.Set(content.TypeKey, media.JSON)
+	header.Set(content.AcceptKey, media.YAML)
+
+	res, responseBody, err := world.ResponseWithBody(
+		t.Context(),
+		world.NamedServerURL("http", "hello"),
+		http.MethodPost,
+		header,
+		body,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, media.YAML, res.Header.Get(content.TypeKey))
+	var response test.Response
+	require.NoError(t, test.Encoder.Get("yaml").Decode(strings.NewReader(responseBody), &response))
+	require.Equal(t, "Hello Bob", response.Greeting)
 }
 
 func TestRestInvalidStatusCode(t *testing.T) {


### PR DESCRIPTION
## What

- Split HTTP request and response media negotiation for content-aware helpers.
- Add `client.Options.Accept` and `rpc.WithClientAccept` so callers can send one media type and request a different response media type.
- Update content handlers, README, and GoDoc so response encoding follows `Accept` first and falls back to request `Content-Type`.

## Why

- REST/RPC helper users can now express normal HTTP workflows such as sending JSON while accepting YAML without custom handlers or round trippers.
- Existing `ContentType`-only callers keep their current fallback path when `Accept` is unset.

## Testing

- `make package=net/http/content specs` - passed
- `make package=net/http/client specs` - passed
- `make package=net/http/rest specs` - passed
- `make package=net/http/rpc specs` - passed
- `make package=transport/http specs` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
