### PR TITLE
feat(http): centralize handler registration through policy registry

### DIFF
--- a/internal/test/mvc.go
+++ b/internal/test/mvc.go
@@ -41,9 +41,9 @@ var Model = Page{
 	},
 }
 
-func registerMVC(mux *http.ServeMux, logger *slog.Logger) {
+func registerMVC(router *http.Router, logger *slog.Logger) {
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      router,
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: logger}),
 		FileSystem:  FileSystem,
 		Pool:        Pool,

--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -86,9 +86,9 @@ func RestRequestError(_ context.Context, _ *Request) (*Response, error) {
 	return nil, ErrInvalid
 }
 
-func registerRest(mux *http.ServeMux) {
+func registerRest(router *http.Router) {
 	rest.Register(rest.RegisterParams{
-		Mux:     mux,
+		Router:  router,
 		Pool:    Pool,
 		Content: Content,
 	})

--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -71,7 +71,7 @@ func ErrorsInternalProtobufSayHello(_ context.Context, _ *v1.SayHelloRequest) (*
 
 func (w *World) registerRPC() {
 	rpc.Register(rpc.RegisterParams{
-		Mux:     w.ServeMux,
+		Router:  w.Router,
 		Pool:    Pool,
 		Content: Content,
 	})

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -103,8 +103,8 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	httpClient, err := client.NewHTTP()
 	require.NoError(tb, err)
 
-	registerMVC(mux, logger.Logger)
-	registerRest(mux)
+	registerMVC(router, logger.Logger)
+	registerRest(router)
 
 	receiver, sender, err := NewEvents(router, os.rt, generator)
 	require.NoError(tb, err)
@@ -113,7 +113,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	world := &World{
 		t:      tb,
 		Logger: logger, Tracer: tracer,
-		Lifecycle: lc, ServeMux: mux, Router: router,
+		Lifecycle: lc, Router: router,
 		Server: server, Client: client,
 		Rest:     restClient(httpClient, os),
 		Receiver: receiver, Sender: sender,
@@ -145,15 +145,13 @@ func NewStartedWorld(tb testing.TB, opts ...WorldOption) *World {
 
 // World groups the shared components used by integration-style tests.
 //
-// It exposes the lifecycle, mux, logger, transport builders, cache, event
+// It exposes the lifecycle, router, logger, transport builders, cache, event
 // sender/receiver, and generated configs so tests can compose realistic service
 // scenarios with minimal boilerplate.
 type World struct {
 	t testing.TB
 	// Lifecycle controls startup and shutdown hooks for the test world.
 	*fxtest.Lifecycle
-	// ServeMux is the HTTP mux used by world HTTP handlers.
-	*http.ServeMux
 	// Router registers HTTP handlers with route policy used by transport middleware.
 	*http.Router
 	// Logger is the test logger shared by world components.
@@ -210,9 +208,9 @@ func (w *World) Start() *World {
 
 // HandleHello registers a simple HTTP hello endpoint on the world's mux.
 func (w *World) HandleHello() {
-	w.HandleFunc("GET /hello", func(w http.ResponseWriter, _ *http.Request) {
+	w.Handle("GET /hello", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(strings.Bytes("hello!"))
-	})
+	}))
 }
 
 // NamedServerURL returns a server URL rooted at `/<service-name>/<path>`.

--- a/net/http/handler_test.go
+++ b/net/http/handler_test.go
@@ -59,9 +59,10 @@ func testNotFoundHandler(t *testing.T, tt notFoundHandlerTest) {
 
 	mux := http.NewServeMux()
 	if tt.registerRoute {
-		http.HandleFunc(mux, "GET /hello", func(res http.ResponseWriter, _ *http.Request) {
+		router := http.NewRouter(mux, http.NewRoutePolicy())
+		router.Handle("GET /hello", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 			res.WriteHeader(http.StatusOK)
-		})
+		}))
 	}
 
 	handler := http.NewNotFoundHandler(mux, test.Pool, func(res http.ResponseWriter, _ *http.Request) bool {

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -252,16 +252,6 @@ func NewTelemetryHandler(handler Handler, operation string) Handler {
 	return telemetry.NewHandler(handler, operation)
 }
 
-// HandleFunc registers handler for pattern on mux.
-func HandleFunc(mux *ServeMux, pattern string, handler http.HandlerFunc) {
-	Handle(mux, pattern, handler)
-}
-
-// Handle registers handler for pattern on mux.
-func Handle(mux *ServeMux, pattern string, handler http.Handler) {
-	mux.Handle(pattern, handler)
-}
-
 // StatusText returns the standard HTTP status text for the given status code.
 //
 // This is a thin wrapper around [net/http.StatusText].

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -126,7 +126,8 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 
 func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /users/{id}", func(http.ResponseWriter, *http.Request) {})
+	router := http.NewRouter(mux, http.NewRoutePolicy())
+	router.Handle("GET /users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), mux)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)

--- a/net/http/mvc/doc.go
+++ b/net/http/mvc/doc.go
@@ -1,7 +1,7 @@
 // Package mvc provides a small MVC-style HTML rendering layer for go-service HTTP servers.
 //
 // This package provides helpers to register controller-driven routes that render HTML templates.
-// It relies on package-level registration (see Register) to supply the HTTP mux, template function map,
+// It relies on package-level registration (see Register) to supply the HTTP router, template function map,
 // filesystem, and layout.
 //
 // Registration requirements:

--- a/net/http/mvc/example_test.go
+++ b/net/http/mvc/example_test.go
@@ -14,8 +14,9 @@ import (
 
 func ExampleGet() {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      router,
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  exampleFileSystem(),
 		Pool:        sync.NewBufferPool(),
@@ -41,8 +42,9 @@ func ExampleGet() {
 
 func ExampleNotFound() {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      router,
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  exampleFileSystem(),
 		Pool:        sync.NewBufferPool(),
@@ -68,8 +70,9 @@ func ExampleNotFound() {
 
 func ExampleStaticFile() {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      router,
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  exampleFileSystem(),
 		Pool:        sync.NewBufferPool(),
@@ -111,8 +114,9 @@ func ExampleStaticFile() {
 
 func ExampleStaticPathValue() {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      router,
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  exampleFileSystem(),
 		Pool:        sync.NewBufferPool(),

--- a/net/http/mvc/mvc.go
+++ b/net/http/mvc/mvc.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	mux                *http.ServeMux
+	router             *http.Router
 	fmap               sprout.FunctionMap
 	fileSystem         fs.FS
 	layout             *Layout
@@ -26,8 +26,8 @@ var (
 type RegisterParams struct {
 	di.In
 
-	// Mux is the HTTP mux where MVC routes (Route/Get/Post/etc.) will be registered.
-	Mux *http.ServeMux
+	// Router registers MVC routes (Route/Get/Post/etc.).
+	Router *http.Router
 
 	// FunctionMap is the template function map used when parsing templates.
 	//
@@ -63,7 +63,7 @@ type RegisterParams struct {
 // If MVC is not defined, routing helpers (Route/Get/Post/etc. and static helpers) return false and do not
 // register handlers.
 func Register(params RegisterParams) {
-	mux = params.Mux
+	router = params.Router
 	fmap = params.FunctionMap
 	fileSystem = params.FileSystem
 	pool = params.Pool

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -89,7 +89,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 		writeView(ctx, res, view, model, http.StatusOK)
 	}
 
-	http.HandleFunc(mux, pattern, handler)
+	router.Handle(pattern, http.HandlerFunc(handler))
 	return true
 }
 

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -22,7 +22,7 @@ import (
 func TestStaticPathValueRejectsTraversal(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.FileSystem,
 		Pool:        test.Pool,
@@ -42,7 +42,7 @@ func TestStaticPathValueRejectsTraversal(t *testing.T) {
 func TestStaticPathValueSetsContentType(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"static/icon.svg": &fstest.MapFile{Data: []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`)},
@@ -64,7 +64,7 @@ func TestStaticPathValueSetsContentType(t *testing.T) {
 func TestStaticPathValueRejectsDirectory(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"static/assets": &fstest.MapFile{Mode: fs.ModeDir},
@@ -85,7 +85,7 @@ func TestStaticPathValueRejectsDirectory(t *testing.T) {
 func TestStaticFileSetsContentType(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"static/icon.svg": &fstest.MapFile{Data: []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`)},
@@ -107,7 +107,7 @@ func TestStaticFileSetsContentType(t *testing.T) {
 func TestStaticFileRejectsDirectory(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"static/assets": &fstest.MapFile{Mode: fs.ModeDir},
@@ -128,7 +128,7 @@ func TestStaticFileRejectsDirectory(t *testing.T) {
 func TestStaticFileRejectsPermissionDenied(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  permissionFileSystem{},
 		Pool:        test.Pool,
@@ -147,7 +147,7 @@ func TestStaticFileRejectsPermissionDenied(t *testing.T) {
 func TestStaticFileSetsCacheControl(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"static/asset.txt": &fstest.MapFile{Data: []byte("hello")},
@@ -172,7 +172,7 @@ func TestStaticFileUsesETagValidator(t *testing.T) {
 	modified := time.Now().UTC()
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"static/asset.txt": &fstest.MapFile{Data: []byte("hello"), ModTime: modified},
@@ -236,7 +236,7 @@ func TestStaticPathValueUsesETagValidator(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			mvc.Register(mvc.RegisterParams{
-				Mux:         mux,
+				Router:      newTestRouter(mux),
 				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 				FileSystem: fstest.MapFS{
 					"static/asset.txt": &fstest.MapFile{Data: []byte("hello")},
@@ -272,7 +272,7 @@ func TestStaticPathValueUsesETagValidator(t *testing.T) {
 func TestViewRenderReturnsContextError(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.FileSystem,
 		Pool:        test.Pool,
@@ -291,7 +291,7 @@ func TestViewRenderReturnsContextError(t *testing.T) {
 func TestViewRenderReturnsWriteError(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.FileSystem,
 		Pool:        test.Pool,
@@ -326,7 +326,7 @@ func TestNewViewUsesLayoutPathWhenBasenameCollides(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			mvc.Register(mvc.RegisterParams{
-				Mux:         mux,
+				Router:      newTestRouter(mux),
 				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 				FileSystem: fstest.MapFS{
 					"views/full.tmpl":    &fstest.MapFile{Data: []byte(`full layout {{ block "content" . }}default{{ end }}`)},
@@ -359,7 +359,7 @@ func TestLayoutNames(t *testing.T) {
 func TestRouteErrorIncludesSafeModelAndRawMetaInTemplate(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -387,7 +387,7 @@ func TestRouteErrorIncludesSafeModelAndRawMetaInTemplate(t *testing.T) {
 func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -415,7 +415,7 @@ func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
 func TestRouteRenderErrorDoesNotUseNotFoundController(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -448,7 +448,7 @@ func TestRouteRenderErrorDoesNotUseNotFoundController(t *testing.T) {
 func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -476,7 +476,7 @@ func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
 func TestNotFoundHandlesNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -507,7 +507,7 @@ func TestNotFoundHandlesNotFound(t *testing.T) {
 func TestNotFoundIncludesRequestMeta(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -538,7 +538,7 @@ func TestNotFoundIncludesRequestMeta(t *testing.T) {
 func TestNotFoundUsesDefaultWhenControllerMissing(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.FileSystem,
 		Pool:        test.Pool,
@@ -568,8 +568,9 @@ func TestFallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
 			mvc.Register(mvc.RegisterParams{
-				Mux:         http.NewServeMux(),
+				Router:      newTestRouter(mux),
 				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 				FileSystem: fstest.MapFS{
 					"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -607,7 +608,7 @@ func TestFallback(t *testing.T) {
 func TestNotFoundWritesRenderStatusWhenViewMissing(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.FileSystem,
 		Pool:        test.Pool,
@@ -630,7 +631,7 @@ func TestNotFoundWritesRenderStatusWhenViewMissing(t *testing.T) {
 func TestNotFoundDoesNotReplaceMethodNotAllowed(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem: fstest.MapFS{
 			"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
@@ -661,7 +662,7 @@ func TestNotFoundDoesNotReplaceMethodNotAllowed(t *testing.T) {
 func TestStaticFileSetsContentLength(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
-		Mux:         mux,
+		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.ErrFileSystem{},
 		Pool:        test.Pool,
@@ -683,6 +684,10 @@ func TestStaticFileSetsContentLength(t *testing.T) {
 type requestModel struct {
 	Method string
 	Path   string
+}
+
+func newTestRouter(mux *http.ServeMux) *http.Router {
+	return http.NewRouter(mux, http.NewRoutePolicy())
 }
 
 type permissionFileSystem struct{}

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -34,7 +34,7 @@ func StaticFile(pattern, name string, opts ...StaticOption) bool {
 		serveFile(res, req, name, options)
 	}
 
-	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
+	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
 	return true
 }
 
@@ -61,7 +61,7 @@ func StaticPathValue(pattern, value, prefix string, opts ...StaticOption) bool {
 		serveFile(res, req, name, options)
 	}
 
-	http.HandleFunc(mux, strings.Join(strings.Space, http.MethodGet, pattern), handler)
+	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
 	return true
 }
 

--- a/net/http/rest/doc.go
+++ b/net/http/rest/doc.go
@@ -1,11 +1,11 @@
 // Package rest provides REST-style HTTP handler registration and client helpers for go-service.
 //
 // This package is built on top of [github.com/alexfalkowski/go-service/v2/net/http/content]. It relies on package-level registration (see [Register])
-// to supply the HTTP mux, content codec helpers, and buffer pool that are used when wiring handlers and clients.
+// to supply the HTTP router, content codec helpers, and buffer pool that are used when wiring handlers and clients.
 //
 // # Server-side routing
 //
-// Server-side helpers (Get/Post/etc.) register handlers on the configured mux using method-qualified
+// Server-side helpers (Get/Post/etc.) register handlers on the configured router using method-qualified
 // patterns of the form:
 //
 //	"<METHOD> <pattern>"

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -15,9 +15,10 @@ import (
 
 func ExampleGet() {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
 	rest.Register(rest.RegisterParams{
-		Mux: mux,
+		Router: router,
 		Content: content.NewContent(
 			encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
 			pool,

--- a/net/http/rest/rest.go
+++ b/net/http/rest/rest.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	mux  *http.ServeMux
-	cont *content.Content
-	pool *sync.BufferPool
+	router *http.Router
+	cont   *content.Content
+	pool   *sync.BufferPool
 )
 
 // RegisterParams defines dependencies used to register REST package globals.
@@ -20,8 +20,8 @@ var (
 type RegisterParams struct {
 	di.In
 
-	// Mux is the HTTP mux where server-side routes will be registered by this package's helpers.
-	Mux *http.ServeMux
+	// Router registers server-side routes for this package's helpers.
+	Router *http.Router
 
 	// Content resolves encoders/decoders based on HTTP media types (Content-Type).
 	Content *content.Content
@@ -38,10 +38,10 @@ type RegisterParams struct {
 // package. If it is not called, globals will be nil and helper calls will panic.
 //
 // After registration:
-//   - server-side helpers (Get/Post/etc.) register handlers on the registered mux, and
+//   - server-side helpers (Get/Post/etc.) register handlers on the registered router, and
 //   - client helpers (NewClient) build clients using the registered content codecs and buffer pool.
 func Register(params RegisterParams) {
-	mux = params.Mux
+	router = params.Router
 	cont = params.Content
 	pool = params.Pool
 }

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -8,7 +8,7 @@ import (
 
 // Delete registers an HTTP DELETE handler under pattern.
 //
-// The effective route pattern passed to the underlying mux is a method-qualified pattern of the form:
+// The effective route pattern passed to the router is a method-qualified pattern of the form:
 //
 //	"<METHOD> <pattern>"
 //
@@ -23,7 +23,7 @@ func Delete[Res any](pattern string, handler content.Handler[Res]) {
 
 // Get registers an HTTP GET handler under pattern.
 //
-// The effective route pattern passed to the underlying mux is method-qualified (see Delete for details).
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to Route.
 func Get[Res any](pattern string, handler content.Handler[Res]) {
 	Route(strings.Join(strings.Space, http.MethodGet, pattern), handler)
@@ -31,7 +31,7 @@ func Get[Res any](pattern string, handler content.Handler[Res]) {
 
 // Post registers an HTTP POST handler under pattern.
 //
-// The effective route pattern passed to the underlying mux is method-qualified (see Delete for details).
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
 func Post[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
 	RouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler)
@@ -39,7 +39,7 @@ func Post[Req any, Res any](pattern string, handler content.RequestHandler[Req, 
 
 // Put registers an HTTP PUT handler under pattern.
 //
-// The effective route pattern passed to the underlying mux is method-qualified (see Delete for details).
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
 func Put[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
 	RouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler)
@@ -47,7 +47,7 @@ func Put[Req any, Res any](pattern string, handler content.RequestHandler[Req, R
 
 // Patch registers an HTTP PATCH handler under pattern.
 //
-// The effective route pattern passed to the underlying mux is method-qualified (see Delete for details).
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
 func Patch[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
 	RouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler)
@@ -61,10 +61,10 @@ func Patch[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 //   - encodes the returned response model using the negotiated media type.
 //
 // Registration:
-// The resulting handler is registered on the package-level mux configured via [Register].
-// [Register] must be called before RouteRequest; otherwise mux/cont will be nil and this function will panic.
+// The resulting handler is registered on the package-level router configured via [Register].
+// [Register] must be called before RouteRequest; otherwise router/cont will be nil and this function will panic.
 func RouteRequest[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
-	http.HandleFunc(mux, pattern, content.NewRequestHandler(cont, handler))
+	router.Handle(pattern, content.NewRequestHandler(cont, handler))
 }
 
 // Route registers a handler under pattern that encodes a response.
@@ -75,8 +75,8 @@ func RouteRequest[Req any, Res any](pattern string, handler content.RequestHandl
 //   - encodes the returned response model using the negotiated media type.
 //
 // Registration:
-// The resulting handler is registered on the package-level mux configured via Register.
-// Register must be called before Route; otherwise mux/cont will be nil and this function will panic.
+// The resulting handler is registered on the package-level router configured via Register.
+// Register must be called before Route; otherwise router/cont will be nil and this function will panic.
 func Route[Res any](pattern string, handler content.Handler[Res]) {
-	http.HandleFunc(mux, pattern, content.NewHandler(cont, handler))
+	router.Handle(pattern, content.NewHandler(cont, handler))
 }

--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -61,7 +61,7 @@ type Router struct {
 
 // Handle registers handler for pattern on the Router's mux.
 func (r *Router) Handle(pattern string, handler Handler) {
-	Handle(r.mux, pattern, handler)
+	r.mux.Handle(pattern, handler)
 }
 
 // HandleOperation registers handler and marks pattern as a service-owned operation path.

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -43,8 +43,9 @@ func TestPostRequiresNonNilTypedResponse(t *testing.T) {
 
 func TestPostUsesAccept(t *testing.T) {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	rpc.Register(rpc.RegisterParams{
-		Mux:     mux,
+		Router:  router,
 		Content: test.Content,
 		Pool:    test.Pool,
 	})

--- a/net/http/rpc/doc.go
+++ b/net/http/rpc/doc.go
@@ -1,11 +1,11 @@
 // Package rpc provides RPC-style HTTP handler registration and client helpers for go-service.
 //
 // This package is built on top of [github.com/alexfalkowski/go-service/v2/net/http/content]. It relies on package-level registration (see [Register])
-// to supply the HTTP mux, content codec helpers, and buffer pool that are used when wiring handlers and clients.
+// to supply the HTTP router, content codec helpers, and buffer pool that are used when wiring handlers and clients.
 //
 // # Server-side routing
 //
-// Server-side helpers register POST handlers on the configured mux using method-qualified patterns of the form:
+// Server-side helpers register POST handlers on the configured router using method-qualified patterns of the form:
 //
 //	"POST <pattern>"
 //

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -15,9 +15,10 @@ import (
 
 func ExampleClient_Post() {
 	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
 	rpc.Register(rpc.RegisterParams{
-		Mux: mux,
+		Router: router,
 		Content: content.NewContent(
 			encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
 			pool,

--- a/net/http/rpc/rpc.go
+++ b/net/http/rpc/rpc.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	mux  *http.ServeMux
-	cont *content.Content
-	pool *sync.BufferPool
+	router *http.Router
+	cont   *content.Content
+	pool   *sync.BufferPool
 )
 
 // RegisterParams defines dependencies used to register RPC package globals.
@@ -20,8 +20,8 @@ var (
 type RegisterParams struct {
 	di.In
 
-	// Mux is the HTTP mux where server-side routes will be registered by this package's helpers.
-	Mux *http.ServeMux
+	// Router registers server-side routes for this package's helpers.
+	Router *http.Router
 
 	// Content resolves encoders/decoders based on HTTP media types (Content-Type).
 	Content *content.Content
@@ -37,7 +37,7 @@ type RegisterParams struct {
 // Important: Register must be called before using any server-side route helpers or client helpers in this
 // package. If it is not called, globals will be nil and helper calls will panic.
 func Register(params RegisterParams) {
-	mux = params.Mux
+	router = params.Router
 	cont = params.Content
 	pool = params.Pool
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -8,7 +8,7 @@ import (
 
 // Route registers an RPC-style HTTP POST handler under pattern.
 //
-// The effective route pattern passed to the underlying mux is method-qualified and has the form:
+// The effective route pattern passed to the router is method-qualified and has the form:
 //
 //	"<METHOD> <pattern>"
 //
@@ -22,11 +22,10 @@ import (
 //   - encodes the returned response model using Accept, falling back to Content-Type when Accept is absent.
 //
 // Registration:
-// The resulting handler is registered on the package-level mux configured via [Register].
-// [Register] must be called before Route; otherwise mux/cont will be nil and this function will panic.
+// The resulting handler is registered on the package-level router configured via [Register].
+// [Register] must be called before Route; otherwise router/cont will be nil and this function will panic.
 func Route[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
-	http.HandleFunc(
-		mux,
+	router.Handle(
 		strings.Join(strings.Space, http.MethodPost, pattern),
 		content.NewRequestHandler(cont, handler),
 	)

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -112,9 +112,9 @@ func TestAccessDeniedUnary(t *testing.T) {
 func TestAuthDoesNotBypassApplicationMetricsPath(t *testing.T) {
 	world := test.NewWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldHTTP())
 
-	http.HandleFunc(world.ServeMux, "GET /admin/metrics", func(res http.ResponseWriter, _ *http.Request) {
+	world.Handle("GET /admin/metrics", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		_, _ = res.Write([]byte("secret"))
-	})
+	}))
 	world.Start()
 
 	res, body, err := world.ResponseWithBody(t.Context(), world.PathServerURL("http", "admin/metrics"), http.MethodGet, http.Header{}, http.NoBody)

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -73,7 +73,8 @@ func BenchmarkHTTP(b *testing.B) {
 
 		mux := transporthttp.NewServeMux()
 		policy := transporthttp.NewRoutePolicy()
-		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
+		router := transporthttp.NewRouter(mux, policy)
+		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 		lc := fxtest.NewLifecycle(b)
 		cfg := test.NewInsecureTransportConfig()
 
@@ -121,7 +122,8 @@ func BenchmarkHTTP(b *testing.B) {
 
 		mux := transporthttp.NewServeMux()
 		policy := transporthttp.NewRoutePolicy()
-		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
+		router := transporthttp.NewRouter(mux, policy)
+		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 		lc := fxtest.NewLifecycle(b)
 		logger, err := logger.NewLogger(logger.LoggerParams{})
 		require.NoError(b, err)
@@ -173,7 +175,8 @@ func BenchmarkHTTP(b *testing.B) {
 
 		mux := transporthttp.NewServeMux()
 		policy := transporthttp.NewRoutePolicy()
-		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
+		router := transporthttp.NewRouter(mux, policy)
+		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 		lc := fxtest.NewLifecycle(b)
 		logger, err := logger.NewLogger(logger.LoggerParams{})
 		require.NoError(b, err)

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -142,16 +142,6 @@ func MaxBytesHandler(h Handler, n int64) Handler {
 	return http.MaxBytesHandler(h, n)
 }
 
-// HandleFunc registers handler for pattern on mux.
-func HandleFunc(mux *ServeMux, pattern string, handler HandlerFunc) {
-	http.HandleFunc(mux, pattern, handler)
-}
-
-// Handle registers handler for pattern on mux.
-func Handle(mux *ServeMux, pattern string, handler Handler) {
-	http.Handle(mux, pattern, handler)
-}
-
 // ParseServiceMethod derives a logical "service" and "method" name from an HTTP request.
 func ParseServiceMethod(req *Request) (string, string) {
 	return http.ParseServiceMethod(req)

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -86,9 +86,9 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
 		test.WithWorldHTTP(),
 	)
-	http.HandleFunc(world.ServeMux, "GET /admin/metrics", func(res http.ResponseWriter, _ *http.Request) {
+	world.Handle("GET /admin/metrics", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		_, _ = res.Write([]byte("secret"))
-	})
+	}))
 	world.Start()
 
 	url := world.PathServerURL("http", "admin/metrics")

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -224,7 +224,7 @@ func TestStaticPathValueError(t *testing.T) {
 
 func TestMissingViews(t *testing.T) {
 	mvc.Register(mvc.RegisterParams{
-		Mux:         http.NewServeMux(),
+		Router:      newTestRouter(),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		Pool:        test.Pool,
 		Layout:      test.Layout,
@@ -240,7 +240,7 @@ func TestMissingViews(t *testing.T) {
 	require.False(t, mvc.StaticPathValue("/{file}", "file", "static"))
 
 	mvc.Register(mvc.RegisterParams{
-		Mux:         http.NewServeMux(),
+		Router:      newTestRouter(),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
 		FileSystem:  test.FileSystem,
 		Pool:        test.Pool,
@@ -254,4 +254,8 @@ func TestMissingViews(t *testing.T) {
 	}))
 	require.False(t, mvc.StaticFile("/robots.txt", "static/robots.txt"))
 	require.False(t, mvc.StaticPathValue("/{file}", "file", "static"))
+}
+
+func newTestRouter() *http.Router {
+	return http.NewRouter(http.NewServeMux(), http.NewRoutePolicy())
 }

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -56,7 +56,7 @@ func TestServerMaxReceiveSize(t *testing.T) {
 	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
-	http.Handle(world.ServeMux, "POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+	world.Handle("POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "hello"}, nil
 	}))
 	world.Start()
@@ -80,7 +80,7 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
-	http.Handle(world.ServeMux, "POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+	world.Handle("POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "hello"}, nil
 	}))
 	world.Start()
@@ -101,9 +101,9 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 
 func TestServerRecoversPanic(t *testing.T) {
 	world := test.NewWorld(t, test.WithWorldHTTP())
-	http.HandleFunc(world.ServeMux, "GET /panic", func(http.ResponseWriter, *http.Request) {
+	world.Handle("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test panic")
-	})
+	}))
 	world.HandleHello()
 	world.Start()
 


### PR DESCRIPTION
## What

- Route RPC, REST, and MVC server registration through the shared router instead of registering handlers directly on the mux.
- Keep regular application routes authenticated, logged, and limited by default while preserving router policy support for operation and unauthenticated routes.
- Remove the direct mux registration wrappers from the service HTTP packages so new route registration uses the router surface.
- Update internal test wiring, examples, and benchmarks to register application handlers through the router, while leaving mux usage for server wiring, metadata pattern lookup, MVC not-found handling, debug routing, and the standard-library benchmark baseline.

## Why

- Centralizing handler registration keeps route policy decisions attached to the same path that installs handlers.
- This prevents future HTTP endpoints from accidentally bypassing policy metadata by reaching around the router and registering directly on the mux.
- Removing the direct wrapper functions makes the intended registration surface clearer for service code and tests.

## Testing

- `go test ./net/http ./net/http/meta ./net/http/rest ./net/http/rpc ./net/http/mvc ./transport/http` - passed
- `make lint` - passed
- `make specs` - passed, 2247 tests
- `rg -n "\\b[a-zA-Z0-9_]*http\\.Handle(Func)?\\(" -g '*.go'` in `/Users/alejandro/code/web` - passed, no deleted wrapper usage found
