### PR TITLE
feat(http): exclude caller cancellations from breaker failures and cover post-commit panic recovery

### DIFF
--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -3,6 +3,7 @@ package breaker
 import (
 	"cmp"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -145,6 +146,9 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 		}
 		if _, ok := errors.AsType[responseError](err); ok {
 			return false
+		}
+		if errors.Is(err, context.Canceled) {
+			return true
 		}
 		if isSuccessful != nil {
 			return isSuccessful(err)

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -3,6 +3,7 @@ package breaker_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -12,6 +13,28 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRoundTripperDoesNotOpenOnCallerCancellation(t *testing.T) {
+	rt := breaker.NewRoundTripper(
+		&test.ErrorRoundTripper{Err: context.Canceled},
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, context.Canceled)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, breaker.ErrOpenState)
+}
 
 func TestRoundTripperOpensOnTransportError(t *testing.T) {
 	transportErr := errors.New("transport unavailable")

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -104,6 +104,12 @@ func TestServerRecoversPanic(t *testing.T) {
 	world.Handle("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test panic")
 	}))
+	world.Handle("GET /panic-after-write", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		_, _ = res.Write([]byte("partial"))
+		res.(interface{ Flush() }).Flush()
+		panic("test panic after commit")
+	}))
 	world.HandleHello()
 	world.Start()
 
@@ -111,6 +117,9 @@ func TestServerRecoversPanic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	require.Equal(t, "http: internal server error", body)
+
+	_, _, err = world.GetBody(t.Context(), world.PathServerURL("http", "panic-after-write"), http.Header{"Accept-Encoding": {"identity"}})
+	require.Error(t, err)
 
 	res, body, err = world.GetBody(t.Context(), world.PathServerURL("http", "hello"), http.Header{})
 	require.NoError(t, err)


### PR DESCRIPTION
## What

- The HTTP client circuit breaker (`transport/http/breaker/breaker.go`) now treats a caller's `context.Canceled` abort as a breaker success instead of a failure, matching the gRPC client breaker, which already excludes `codes.Canceled` from its failure set. Genuine transport errors and `context.DeadlineExceeded` still count as failures, so the breaker still reacts to a slow or unhealthy upstream.
- Added regression coverage in `transport/http/breaker/breaker_test.go` asserting that a burst of caller cancellations does not open the breaker.
- Added regression coverage in `transport/http/server_test.go` for the HTTP recovery middleware's "panic after the response is already committed" branch, which previously had no test exercising it. The new case commits a partial response, flushes it, then panics, and asserts the client observes an aborted/truncated read rather than a clean response.

## Why

- Without the breaker fix, a burst of five consecutive caller-cancelled in-flight requests to one upstream host was enough to open the breaker for ~10s, causing the client to locally reject requests to a perfectly healthy upstream with a 503. This is pure self-inflicted availability loss driven by client-side behavior (e.g. an inbound request context propagated downstream when a caller disconnects), and it was inconsistent with the gRPC client, which already ignores cancellation for breaker accounting.
- The recovery middleware deliberately re-panics instead of writing a clean 500 once a response is already on the wire, so `net/http` aborts the broken response instead of corrupting it with a mixed body. That contract had zero test coverage: every existing panic test panicked before writing any bytes. A plausible future "simplification" that always wrote a clean 500 on panic would have silently corrupted in-flight or streamed responses, and no existing test would have caught it.

## Testing

- `make specs package=transport/http/breaker` - passed (11/11, including the new cancellation regression case)
- `make specs package=transport/http` - passed (168/168, including the new panic-after-commit regression case)
- `make lint` - passed, 0 issues
- `make sec` - passed, 0 vulnerabilities in this repository's code
- Proved both new tests are non-vacuous by temporarily reintroducing each described regression locally (removing the breaker's cancellation check, and removing the recovery handler's re-panic branch) and confirming the corresponding new test failed, then reverted and confirmed green against the real implementation.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
