### PR TITLE
feat(telemetry): isolate otel error handler on a format-matched stdout sink

### DIFF
--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -59,7 +59,7 @@ func NewLogger(lc di.Lifecycle, config *logger.Config) (*logger.Logger, error) {
 }
 
 func (w *World) registerTelemetry() {
-	errors.Register(errors.NewHandler(w.Logger))
+	errors.Register(errors.NewHandler(nil))
 }
 
 func createLogger(lc di.Lifecycle, os *worldOpts) (*logger.Logger, error) {

--- a/os/os.go
+++ b/os/os.go
@@ -31,6 +31,21 @@ var Args = os.Args
 // output from CLIs.
 var Stdout = os.Stdout
 
+// File is an alias of [os.File].
+//
+// It represents an open file descriptor and is provided so go-service code can
+// depend on go-service packages consistently.
+type File = os.File
+
+// CreateTemp creates a new temporary file in the directory dir, opens it for
+// reading and writing, and returns the resulting *[File].
+//
+// It forwards to [os.CreateTemp]. If dir is empty, CreateTemp uses the default
+// directory for temporary files (see [os.TempDir]).
+func CreateTemp(dir, pattern string) (*File, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
 // Getenv returns the value of the environment variable named by key.
 func Getenv(key string) string {
 	return os.Getenv(key)

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -10,7 +10,7 @@
 //     Prometheus), plus helpers for obtaining a Meter from a configured provider.
 //   - telemetry/tracer: tracing SDK wiring and OTLP exporter configuration.
 //   - telemetry/errors: OpenTelemetry error handler wiring so OTel SDK/internal
-//     errors are logged.
+//     errors are written to an independent stdout diagnostic sink.
 //   - telemetry/header: helpers for exporter/request headers, including secret
 //     resolution via the go-service "source string" convention (env:NAME,
 //     file:<path>, or literal values).

--- a/telemetry/errors/doc.go
+++ b/telemetry/errors/doc.go
@@ -1,4 +1,4 @@
-// Package errors wires OpenTelemetry global error handling into go-service logging.
+// Package errors wires OpenTelemetry global error handling into an independent stdout diagnostic sink.
 //
 // OpenTelemetry SDKs and instrumentations may emit internal errors (for example exporter
 // failures, dropped data warnings, or other SDK/runtime issues). The OpenTelemetry API
@@ -11,11 +11,13 @@
 // # Handler
 //
 // Handler implements the OpenTelemetry error handler interface by logging errors through
-// a go-service *[github.com/alexfalkowski/go-service/v2/telemetry/logger.Logger]. Errors are logged at error level using a
-// consistent message and attribute key ("error").
+// a private [log/slog.Logger] that writes to os.Stdout and mirrors the configured logger
+// format (json, text, or tint). Errors are logged at error level using a consistent
+// message and attribute key ("error").
 //
-// When logging is disabled and no *[github.com/alexfalkowski/go-service/v2/telemetry/logger.Logger] is available, NewHandler
-// returns nil so callers can keep the OpenTelemetry default global error handler.
+// This diagnostic sink is intentionally independent of the configured application logger
+// and its OTLP export pipeline. It ensures OpenTelemetry export failures remain locally
+// visible without feeding their own diagnostics back into a failing exporter.
 //
 // # Registration
 //
@@ -39,10 +41,9 @@
 // into an Fx application.
 //
 // Including [github.com/alexfalkowski/go-service/v2/telemetry/errors.Module] (or the top-level [github.com/alexfalkowski/go-service/v2/telemetry.Module]) wires this
-// handler into your service. When a go-service logger is configured, OpenTelemetry
-// internal errors are routed into service logging. When logging is disabled,
-// NewHandler returns nil and Register preserves the OpenTelemetry default global
-// error handler instead.
+// handler into your service, so OpenTelemetry internal errors are written to the
+// handler's private stdout sink regardless of the application logger
+// configuration.
 //
 // # Notes
 //
@@ -50,5 +51,5 @@
 // startup. If you install multiple handlers, the last one set wins.
 //
 // This package only handles OpenTelemetry internal errors; it does not affect how spans,
-// metrics, or logs are exported beyond ensuring SDK errors are visible in logs.
+// metrics, or logs are exported beyond ensuring SDK errors are visible on stdout.
 package errors

--- a/telemetry/errors/errors.go
+++ b/telemetry/errors/errors.go
@@ -1,6 +1,8 @@
 package errors
 
 import (
+	"log/slog"
+
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 )
 
@@ -11,7 +13,8 @@ import (
 //
 // Register is typically invoked once during service startup (for example via an
 // Fx module) so that OpenTelemetry SDK/internal errors (exporter failures,
-// dropped data warnings, etc.) are routed into application logging.
+// dropped data warnings, etc.) are surfaced through the handler's independent
+// diagnostic sink.
 //
 // If handler is nil, Register leaves the current global OpenTelemetry error
 // handler unchanged.
@@ -26,32 +29,31 @@ func Register(handler *Handler) {
 // NewHandler constructs a Handler that logs OpenTelemetry internal errors.
 //
 // The returned Handler implements the OpenTelemetry error handler interface and
-// writes errors using the provided go-service *[logger.Logger].
-//
-// If logger is nil, NewHandler returns nil so callers can preserve the
-// OpenTelemetry default global error handler when logging is disabled.
-func NewHandler(logger *logger.Logger) *Handler {
-	if logger == nil {
-		return nil
-	}
-
-	return &Handler{logger: logger}
+// owns a private stdout logger built by [logger.NewDiagnosticLogger]. That sink
+// mirrors the configured logger format (json, text, or tint) while remaining
+// independent of the configured application logger and its OTLP export pipeline,
+// so OpenTelemetry export failures cannot feed their own diagnostics back into a
+// failing exporter. A nil cfg, the "otlp" kind, or an unknown kind fall back to
+// JSON on stdout.
+func NewHandler(cfg *logger.Config) *Handler {
+	return &Handler{logger: logger.NewDiagnosticLogger(cfg)}
 }
 
-// Handler routes OpenTelemetry SDK/internal errors into a go-service logger.
+// Handler routes OpenTelemetry SDK/internal errors into a private diagnostic logger.
 //
 // Handler is intended to be registered via Register so that OpenTelemetry errors
-// are visible in service logs. It logs a consistent message and includes a
-// standardized "error" attribute produced by [logger.Error].
+// are visible on stdout independently of the configured application logger. It
+// logs a consistent message and includes a standardized "error" attribute
+// produced by [logger.Error].
 type Handler struct {
-	logger *logger.Logger
+	logger *slog.Logger
 }
 
 // Handle logs an OpenTelemetry internal error.
 //
 // This method is called by the OpenTelemetry SDK when it encounters an internal
-// error. It logs at error level using the go-service logger, attaching the error
-// under the "error" key.
+// error. It logs at error level using the handler's private logger, attaching
+// the error under the "error" key.
 //
 // Handle is nil-safe. If the receiver or its logger is nil, the error is ignored.
 func (e *Handler) Handle(err error) {

--- a/telemetry/errors/errors_test.go
+++ b/telemetry/errors/errors_test.go
@@ -5,15 +5,12 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
-	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/stretchr/testify/require"
 )
-
-func TestNewHandlerNilLogger(t *testing.T) {
-	require.Nil(t, errors.NewHandler(nil))
-}
 
 func TestRegisterNilHandler(t *testing.T) {
 	original := errors.GetHandler()
@@ -33,14 +30,36 @@ func TestHandleNilHandler(t *testing.T) {
 }
 
 func TestHandleLogsError(t *testing.T) {
-	capture := &test.CaptureHandler{}
-	handler := errors.NewHandler(&logger.Logger{Logger: slog.New(capture)})
+	file, err := os.CreateTemp(t.TempDir(), "otel-*.log")
+	require.NoError(t, err)
+
+	stdout := os.Stdout
+	os.Stdout = file
+	t.Cleanup(func() {
+		os.Stdout = stdout
+		_ = file.Close()
+	})
+
+	handler := errors.NewHandler(nil)
 	require.NotNil(t, handler)
+
+	// Replace the process-wide default logger to prove the handler writes to its
+	// own independent sink rather than slog.Default.
+	original := slog.Default()
+	capture := &test.CaptureHandler{}
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(original) })
 
 	handler.Handle(context.Canceled)
 
-	require.Len(t, capture.Records, 1)
-	require.Equal(t, slog.LevelError, capture.Records[0].Level)
-	require.Equal(t, "telemetry: global error", capture.Records[0].Message)
-	require.Equal(t, context.Canceled, capture.Records[0].Attrs["error"].Any())
+	content, err := test.FS.ReadFile(file.Name())
+	require.NoError(t, err)
+
+	record := map[string]any{}
+	require.NoError(t, json.Unmarshal(content, &record))
+	require.Equal(t, "error", record["level"])
+	require.Equal(t, "telemetry: global error", record["msg"])
+	require.Equal(t, context.Canceled.Error(), record["error"])
+
+	require.Empty(t, capture.Records)
 }

--- a/telemetry/errors/module.go
+++ b/telemetry/errors/module.go
@@ -7,15 +7,15 @@ import "github.com/alexfalkowski/go-service/v2/di"
 // Including this module in an Fx application provides:
 //
 //   - NewHandler: constructs a *[Handler] that logs OpenTelemetry internal/SDK errors
-//     through the go-service telemetry logger when logging is enabled. If no
-//     go-service logger is available, NewHandler returns nil.
+//     through a private stdout logger which mirrors the configured logger format
+//     (json, text, or tint). This sink is independent of the configured
+//     application logger and its OTLP export pipeline.
 //   - Register: installs that handler as the process-wide OpenTelemetry error
 //     handler via otel.SetErrorHandler. If the constructed handler is nil,
 //     Register leaves the current global handler unchanged.
 //
-// This surfaces OpenTelemetry exporter/SDK errors in service logs when logging
-// is configured, while preserving the OpenTelemetry default error handling when
-// it is not.
+// This surfaces OpenTelemetry exporter/SDK errors on stdout so that export
+// failures cannot feed their own diagnostics back into a failing exporter.
 //
 // Note: the OpenTelemetry error handler is global; the last handler registered
 // wins.

--- a/telemetry/logger/config.go
+++ b/telemetry/logger/config.go
@@ -73,6 +73,18 @@ func (c *Config) IsEnabled() bool {
 	return c != nil
 }
 
+// GetKind returns the configured logger kind.
+//
+// A nil receiver returns an empty kind, which callers treat as no configured
+// stdout format.
+func (c *Config) GetKind() string {
+	if c == nil {
+		return ""
+	}
+
+	return c.Kind
+}
+
 // GetProtocol returns the configured OTLP transport protocol.
 //
 // A nil receiver or an empty value falls back to OTLP/HTTP.

--- a/telemetry/logger/diagnostic.go
+++ b/telemetry/logger/diagnostic.go
@@ -1,0 +1,31 @@
+package logger
+
+import (
+	"log/slog"
+
+	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/lmittmann/tint"
+)
+
+// NewDiagnosticLogger builds a stdout logger for internal diagnostics that
+// mirrors the configured logger format without depending on the OTLP export
+// pipeline.
+//
+// It selects the stdout handler for cfg.Kind ("json", "text", or "tint") and
+// applies the configured level. The "otlp" kind, an unknown kind, and a nil cfg
+// (logging disabled) all fall back to JSON on stdout, because those have no
+// local stdout format and this sink must never route through OTLP.
+//
+// Unlike the application logger, the returned logger does not attach identity
+// resource attributes or trace context; it is intended for a self-contained
+// local diagnostic sink such as the OpenTelemetry error handler.
+func NewDiagnosticLogger(cfg *Config) *slog.Logger {
+	switch cfg.GetKind() {
+	case "text":
+		return slog.New(slog.NewTextHandler(os.Stdout, handlerOptions(cfg)))
+	case "tint":
+		return slog.New(tint.NewHandler(os.Stdout, tintOptions(cfg)))
+	default:
+		return slog.New(slog.NewJSONHandler(os.Stdout, handlerOptions(cfg)))
+	}
+}

--- a/telemetry/logger/levels.go
+++ b/telemetry/logger/levels.go
@@ -21,6 +21,9 @@ func validateLevel(cfg *Config) error {
 }
 
 func level(cfg *Config) slog.Level {
+	if cfg == nil {
+		return slog.LevelInfo
+	}
 	if level, ok := levels[cfg.Level]; ok {
 		return level
 	}

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
@@ -47,6 +49,58 @@ func TestConfigGetProtocol(t *testing.T) {
 	require.Equal(t, otlp.ProtocolHTTP, (*logger.Config)(nil).GetProtocol())
 	require.Equal(t, otlp.ProtocolHTTP, (&logger.Config{}).GetProtocol())
 	require.Equal(t, otlp.ProtocolGRPC, (&logger.Config{Protocol: otlp.ProtocolGRPC}).GetProtocol())
+}
+
+func TestConfigGetKind(t *testing.T) {
+	require.Equal(t, strings.Empty, (*logger.Config)(nil).GetKind())
+	require.Equal(t, strings.Empty, (&logger.Config{}).GetKind())
+	require.Equal(t, "tint", (&logger.Config{Kind: "tint"}).GetKind())
+}
+
+func TestNewDiagnosticLogger(t *testing.T) {
+	tests := []struct {
+		config *logger.Config
+		name   string
+		json   bool
+	}{
+		{name: "json uses json", config: &logger.Config{Kind: "json"}, json: true},
+		{name: "text uses text", config: &logger.Config{Kind: "text"}, json: false},
+		{name: "tint uses tint", config: &logger.Config{Kind: "tint"}, json: false},
+		{name: "otlp falls back to json", config: &logger.Config{Kind: "otlp"}, json: true},
+		{name: "disabled falls back to json", config: nil, json: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := os.CreateTemp(t.TempDir(), "diagnostic-*.log")
+			require.NoError(t, err)
+
+			stdout := os.Stdout
+			os.Stdout = file
+			t.Cleanup(func() {
+				os.Stdout = stdout
+				_ = file.Close()
+			})
+
+			logger.NewDiagnosticLogger(tt.config).Error("diagnostic", logger.Error(context.Canceled))
+
+			content, err := test.FS.ReadFile(file.Name())
+			require.NoError(t, err)
+
+			require.Contains(t, string(content), "diagnostic")
+			require.Contains(t, string(content), context.Canceled.Error())
+
+			record := map[string]any{}
+			if tt.json {
+				require.NoError(t, json.Unmarshal(content, &record))
+				require.Equal(t, "diagnostic", record["msg"])
+				require.Equal(t, "error", record["level"])
+				require.Equal(t, context.Canceled.Error(), record["error"])
+			} else {
+				require.Error(t, json.Unmarshal(content, &record))
+			}
+		})
+	}
 }
 
 func TestMetaTruncatesLongValues(t *testing.T) {

--- a/telemetry/logger/tint.go
+++ b/telemetry/logger/tint.go
@@ -7,9 +7,9 @@ import (
 	"github.com/lmittmann/tint"
 )
 
-func newTintLogger(params LoggerParams) *slog.Logger {
-	opts := &tint.Options{
-		Level: level(params.Config),
+func tintOptions(cfg *Config) *tint.Options {
+	return &tint.Options{
+		Level: level(cfg),
 		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
 			if attr.Value.Kind() == slog.KindAny {
 				if err, ok := attr.Value.Any().(error); ok {
@@ -23,8 +23,10 @@ func newTintLogger(params LoggerParams) *slog.Logger {
 			return attr
 		},
 	}
+}
 
-	return slog.New(NewTraceHandler(tint.NewHandler(os.Stdout, opts))).With(
+func newTintLogger(params LoggerParams) *slog.Logger {
+	return slog.New(NewTraceHandler(tint.NewHandler(os.Stdout, tintOptions(params.Config)))).With(
 		slog.String("id", params.ID.String()),
 		slog.String("name", params.Name.String()),
 		slog.String("version", params.Version.String()),

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -121,7 +121,7 @@ func BenchmarkGRPC(b *testing.B) {
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler(nil))
 
 		lc.RequireStart()
 
@@ -169,7 +169,7 @@ func BenchmarkGRPC(b *testing.B) {
 
 		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler(nil))
 
 		lc.RequireStart()
 

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -144,7 +144,7 @@ func BenchmarkHTTP(b *testing.B) {
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler(nil))
 
 		lc.RequireStart()
 
@@ -199,7 +199,7 @@ func BenchmarkHTTP(b *testing.B) {
 		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
 
 		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-		errors.Register(errors.NewHandler(logger))
+		errors.Register(errors.NewHandler(nil))
 
 		lc.RequireStart()
 


### PR DESCRIPTION
## What

- `telemetry/errors.NewHandler` now takes a `*telemetry/logger.Config` and logs
  OpenTelemetry internal/SDK errors through a private stdout `slog` logger built
  by the new `logger.NewDiagnosticHandler`. The sink is independent of the
  configured application logger and the OTLP export pipeline.
- The diagnostic sink mirrors the configured logger format: `json`, `text`, or
  `tint`. The `otlp` kind, an unknown kind, and disabled logging (nil config)
  fall back to JSON on stdout, since those have no local stdout format and the
  sink must never route through OTLP.
- The OpenTelemetry global error handler is now always installed. Previously it
  was skipped when application logging was disabled, leaving the OTel default
  handler in place; it now consistently surfaces OTel internal errors on stdout.
- Supporting changes: new `logger.NewDiagnosticHandler`, a nil-safe
  `logger.Config.GetKind`, an extracted `tintOptions` shared by the application
  tint logger and the diagnostic sink, and thin `os.File`/`os.CreateTemp`
  passthroughs used by the stdout-capturing tests.
- Compatibility: `errors.NewHandler(cfg)` is a source-breaking signature change.
  Standard module wiring injects the already-registered `*logger.Config`; there
  is no runtime or configuration migration.

## Why

- During an OTLP collector outage the error handler logged through the same
  failing OTLP logger, so exporter-failure diagnostics were themselves enqueued
  into the failing exporter. That obscured the incident and sustained avoidable
  export work in the bounded queue. An independent stdout sink at the handler's
  ownership boundary breaks that feedback loop, and matching the configured
  json/text/tint format keeps those local diagnostics consistent with the
  service's other stdout logs for operators reading them.

## Testing

- `make specs package=telemetry/logger` - passed (29 tests; `NewDiagnosticHandler`
  covers json/text/tint format selection, the otlp/nil JSON fallback, and the
  tint error-attribute branch; `GetKind` covered)
- `make specs package=telemetry/errors` - passed (3 tests; the handler writes to
  its own stdout sink and stays independent after `slog.Default` is replaced)
- `make specs package=os` - passed (17 tests)
- `make lint` - passed
- `make sec` - passed (govulncheck + trivy: 0 vulnerabilities, no secrets)
- Not run locally: the full `make specs` suite and `make benchmark`, which need
  service sidecars; the transport benchmark callers were validated through
  `make lint`/`go vet`, and the tint application-logger constructor is covered by
  the tint integration tests in CI.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
