### PR TITLE
feat(metrics): add configurable histogram bucket boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,25 @@ telemetry:
 `interval` and `timeout` apply only to OTLP push metrics. When either value is
 unset or zero, the OpenTelemetry SDK default is used.
 
+#### Histogram buckets
+
+Override the default histogram bucket boundaries per instrument with
+`telemetry.metrics.views`, keyed by instrument name (OpenTelemetry name matching,
+including `*` wildcards):
+
+```yaml
+telemetry:
+  metrics:
+    views:
+      http.server.request.duration: [0.005, 0.01, 0.05, 0.1, 0.5, 1, 5]
+      "rpc.*.duration": [0.01, 0.1, 1]
+```
+
+Boundaries are in the instrument's unit (seconds for duration histograms, bytes
+for size histograms) and must be listed in increasing order. Views apply to
+histogram instruments regardless of metrics kind; an unset or empty map keeps the
+OpenTelemetry SDK default buckets.
+
 ### Tracing
 
 Tracing supports OTLP exporter config:

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -26,6 +26,17 @@ type Config struct {
 	// config enables TLS; Cert, Key, and CA values use go-service source strings.
 	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
+	// Views maps OpenTelemetry instrument names to explicit histogram bucket
+	// boundaries, overriding the SDK default boundaries for matching histogram
+	// instruments such as "http.server.request.duration" or "rpc.server.call.duration".
+	//
+	// Instrument name matching follows OpenTelemetry view semantics and supports
+	// "*" wildcards (for example "rpc.*.duration"). Boundaries are expressed in the
+	// instrument's unit (seconds for duration histograms, bytes for size
+	// histograms) and must be listed in increasing order. A nil or empty map keeps
+	// the SDK default boundaries, so this field is a no-op unless configured.
+	Views map[string][]float64 `yaml:"views,omitempty" json:"views,omitempty" toml:"views,omitempty"`
+
 	// Kind selects the metrics reader/exporter implementation.
 	//
 	// Supported kinds depend on what the service links in, but this package typically supports:

--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -130,6 +130,9 @@ type Gauge[T int64 | float64] = metricdata.Gauge[T]
 // Sum is an alias for [metricdata.Sum].
 type Sum[T int64 | float64] = metricdata.Sum[T]
 
+// Histogram is an alias for [metricdata.Histogram].
+type Histogram[T int64 | float64] = metricdata.Histogram[T]
+
 // NewMeter returns a Meter from provider using the service name and version.
 //
 // The returned meter uses `name` as the instrumentation scope name and `version` as the

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -80,7 +80,12 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 		params.Version.String(),
 		params.Environment.String(),
 	)
-	provider := sdk.NewMeterProvider(sdk.WithReader(params.Reader), sdk.WithResource(attrs))
+	options := []sdk.Option{sdk.WithReader(params.Reader), sdk.WithResource(attrs)}
+	if views := configViews(params.Config); len(views) > 0 {
+		options = append(options, sdk.WithView(views...))
+	}
+
+	provider := sdk.NewMeterProvider(options...)
 	setMeterProvider(provider, true)
 
 	params.Lifecycle.Append(di.Hook{
@@ -99,6 +104,25 @@ func NewMeterProvider(params MeterProviderParams) MeterProvider {
 	})
 
 	return provider
+}
+
+// configViews builds explicit-bucket-histogram views from the configured
+// instrument-name-to-boundaries map. It returns nil when no views are
+// configured, leaving the OpenTelemetry SDK default boundaries in place.
+func configViews(cfg *Config) []sdk.View {
+	if cfg == nil || len(cfg.Views) == 0 {
+		return nil
+	}
+
+	views := make([]sdk.View, 0, len(cfg.Views))
+	for name, boundaries := range cfg.Views {
+		views = append(views, sdk.NewView(
+			sdk.Instrument{Name: name},
+			sdk.Stream{Aggregation: sdk.AggregationExplicitBucketHistogram{Boundaries: boundaries}},
+		))
+	}
+
+	return views
 }
 
 // IsEnabled reports whether this package has registered metrics as enabled.

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -127,6 +127,33 @@ func TestMeterProviderAttributes(t *testing.T) {
 	require.Equal(t, "payments", attrs[attributes.Key("k8s.namespace.name")])
 }
 
+func TestMeterProviderViews(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
+	})
+
+	boundaries := []float64{0.1, 0.5, 1}
+	reader := metrics.NewManualReader()
+	provider := metrics.NewMeterProvider(metrics.MeterProviderParams{
+		Lifecycle:   fxtest.NewLifecycle(t),
+		Config:      &metrics.Config{Views: map[string][]float64{"test.duration": boundaries}},
+		Reader:      reader,
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	})
+
+	histogram, err := provider.Meter(test.Name.String()).Float64Histogram("test.duration")
+	require.NoError(t, err)
+	histogram.Record(t.Context(), 0.3)
+
+	rm := metrics.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	require.Equal(t, boundaries, collectHistogramBounds(t, rm, "test.duration"))
+}
+
 func TestOTLPReaderUsesConfiguredInterval(t *testing.T) {
 	t.Cleanup(func() {
 		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
@@ -168,4 +195,25 @@ func TestOTLPReaderUsesConfiguredInterval(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return exports.Load() > 0
 	}, (2 * time.Second).Duration(), (20 * time.Millisecond).Duration())
+}
+
+func collectHistogramBounds(t *testing.T, rm metrics.ResourceMetrics, name string) []float64 {
+	t.Helper()
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+
+			histogram, ok := m.Data.(metrics.Histogram[float64])
+			require.True(t, ok)
+			require.NotEmpty(t, histogram.DataPoints)
+
+			return histogram.DataPoints[0].Bounds
+		}
+	}
+
+	t.Fatalf("histogram %q not collected", name)
+	return nil
 }


### PR DESCRIPTION
## What

- Adds a `telemetry.metrics.views` config field (`map[string][]float64`,
  instrument name -> explicit histogram bucket boundaries) that lets a service
  override the OpenTelemetry SDK default buckets for the latency/size histograms
  go-service emits (via `otelhttp`, the `otelgrpc` stats handler, and
  `XSAM/otelsql`). `NewMeterProvider` projects the map to `sdk.WithView(...)`.
- Instrument-name matching follows OpenTelemetry view semantics, including `*`
  wildcards; boundaries are in the instrument's unit (seconds for duration
  histograms, bytes for size histograms) and must be listed in increasing order.
- Additive and backward compatible: an empty or absent map keeps today's default
  buckets exactly. No new DI field and no consumer-facing OTel-SDK types — it
  rides the existing `*metrics.Config` projection. Adds a `metrics.Histogram[T]`
  alias alongside the existing `Gauge`/`Sum`/`DataPoint` aliases, and documents
  the field in the README metrics section.
- Non-monotonic boundaries are surfaced through the wired OpenTelemetry error
  handler (`telemetry/errors`, logged via the service logger) and fall back to
  the default buckets for that instrument, so a misconfiguration is observable
  rather than silent.

## Why

- The framework's histograms come from upstream instrumentation, so they inherit
  the SDK default bucket boundaries — an irreducibly client-side concern that no
  backend or exporter config can re-bucket. Services whose latency SLO thresholds
  do not line up with the OTel defaults previously had no supported go-service
  path to align their duration/size quantiles, producing coarse or misleading
  histograms on dashboards and alerts. This adds that capability through the
  standard config surface.

## Testing

- `make specs package=telemetry/metrics` - passed (13 tests)
- `make lint` - passed (0 issues; includes the field-alignment check)
- New `TestMeterProviderViews` records into a configured histogram and asserts
  the collected explicit bounds equal the configured boundaries (distinct from
  the SDK default 15-bucket set, so it fails without the `WithView` wiring);
  `TestMeterProviderAttributes` still passes.
- `gofmt` clean. Independent review verdict SHIP WITH NITS (both doc nits fixed:
  the GoDoc example now uses the default-emitted `rpc.server.call.duration`, and
  the README clarifies views apply to histogram instruments).

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
