### PR TITLE
feat(cache): release coalesced GetOrPersist waiters on their own context cancellation

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -151,6 +151,13 @@ func (c *Cache) Persist(ctx context.Context, key string, value any, ttl time.Dur
 // for the same key run fn once and share the produced value; separate processes may each run fn once, but the
 // atomic publish still yields a single stored winner that every caller decodes.
 //
+// Each concurrent caller waits for the shared fill on its own ctx: if a caller's ctx is canceled or its
+// deadline passes before the fill publishes, that caller returns ctx.Err() instead of blocking until the fill
+// completes. The shared fill runs under the first caller's ctx in a background goroutine and continues even if
+// later callers stop waiting, so a caller that returns early on cancellation must not read value. Because the
+// fill uses the first caller's ctx, canceling that first caller can surface as an error to other callers still
+// waiting on the same fill.
+//
 // The value parameter should be a pointer to the destination value (for example *MyStruct). It is both
 // populated by fn and used as the decode destination for the resolved value.
 func (c *Cache) GetOrPersist(ctx context.Context, key string, value any, ttl time.Duration, fn func() error) error {
@@ -164,14 +171,20 @@ func (c *Cache) GetOrPersist(ctx context.Context, key string, value any, ttl tim
 
 	driverKey := c.driverKey(key)
 
-	result, err, _ := c.single.Do(driverKey, func() (any, error) {
+	result := c.single.DoChan(driverKey, func() (any, error) {
 		return c.loadOrSave(ctx, driverKey, value, ttl, fn)
 	})
-	if err != nil {
-		return err
-	}
 
-	return c.decode(result.(string), value)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case res := <-result:
+		if res.Err != nil {
+			return res.Err
+		}
+
+		return c.decode(res.Val.(string), value)
+	}
 }
 
 // loadOrSave re-checks the driver for driverKey, then produces and atomically publishes a value on a miss.

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -134,6 +134,110 @@ func TestGetOrPersistSingleWinner(t *testing.T) {
 	require.NoError(t, world.Remove(ctx, "test"))
 }
 
+func TestGetOrPersistReleasesWaiterOnItsOwnCancellation(t *testing.T) {
+	drv := &blockingGetDriver{gets: make(chan string, 16)}
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldCacheDriver(drv))
+
+	leaderStarted := make(chan struct{})
+	release := make(chan struct{})
+	leaderErr := make(chan error, 1)
+	leaderValue := "unchanged"
+	go func() {
+		leaderErr <- world.GetOrPersist(context.Background(), "test", &leaderValue, time.Minute, func() error {
+			close(leaderStarted)
+			<-release
+			leaderValue = "leader"
+
+			return nil
+		})
+	}()
+
+	<-leaderStarted
+	<-drv.gets // leader's initial Get
+	<-drv.gets // leader's single-flight recheck Get
+
+	dupCtx, dupCancel := context.WithCancel(context.Background())
+	dupErr := make(chan error, 1)
+	dupValue := "unchanged"
+	go func() {
+		dupErr <- world.GetOrPersist(dupCtx, "test", &dupValue, time.Minute, func() error {
+			dupValue = "duplicate"
+
+			return nil
+		})
+	}()
+
+	<-drv.gets // duplicate missed and joined the in-flight fill
+	dupCancel()
+
+	select {
+	case err := <-dupErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("duplicate blocked on the shared fill instead of returning on its own cancellation")
+	}
+	require.Equal(t, "unchanged", dupValue)
+
+	close(release)
+	require.NoError(t, <-leaderErr)
+	require.Equal(t, "leader", leaderValue)
+}
+
+func TestGetOrPersistLeaderCancellationFailsWaiters(t *testing.T) {
+	drv := &blockingGetDriver{gets: make(chan string, 16)}
+	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldCacheDriver(drv))
+
+	leaderStarted := make(chan struct{})
+	release := make(chan struct{})
+	leaderCtx, leaderCancel := context.WithCancel(context.Background())
+	leaderErr := make(chan error, 1)
+	leaderValue := "unchanged"
+	go func() {
+		leaderErr <- world.GetOrPersist(leaderCtx, "test", &leaderValue, time.Minute, func() error {
+			close(leaderStarted)
+			<-release
+			leaderValue = "leader"
+
+			return nil
+		})
+	}()
+
+	<-leaderStarted
+	<-drv.gets
+	<-drv.gets
+
+	followerCalled := make(chan struct{}, 1)
+	followerErr := make(chan error, 1)
+	followerValue := "unchanged"
+	go func() {
+		followerErr <- world.GetOrPersist(context.Background(), "test", &followerValue, time.Minute, func() error {
+			followerCalled <- struct{}{}
+
+			return nil
+		})
+	}()
+
+	<-drv.gets // follower missed and is joining the shared fill
+	// Give the follower time to park on the shared fill before it publishes.
+	time.Sleep(100 * time.Millisecond)
+
+	// The shared fill runs under the leader context, so canceling the leader and
+	// then letting the fill publish fails the still-live follower too.
+	leaderCancel()
+	close(release)
+
+	require.ErrorIs(t, <-followerErr, context.Canceled)
+	require.ErrorIs(t, <-leaderErr, context.Canceled)
+
+	select {
+	case <-followerCalled:
+		t.Fatal("follower ran its own loader instead of sharing the leader's fill")
+	default:
+	}
+}
+
 func TestGenericGetOrPersistDisabledCache(t *testing.T) {
 	cache.Register(nil)
 	t.Cleanup(func() {
@@ -824,5 +928,40 @@ func (*recheckCacheDriver) Save(context.Context, string, string, time.Duration) 
 }
 
 func (*recheckCacheDriver) GetOrSave(context.Context, string, string, time.Duration) (string, bool, error) {
+	return strings.Empty, false, nil
+}
+
+// blockingGetDriver reports every Get on gets and always misses, letting a test observe when callers reach
+// Cache.GetOrPersist's single-flight path while a loader is held blocked.
+type blockingGetDriver struct {
+	gets chan string
+}
+
+func (*blockingGetDriver) Delete(context.Context, string) error {
+	return nil
+}
+
+func (d *blockingGetDriver) Get(ctx context.Context, key string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return strings.Empty, err
+	}
+	d.gets <- key
+
+	return strings.Empty, drivererrors.ErrMissing
+}
+
+func (*blockingGetDriver) Flush(context.Context) error {
+	return nil
+}
+
+func (*blockingGetDriver) Save(context.Context, string, string, time.Duration) error {
+	return nil
+}
+
+func (*blockingGetDriver) GetOrSave(ctx context.Context, _, _ string, _ time.Duration) (string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return strings.Empty, false, err
+	}
+
 	return strings.Empty, false, nil
 }


### PR DESCRIPTION
## What

- `Cache.GetOrPersist` now coalesces concurrent misses with `singleflight.Group.DoChan` and waits on each caller's own context. A caller whose context is canceled or whose deadline passes before the shared fill publishes returns `ctx.Err()` immediately instead of blocking until the fill finishes.
- The single in-process fill and atomic publish are unchanged: concurrent callers still run the loader once and converge on one stored value.
- GoDoc now states the boundary: the shared fill runs under the first caller's context in a background goroutine and continues even if later callers stop waiting; a caller that returns early on cancellation must not read `value`; and canceling the first caller can surface as an error to callers still waiting on the same fill. The fill is intentionally left leader-scoped rather than decoupled.

## Why

- Duplicate callers previously blocked in `singleflight.Group.Do` with no context selector, so a slow or stuck hot-key loader retained every canceled duplicate's goroutine and request resources until the leader finished — letting dependency slowness amplify into service saturation (reliability gap REL-1).
- Releasing waiters on their own cancellation restores load-shedding for coalesced reads without giving up the coalescing benefit.
- Known, documented boundary (not fixed here): a direct `Cache.GetOrPersist` caller that reads `value` after an early-cancellation return can race the still-running background fill. The supported generic `GetOrPersist[T]` helper does not (it returns nil on error). Full leader/follower context isolation was intentionally out of scope.

## Testing

- `go test -race ./cache/...` - passed
- `golangci-lint run ./cache/...` - passed (0 issues)
- `go vet ./cache/` and `gofmt -l` - passed (clean)
- New `TestGetOrPersistReleasesWaiterOnItsOwnCancellation`: a joined duplicate returns `context.Canceled` before the blocked leader is released (blocked for 5s before the fix; returns immediately after).
- New `TestGetOrPersistLeaderCancellationFailsWaiters`: characterizes the documented leader-scoped behavior — canceling the leader surfaces `context.Canceled` to a still-live follower sharing the fill.
- Independent review stress-ran both new tests under `-race -count=20` and up to ~600 aggregate iterations across CPU/`GOMAXPROCS` variations with no failures or race reports.
- `make specs` not run locally (needs service sidecars); expected to run in CI.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
