### PR TITLE
feat(telemetry): keep exporter diagnostics out of otlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,12 @@ Supported built-in logger kinds:
 Supported logger levels are `debug`, `info`, `warn`, and `error`. When `level`
 is unset, logging defaults to `info`; unknown values fail logger construction.
 
+The standard telemetry module writes OpenTelemetry SDK and exporter failures as
+JSON to stdout through a handler-owned logger that is independent of the
+configured application logger. This keeps OTLP outage diagnostics local without
+duplicating normal application logs or feeding failures back into the OTLP log
+exporter.
+
 #### JSON logger
 
 ```yaml

--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -59,7 +59,7 @@ func NewLogger(lc di.Lifecycle, config *logger.Config) (*logger.Logger, error) {
 }
 
 func (w *World) registerTelemetry() {
-	errors.Register(errors.NewHandler(w.Logger))
+	errors.Register(errors.NewHandler())
 }
 
 func createLogger(lc di.Lifecycle, os *worldOpts) (*logger.Logger, error) {

--- a/os/doc.go
+++ b/os/doc.go
@@ -67,10 +67,10 @@
 // # Relationship to the standard library
 //
 // Several identifiers are thin wrappers or aliases of the standard library
-// package os (for example [Getenv], [LookupEnv], [Setenv], [Unsetenv], [Exit],
-// [Args], and [Stdout]). They exist to keep go-service code depending on
-// go-service packages consistently, while still delegating to the underlying OS
-// implementation.
+// package os (for example [File], [CreateTemp], [Getenv], [LookupEnv], [Setenv],
+// [Unsetenv], [Exit], [Args], and [Stdout]). They exist to keep go-service code
+// depending on go-service packages consistently, while still delegating to the
+// underlying OS implementation.
 //
 // # Process exit codes
 //

--- a/os/os.go
+++ b/os/os.go
@@ -17,6 +17,9 @@ const ExitCodeFailure = 1
 // ExitCodeServeFailure indicates an asynchronous server Serve failure.
 const ExitCodeServeFailure = 2
 
+// File aliases [os.File] so file-returning helpers stay on the go-service OS surface.
+type File = os.File
+
 // Args is the process argument vector used by go-service CLI helpers.
 //
 // It is initialized from [os.Args] at package init time and is provided so
@@ -30,6 +33,11 @@ var Args = os.Args
 // It is an alias of [os.Stdout] and is typically used for writing user-facing
 // output from CLIs.
 var Stdout = os.Stdout
+
+// CreateTemp wraps [os.CreateTemp] without changing its semantics.
+func CreateTemp(dir, pattern string) (*File, error) {
+	return os.CreateTemp(dir, pattern)
+}
 
 // Getenv returns the value of the environment variable named by key.
 func Getenv(key string) string {

--- a/telemetry/errors/doc.go
+++ b/telemetry/errors/doc.go
@@ -10,12 +10,9 @@
 //
 // # Handler
 //
-// Handler implements the OpenTelemetry error handler interface by logging errors through
-// a go-service *[github.com/alexfalkowski/go-service/v2/telemetry/logger.Logger]. Errors are logged at error level using a
-// consistent message and attribute key ("error").
-//
-// When logging is disabled and no *[github.com/alexfalkowski/go-service/v2/telemetry/logger.Logger] is available, NewHandler
-// returns nil so callers can keep the OpenTelemetry default global error handler.
+// Handler implements the OpenTelemetry error handler interface with its own
+// JSON logger on stdout. Errors are logged at error level using a consistent
+// message and attribute key ("error").
 //
 // # Registration
 //
@@ -33,16 +30,16 @@
 // # Dependency injection (Fx)
 //
 // This package also exports [Module], which wires:
-//   - construction of the Handler (NewHandler), and
-//   - registration of the handler (Register)
+//   - construction of [Handler] with [NewHandler], and
+//   - registration with [Register]
 //
 // into an Fx application.
 //
 // Including [github.com/alexfalkowski/go-service/v2/telemetry/errors.Module] (or the top-level [github.com/alexfalkowski/go-service/v2/telemetry.Module]) wires this
-// handler into your service. When a go-service logger is configured, OpenTelemetry
-// internal errors are routed into service logging. When logging is disabled,
-// NewHandler returns nil and Register preserves the OpenTelemetry default global
-// error handler instead.
+// handler into your service. OpenTelemetry internal errors are written as JSON
+// to local stdout independently of the configured logger. This prevents an OTLP
+// exporter failure from feeding its diagnostic back into the same failed
+// exporter.
 //
 // # Notes
 //

--- a/telemetry/errors/errors.go
+++ b/telemetry/errors/errors.go
@@ -1,7 +1,9 @@
 package errors
 
 import (
-	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	"log/slog"
+
+	"github.com/alexfalkowski/go-service/v2/os"
 )
 
 // Register installs handler as the global OpenTelemetry error handler.
@@ -11,7 +13,7 @@ import (
 //
 // Register is typically invoked once during service startup (for example via an
 // Fx module) so that OpenTelemetry SDK/internal errors (exporter failures,
-// dropped data warnings, etc.) are routed into application logging.
+// dropped data warnings, etc.) are written to the handler's local logger.
 //
 // If handler is nil, Register leaves the current global OpenTelemetry error
 // handler unchanged.
@@ -23,35 +25,30 @@ func Register(handler *Handler) {
 	SetHandler(handler)
 }
 
-// NewHandler constructs a Handler that logs OpenTelemetry internal errors.
+// NewHandler constructs a Handler that logs OpenTelemetry internal errors to an
+// independent JSON logger on stdout.
 //
-// The returned Handler implements the OpenTelemetry error handler interface and
-// writes errors using the provided go-service *[logger.Logger].
-//
-// If logger is nil, NewHandler returns nil so callers can preserve the
-// OpenTelemetry default global error handler when logging is disabled.
-func NewHandler(logger *logger.Logger) *Handler {
-	if logger == nil {
-		return nil
+// The logger does not use the configured application logger or process-wide
+// slog default, so exporter errors cannot feed back into a failing OTLP logger.
+func NewHandler() *Handler {
+	return &Handler{
+		logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-
-	return &Handler{logger: logger}
 }
 
-// Handler routes OpenTelemetry SDK/internal errors into a go-service logger.
+// Handler routes OpenTelemetry SDK/internal errors to a local JSON logger.
 //
 // Handler is intended to be registered via Register so that OpenTelemetry errors
-// are visible in service logs. It logs a consistent message and includes a
-// standardized "error" attribute produced by [logger.Error].
+// are visible without depending on the application logging pipeline.
 type Handler struct {
-	logger *logger.Logger
+	logger *slog.Logger
 }
 
 // Handle logs an OpenTelemetry internal error.
 //
 // This method is called by the OpenTelemetry SDK when it encounters an internal
-// error. It logs at error level using the go-service logger, attaching the error
-// under the "error" key.
+// error. It logs at error level using the handler's local logger, attaching the
+// error under the "error" key.
 //
 // Handle is nil-safe. If the receiver or its logger is nil, the error is ignored.
 func (e *Handler) Handle(err error) {
@@ -59,5 +56,5 @@ func (e *Handler) Handle(err error) {
 		return
 	}
 
-	e.logger.Error("telemetry: global error", logger.Error(err))
+	e.logger.Error("telemetry: global error", slog.Any("error", err))
 }

--- a/telemetry/errors/errors_test.go
+++ b/telemetry/errors/errors_test.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
-	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/stretchr/testify/require"
 )
-
-func TestNewHandlerNilLogger(t *testing.T) {
-	require.Nil(t, errors.NewHandler(nil))
-}
 
 func TestRegisterNilHandler(t *testing.T) {
 	original := errors.GetHandler()
@@ -32,15 +30,43 @@ func TestHandleNilHandler(t *testing.T) {
 	})
 }
 
-func TestHandleLogsError(t *testing.T) {
+func TestHandleLogsErrors(t *testing.T) {
+	stdout := captureStdout(t)
+	handler := errors.NewHandler()
+	originalDefault := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(originalDefault)
+	})
 	capture := &test.CaptureHandler{}
-	handler := errors.NewHandler(&logger.Logger{Logger: slog.New(capture)})
-	require.NotNil(t, handler)
+	slog.SetDefault(slog.New(capture))
 
 	handler.Handle(context.Canceled)
+	handler.Handle(context.DeadlineExceeded)
 
-	require.Len(t, capture.Records, 1)
-	require.Equal(t, slog.LevelError, capture.Records[0].Level)
-	require.Equal(t, "telemetry: global error", capture.Records[0].Message)
-	require.Equal(t, context.Canceled, capture.Records[0].Attrs["error"].Any())
+	require.Empty(t, capture.Records)
+	_, err := stdout.Seek(0, 0)
+	require.NoError(t, err)
+	data, reader, err := io.ReadAll(stdout)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	logs := string(data)
+	require.Equal(t, 2, strings.Count(logs, "\n"))
+	require.Equal(t, 2, strings.Count(logs, `"msg":"telemetry: global error"`))
+	require.Contains(t, logs, `"error":"context canceled"`)
+	require.Contains(t, logs, `"error":"context deadline exceeded"`)
+}
+
+func captureStdout(t *testing.T) *os.File {
+	t.Helper()
+
+	original := os.Stdout
+	file, err := os.CreateTemp(t.TempDir(), "telemetry-errors-*.log")
+	require.NoError(t, err)
+	os.Stdout = file
+	t.Cleanup(func() {
+		os.Stdout = original
+		require.NoError(t, file.Close())
+	})
+
+	return file
 }

--- a/telemetry/errors/module.go
+++ b/telemetry/errors/module.go
@@ -6,16 +6,12 @@ import "github.com/alexfalkowski/go-service/v2/di"
 //
 // Including this module in an Fx application provides:
 //
-//   - NewHandler: constructs a *[Handler] that logs OpenTelemetry internal/SDK errors
-//     through the go-service telemetry logger when logging is enabled. If no
-//     go-service logger is available, NewHandler returns nil.
+//   - NewHandler: constructs a *[Handler] with its own local JSON logger.
 //   - Register: installs that handler as the process-wide OpenTelemetry error
-//     handler via otel.SetErrorHandler. If the constructed handler is nil,
-//     Register leaves the current global handler unchanged.
+//     handler via otel.SetErrorHandler.
 //
-// This surfaces OpenTelemetry exporter/SDK errors in service logs when logging
-// is configured, while preserving the OpenTelemetry default error handling when
-// it is not.
+// This keeps OpenTelemetry exporter/SDK failures visible on local stdout without
+// feeding them back into a failing configured OTLP logger.
 //
 // Note: the OpenTelemetry error handler is global; the last handler registered
 // wins.

--- a/telemetry/module.go
+++ b/telemetry/module.go
@@ -16,7 +16,7 @@ import (
 //   - logging ([github.com/alexfalkowski/go-service/v2/telemetry/logger.Module]),
 //   - metrics ([github.com/alexfalkowski/go-service/v2/telemetry/metrics.Module]),
 //   - tracing ([github.com/alexfalkowski/go-service/v2/telemetry/tracer.Module]), and
-//   - OpenTelemetry internal error handling ([github.com/alexfalkowski/go-service/v2/telemetry/errors.Module]).
+//   - local OpenTelemetry internal error handling ([github.com/alexfalkowski/go-service/v2/telemetry/errors.Module]).
 //
 // In addition, Module constructs [NewPropagator] and registers it with
 // [RegisterPropagation], which configures the global OpenTelemetry
@@ -24,6 +24,10 @@ import (
 // for extraction and injection. This affects context extraction/injection
 // performed by instrumentation that relies on the global propagator (for example
 // HTTP/gRPC instrumentation).
+//
+// OpenTelemetry internal errors use an independent handler-owned JSON logger on
+// stdout so a failing configured OTLP logger cannot receive its own exporter
+// diagnostics. Normal application logging is not fanned out to that logger.
 //
 // Note: This module wires providers/exporters and global configuration. It does
 // not itself create spans/metrics/log records; instrumentation elsewhere in your

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -121,7 +121,7 @@ func BenchmarkGRPC(b *testing.B) {
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler())
 
 		lc.RequireStart()
 
@@ -169,7 +169,7 @@ func BenchmarkGRPC(b *testing.B) {
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler())
 
 		lc.RequireStart()
 

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -144,7 +144,7 @@ func BenchmarkHTTP(b *testing.B) {
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler())
 
 		lc.RequireStart()
 
@@ -199,7 +199,7 @@ func BenchmarkHTTP(b *testing.B) {
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler())
 
 		lc.RequireStart()
 


### PR DESCRIPTION
## What

- Route OpenTelemetry SDK and exporter failures to a handler-owned JSON logger on stdout that is independent of the configured application logger.
- Construct the error handler without an injected logger, update repository callers, and document the local diagnostic behavior.
- Add the project OS surface used by the public-behavior test. Downstream manual callers must change `errors.NewHandler(logger)` to `errors.NewHandler()`.

## Why

- OTLP exporter failures were reported through the same OTLP-backed application logger, which could feed diagnostics back into the failed exporter and hide the reason logs were being lost.
- A private local slog sink keeps exporter diagnostics visible without duplicating normal application logs or adding a broader fallback-logger API.

## Testing

- `make package=telemetry/errors specs` - passed (3 tests)
- `make package=telemetry/logger specs` - passed (22 tests)
- `make package=os specs` - passed (17 tests)
- `make lint` - passed with 0 issues
- `make sec` - passed with no code vulnerabilities or secrets
- `make specs` - passed (2,292 race-enabled tests)

AI-assisted-by: [Codex](https://openai.com/codex/)
