### PR TITLE
feat(http): honor matched patterns for unauthenticated routes

### DIFF
--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -40,6 +40,11 @@ func (r *RoutePolicy) IsOperation(req *Request) bool {
 
 // IsUnauthenticated reports whether req targets a route that does not require transport token authentication.
 func (r *RoutePolicy) IsUnauthenticated(req *Request) bool {
+	if !strings.IsEmpty(req.Pattern) {
+		_, ok := r.unauthenticated[req.Pattern]
+		return ok
+	}
+
 	if _, ok := r.unauthenticated[routeRequestPattern(req)]; ok {
 		return true
 	}

--- a/net/http/routes_test.go
+++ b/net/http/routes_test.go
@@ -62,15 +62,16 @@ func TestRouterRegistersHandlerAndPolicy(t *testing.T) {
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
 
-	router.HandleUnauthenticated("POST /events", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	router.HandleUnauthenticated("POST /events/{tenant}", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		res.WriteHeader(http.StatusAccepted)
 	}))
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/events", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/events/acme", http.NoBody)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
+	require.Equal(t, "POST /events/{tenant}", req.Pattern)
 	require.True(t, policy.IsUnauthenticated(req))
 	require.Equal(t, http.StatusAccepted, res.Code)
 }


### PR DESCRIPTION
## What

- Use the ServeMux-selected route pattern when classifying unauthenticated requests, while retaining method/path and path fallbacks for requests that have not been matched.
- Cover parameterized route registration so concrete tenant paths inherit the intended transport authentication and access-control bypass.
- Keep populated but unregistered matched patterns fail-closed.

## Why

- Reconstructing a policy key from the concrete request path cannot match parameterized ServeMux patterns such as `POST /events/{tenant}`.
- Using the canonical matched pattern aligns middleware policy with router registration without broadening unauthenticated access to sibling routes.

## Testing

- `make specs package=net/http` - passed; 57 tests, including the parameterized-route regression.
- `make specs package=net/http/meta` - passed; 10 tests, including route-pattern resolution before downstream middleware.
- `make specs package=transport/http/token` - passed; 13 token and access middleware tests.
- `GOLANGCI_LINT_CACHE=/private/tmp/go-service-golangci-lint-cache make lint` - passed with 0 issues; the temporary cache avoids the local Codex cache-write restriction.
- `git diff --check` - passed.
- `make specs package=transport/http` - failed during telemetry shutdown because vendored `gopsutil` panicked while parsing the macOS `netstat` permission error; the focused transport middleware checks passed, and CI remains the full integration verification.
