### PR TITLE
feat(retry): honor extended http status codes

### DIFF
--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -283,7 +283,7 @@ func retryableStatusCodes(cfg *Config) []int {
 
 	codes := make([]int, 0, len(cfg.StatusCodes))
 	for _, code := range cfg.StatusCodes {
-		if code >= http.StatusBadRequest && code <= http.StatusNetworkAuthenticationRequired {
+		if code >= http.StatusBadRequest && code <= 599 {
 			codes = append(codes, code)
 		}
 	}

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -20,7 +20,11 @@ import (
 )
 
 func TestConfigRejectsInvalidStatusCodes(t *testing.T) {
-	require.NoError(t, test.Validator.Struct(&retry.Config{StatusCodes: []int{http.StatusBadRequest, http.StatusNetworkAuthenticationRequired}}))
+	require.NoError(t, test.Validator.Struct(&retry.Config{StatusCodes: []int{
+		http.StatusBadRequest,
+		http.StatusNetworkAuthenticationRequired,
+		520,
+	}}))
 	require.Error(t, test.Validator.Struct(&retry.Config{StatusCodes: []int{http.StatusContinue}}))
 	require.Error(t, test.Validator.Struct(&retry.Config{StatusCodes: []int{600}}))
 }
@@ -67,6 +71,18 @@ func TestRoundTripperRetriesRetryableResponses(t *testing.T) {
 func TestRoundTripperRetriesConfiguredStatusCodes(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusBadGateway, http.StatusOK}}
 	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, time.Millisecond, http.StatusBadGateway), rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 2, rt.Calls)
+}
+
+func TestRoundTripperRetriesConfiguredExtended5xxStatusCodes(t *testing.T) {
+	rt := &test.StatusSequenceRoundTripper{Codes: []int{520, http.StatusOK}}
+	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, time.Millisecond, 520), rt)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
 


### PR DESCRIPTION
## What

- Configured HTTP failure status codes now remain retryable through the full decoded 400-599 range.
- Added regression coverage for an extended 5xx status code to confirm config validation accepts it and the round tripper retries it.

## Why

- Operators can configure status codes such as 520 without the retry transport silently dropping them at runtime.
- This keeps retry runtime behavior aligned with its config validation, GoDoc, and nearby HTTP error classification.

## Testing

- `make package=transport/http/retry specs` - passed; covered retry package behavior including the new configured extended 5xx regression.
- `make package=transport/http/retry lint` - passed; package lint returned 0 issues.
