### PR TITLE
feat(cache): add atomic get-or-persist with single-flight population

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -85,6 +85,7 @@ type Cache struct {
 	config   *config.Config
 	pool     *sync.BufferPool
 	driver   driver.Driver
+	single   sync.AnySingleFlightGroup
 }
 
 // Flush removes cached data according to the underlying driver's flush semantics.
@@ -141,6 +142,68 @@ func (c *Cache) Persist(ctx context.Context, key string, value any, ttl time.Dur
 	}
 
 	return c.driver.Save(ctx, c.driverKey(key), enc, ttl)
+}
+
+// GetOrPersist returns the cached value for key, or produces and stores it via fn when the key is absent.
+//
+// On a cache hit fn is not called and no write occurs. On a miss fn populates value and the encoded value is
+// published atomically, so concurrent callers converge on a single stored value. Concurrent in-process misses
+// for the same key run fn once and share the produced value; separate processes may each run fn once, but the
+// atomic publish still yields a single stored winner that every caller decodes.
+//
+// The value parameter should be a pointer to the destination value (for example *MyStruct). It is both
+// populated by fn and used as the decode destination for the resolved value.
+func (c *Cache) GetOrPersist(ctx context.Context, key string, value any, ttl time.Duration, fn func() error) error {
+	ok, err := c.Get(ctx, key, value)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+
+	driverKey := c.driverKey(key)
+
+	result, err, _ := c.single.Do(driverKey, func() (any, error) {
+		return c.loadOrSave(ctx, driverKey, value, ttl, fn)
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.decode(result.(string), value)
+}
+
+// loadOrSave re-checks the driver for driverKey, then produces and atomically publishes a value on a miss.
+//
+// It runs inside the single-flight group, so it executes once per key for concurrent in-process callers. It
+// returns the encoded value that every caller decodes: the existing stored value when another writer won, or
+// the value just produced and stored.
+func (c *Cache) loadOrSave(ctx context.Context, driverKey string, value any, ttl time.Duration, fn func() error) (string, error) {
+	if val, err := c.driver.Get(ctx, driverKey); err == nil {
+		return val, nil
+	} else if !drivererrors.IsMissingError(err) && !drivererrors.IsExpiredError(err) {
+		return strings.Empty, err
+	}
+
+	if err := fn(); err != nil {
+		return strings.Empty, err
+	}
+
+	enc, err := c.encode(value)
+	if err != nil {
+		return strings.Empty, err
+	}
+
+	existing, loaded, err := c.driver.GetOrSave(ctx, driverKey, enc, ttl)
+	if err != nil {
+		return strings.Empty, err
+	}
+	if loaded {
+		return existing, nil
+	}
+
+	return enc, nil
 }
 
 func (c *Cache) driverKey(key string) string {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
@@ -45,6 +47,234 @@ func TestGenericValidCache(t *testing.T) {
 	require.Equal(t, "hello?", *value)
 
 	require.NoError(t, world.Remove(t.Context(), "test"))
+}
+
+func TestGetOrPersist(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+
+		return "hello?", nil
+	}
+
+	value, err := cache.GetOrPersist(t.Context(), "test", time.Minute, fn)
+	require.NoError(t, err)
+	require.Equal(t, "hello?", *value)
+	require.Equal(t, 1, calls)
+
+	value, err = cache.GetOrPersist(t.Context(), "test", time.Minute, fn)
+	require.NoError(t, err)
+	require.Equal(t, "hello?", *value)
+	require.Equal(t, 1, calls)
+
+	require.NoError(t, world.Remove(t.Context(), "test"))
+}
+
+func TestGetOrPersistRedis(t *testing.T) {
+	cfg := test.NewCacheConfig("redis", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+	ctx := t.Context()
+	require.NoError(t, world.Remove(ctx, "test"))
+
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+
+		return "hello?", nil
+	}
+
+	value, err := cache.GetOrPersist(ctx, "test", time.Minute, fn)
+	require.NoError(t, err)
+	require.Equal(t, "hello?", *value)
+	require.Equal(t, 1, calls)
+
+	value, err = cache.GetOrPersist(ctx, "test", time.Minute, fn)
+	require.NoError(t, err)
+	require.Equal(t, "hello?", *value)
+	require.Equal(t, 1, calls)
+
+	require.NoError(t, world.Remove(ctx, "test"))
+}
+
+func TestGetOrPersistSingleWinner(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+	ctx := t.Context()
+
+	const goroutines = 16
+	var group sync.WaitGroup
+	values := make([]string, goroutines)
+	errs := make([]error, goroutines)
+
+	group.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer group.Done()
+
+			value, err := cache.GetOrPersist(ctx, "test", time.Minute, func() (string, error) {
+				return fmt.Sprintf("value-%d", i), nil
+			})
+			errs[i] = err
+			if err == nil {
+				values[i] = *value
+			}
+		}(i)
+	}
+	group.Wait()
+
+	for i := range goroutines {
+		require.NoError(t, errs[i])
+		require.Equal(t, values[0], values[i])
+	}
+	require.NotEmpty(t, values[0])
+
+	require.NoError(t, world.Remove(ctx, "test"))
+}
+
+func TestGenericGetOrPersistDisabledCache(t *testing.T) {
+	cache.Register(nil)
+	t.Cleanup(func() {
+		cache.Register(nil)
+	})
+
+	called := false
+	value, err := cache.GetOrPersist(t.Context(), "test", time.Minute, func() (string, error) {
+		called = true
+
+		return "hello?", nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, value)
+	require.False(t, called)
+}
+
+func TestGetOrPersistLoaderError(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+	ctx := t.Context()
+
+	_, err := cache.GetOrPersist(ctx, "test", time.Minute, func() (string, error) {
+		return strings.Empty, test.ErrFailed
+	})
+	require.ErrorIs(t, err, test.ErrFailed)
+
+	value, ok, err := cache.Get[string](ctx, "test")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, *value)
+
+	require.NoError(t, world.Remove(ctx, "test"))
+}
+
+func TestGetOrPersistPublish(t *testing.T) {
+	winner := base64.Encode(strings.Bytes(`"winner"`))
+	tests := []struct {
+		driver  driver.Driver
+		name    string
+		want    string
+		wantErr bool
+	}{
+		{name: "returns existing winner", driver: getOrSaveCacheDriver{existing: winner, loaded: true}, want: "winner"},
+		{name: "propagates save error", driver: getOrSaveCacheDriver{err: test.ErrFailed}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+			world := test.NewStartedWorld(t,
+				test.WithWorldCacheConfig(cfg),
+				test.WithWorldCacheDriver(tt.driver),
+			)
+
+			value := "unchanged"
+			called := false
+			err := world.GetOrPersist(t.Context(), "test", &value, time.Minute, func() error {
+				called = true
+				value = "produced"
+
+				return nil
+			})
+
+			require.True(t, called)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, value)
+		})
+	}
+}
+
+func TestGetOrPersistEncodeError(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "snappy", "error", "redis")
+	test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+
+	_, err := cache.GetOrPersist(t.Context(), "test", time.Minute, func() (string, error) {
+		return "hello?", nil
+	})
+	require.Error(t, err)
+}
+
+func TestGetOrPersistDriverGetError(t *testing.T) {
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t,
+		test.WithWorldCacheConfig(cfg),
+		test.WithWorldCacheDriver(&test.ErrCache{}),
+	)
+
+	value := "unchanged"
+	called := false
+	err := world.GetOrPersist(t.Context(), "test", &value, time.Minute, func() error {
+		called = true
+
+		return nil
+	})
+	require.ErrorIs(t, err, test.ErrFailed)
+	require.False(t, called)
+}
+
+func TestGetOrPersistRecheck(t *testing.T) {
+	winner := base64.Encode(strings.Bytes(`"winner"`))
+	tests := []struct {
+		driver  *recheckCacheDriver
+		name    string
+		wantErr bool
+	}{
+		{name: "recheck finds concurrently stored value", driver: &recheckCacheDriver{value: winner}},
+		{name: "recheck surfaces backend error", driver: &recheckCacheDriver{recheck: test.ErrFailed}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+			world := test.NewStartedWorld(t,
+				test.WithWorldCacheConfig(cfg),
+				test.WithWorldCacheDriver(tt.driver),
+			)
+
+			value := "unchanged"
+			called := false
+			err := world.GetOrPersist(t.Context(), "test", &value, time.Minute, func() error {
+				called = true
+
+				return nil
+			})
+
+			require.False(t, called)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, "winner", value)
+		})
+	}
 }
 
 func TestModuleRegistersGenericCache(t *testing.T) {
@@ -527,4 +757,72 @@ func (expiredCacheDriver) Flush(context.Context) error {
 
 func (expiredCacheDriver) Save(context.Context, string, string, time.Duration) error {
 	return nil
+}
+
+func (expiredCacheDriver) GetOrSave(context.Context, string, string, time.Duration) (string, bool, error) {
+	return strings.Empty, false, nil
+}
+
+// getOrSaveCacheDriver misses on Get and returns a configured result from GetOrSave, exercising the publish
+// path of Cache.GetOrPersist without a live backend.
+type getOrSaveCacheDriver struct {
+	err      error
+	existing string
+	loaded   bool
+}
+
+func (getOrSaveCacheDriver) Delete(context.Context, string) error {
+	return nil
+}
+
+func (getOrSaveCacheDriver) Get(context.Context, string) (string, error) {
+	return strings.Empty, drivererrors.ErrMissing
+}
+
+func (getOrSaveCacheDriver) Flush(context.Context) error {
+	return nil
+}
+
+func (getOrSaveCacheDriver) Save(context.Context, string, string, time.Duration) error {
+	return nil
+}
+
+func (d getOrSaveCacheDriver) GetOrSave(context.Context, string, string, time.Duration) (string, bool, error) {
+	return d.existing, d.loaded, d.err
+}
+
+// recheckCacheDriver misses the first Get, then hits or errors on later Gets, simulating a value stored or a
+// backend failure between Cache.GetOrPersist's initial read and its single-flight re-check.
+type recheckCacheDriver struct {
+	recheck error
+	value   string
+	gets    int
+}
+
+func (*recheckCacheDriver) Delete(context.Context, string) error {
+	return nil
+}
+
+func (d *recheckCacheDriver) Get(context.Context, string) (string, error) {
+	d.gets++
+	if d.gets == 1 {
+		return strings.Empty, drivererrors.ErrMissing
+	}
+	if d.recheck != nil {
+		return strings.Empty, d.recheck
+	}
+
+	return d.value, nil
+}
+
+func (*recheckCacheDriver) Flush(context.Context) error {
+	return nil
+}
+
+func (*recheckCacheDriver) Save(context.Context, string, string, time.Duration) error {
+	return nil
+}
+
+func (*recheckCacheDriver) GetOrSave(context.Context, string, string, time.Duration) (string, bool, error) {
+	return strings.Empty, false, nil
 }

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -8,9 +8,10 @@
 // and callers are expected to tolerate a nil cache instance.
 //
 // In addition to the instance API on *[Cache], this package exposes package-level generic helpers
-// ([Get] and [Persist]). Those helpers are nil-safe after [Register] has been called (via DI wiring in
-// [Module]). When caching is disabled, [Persist] is a no-op and [Get] returns nil, false, nil. In the
-// standard service composition this registration is performed for you by the module graph.
+// ([Get], [Persist], and [GetOrPersist]). Those helpers are nil-safe after [Register] has been called (via DI
+// wiring in [Module]). When caching is disabled, [Persist] is a no-op, [Get] returns nil, false, nil, and
+// [GetOrPersist] returns a nil value without calling its loader. In the standard service composition this
+// registration is performed for you by the module graph.
 //
 // # Value encoding
 //

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -89,6 +89,14 @@ type Driver interface {
 	// Get retrieves the cached value for key.
 	Get(ctx context.Context, key string) (string, error)
 
+	// GetOrSave atomically returns the value stored for key, or stores value
+	// when the key is absent.
+	//
+	// The returned bool reports whether an existing value was found: when true,
+	// the returned string is the value already stored and value was not written;
+	// when false, value was stored and the returned string is empty.
+	GetOrSave(ctx context.Context, key, value string, lifetime time.Duration) (string, bool, error)
+
 	// Flush removes cached data according to backend-specific semantics.
 	//
 	// Implementations may clear more than go-service cache namespace keys. For

--- a/cache/driver/internal/redis/redis.go
+++ b/cache/driver/internal/redis/redis.go
@@ -99,3 +99,22 @@ func (d *Driver) Ping(ctx context.Context) error {
 func (d *Driver) Save(ctx context.Context, key, value string, lifetime time.Duration) error {
 	return d.client.Set(ctx, key, value, lifetime.Duration()).Err()
 }
+
+// GetOrSave atomically returns the value stored for key, or stores value when the key is absent.
+//
+// It issues a single SET ... NX GET command, so it requires Redis 7.0 or later.
+func (d *Driver) GetOrSave(ctx context.Context, key, value string, lifetime time.Duration) (string, bool, error) {
+	existing, err := d.client.SetArgs(ctx, key, value, redis.SetArgs{
+		Mode: "NX",
+		Get:  true,
+		TTL:  lifetime.Duration(),
+	}).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+
+	return existing, true, nil
+}

--- a/cache/driver/internal/redis/redis_test.go
+++ b/cache/driver/internal/redis/redis_test.go
@@ -44,6 +44,35 @@ func TestDriverPings(t *testing.T) {
 	require.NoError(t, d.Ping(t.Context()))
 }
 
+func TestDriverGetOrSave(t *testing.T) {
+	lc := fxtest.NewLifecycle(t)
+	cfg := redisConfig("redis://localhost:6379")
+
+	d, err := cacheredis.NewDriver(lc, test.FS, cfg, nil)
+	require.NoError(t, err)
+	t.Cleanup(lc.RequireStop)
+	lc.RequireStart()
+
+	key := "get-or-save"
+	require.NoError(t, d.Delete(t.Context(), key))
+
+	existing, loaded, err := d.GetOrSave(t.Context(), key, "first", time.Minute)
+	require.NoError(t, err)
+	require.False(t, loaded)
+	require.Empty(t, existing)
+
+	existing, loaded, err = d.GetOrSave(t.Context(), key, "second", time.Minute)
+	require.NoError(t, err)
+	require.True(t, loaded)
+	require.Equal(t, "first", existing)
+
+	value, err := d.Get(t.Context(), key)
+	require.NoError(t, err)
+	require.Equal(t, "first", value)
+
+	require.NoError(t, d.Delete(t.Context(), key))
+}
+
 func TestParseURLDoesNotLeakCredentials(t *testing.T) {
 	url := "redis://user:" + "secret%zz@localhost:6379"
 	cfg := redisConfig(url)

--- a/cache/driver/internal/ttlcache/ttlcache.go
+++ b/cache/driver/internal/ttlcache/ttlcache.go
@@ -76,6 +76,22 @@ func (d *Driver) Save(ctx context.Context, key, value string, lifetime time.Dura
 	return nil
 }
 
+// GetOrSave atomically returns the value stored for key, or stores value when the key is absent.
+func (d *Driver) GetOrSave(ctx context.Context, key, value string, lifetime time.Duration) (string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return "", false, err
+	}
+
+	d.cache.DeleteExpired()
+
+	item, retrieved := d.cache.GetOrSet(key, value, ttlcache.WithTTL[string, string](ttl(lifetime).Duration()))
+	if !retrieved {
+		return "", false, nil
+	}
+
+	return item.Value(), true, nil
+}
+
 func ttl(lifetime time.Duration) time.Duration {
 	if lifetime <= 0 {
 		return time.Duration(ttlcache.NoTTL)

--- a/cache/driver/internal/ttlcache/ttlcache_test.go
+++ b/cache/driver/internal/ttlcache/ttlcache_test.go
@@ -26,6 +26,27 @@ func TestDriverHonorsCanceledContext(t *testing.T) {
 	require.ErrorIs(t, d.Delete(ctx, "key"), context.Canceled)
 	require.ErrorIs(t, d.Flush(ctx), context.Canceled)
 	require.ErrorIs(t, d.Ping(ctx), context.Canceled)
+
+	_, _, err = d.GetOrSave(ctx, "key", "value", 0)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDriverGetOrSave(t *testing.T) {
+	d := cachettl.NewDriver(config.DefaultMaxEntries)
+
+	existing, loaded, err := d.GetOrSave(t.Context(), "key", "first", 0)
+	require.NoError(t, err)
+	require.False(t, loaded)
+	require.Empty(t, existing)
+
+	existing, loaded, err = d.GetOrSave(t.Context(), "key", "second", 0)
+	require.NoError(t, err)
+	require.True(t, loaded)
+	require.Equal(t, "first", existing)
+
+	value, err := d.Get(t.Context(), "key")
+	require.NoError(t, err)
+	require.Equal(t, "first", value)
 }
 
 func TestDriverPings(t *testing.T) {

--- a/cache/generic.go
+++ b/cache/generic.go
@@ -49,3 +49,33 @@ func Persist[T any](ctx context.Context, key string, value *T, ttl time.Duration
 
 	return cache.Persist(ctx, key, value, ttl)
 }
+
+// GetOrPersist returns the cached value for key, or produces and stores a new value of type T via fn when the key is absent.
+//
+// If caching is disabled (no cache registered), GetOrPersist does not call fn and returns a nil value with a
+// nil error, mirroring how [Get] reports a disabled cache. Callers must tolerate a nil value rather than
+// assuming a value was produced or cached.
+// Concurrent in-process calls for the same key run fn once and share the produced value.
+func GetOrPersist[T any](ctx context.Context, key string, ttl time.Duration, fn func() (T, error)) (*T, error) {
+	if cache == nil {
+		return nil, nil
+	}
+
+	value := ptr.Zero[T]()
+	load := func() error {
+		v, err := fn()
+		if err != nil {
+			return err
+		}
+
+		*value = v
+
+		return nil
+	}
+
+	if err := cache.GetOrPersist(ctx, key, value, ttl, load); err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -41,6 +41,11 @@ func (c *Cache) Save(context.Context, string, string, time.Duration) error {
 	return nil
 }
 
+// GetOrSave returns the cached value as an existing entry.
+func (c *Cache) GetOrSave(context.Context, string, string, time.Duration) (string, bool, error) {
+	return c.Value, true, nil
+}
+
 // ErrCache is a [cache.Cache] test double that fails fetch, delete, and save operations with ErrFailed.
 //
 // Flush succeeds so tests can use ErrCache in started worlds without turning cleanup into the failure under test.
@@ -64,6 +69,11 @@ func (*ErrCache) Flush(context.Context) error {
 // Save returns ErrFailed.
 func (*ErrCache) Save(context.Context, string, string, time.Duration) error {
 	return ErrFailed
+}
+
+// GetOrSave returns ErrFailed.
+func (*ErrCache) GetOrSave(context.Context, string, string, time.Duration) (string, bool, error) {
+	return strings.Empty, false, ErrFailed
 }
 
 // RequireCacheRoundTrip persists a value, reads it back, and asserts the shared hello payload.


### PR DESCRIPTION
## What

- Adds a supported get-or-set across the three cache layers: `driver.Driver.GetOrSave`
  (atomic store-if-absent), the `Cache.GetOrPersist` facade method, and the generic
  `cache.GetOrPersist[T]` helper.
- On a hit the loader is not called and no write is issued. On a miss the value is produced
  once via in-process single-flight (go-sync `AnySingleFlightGroup`) and published atomically,
  so concurrent callers converge on a single stored value instead of clobbering each other.
- Redis publishes with `SET ... NX GET` (requires Redis 7.0+); the in-memory ttlcache backend
  uses its native `GetOrSet`. Values flow through the existing encode/compress/base64 and
  `cache:v1` key namespace, identical to `Get`/`Persist`.
- Breaking: the exported `driver.Driver` interface gains `GetOrSave`, so any custom driver
  implementation must add the method.
- When caching is disabled, `GetOrPersist[T]` returns `(nil, nil)` without calling the loader,
  so a disabled cache is not mistaken for a working one (no fabricated value).
- Non-goal: exactly-once compute across processes (distributed lock). Concurrent misses may run
  the loader once per replica; a single stored value still wins.

## Why

- Consumers previously had to hand-roll `Get` -> check -> `Persist`, which runs the producer
  even on a cache hit and, on Redis, lets concurrent misses clobber each other (last-write-wins).
  The only atomic alternative was dropping to the raw Redis client, abandoning the facade's
  encoding, size limits, and key namespace. This adds a race-safe, populate-on-miss primitive
  that keeps the facade contract on both built-in backends.

## Testing

- `go test -race ./cache/...` - passed
- `go build ./...` - passed
- `go vet ./cache/... ./internal/test/...` - passed
- `golangci-lint run ./cache/... ./internal/test/...` - passed (0 issues)
- New tests: `GetOrPersist` on ttlcache and redis (loader runs once, hit does not run it);
  single-winner convergence under 16 concurrent goroutines (race-checked); disabled-cache
  returns nil without calling the loader; driver-level `GetOrSave` NX semantics (redis +
  ttlcache) and canceled-context handling.
- An independent adversarial review (single-flight `-race` stress against live Redis) found no
  bugs.
- CI `make specs` was not run locally (broad suite); verification used the targeted race suite
  plus build/vet/lint above.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
