### PR TITLE
feat(grpc): bound stream limiter response metadata to a single emission per decision

### DIFF
--- a/transport/grpc/limiter/server.go
+++ b/transport/grpc/limiter/server.go
@@ -115,8 +115,11 @@ func (s *serverStream) RecvMsg(m any) error {
 		return err
 	}
 
-	setStreamHeader(s, decision)
+	// The stream open interceptor already emitted the quota metadata, and gRPC appends rather than
+	// overwrites header/trailer values, so re-emitting per message only bloats the response. Emit
+	// again only on rejection so clients still observe the terminating quota state.
 	if !decision.Allowed() {
+		setStreamHeader(s, decision)
 		return limitError()
 	}
 
@@ -129,8 +132,9 @@ func (s *serverStream) SendMsg(m any) error {
 		return err
 	}
 
-	setStreamHeader(s, decision)
+	// See RecvMsg: the quota metadata is emitted once at stream open, and again only on rejection.
 	if !decision.Allowed() {
+		setStreamHeader(s, decision)
 		return limitError()
 	}
 

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -77,6 +77,26 @@ func TestServerLimiterStreamHeader(t *testing.T) {
 	require.NotEmpty(t, rejected.Header.Get("ratelimit-policy"))
 }
 
+func TestServerLimiterStreamHeaderNotDuplicated(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 10)), test.WithWorldGRPC())
+
+	conn := test.RequireGRPCConn(t, world)
+	defer conn.Close()
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	_, err = test.SendStreamHello(t, stream, "test")
+	require.NoError(t, err)
+
+	header, err := stream.Header()
+	require.NoError(t, err)
+	require.Len(t, header.Get("ratelimit"), 1)
+	require.Len(t, header.Get("ratelimit-policy"), 1)
+}
+
 func TestClientLimiterUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
 


### PR DESCRIPTION
## What

- The gRPC server stream rate limiter no longer re-attaches `ratelimit` /
  `ratelimit-policy` response metadata on every `RecvMsg` and `SendMsg`. Quota
  metadata is now emitted once at stream open and again only when a later
  message is rejected.
- Client-visible behavior on the allowed path is unchanged: allowed stream opens
  (and unary responses) still carry a single set of quota headers, and rejected
  streams still surface the terminating quota state (via trailer once headers are
  already sent).
- Per-operation token metering is intentionally unchanged; only the redundant
  response-metadata emission was bounded.

## Why

- gRPC appends header/trailer metadata (`metadata.Join`) rather than overwriting
  it. Re-attaching the quota values on every stream message caused the pending
  header (recv-heavy / client-streaming) or trailer (post-first-send /
  server-streaming) to grow O(number of messages) for the stream's lifetime —
  retained in the transport stream map and flushed on the wire, with clients
  seeing many duplicate `ratelimit` values.
- Because gRPC cannot overwrite an already-set value, per-message re-emission
  could never express an updated quota anyway; it was pure memory and wire bloat
  on long-lived or high-volume streams such as health `Watch` or any client-/
  server-streaming method. This addresses reliability gap REL-1.

## Testing

- `go test ./transport/grpc/... -count=1` - passed
- `make lint` - passed (0 issues)
- `gofmt -l` and `go vet ./transport/grpc/...` - passed
- Added `TestServerLimiterStreamHeaderNotDuplicated`, which drives a real
  streaming RPC and asserts the response header carries exactly one `ratelimit`
  / `ratelimit-policy` value (previously three: open + recv + send). Existing
  rejection tests continue to assert quota metadata is still emitted on rejected
  streams.
- Full-suite `make specs` not run locally (requires sidecars / network); relying
  on CI for that coverage.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
