### PR TITLE
feat(telemetry): correlate stdout logs with traces and stamp request metadata on spans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,17 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 ## Gotchas
 
 - Manual transport TLS setup must call the HTTP and gRPC transport register functions; `transport.Module` does this on the normal path.
+- Runtime TLS material, like other resolved configuration, is intentionally
+  materialized once at startup; the leaf certificate and CA pools are pinned for
+  the process lifetime. This framework targets container platforms where
+  certificate rotation and other configuration changes are rolled out by
+  restarting or recreating the workload (cert-manager renewal plus rolling
+  restart, mounted-secret refresh plus pod recreation), so there is no
+  `GetCertificate`/`GetClientCertificate` callback, fsnotify watch, or SIGHUP
+  reload. Do not flag the absence of TLS certificate hot-reload as a reliability
+  or operability gap; report only concrete bugs such as certs not being resolved
+  at startup, ignored explicit TLS config, or a public API promise of in-process
+  certificate rotation.
 - Manual server lifecycle wiring should use `net/server.Register(...)`.
 - `transport.Module` is normally consumed through `module.Server`, which also
   wires `debug.Module`; do not flag `transport.NewServers` requiring
@@ -139,6 +150,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   zero-sample profile export edge cases as upstream behavior, not local debug
   findings, unless this repository adds local fgprof handler logic or promises
   cancellation-aware profiling semantics.
+- Build and version provenance is intentionally owned by the container image and
+  deployment platform, not a service endpoint. Services built with this framework
+  learn their version from the image tag/metadata supplied at build/deploy time,
+  surfaced through `service.version`/`deployment.environment.name` telemetry
+  resource attributes and static log attributes, and the platform already tracks
+  which image a pod runs. Do not flag the absence of a build-info/version debug
+  endpoint (for example `runtime/debug.ReadBuildInfo`, `expvar`, or
+  `/debug/vars`) as a feature or operability gap; report only concrete bugs where
+  configured version/environment attributes are dropped from telemetry or logs.
 - `cli.RunCode` returns `os.ExitCodeSuccess` on success, preserves non-zero
   shutdown exit codes requested through `di.ExitCode(...)`, and otherwise
   returns `os.ExitCodeFailure`.
@@ -158,6 +178,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   user-facing flag with the reserved `test.` prefix; report only concrete
   breakage in a supported CLI contract or an explicit public promise to
   preserve `-test.*` command flags.
+- `config.NewConfig[T]` intentionally decodes and validates configuration on the
+  normal startup path, so a service started with bad configuration fails fast at
+  run time. There is no separate config validate/preflight subcommand (for
+  example an `AddCheck` command or `svc check`), and its absence is not a feature
+  gap: running the service is the check. Do not flag the missing side-effect-free
+  config-only command solely because CI or pre-deploy config linting would prefer
+  not to start subsystems; report only concrete bugs where documented config
+  validation is skipped, invalid config is accepted, or the decode/validate path
+  does not run at startup.
 - `net/server.Service` intentionally logs asynchronous `Server.Serve` errors
   and requests shutdown with `di.ExitCode(os.ExitCodeServeFailure)`; it does not
   return the raw serve error from `Stop`.
@@ -456,6 +485,16 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   broken behavior such as missing documented endpoints, ignored observer
   errors, wrong probe names, or a public API promise that standard probes are
   auto-composed.
+- The `healthz`/`livez`/`readyz` probes intentionally return only the plain-text
+  `SERVING`/`503` probe contract, not a per-check status breakdown. This
+  framework targets container platforms where per-dependency health aggregation,
+  rollout gating, and outage attribution live at the orchestration and
+  observability layer (Kubernetes probes plus events, service mesh, dashboards),
+  and a service owner who wants a structured per-check detail route can register
+  one. Do not flag the absence of an aggregated health-detail endpoint (per-check
+  JSON from the go-health `Observer.Errors()` map) as a feature or operability
+  gap; report only concrete bugs such as a documented probe endpoint missing,
+  ignored observer errors, or wrong probe names/status codes.
 - Shared metadata, header, and string helpers live under `net/...`, not `transport/...`.
 - `vendor/` is gitignored and regenerated via `make dep`.
 - HTTP webhook verification buffers `req.Body` intentionally for signature checks.

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/health"
 	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/method"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/peer"
 )
@@ -152,6 +153,51 @@ func TestStreamClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Nil(t, stream)
+}
+
+func TestUnaryServerInterceptorStampsSpanWithMeta(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+
+	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{}), "request")
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(context.Context, any) (any, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	span.End()
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+
+	values := make(map[string]string)
+	for _, attr := range spans[0].Attributes() {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "request-id", values[meta.RequestIDKey])
+}
+
+func TestStreamServerInterceptorStampsSpanWithMeta(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+
+	interceptor := grpcmeta.StreamServerInterceptor(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{}), "request")
+	stream := &test.MetaServerStream{Ctx: ctx}
+
+	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(any, grpc.ServerStream) error {
+		return nil
+	})
+	require.NoError(t, err)
+	span.End()
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+
+	values := make(map[string]string)
+	for _, attr := range spans[0].Attributes() {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "request-id", values[meta.RequestIDKey])
 }
 
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/header"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -66,6 +67,7 @@ func UnaryServerInterceptor(policy *method.Policy, userAgent env.UserAgent, vers
 			meta.WithGeolocation(geolocation),
 			meta.WithAuthorization(auth),
 		)
+		stampSpan(ctx)
 
 		_ = grpc.SetHeader(ctx, serverResponseHeaders(serviceVersion, id.Value()))
 
@@ -115,6 +117,7 @@ func StreamServerInterceptor(policy *method.Policy, userAgent env.UserAgent, ver
 			meta.WithGeolocation(geolocation),
 			meta.WithAuthorization(auth),
 		)
+		stampSpan(ctx)
 
 		_ = stream.SetHeader(serverResponseHeaders(serviceVersion, id.Value()))
 
@@ -123,6 +126,16 @@ func StreamServerInterceptor(policy *method.Policy, userAgent env.UserAgent, ver
 
 		return handler(srv, wrappedStream)
 	}
+}
+
+// stampSpan copies the request metadata in ctx onto the active span so the
+// server/root span carries the same request/service context as the logs.
+//
+// The tracer's metadata span processor cannot cover the server span, because
+// its context has no metadata yet when the span starts; child spans (database,
+// cache, ...) are stamped by that processor instead.
+func stampSpan(ctx context.Context) {
+	attributes.Record(ctx, attributes.Strings(meta.CamelStrings(ctx, meta.NoPrefix))...)
 }
 
 func serverResponseHeaders(serviceVersion, requestID string) Map {

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	httpmeta "github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,6 +110,28 @@ func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 		require.Equal(t, []string{"1", "v2"}, res.Header().Values("Service-Version"))
 		require.Equal(t, []string{"request-id"}, res.Header().Values("Request-Id"))
 	})
+}
+
+func TestHandlerStampsSpanWithMeta(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "request")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users/123", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {})
+	span.End()
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+
+	values := make(map[string]string)
+	for _, attr := range spans[0].Attributes() {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "request-id", values[meta.RequestIDKey])
 }
 
 func TestHandlerStoresServiceMethodFromPath(t *testing.T) {

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 )
 
 // NewHandler constructs server-side metadata middleware for HTTP requests.
@@ -81,8 +82,19 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		meta.WithGeolocation(geolocation),
 		meta.WithAuthorization(auth),
 	)
+	stampSpan(ctx)
 
 	next(res, req.WithContext(ctx))
+}
+
+// stampSpan copies the request metadata in ctx onto the active span so the
+// server/root span carries the same request/service context as the logs.
+//
+// The tracer's metadata span processor cannot cover the server span, because
+// its context has no metadata yet when the span starts; child spans (database,
+// cache, ...) are stamped by that processor instead.
+func stampSpan(ctx context.Context) {
+	attributes.Record(ctx, attributes.Strings(meta.CamelStrings(ctx, meta.NoPrefix))...)
 }
 
 func serverSetResponseHeaders(header http.Header, serviceVersion, requestID string) {

--- a/telemetry/attributes/attributes.go
+++ b/telemetry/attributes/attributes.go
@@ -1,9 +1,11 @@
 package attributes
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // SchemaURL is the OpenTelemetry semantic conventions schema URL used by this package.
@@ -38,6 +40,33 @@ type Resource = resource.Resource
 // attributes added by [NewResource] take precedence over duplicate configured
 // keys.
 type Map map[string]string
+
+// Strings converts a string map into OpenTelemetry string attributes.
+//
+// It lets callers turn a set of key/value strings, such as request metadata,
+// into span or log attributes without importing the attribute package directly.
+// It returns no attributes for an empty map.
+func Strings(values map[string]string) []KeyValue {
+	attrs := make([]KeyValue, 0, len(values))
+	for key, value := range values {
+		attrs = append(attrs, attribute.String(key, value))
+	}
+
+	return attrs
+}
+
+// Record attaches attrs to the span active in ctx.
+//
+// It returns early for empty attrs. When ctx carries no span, the attributes
+// are applied to a non-recording span, which discards them, so callers can
+// stamp the current span unconditionally.
+func Record(ctx context.Context, attrs ...KeyValue) {
+	if len(attrs) == 0 {
+		return
+	}
+
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
+}
 
 // DBSystemNamePostgreSQL identifies PostgreSQL as the value of the
 // db.system.name semantic-convention attribute.

--- a/telemetry/logger/doc.go
+++ b/telemetry/logger/doc.go
@@ -42,6 +42,15 @@
 // record. Truncation preserves UTF-8 validity so multi-byte characters are not
 // split.
 //
+// # Trace correlation
+//
+// The stdout kinds ("json", "text", "tint") additionally attach "trace_id" and
+// "span_id" attributes to any record emitted while a valid OpenTelemetry span
+// is active in the context, named per the OpenTelemetry log data model so a log
+// line can be linked to its trace. Records emitted without an active span are
+// unchanged. The "otlp" kind does not add these attributes; it correlates
+// through the OpenTelemetry logging bridge instead. See [Trace].
+//
 // # Exporter headers and secret resolution
 //
 // Some kinds (notably "otlp") support outbound request headers for authentication or

--- a/telemetry/logger/json.go
+++ b/telemetry/logger/json.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newJSONLogger(params LoggerParams) *slog.Logger {
-	return slog.New(slog.NewJSONHandler(os.Stdout, handlerOptions(params.Config))).With(
+	return slog.New(NewTraceHandler(slog.NewJSONHandler(os.Stdout, handlerOptions(params.Config)))).With(
 		slog.String("id", params.ID.String()),
 		slog.String("name", params.Name.String()),
 		slog.String("version", params.Version.String()),

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -94,6 +95,69 @@ func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
 			require.Equal(t, prefix, truncated)
 		})
 	}
+}
+
+func TestTraceAddsSpanCorrelation(t *testing.T) {
+	test.EnableIsolatedSpanExporter(t)
+
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "request")
+	defer span.End()
+
+	attrs := logger.Trace(ctx)
+	require.Len(t, attrs, 2)
+
+	values := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		values[attr.Key] = attr.Value.String()
+	}
+	require.Equal(t, span.SpanContext().TraceID().String(), values["trace_id"])
+	require.Equal(t, span.SpanContext().SpanID().String(), values["span_id"])
+}
+
+func TestTraceWithoutSpanReturnsNoAttrs(t *testing.T) {
+	require.Empty(t, logger.Trace(t.Context()))
+}
+
+func TestTraceHandlerInjectsSpanAttributes(t *testing.T) {
+	test.EnableIsolatedSpanExporter(t)
+
+	capture := &test.CaptureHandler{}
+	log := slog.New(logger.NewTraceHandler(capture))
+
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "request")
+	defer span.End()
+
+	log.InfoContext(ctx, "message")
+
+	require.Len(t, capture.Records, 1)
+	require.Equal(t, span.SpanContext().TraceID().String(), capture.Records[0].Attrs["trace_id"].String())
+	require.Equal(t, span.SpanContext().SpanID().String(), capture.Records[0].Attrs["span_id"].String())
+}
+
+func TestTraceHandlerWithoutSpanLeavesRecordUnchanged(t *testing.T) {
+	capture := &test.CaptureHandler{}
+	log := slog.New(logger.NewTraceHandler(capture))
+
+	log.InfoContext(t.Context(), "message")
+
+	require.Len(t, capture.Records, 1)
+	require.NotContains(t, capture.Records[0].Attrs, "trace_id")
+	require.NotContains(t, capture.Records[0].Attrs, "span_id")
+}
+
+func TestStdoutLoggerLogsUnderSpan(t *testing.T) {
+	test.EnableIsolatedSpanExporter(t)
+
+	lc := fxtest.NewLifecycle(t)
+	log, err := test.NewLogger(lc, test.NewJSONLoggerConfig())
+	require.NoError(t, err)
+
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "request")
+	defer span.End()
+
+	require.NotPanics(t, func() {
+		log.Log(ctx, logger.NewText("test"))
+	})
 }
 
 func TestInvalidLogger(t *testing.T) {

--- a/telemetry/logger/text.go
+++ b/telemetry/logger/text.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newTextLogger(params LoggerParams) *slog.Logger {
-	return slog.New(slog.NewTextHandler(os.Stdout, handlerOptions(params.Config))).With(
+	return slog.New(NewTraceHandler(slog.NewTextHandler(os.Stdout, handlerOptions(params.Config)))).With(
 		slog.String("id", params.ID.String()),
 		slog.String("name", params.Name.String()),
 		slog.String("version", params.Version.String()),

--- a/telemetry/logger/tint.go
+++ b/telemetry/logger/tint.go
@@ -24,7 +24,7 @@ func newTintLogger(params LoggerParams) *slog.Logger {
 		},
 	}
 
-	return slog.New(tint.NewHandler(os.Stdout, opts)).With(
+	return slog.New(NewTraceHandler(tint.NewHandler(os.Stdout, opts))).With(
 		slog.String("id", params.ID.String()),
 		slog.String("name", params.Name.String()),
 		slog.String("version", params.Version.String()),

--- a/telemetry/logger/trace.go
+++ b/telemetry/logger/trace.go
@@ -1,0 +1,62 @@
+package logger
+
+import (
+	"log/slog"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+)
+
+const (
+	traceIDKey = "trace_id"
+	spanIDKey  = "span_id"
+)
+
+// Trace extracts trace correlation attributes from ctx.
+//
+// When ctx carries a valid OpenTelemetry span context, it returns trace_id and
+// span_id string attributes named per the OpenTelemetry log data model so
+// stdout log lines can be correlated with their trace. It returns no attributes
+// when ctx has no valid span, leaving untraced log records unchanged.
+func Trace(ctx context.Context) []slog.Attr {
+	span := tracer.SpanContextFromContext(ctx)
+	if !span.IsValid() {
+		return nil
+	}
+
+	return []slog.Attr{
+		slog.String(traceIDKey, span.TraceID().String()),
+		slog.String(spanIDKey, span.SpanID().String()),
+	}
+}
+
+// NewTraceHandler wraps handler so that records emitted under a valid span gain
+// the trace_id/span_id attributes from [Trace].
+//
+// The stdout-oriented logger kinds (json/text/tint) use it; the otlp logger
+// correlates through the OpenTelemetry logging bridge instead. Wrap the root
+// handler so the correlation keys stay at the record root, matching the
+// OpenTelemetry log data model (the stdout constructors do not open slog groups).
+func NewTraceHandler(handler slog.Handler) slog.Handler {
+	return &traceHandler{Handler: handler}
+}
+
+type traceHandler struct {
+	slog.Handler
+}
+
+func (h *traceHandler) Handle(ctx context.Context, record slog.Record) error {
+	if attrs := Trace(ctx); len(attrs) > 0 {
+		record.AddAttrs(attrs...)
+	}
+
+	return h.Handler.Handle(ctx, record)
+}
+
+func (h *traceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &traceHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h *traceHandler) WithGroup(name string) slog.Handler {
+	return &traceHandler{Handler: h.Handler.WithGroup(name)}
+}

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -23,6 +23,15 @@
 // Instrumentation that relies on the global provider (directly or indirectly) will create
 // spans using this provider.
 //
+// # Metadata on spans
+//
+// The provider installs a span processor that copies request/service metadata
+// from the context onto each span as it starts (see [Meta]), so spans created
+// by any instrumentation (server, database, cache, ...) carry the same context
+// used to correlate them with logs. The server/root span is created before that
+// metadata is available, so the transport metadata middleware stamps it
+// directly.
+//
 // This package does not configure propagation. Propagation is configured at the top-level
 // telemetry package ([github.com/alexfalkowski/go-service/v2/telemetry.RegisterPropagation]), which sets the global
 // TextMapPropagator used for context extraction/injection on supported transports

--- a/telemetry/tracer/meta.go
+++ b/telemetry/tracer/meta.go
@@ -1,0 +1,45 @@
+package tracer
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	sdk "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Meta extracts context metadata as OpenTelemetry span attributes.
+//
+// It reads the same exported metadata as the logger (via the meta package) and
+// converts it to camel-cased string key/value attributes with no prefix, so a
+// span carries the request/service context (request id, user id, ip, ...) used
+// to correlate it with logs. It returns no attributes when ctx carries none.
+func Meta(ctx context.Context) []attributes.KeyValue {
+	return attributes.Strings(meta.CamelStrings(ctx, meta.NoPrefix))
+}
+
+// newMetaProcessor constructs a span processor that copies context metadata
+// onto every span as it starts.
+//
+// It lets spans created by any instrumentation (server, database, cache, ...)
+// carry the same request/service context as the logs (see [Meta]) without each
+// instrumentation having to wire metadata itself. Metadata is read from the
+// span's starting context, so the server/root span, whose context is not yet
+// populated when it starts, is stamped explicitly by the transport metadata
+// middleware instead.
+func newMetaProcessor() sdk.SpanProcessor {
+	return &metaProcessor{}
+}
+
+type metaProcessor struct{}
+
+func (*metaProcessor) OnStart(parent context.Context, span sdk.ReadWriteSpan) {
+	if attrs := Meta(parent); len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+}
+
+func (*metaProcessor) OnEnd(sdk.ReadOnlySpan) {}
+
+func (*metaProcessor) Shutdown(context.Context) error { return nil }
+
+func (*metaProcessor) ForceFlush(context.Context) error { return nil }

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -68,8 +68,23 @@ func NewSpanContext(config SpanContextConfig) SpanContext {
 	return trace.NewSpanContext(config)
 }
 
+// SpanContextFromContext returns the [SpanContext] of the span currently active
+// in ctx.
+//
+// The returned SpanContext is invalid (see [SpanContext.IsValid]) when ctx
+// carries no span, so callers can treat an untraced context as "no correlation".
+func SpanContextFromContext(ctx context.Context) SpanContext {
+	return trace.SpanContextFromContext(ctx)
+}
+
 // NewProvider constructs an OpenTelemetry SDK tracer provider.
+//
+// It always installs the metadata span processor (see [Meta]) so spans created
+// by any instrumentation carry the request/service context used to correlate
+// them with logs.
 func NewProvider(opts ...ProviderOption) *SDKProvider {
+	opts = append([]ProviderOption{sdk.WithSpanProcessor(newMetaProcessor())}, opts...)
+
 	return sdk.NewTracerProvider(opts...)
 }
 
@@ -168,7 +183,7 @@ func Register(params TracerParams) error {
 			providerOpts = append(providerOpts, sdk.WithSampler(sampler))
 		}
 
-		provider := sdk.NewTracerProvider(providerOpts...)
+		provider := NewProvider(providerOpts...)
 		setProvider(provider, true)
 
 		params.Lifecycle.Append(di.Hook{

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -6,12 +6,52 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
+
+func TestMeta(t *testing.T) {
+	ctx := meta.WithAttributes(t.Context(),
+		meta.WithRequestID(meta.String("request-id")),
+		meta.WithUserID(meta.String("user-id")),
+	)
+
+	attrs := tracer.Meta(ctx)
+
+	values := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+
+	require.Equal(t, "request-id", values[meta.RequestIDKey])
+	require.Equal(t, "user-id", values[meta.UserIDKey])
+}
+
+func TestMetaWithoutAttributesIsEmpty(t *testing.T) {
+	require.Empty(t, tracer.Meta(t.Context()))
+}
+
+func TestMetaSpanProcessorStampsChildSpans(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+
+	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
+
+	_, span := tracer.GetProvider().Tracer(test.Name.String()).Start(ctx, "child")
+	span.End()
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+
+	values := make(map[string]string)
+	for _, attr := range spans[0].Attributes() {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "request-id", values[meta.RequestIDKey])
+}
 
 func TestIsEnabled(t *testing.T) {
 	t.Cleanup(func() {

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -88,7 +88,8 @@ type ServerParams struct {
 // as not configured.
 //
 // The constructed server includes:
-//   - OpenTelemetry stats handling when tracing or metrics are enabled.
+//   - OpenTelemetry stats handling when tracing or metrics are enabled. The stats handler starts the server
+//     span before any interceptor runs, so the metadata interceptor can stamp request metadata onto that span.
 //   - A unary interceptor chain that performs metadata extraction/injection, applies the configured
 //     server timeout, and optionally logging, token verification, rate limiting, and access control,
 //     followed by any user-provided interceptors.

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -92,7 +92,9 @@ type ServerParams struct {
 // Middleware composition:
 //
 // When OpenTelemetry tracing or metrics are enabled, the full transport chain is wrapped with HTTP server
-// instrumentation so transport-level rejections are observed before the request reaches the mux.
+// instrumentation so transport-level rejections are observed before the request reaches the mux. This wrapper
+// must stay outermost: it starts the server span before the metadata middleware runs, and the metadata
+// middleware stamps request metadata onto that span, so reordering would leave the server span without it.
 //
 // The server is built using Negroni and composes middleware in this order inside that instrumentation wrapper
 // (first listed runs first):


### PR DESCRIPTION
## What

- Stdout loggers (`json`/`text`/`tint`) now attach `trace_id`/`span_id` to records emitted under an active span, using the OpenTelemetry log data model names so a log line links to its trace; the `otlp` logger is unchanged (it already correlates through the logging bridge). Exposed as the reusable `logger.NewTraceHandler`.
- Request/service metadata (request id, user id, ip, …) is now attached to spans: the server span via the HTTP and gRPC metadata middleware, and every child span (database, cache, and any future instrumentation) via a metadata span processor installed on the tracer provider. Metric labels are intentionally left untouched.
- Added `attributes.Strings`/`attributes.Record`, `tracer.Meta`, and `tracer.SpanContextFromContext` wrappers so non-telemetry packages route through go-service wrappers instead of importing OpenTelemetry directly.
- `AGENTS.md`: recorded four intentional non-features as "do not flag" gotchas — TLS certificate hot-reload, build-info/version endpoint, config validate/preflight subcommand, and aggregated health-detail endpoint — because this framework targets container platforms.
- Additive: no public API removed; untraced log records and metric labels are unchanged.

## Why

- Operators on the common "stdout logs + OTLP traces" split had no way to pivot from a log line to its trace (only the otlp logger correlated), and spans — including database and cache calls — carried no request identity, so a trace could not be tied back to its request id or user. This closes both gaps through one framework mechanism, so services get correlation without wiring anything per call.
- The `AGENTS.md` gotchas stop already-decided feature requests from being re-raised during reviews.
- The server-before-metadata middleware ordering this relies on is documented in the `NewServer` GoDocs but, by decision, is not guarded by an integration test.

## Testing

- `go test ./...` - passed (121 packages, 0 failures)
- `go vet ./...` - passed
- `gofmt -l` on changed Go files - passed (no output)
- New behavioral tests through public APIs: `logger.Trace`/`NewTraceHandler` add `trace_id`/`span_id` under a span and nothing without one; `tracer.Meta` conversion; the span processor stamps a child span; the HTTP and gRPC (unary + stream) meta handlers stamp the server span — using the existing `test.CaptureHandler` and span exporter.
- Not covered by tests: the production middleware ordering (documented in GoDoc instead, per maintainer decision).

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
