### PR TITLE
feat(grpc): honor downstream retry delays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,14 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   path that demonstrates `Serve` is invoked after `Stop`/`GracefulStop` and
   causes an incorrect exit code.
 - `telemetry.Register()` installs the global OpenTelemetry propagator.
+- OTLP exporter endpoints intentionally come from explicit go-service config
+  fields such as `telemetry.logger.url`, `telemetry.metrics.url`, and
+  `telemetry.tracer.url`. Standard OpenTelemetry endpoint environment variables
+  such as `OTEL_EXPORTER_OTLP_ENDPOINT` are not fallback sources and should not
+  be projected into config by default. Operators that want env-managed endpoints
+  should set the go-service config values through their deployment/config
+  source; do not flag missing automatic `OTEL_*` endpoint projection as a
+  feature gap unless the documented support boundary changes.
 - Telemetry logger, metrics, and tracer setup installs process-global
   OpenTelemetry providers. Do not flag provider globals leaking after DI startup
   failure solely because lifecycle `OnStop` does not run; supported service

--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,11 @@ Default retry policy is intentionally conservative:
 - gRPC retries AIP-style read methods named `Get*` or `List*`, or calls with a `Request-Id`.
 - gRPC retries only `Unavailable` by default.
 
+HTTP retryable responses with a valid `Retry-After` delay greater than the
+minimum jittered backoff suppress another attempt and return the current
+response. gRPC retryable status errors with `google.rpc RetryInfo.retry_delay`
+use the same suppression policy.
+
 `Request-Id` identifies the logical request, not an individual wire attempt.
 Services that allow retried writes should treat it as the idempotency key and
 deduplicate repeated attempts when duplicate processing would be unsafe.

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -37,10 +37,12 @@ func ExampleNewConfig() {
 	flags.AddConfig("file:" + path)
 
 	decoder := config.NewDecoder(config.DecoderParams{
-		Flags:   flags,
-		Encoder: exampleEncodingMap(),
-		FS:      fs,
-		Name:    env.Name("payments"),
+		Flags: flags,
+		Encoder: encoding.NewMap(encoding.MapParams{
+			YAML: yaml.NewEncoder(),
+		}),
+		FS:   fs,
+		Name: env.Name("payments"),
 	})
 
 	cfg, err := config.NewConfig[exampleConfig](decoder, config.NewValidator())
@@ -50,10 +52,4 @@ func ExampleNewConfig() {
 
 	fmt.Println(cfg.Name)
 	// Output: payments
-}
-
-func exampleEncodingMap() *encoding.Map {
-	return encoding.NewMap(encoding.MapParams{
-		YAML: yaml.NewEncoder(),
-	})
 }

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -85,7 +85,9 @@ func TestInvalidConfig(t *testing.T) {
 }
 
 func TestInvalidPublicKeyConfig(t *testing.T) {
-	public := sshPublic(t)
+	data, err := test.FS.ReadSource(test.FilePath("secrets/ssh_public"))
+	require.NoError(t, err)
+	public := bytes.String(data)
 
 	t.Run("invalid verifier public key", func(t *testing.T) {
 		_, err := ssh.NewVerifier(test.FS, &ssh.Config{Public: test.FilePath("secrets/redis")})
@@ -213,13 +215,4 @@ func TestInvalidKeyType(t *testing.T) {
 		_, signerErr = ssh.NewSigner(test.FS, &ssh.Config{Private: test.FilePath("secrets/rsa_private")})
 	})
 	require.ErrorIs(t, signerErr, errors.ErrInvalidKeyType)
-}
-
-func sshPublic(t *testing.T) string {
-	t.Helper()
-
-	data, err := test.FS.ReadSource(test.FilePath("secrets/ssh_public"))
-	require.NoError(t, err)
-
-	return bytes.String(data)
 }

--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,6 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260622175928-b703f567277d // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/net/grpc/status/details.go
+++ b/net/grpc/status/details.go
@@ -1,0 +1,21 @@
+package status
+
+import (
+	"github.com/alexfalkowski/go-service/v2/time"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// RetryInfo aliases the standard google.rpc RetryInfo detail.
+//
+// It is commonly attached to retryable gRPC status errors to communicate how
+// long clients should wait before retrying the same request.
+type RetryInfo = errdetails.RetryInfo
+
+// Duration aliases the protobuf duration type used by structured status details.
+type Duration = durationpb.Duration
+
+// NewDuration returns a protobuf duration for structured gRPC status details.
+func NewDuration(d time.Duration) *Duration {
+	return durationpb.New(d.Duration())
+}

--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -23,7 +23,7 @@
 //
 //   - a status code (codes.Code), and
 //   - a human-readable message,
-//   - optionally, structured details (not handled by this package).
+//   - optionally, structured details.
 //
 // Clients can inspect errors to extract the status code and decide how to react
 // (retry, surface a user-facing error, map to HTTP status codes, etc.).
@@ -33,6 +33,17 @@
 // Use Error to create an error with a specific gRPC code:
 //
 //	err := status.Error(codes.NotFound, "widget does not exist")
+//
+// Use New when a caller needs a Status value before converting it to an error,
+// for example to attach structured details:
+//
+//	s, err := status.New(codes.Unavailable, "retry later").WithDetails(&status.RetryInfo{
+//		RetryDelay: status.NewDuration(delay),
+//	})
+//	if err != nil {
+//		return err
+//	}
+//	return s.Err()
 //
 // Use Errorf when the client-visible message should be formatted:
 //
@@ -73,6 +84,9 @@
 //     constants (OK, NotFound, Unavailable, etc.).
 //   - google.golang.org/grpc/status is the upstream implementation; this package
 //     forwards directly to it.
+//   - RetryInfo and NewDuration expose the protobuf detail types used by
+//     go-service retry behavior without requiring transport packages to import
+//     protobuf packages directly.
 //
 // # Client-visible messages
 //
@@ -84,8 +98,9 @@
 // # Non-goals
 //
 // This package intentionally exposes only the small subset of the upstream
-// status API that go-service uses broadly: Code, FromError, Error, Errorf,
-// SafeError, SafeErrorf, and the Status type alias. Higher-level code that
-// needs additional constructors or richer structured-detail helpers should use
-// the upstream status package directly.
+// status API and structured detail types that go-service uses broadly: Code,
+// FromError, New, Error, Errorf, SafeError, SafeErrorf, Status, RetryInfo, and
+// NewDuration. Higher-level code that needs unrelated structured-detail helpers
+// should add a narrow go-service alias here before reaching through to upstream
+// packages from transport code.
 package status

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -50,13 +50,22 @@ func FromError(err error) (*Status, bool) {
 	return status.FromError(err)
 }
 
+// New returns a Status with code c and message msg.
+//
+// This forwards to [google.golang.org/grpc/status.New]. Use it when callers
+// need a status value, for example to attach structured details before calling
+// Err.
+func New(c codes.Code, msg string) *Status {
+	return status.New(c, msg)
+}
+
 // Error constructs a gRPC status error with code c and message msg.
 //
 // The returned error is suitable to be returned from a gRPC handler so the runtime can send the
 // corresponding status code and message to the client. The message is client-visible by design.
 //
-// For structured status details (protobuf Any details), use the upstream status
-// API directly (for example [status.New](...).WithDetails(...)).
+// For structured status details, use [New] and local detail aliases such as
+// [RetryInfo] before calling Err.
 func Error(c codes.Code, msg string) error {
 	if c == codes.OK {
 		return nil

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,20 @@ func TestFromErrorUnknown(t *testing.T) {
 	s, ok := status.FromError(errors.New("plain error"))
 	require.False(t, ok)
 	require.Equal(t, codes.Unknown, s.Code())
+}
+
+func TestNewWithRetryInfo(t *testing.T) {
+	s, err := status.New(codes.Unavailable, "retry later").WithDetails(&status.RetryInfo{
+		RetryDelay: status.NewDuration(time.Second),
+	})
+	require.NoError(t, err)
+
+	details := s.Details()
+	require.Len(t, details, 1)
+
+	retryInfo, ok := details[0].(*status.RetryInfo)
+	require.True(t, ok)
+	require.Equal(t, time.Second.Duration(), retryInfo.GetRetryDelay().AsDuration())
 }
 
 func TestErrorf(t *testing.T) {

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -17,9 +17,12 @@ func ExampleGet() {
 	mux := http.NewServeMux()
 	pool := sync.NewBufferPool()
 	rest.Register(rest.RegisterParams{
-		Mux:     mux,
-		Content: exampleContent(pool),
-		Pool:    pool,
+		Mux: mux,
+		Content: content.NewContent(
+			encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
+			pool,
+		),
+		Pool: pool,
 	})
 
 	rest.Get("/hello", func(context.Context) (*exampleResponse, error) {
@@ -42,11 +45,4 @@ func ExampleGet() {
 
 type exampleResponse struct {
 	Message string `json:"message"`
-}
-
-func exampleContent(pool *sync.BufferPool) *content.Content {
-	return content.NewContent(
-		encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
-		pool,
-	)
 }

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -17,9 +17,12 @@ func ExampleClient_Post() {
 	mux := http.NewServeMux()
 	pool := sync.NewBufferPool()
 	rpc.Register(rpc.RegisterParams{
-		Mux:     mux,
-		Content: exampleContent(pool),
-		Pool:    pool,
+		Mux: mux,
+		Content: content.NewContent(
+			encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
+			pool,
+		),
+		Pool: pool,
 	})
 
 	rpc.Route("/hello", func(_ context.Context, req *exampleRequest) (*exampleResponse, error) {
@@ -45,11 +48,4 @@ type exampleRequest struct {
 
 type exampleResponse struct {
 	Message string `json:"message"`
-}
-
-func exampleContent(pool *sync.BufferPool) *content.Content {
-	return content.NewContent(
-		encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
-		pool,
-	)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -25,20 +25,19 @@ func TestRecover(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := recoverPanic(tt.value)
+			var err error
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						err = runtime.ConvertRecover(recovered)
+					}
+				}()
+
+				panic(tt.value)
+			}()
 
 			require.Error(t, err)
 			require.Equal(t, tt.message, err.Error())
 		})
 	}
-}
-
-func recoverPanic(value any) (err error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			err = runtime.ConvertRecover(recovered)
-		}
-	}()
-
-	panic(value)
 }

--- a/telemetry/attributes/attributes_test.go
+++ b/telemetry/attributes/attributes_test.go
@@ -23,7 +23,10 @@ func TestResourceMergesConfiguredAttributesWithIdentity(t *testing.T) {
 		"service-version",
 		"prod",
 	)
-	attrs := resourceAttributes(resource.Attributes())
+	attrs := make(map[string]string)
+	for _, attr := range resource.Attributes() {
+		attrs[string(attr.Key)] = attr.Value.AsString()
+	}
 
 	require.Equal(t, "payments", attrs["k8s.namespace.name"])
 	require.Equal(t, "host-id", attrs["host.id"])
@@ -63,12 +66,4 @@ func TestDeploymentEnvironmentName(t *testing.T) {
 			require.Equal(t, tt.expected, attribute.Value.AsString())
 		})
 	}
-}
-
-func resourceAttributes(attrs []attributes.KeyValue) map[string]string {
-	values := make(map[string]string)
-	for _, attr := range attrs {
-		values[string(attr.Key)] = attr.Value.AsString()
-	}
-	return values
 }

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -63,7 +63,14 @@ func TestMetaTruncatesLongValues(t *testing.T) {
 }
 
 func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
-	maxLength := metaValueLength(t, strings.Repeat("a", 2048))
+	ctx := meta.WithAttributes(
+		t.Context(),
+		meta.WithRequestID(meta.String(strings.Repeat("a", 2048))),
+	)
+	attrs := logger.Meta(ctx)
+	require.Len(t, attrs, 1)
+
+	maxLength := len(attrs[0].Value.String())
 	prefix := strings.Repeat("a", maxLength-1)
 
 	for _, tt := range []struct {
@@ -315,17 +322,4 @@ func TestOTLPLoggerUsesConfiguredLevel(t *testing.T) {
 	require.NotPanics(t, func() {
 		child.ErrorContext(ctx, "exported")
 	})
-}
-
-func metaValueLength(t *testing.T, value string) int {
-	t.Helper()
-
-	ctx := meta.WithAttributes(
-		t.Context(),
-		meta.WithRequestID(meta.String(value)),
-	)
-	attrs := logger.Meta(ctx)
-
-	require.Len(t, attrs, 1)
-	return len(attrs[0].Value.String())
 }

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -115,7 +115,10 @@ func TestMeterProviderAttributes(t *testing.T) {
 
 	rm := metrics.ResourceMetrics{}
 	require.NoError(t, reader.Collect(t.Context(), &rm))
-	attrs := resourceAttributes(rm)
+	attrs := make(map[attributes.Key]string)
+	for _, attr := range rm.Resource.Attributes() {
+		attrs[attr.Key] = attr.Value.AsString()
+	}
 
 	require.Equal(t, test.ID.String(), attrs[attributes.HostID("").Key])
 	require.Equal(t, test.Name.String(), attrs[attributes.ServiceName("").Key])
@@ -165,12 +168,4 @@ func TestOTLPReaderUsesConfiguredInterval(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return exports.Load() > 0
 	}, (2 * time.Second).Duration(), (20 * time.Millisecond).Duration())
-}
-
-func resourceAttributes(rm metrics.ResourceMetrics) map[attributes.Key]string {
-	attrs := make(map[attributes.Key]string)
-	for _, attr := range rm.Resource.Attributes() {
-		attrs[attr.Key] = attr.Value.AsString()
-	}
-	return attrs
 }

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -9,5 +9,9 @@
 // request-id identifies the logical request and is stable across retry attempts, so services that retry writes
 // should deduplicate by request-id. Callers that need different retry eligibility can pass an explicit policy.
 //
+// RetryInfo handling: when a retryable gRPC status error includes google.rpc RetryInfo with a retry_delay
+// greater than the minimum jittered backoff, the error is returned without another attempt. Missing, zero, or
+// shorter retry_delay values do not suppress a retry.
+//
 // Start with [Config] and [UnaryClientInterceptor].
 package retry

--- a/transport/grpc/retry/info.go
+++ b/transport/grpc/retry/info.go
@@ -1,0 +1,35 @@
+package retry
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/time"
+	config "github.com/alexfalkowski/go-service/v2/transport/retry"
+)
+
+func retryInfoDelayExceedsBackoff(err error, backoff time.Duration) bool {
+	return retryInfoDelay(err) > minimumJitteredBackoff(backoff)
+}
+
+func retryInfoDelay(err error) time.Duration {
+	grpcStatus, ok := status.FromError(err)
+	if !ok {
+		return 0
+	}
+
+	for _, detail := range grpcStatus.Details() {
+		if retryInfo, ok := detail.(*status.RetryInfo); ok {
+			delay := retryInfo.GetRetryDelay()
+			if delay == nil {
+				return 0
+			}
+
+			return time.Duration(delay.AsDuration())
+		}
+	}
+
+	return 0
+}
+
+func minimumJitteredBackoff(backoff time.Duration) time.Duration {
+	return backoff - (backoff * time.Duration(config.DefaultJitterPercent) / 100)
+}

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -83,6 +83,9 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 			if err == nil || !isRetryableCode(status.Code(err), codes) {
 				return err
 			}
+			if retryInfoDelayExceedsBackoff(err, backoff) {
+				return err
+			}
 
 			return retry.RetryableError(err)
 		})

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -133,6 +133,66 @@ func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsMinimumBackoff(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 10*time.Millisecond))
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return retryInfoError(t, codes.Unavailable, 20*time.Millisecond)
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *testing.T) {
+	tests := map[string]time.Duration{
+		"minimum": 8 * time.Millisecond,
+		"zero":    0,
+		"smaller": time.Millisecond,
+	}
+
+	for name, delay := range tests {
+		t.Run(name, func(t *testing.T) {
+			interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 10*time.Millisecond))
+
+			calls := 0
+			err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				if calls == 1 {
+					return retryInfoError(t, codes.Unavailable, delay)
+				}
+
+				return nil
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, 2, calls)
+		})
+	}
+}
+
+func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayIsMissing(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 10*time.Millisecond))
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		if calls == 1 {
+			grpcStatus, err := status.New(codes.Unavailable, "retry later").WithDetails(&status.RetryInfo{})
+			require.NoError(t, err)
+
+			return grpcStatus.Err()
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
 func TestUnaryClientInterceptorSetsDeadlineForEachAttempt(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond))
 
@@ -297,4 +357,15 @@ func TestUnaryClientInterceptorRetriesWhenPolicyAllowsRequestID(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
+}
+
+func retryInfoError(t *testing.T, code codes.Code, delay time.Duration) error {
+	t.Helper()
+
+	grpcStatus, err := status.New(code, "retry later").WithDetails(&status.RetryInfo{
+		RetryDelay: status.NewDuration(delay),
+	})
+	require.NoError(t, err)
+
+	return grpcStatus.Err()
 }


### PR DESCRIPTION
## What

- Honor `google.rpc RetryInfo.retry_delay` on retryable unary gRPC status errors by suppressing another attempt when the requested delay exceeds the minimum jittered backoff.
- Add `net/grpc/status` wrappers for status construction and RetryInfo duration details so transport code can stay on go-service import paths.
- Document the gRPC RetryInfo retry policy and record the OTLP endpoint environment projection behavior as by design in `AGENTS.md`.

## Why

- Lets service authors cooperate with downstream overload guidance instead of retrying earlier than the server asked.
- Keeps protobuf/gRPC detail dependencies behind the lower-level status wrapper rather than importing them directly from transport packages.
- Prevents future feature-gap passes from reopening standard OTEL endpoint environment projection, which is intentionally explicit-config behavior.

## Testing

- `make package=net/grpc/status specs` - passed
- `make package=transport/grpc/retry specs` - passed
- `make package=transport/grpc specs` - passed
- `make dep` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning and 0 issues
- `git diff --check` - passed
