### PR TITLE
docs(readme): clarify service integration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 This repo is primarily a **library of packages** (no top-level `cmd/` binary). Services built on top typically define their own `main` package elsewhere and import this module.
 
-Most services are expected to be bootstrapped from [`go-service-template`](https://github.com/alexfalkowski/go-service-template) and to compose the high-level module bundles from this repository. That is the primary supported path. Lower-level package-by-package composition is still available, but it is an advanced mode and may require extra manual registration.
+Long-running services are expected to start from [`go-service-template`](https://github.com/alexfalkowski/go-service-template), while short-lived client commands start from [`go-client-template`](https://github.com/alexfalkowski/go-client-template). Both compose the high-level module bundles from this repository. These are the primary supported paths. Lower-level package-by-package composition is still available, but it is an advanced mode and may require extra manual registration.
 
 ---
 
 ## 🚀 Install
 
-For a new service, start from `go-service-template` so the application `main`, command wiring, configuration fixtures, and standard module composition are generated together.
+For a new long-running service, start from `go-service-template` so the application `main`, server command wiring, configuration fixtures, and standard module composition are generated together. For a short-lived control, migration, or batch command, start from `go-client-template`; it demonstrates `cli.Application.AddClient`, `module.Client`, and lifecycle startup work.
 
 For direct package use in an existing module, add the library dependency with the versioned module path:
 
@@ -97,7 +97,7 @@ Services commonly expose two command shapes:
 
 The framework uses [acmd](https://github.com/cristalhq/acmd). Your service’s `main` typically wires Fx modules + commands.
 
-> This repo intentionally does not ship a ready-to-run `main` — it provides the building blocks. In normal usage those building blocks are consumed through `go-service-template` plus `module.Server` / `module.Client`, not by wiring every subsystem manually.
+> This repo intentionally does not ship a ready-to-run `main` — it provides the building blocks. In normal usage server applications consume them through `go-service-template` plus `module.Server`, while short-lived commands use `go-client-template` plus `module.Client`, rather than wiring every subsystem manually.
 
 ---
 
@@ -191,14 +191,39 @@ non-comparable fields.
 Example:
 
 ```go
+type WorkerConfig struct {
+    Queue string `yaml:"queue" json:"queue" toml:"queue" validate:"required"`
+}
+
 type AppConfig struct {
-    config.Config `yaml:",inline" json:",inline" toml:",inline"`
+    Worker         *WorkerConfig `yaml:"worker" json:"worker" toml:"worker" validate:"required"`
+    *config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`
 }
 
 func loadConfig(decoder config.Decoder, validator *config.Validator) (*AppConfig, error) {
     return config.NewConfig[AppConfig](decoder, validator)
 }
+
+func sharedConfig(cfg *AppConfig) *config.Config {
+    return cfg.Config
+}
+
+func workerConfig(cfg *AppConfig) *WorkerConfig {
+    return cfg.Worker
+}
+
+var AppConfigModule = di.Module(
+    di.Constructor(config.NewConfig[AppConfig]),
+    di.Decorate(sharedConfig),
+    di.Constructor(workerConfig),
+)
 ```
+
+Compose `AppConfigModule` alongside `module.Server` or `module.Client`. The
+decorator projects the embedded shared `*config.Config` into the standard graph,
+so the service-specific config is decoded once while existing transport, SQL,
+and telemetry projections continue to work. Add constructors like
+`workerConfig` for service-owned sub-configs.
 
 ### The standard top-level config shape
 
@@ -302,6 +327,7 @@ cache:
 > - `max_size` limits encoded cache values before compression, after compression, and after decompression. A zero value uses the default `4MB`.
 > - `max_entries` limits entries retained by bounded in-memory cache drivers. A zero value uses the default `1024`; negative values are invalid.
 > - `options` is backend-specific and decoded as `map[string]any`.
+> - Redis-backed `GetOrPersist` requires [Redis 7.0-compatible `SET` semantics](https://redis.io/docs/latest/commands/set/) because atomic publication uses `SET ... NX GET`.
 > - Configure each cache backend for a specific service or purpose. For Redis, use a dedicated database, endpoint, or deployment-level key namespace in the connection/configuration instead of sharing one general cache for unrelated data.
 
 > [!WARNING]
@@ -491,6 +517,15 @@ orchestrators can stop sending new traffic before the listener fully stops.
 
 Built-in checker helpers under `health/checker` include DB connectivity checks and
 cache connectivity checks for pingable cache drivers such as Redis and ttlcache.
+
+`module.Server` installs the HTTP/gRPC health transports, but services own the
+checks and observer mapping. Create go-health `server.Registration` values,
+register them under the service or gRPC service name on `*server.Server`, and
+map them to `healthz`, `livez`, `readyz`, or `grpc` with `Observe`. See the
+executable [`Registrations` example](health/example_test.go) and the
+[`go-service-template` health module](https://github.com/alexfalkowski/go-service-template/tree/master/internal/health)
+for the standard DI pattern. A checker is not exposed by a probe until that
+registration and observer mapping exists.
 
 When gRPC transport is enabled, `transport/grpc/health` registers the standard
 `grpc.health.v1.Health` service on the gRPC server. Named checks use the service
@@ -802,6 +837,11 @@ The `p` rows define permissions and must match the model's `p = sub, obj, act`
 shape, so they include `invoke`. The `g` rows define role membership and match
 `g = _, _`, so they only contain `subject, role`.
 
+> [!WARNING]
+> Casbin's string policy adapter can skip malformed policy rows without failing
+> startup. Validate policy files before deployment; a successful startup does
+> not prove that every configured row was loaded.
+
 For HTTP servers the object uses the matched route pattern when available, such
 as `http:GET /users/{id}`. HTTP tokens are authenticated against the concrete
 request method and path, such as `GET /users/123`; access policy enforcement
@@ -991,7 +1031,7 @@ The transport layer provides higher-level wiring and middleware policy for commu
 At a high level:
 
 - `transport/...` contains the opinionated service transport layer: Fx wiring, composed HTTP/gRPC server and client stacks, retries, breakers, token middleware, health wiring, and related policy.
-- `net/...` contains lower-level protocol helpers and reusable primitives such as `net/http`, `net/grpc`, `net/http/meta`, `net/grpc/meta`, `net/http/strings`, `net/grpc/strings`, `net/grpc/health`, `net/header`, and `net/server`.
+- `net/...` contains lower-level protocol helpers and reusable primitives such as `net/http`, `net/grpc`, `net/http/meta`, `net/grpc/meta`, `net/grpc/health`, `net/header`, and `net/server`.
 
 Supported stacks include:
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -160,6 +160,9 @@ func (c *Cache) Persist(ctx context.Context, key string, value any, ttl time.Dur
 //
 // The value parameter should be a pointer to the destination value (for example *MyStruct). It is both
 // populated by fn and used as the decode destination for the resolved value.
+//
+// With the built-in Redis driver, atomic publication requires Redis
+// 7.0-compatible `SET ... NX GET` semantics.
 func (c *Cache) GetOrPersist(ctx context.Context, key string, value any, ttl time.Duration, fn func() error) error {
 	ok, err := c.Get(ctx, key, value)
 	if err != nil {

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -20,6 +20,13 @@
 // The configured encoder and compressor are also included in the driver key namespace so format changes
 // create cache misses instead of decoding values written by an incompatible format.
 //
+// # Redis compatibility
+//
+// Atomic publication through [Cache.GetOrPersist] and the package-level
+// [GetOrPersist] helper requires Redis 7.0-compatible `SET` semantics when the
+// built-in Redis driver is selected. The driver publishes with `SET ... NX GET`
+// so concurrent writers converge on the stored winner.
+//
 // # TTL resolution
 //
 // TTL handling depends on the selected driver. The built-in in-memory "ttlcache"

--- a/cache/generic.go
+++ b/cache/generic.go
@@ -56,6 +56,8 @@ func Persist[T any](ctx context.Context, key string, value *T, ttl time.Duration
 // nil error, mirroring how [Get] reports a disabled cache. Callers must tolerate a nil value rather than
 // assuming a value was produced or cached.
 // Concurrent in-process calls for the same key run fn once and share the produced value.
+// With the built-in Redis driver, atomic publication requires Redis
+// 7.0-compatible `SET ... NX GET` semantics.
 func GetOrPersist[T any](ctx context.Context, key string, ttl time.Duration, fn func() (T, error)) (*T, error) {
 	if cache == nil {
 		return nil, nil

--- a/cli/application.go
+++ b/cli/application.go
@@ -108,6 +108,9 @@ func (a *Application) AddServer(name, description string, opts ...Option) *Comma
 //   - start the DI application
 //   - stop the DI application immediately after startup completes
 //
+// Client commands should perform their main action from an invoked constructor or a lifecycle OnStart
+// hook so the work completes before startup returns and the graph is stopped.
+//
 // Any start/stop error is wrapped with the subcommand name for easier attribution.
 func (a *Application) AddClient(name, description string, opts ...Option) *Command {
 	opts = slices.Clone(opts)

--- a/cli/commander.go
+++ b/cli/commander.go
@@ -30,5 +30,8 @@ type Commander interface {
 	//   - parses command args into the returned `*Command`'s FlagSet,
 	//   - starts a DI application built from opts plus client-specific wiring,
 	//   - then stops the DI application immediately after startup completes.
+	//
+	// Run the command's main action from an invoked constructor or a lifecycle
+	// OnStart hook so it completes before startup returns.
 	AddClient(name, description string, opts ...Option) *Command
 }

--- a/config/doc.go
+++ b/config/doc.go
@@ -33,8 +33,17 @@
 // [Module] wires the decoder, validator, and a standard top-level [Config] into [go.uber.org/fx]/[go.uber.org/dig], and also
 // provides constructors for commonly-used sub-config projections.
 //
-// In normal service applications, this package is consumed through higher-level bundles such as
-// [github.com/alexfalkowski/go-service/v2/module.Server] or [github.com/alexfalkowski/go-service/v2/module.Client] from `go-service-template`, which also include the standard
-// encoder registrations needed by the config decoders. Custom or partial wiring is still supported,
-// but advanced compositions are responsible for registering any required encoders themselves.
+// In normal applications, this package is consumed through higher-level bundles such as
+// [github.com/alexfalkowski/go-service/v2/module.Server] from `go-service-template` or
+// [github.com/alexfalkowski/go-service/v2/module.Client] from `go-client-template`. Those bundles also include
+// the standard encoder registrations needed by the config decoders. Custom or partial wiring is still
+// supported, but advanced compositions are responsible for registering any required encoders themselves.
+//
+// Services that extend the standard top-level configuration should construct one
+// service-specific type with [NewConfig], embed *[Config], and use
+// [github.com/alexfalkowski/go-service/v2/di.Decorate] to project that embedded
+// value into the standard module graph. Service-local constructors can then
+// project application-specific sub-configs from the same decoded value. This is
+// the supported way to compose custom configuration with the standard bundles
+// without forcing a second shared-config decode.
 package config

--- a/health/example_test.go
+++ b/health/example_test.go
@@ -1,0 +1,27 @@
+package health_test
+
+import (
+	"fmt"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	"github.com/alexfalkowski/go-health/v2/server"
+	"github.com/alexfalkowski/go-service/v2/health"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
+
+func ExampleRegistrations() {
+	healthServer := server.NewServer()
+	registrations := health.Registrations{
+		server.NewRegistration("noop", time.Second.Duration(), checker.NewNoopChecker()),
+	}
+
+	healthServer.Register("payments", registrations...)
+	for _, probe := range []string{"healthz", "livez", "readyz"} {
+		if err := healthServer.Observe("payments", probe, "noop"); err != nil {
+			panic(err)
+		}
+	}
+
+	fmt.Println("registered healthz, livez, and readyz")
+	// Output: registered healthz, livez, and readyz
+}

--- a/module/doc.go
+++ b/module/doc.go
@@ -2,8 +2,8 @@
 //
 // This package defines opinionated, high-level module bundles that compose multiple lower-level
 // feature modules into a single `di.Option` suitable for inclusion in an Fx/Dig application graph.
-// These bundles are the primary supported entrypoints for service applications and are the defaults
-// used by `go-service-template`.
+// These bundles are the primary supported entrypoints for applications and are the defaults used by
+// `go-service-template` for long-running servers and `go-client-template` for short-lived commands.
 //
 // # Bundles
 //

--- a/module/example_test.go
+++ b/module/example_test.go
@@ -2,6 +2,8 @@ package module_test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/cli"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/module"
 )
 
@@ -16,8 +18,17 @@ func ExampleServer() {
 }
 
 func ExampleClient() {
+	task := di.Register(func(lifecycle di.Lifecycle) {
+		lifecycle.Append(di.Hook{
+			OnStart: func(context.Context) error {
+				// Perform the short-lived command action here.
+				return nil
+			},
+		})
+	})
+
 	application := cli.NewApplication(func(commander cli.Commander) {
-		client := commander.AddClient("migrate", "Run client tasks", module.Client)
+		client := commander.AddClient("migrate", "Run client tasks", module.Client, task)
 		client.AddConfig("file:./config.yml")
 	})
 

--- a/module/module.go
+++ b/module/module.go
@@ -93,7 +93,7 @@ var Server = di.Module(
 // modules, such as [transport.Module] or [github.com/alexfalkowski/go-service/v2/transport/http/hooks.Module],
 // on top of Client if needed.
 //
-// This is the primary entrypoint for client-style applications built from `go-service-template`.
+// This is the primary entrypoint for client-style applications built from `go-client-template`.
 var Client = di.Module(
 	Library,
 	config.Module,

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -280,7 +280,9 @@ func Header(md *meta.Map) CallOption {
 // TimeoutUnaryClientInterceptor returns a unary client interceptor that applies a per-RPC timeout.
 //
 // This forwards to [timeout.UnaryClientInterceptor] from go-grpc-middleware.
-// The interceptor typically wraps the outgoing context with a deadline of d.
+// The interceptor derives every outgoing context with a timeout of d. If the
+// parent already has an earlier deadline, that earlier deadline remains in
+// effect; the derived timeout cannot extend it.
 func TimeoutUnaryClientInterceptor(d time.Duration) grpc.UnaryClientInterceptor {
 	return timeout.UnaryClientInterceptor(d.Duration())
 }

--- a/net/grpc/method/doc.go
+++ b/net/grpc/method/doc.go
@@ -1,2 +1,19 @@
 // Package method defines gRPC method policy helpers.
+//
+// Policy classifies methods before the server begins serving. Under the
+// standard go-service gRPC server stack, the classifications have these
+// middleware consequences:
+//
+//   - Normal methods participate in metadata extraction, logging, and any
+//     configured token verification, limiting, and access control.
+//   - Unauthenticated methods retain metadata extraction, logging, and
+//     limiting, but bypass token verification and access control.
+//   - Operation unary methods bypass metadata extraction, logging, token
+//     verification, limiting, and access control.
+//   - Operation streams retain metadata extraction and stream limiting, but
+//     bypass logging, token verification, and access control.
+//
+// Operation streams intentionally remain limited because long-lived streams,
+// such as gRPC health Watch, can hold server resources. Populate a [Policy]
+// during service registration; it is not a runtime reconfiguration API.
 package method

--- a/net/grpc/method/policy.go
+++ b/net/grpc/method/policy.go
@@ -11,22 +11,34 @@ func NewPolicy() *Policy {
 }
 
 // Policy stores gRPC full-method behavior used by server middleware.
+//
+// Populate Policy during service registration before the server starts. See
+// the package documentation for the middleware behavior of each classification.
 type Policy struct {
 	operations      map[string]struct{}
 	unauthenticated map[string]struct{}
 }
 
 // Operation marks name as an operation method.
+//
+// Operation methods bypass transport token verification, access control, and
+// logging. Unary operations also bypass metadata extraction and limiting,
+// while operation streams retain metadata extraction and stream limiting.
 func (p *Policy) Operation(name string) {
 	p.operations[name] = struct{}{}
 }
 
 // AllowUnauthenticated marks name as not requiring transport token authentication.
+//
+// Unauthenticated methods also bypass access control, but retain the normal
+// metadata extraction, logging, and limiting behavior.
 func (p *Policy) AllowUnauthenticated(name string) {
 	p.unauthenticated[name] = struct{}{}
 }
 
 // OperationService marks every unary and stream method in desc as an operation method.
+//
+// See [Policy.Operation] for the middleware consequences.
 func (p *Policy) OperationService(desc *grpc.ServiceDesc) {
 	for _, method := range desc.Methods {
 		p.Operation(fullMethodName(desc.ServiceName, method.MethodName))
@@ -37,6 +49,8 @@ func (p *Policy) OperationService(desc *grpc.ServiceDesc) {
 }
 
 // AllowUnauthenticatedService marks every unary and stream method in desc as not requiring transport token authentication.
+//
+// See [Policy.AllowUnauthenticated] for the middleware consequences.
 func (p *Policy) AllowUnauthenticatedService(desc *grpc.ServiceDesc) {
 	for _, method := range desc.Methods {
 		p.AllowUnauthenticated(fullMethodName(desc.ServiceName, method.MethodName))

--- a/net/grpc/registrar.go
+++ b/net/grpc/registrar.go
@@ -16,13 +16,22 @@ func (r *Registrar) RegisterService(desc *ServiceDesc, impl any) {
 	r.registrar.RegisterService(desc, impl)
 }
 
-// RegisterOperationService marks desc as operations and registers it with the wrapped registrar.
+// RegisterOperationService marks every method in desc as an operation and registers the service.
+//
+// Operation methods bypass transport token verification, access control, and
+// logging. Unary operations also bypass metadata extraction and limiting,
+// while operation streams retain metadata extraction and stream limiting. Use
+// this for operational services such as the standard gRPC health service, not
+// for ordinary application RPCs.
 func (r *Registrar) RegisterOperationService(desc *ServiceDesc, impl any) {
 	r.policy.OperationService(desc)
 	r.RegisterService(desc, impl)
 }
 
-// RegisterUnauthenticatedService marks desc as unauthenticated and registers it with the wrapped registrar.
+// RegisterUnauthenticatedService marks every method in desc as unauthenticated and registers the service.
+//
+// These methods bypass token verification and access control while retaining
+// normal metadata extraction, logging, and limiting.
 func (r *Registrar) RegisterUnauthenticatedService(desc *ServiceDesc, impl any) {
 	r.policy.AllowUnauthenticatedService(desc)
 	r.RegisterService(desc, impl)

--- a/token/doc.go
+++ b/token/doc.go
@@ -50,8 +50,11 @@
 //
 // # Configuration and enablement
 //
-// This package does not enforce that nested config blocks (JWT/Paseto/SSH) are
-// present when the corresponding kind is selected. The concrete token constructors
-// typically treat a nil *[Config] as disabled and may return nil implementations.
-// Ensure your configuration is consistent with the selected kind.
+// The standard startup path through
+// [github.com/alexfalkowski/go-service/v2/config.NewConfig] validates that the
+// nested JWT, PASETO, or SSH block matching [Config.Kind] is present. Direct
+// callers that construct [Config] without validation remain fail-closed:
+// [Token.Generate] and [Token.Verify] return
+// [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig] when
+// the selected nested configuration is missing.
 package token

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -86,9 +86,11 @@ func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 //
 // If unset or negative, a default timeout is applied (see [NewDialOptions] defaults).
 //
-// Note: this timeout is enforced via an interceptor and is independent from any deadlines already set
-// on the incoming context; the interceptor will typically only apply a timeout when a deadline is not
-// already present. Streaming callers should use explicit context deadlines or a custom stream interceptor.
+// The interceptor always derives the outgoing context with this timeout. The
+// effective deadline is the earlier of the parent context's deadline and the
+// configured timeout; a later configured timeout cannot extend an earlier
+// parent deadline. Streaming callers should use explicit context deadlines or
+// a custom stream interceptor.
 func WithClientTimeout(timeout time.Duration) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.timeout = timeout

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -65,8 +65,9 @@ func WithClientCompression() ClientOption {
 // WithClientTokenGenerator enables token injection using gen and id.
 //
 // When configured, the client will generate an Authorization token per request and add it to the outbound
-// request using the `Bearer` scheme. Token generation is typically scoped to the request path and the
-// configured user id.
+// request using the `Bearer` scheme. Token generation is scoped to the request
+// method plus URL path (for example `DELETE /users/123`) and the configured user
+// id. Query parameters are not included in the audience.
 //
 // Token-enabled clients use [http.SameOriginRedirect] so credentials are not forwarded to cross-origin
 // redirect targets. Cross-origin redirects are returned to the caller as [http.ErrUseLastResponse].


### PR DESCRIPTION
## What

- Document the supported server and short-lived client templates, service-specific configuration projection, client lifecycle task pattern, and service-owned health registration flow.
- State the Redis 7.0 requirement for atomic cache publication, warn that malformed Casbin rows may be skipped, and remove stale package references.
- Clarify token fail-closed validation, HTTP token audiences, gRPC timeout inheritance, and the middleware consequences of operation and unauthenticated gRPC methods.
- Add executable module and health examples for the documented integration paths.

## Why

- Give service authors and operators accurate first-use guidance for wiring configuration, client tasks, health checks, caching, and transport security policy without reading private implementation code.
- Keep README and GoDoc contracts aligned with the current implementation and downstream templates without changing runtime behavior or compatibility.

## Testing

- `make lint` - passed with zero issues.
- `make package=config specs` - passed 47 tests.
- `make package=health specs` - passed 2 tests, including the new registrations example.
- `make package=module specs` - passed 2 executable examples.
- `make package=net/grpc/method specs` - passed 2 tests.
- `make package=net/grpc specs` - passed 26 tests.
- `make package=token specs` - passed 35 tests.
- `make package=transport/http specs` - passed 168 tests.
- `make package=cli specs` - passed 31 tests.
- `make package=cache specs` - passed 86 tests.
- `make package=transport/grpc specs` - passed 61 tests.
- `git diff --check` and GoDoc rendering checks - passed.
- Full generated-output, security, fuzz, benchmark, and coverage checks remain delegated to CI.

AI-assisted-by: [Codex](https://openai.com/codex/)
