### PR TITLE
feat(transport): preserve connections and local rejection boundaries

### DIFF
--- a/net/grpc/status/doc.go
+++ b/net/grpc/status/doc.go
@@ -11,9 +11,10 @@
 //
 // Most functions in this package forward to the upstream gRPC status package.
 // SafeError adds go-service safe-message behavior while still exposing a normal
-// gRPC status to the runtime. For authoritative upstream behavior, edge cases,
-// and wire-level details, consult the upstream gRPC documentation for the
-// version you vend.
+// gRPC status to the runtime. LocalError marks locally produced client-control
+// errors without changing their gRPC code, message, details, or wrapped causes.
+// For authoritative upstream behavior, edge cases, and wire-level details,
+// consult the upstream gRPC documentation for the version you vend.
 //
 // # Background: gRPC status errors
 //
@@ -71,6 +72,8 @@
 //	c := status.Code(err)
 //
 // Code delegates to google.golang.org/grpc/status.Code.
+// Use IsLocalError when retry or client policy needs to distinguish a local
+// rejection from a remote status error carrying the same code.
 //
 // If err is nil, Code returns codes.OK (matching upstream behavior). If err is
 // not a gRPC status error, upstream logic typically returns codes.Unknown. Treat
@@ -99,8 +102,8 @@
 //
 // This package intentionally exposes only the small subset of the upstream
 // status API and structured detail types that go-service uses broadly: Code,
-// FromError, New, Error, Errorf, SafeError, SafeErrorf, Status, RetryInfo, and
-// NewDuration. Higher-level code that needs unrelated structured-detail helpers
-// should add a narrow go-service alias here before reaching through to upstream
-// packages from transport code.
+// FromError, New, Error, Errorf, SafeError, SafeErrorf, LocalError,
+// IsLocalError, Status, RetryInfo, and NewDuration. Higher-level code that needs
+// unrelated structured-detail helpers should add a narrow go-service alias here
+// before reaching through to upstream packages from transport code.
 package status

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"fmt"
 
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"google.golang.org/grpc/status"
@@ -97,6 +98,25 @@ func SafeError(c codes.Code, err error) error {
 	return &statusError{code: c, msg: defaultSafeMessage(c), err: err}
 }
 
+// LocalError wraps err to mark a gRPC status error as produced by local client-side controls.
+//
+// Retry middleware can use this marker to distinguish local load-control rejections from upstream
+// gRPC status errors with the same code that may be worth retrying. If err is not a gRPC status
+// error, it is represented with [codes.Unknown].
+func LocalError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &localError{err: err}
+}
+
+// IsLocalError reports whether err was wrapped by LocalError.
+func IsLocalError(err error) bool {
+	_, ok := errors.AsType[*localError](err)
+	return ok
+}
+
 // SafeErrorf formats internal context around err and wraps it with a safe gRPC-prefixed status message.
 //
 // The formatted context and err remain available through Unwrap for internal inspection, while gRPC sends the
@@ -146,21 +166,36 @@ func (s *statusError) GRPCStatus() *Status {
 
 // Is reports whether target has the same gRPC status code and message.
 func (s *statusError) Is(target error) bool {
-	type grpcStatus interface {
-		GRPCStatus() *Status
+	targetStatus, ok := FromError(target)
+	if !ok || targetStatus == nil {
+		return false
 	}
 
-	if target, ok := target.(grpcStatus); ok {
-		t := target.GRPCStatus()
-		return t != nil && s.code == t.Code() && s.msg == t.Message()
-	}
-
-	return false
+	return s.code == targetStatus.Code() && s.msg == targetStatus.Message()
 }
 
 // Unwrap returns the wrapped cause, if any.
 func (s *statusError) Unwrap() error {
 	return s.err
+}
+
+type localError struct {
+	err error
+}
+
+// Error returns the diagnostic error message.
+func (e *localError) Error() string {
+	return e.err.Error()
+}
+
+// GRPCStatus returns the wrapped gRPC status, converting plain errors to [codes.Unknown].
+func (e *localError) GRPCStatus() *Status {
+	return status.Convert(e.err)
+}
+
+// Unwrap returns the wrapped cause.
+func (e *localError) Unwrap() error {
+	return e.err
 }
 
 func defaultSafeMessage(c codes.Code) string {

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -69,6 +69,36 @@ func TestSafeError(t *testing.T) {
 	require.ErrorIs(t, err, cause)
 }
 
+func TestLocalError(t *testing.T) {
+	cause := errors.New("local limiter rejection")
+	err := status.LocalError(status.SafeError(codes.ResourceExhausted, cause))
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.True(t, status.IsLocalError(err))
+	require.True(t, status.IsLocalError(fmt.Errorf("wrapped: %w", err)))
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, codes.ResourceExhausted, s.Code())
+	require.Equal(t, "grpc: resource exhausted", s.Message())
+	require.ErrorIs(t, err, cause)
+}
+
+func TestLocalErrorConvertsPlainError(t *testing.T) {
+	cause := errors.New("local failure")
+	err := status.LocalError(cause)
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.Unknown, s.Code())
+	require.Equal(t, cause.Error(), s.Message())
+	require.ErrorIs(t, err, cause)
+}
+
+func TestLocalErrorAllowsNil(t *testing.T) {
+	require.NoError(t, status.LocalError(nil))
+}
+
 func TestSafeErrorOK(t *testing.T) {
 	err := status.SafeError(codes.OK, errors.New("ignored"))
 
@@ -143,6 +173,7 @@ func TestErrorIs(t *testing.T) {
 	target := status.Error(codes.NotFound, "missing")
 
 	require.ErrorIs(t, err, target)
+	require.ErrorIs(t, err, status.New(codes.NotFound, "missing").Err())
 }
 
 type unwrapper interface {

--- a/transport/grpc/breaker/breaker.go
+++ b/transport/grpc/breaker/breaker.go
@@ -37,7 +37,7 @@ type Settings = breaker.Settings
 //
 // If the breaker rejects a call because it is open ([breaker.ErrOpenState]) or because the half-open
 // MaxRequests limit would be exceeded ([breaker.ErrTooManyRequests]), the interceptor maps that condition to
-// a gRPC `ResourceExhausted` status error.
+// a locally marked gRPC `ResourceExhausted` status error so retry middleware returns it terminally.
 //
 // All other errors from the invoker are returned as-is.
 func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
@@ -55,7 +55,7 @@ func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
 		})
 		if err != nil {
 			if errors.Is(err, breaker.ErrOpenState) || errors.Is(err, breaker.ErrTooManyRequests) {
-				return status.SafeError(codes.ResourceExhausted, err)
+				return status.LocalError(status.SafeError(codes.ResourceExhausted, err))
 			}
 
 			return err

--- a/transport/grpc/breaker/breaker_test.go
+++ b/transport/grpc/breaker/breaker_test.go
@@ -30,6 +30,7 @@ func TestUnaryClientInterceptorUsesConfigFailureCodes(t *testing.T) {
 
 	err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
 	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 	require.Equal(t, 1, calls)
 }
@@ -94,6 +95,7 @@ func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
 
 			err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
 			require.Error(t, err)
+			require.True(t, status.IsLocalError(err))
 			require.Equal(t, codes.ResourceExhausted, status.Code(err))
 			require.Equal(t, 1, calls)
 		})
@@ -130,6 +132,7 @@ func TestUnaryClientInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
 	t.Run("rejects failing method without invoker call", func(t *testing.T) {
 		err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
 		require.Error(t, err)
+		require.True(t, status.IsLocalError(err))
 		require.Equal(t, codes.ResourceExhausted, status.Code(err))
 		require.Equal(t, 1, calls["/test.Service/GetBook"])
 		require.Equal(t, 1, calls["/test.Service/ListBooks"])

--- a/transport/grpc/breaker/doc.go
+++ b/transport/grpc/breaker/doc.go
@@ -17,7 +17,8 @@
 // # Rejections
 //
 // When the breaker rejects a call (open state or too many concurrent half-open probes), the
-// interceptor returns a gRPC ResourceExhausted status error.
+// interceptor returns a locally marked gRPC ResourceExhausted status error. Retry middleware treats
+// the local marker as terminal while preserving the status code and wrapped breaker cause.
 //
 // Start with [UnaryClientInterceptor].
 package breaker

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -328,6 +328,7 @@ func NewClient(target string, opts ...ClientOption) (*ClientConn, error) {
 //
 // The logger wraps retry, limiter, and breaker outcomes so local rejections are recorded.
 // Retry wraps the limiter and breaker so each retry attempt consumes quota and breaker capacity.
+// Locally marked limiter and breaker rejections terminate without re-entering either control.
 // Token injection is inside retry, so each retried unary attempt can generate a fresh token while the
 // metadata request id remains stable for the logical RPC.
 // The limiter stays before the breaker so local quota denials are not counted as upstream failures.

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -3,11 +3,21 @@ package grpc_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/net"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/transport/breaker"
 	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
+	grpcbreaker "github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
+	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
+	grpcretry "github.com/alexfalkowski/go-service/v2/transport/grpc/retry"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +42,99 @@ func TestClientEmptyTLSConfigUsesTLS(t *testing.T) {
 	client := v1.NewGreeterServiceClient(conn)
 	_, err = client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
 	require.Error(t, err)
+}
+
+func TestRetryDoesNotReenterClientLimiter(t *testing.T) {
+	clientLimiter, err := grpclimiter.NewClientLimiter(
+		test.NoopLifecycle{},
+		limiter.NewKeyMap(),
+		test.NewLimiterConfig("user-agent", "1m", 0),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientLimiter.Close(t.Context())) })
+
+	limiting := grpclimiter.UnaryClientInterceptor(clientLimiter)
+	err = limiting(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted))
+	limiterCalls := 0
+	downstreamCalls := 0
+	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
+		limiterCalls++
+		return limiting(ctx, fullMethod, req, resp, conn, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+			downstreamCalls++
+			return nil
+		}, opts...)
+	}
+	err = retrying(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 1, limiterCalls)
+	require.Equal(t, 0, downstreamCalls)
+}
+
+func TestRetryDoesNotReenterClientBreaker(t *testing.T) {
+	breaking := grpcbreaker.UnaryClientInterceptor(
+		grpcbreaker.NewConfig(test.NewBreaker(1), codes.Unavailable).Options()...,
+	)
+	err := breaking(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted))
+	breakerCalls := 0
+	downstreamCalls := 0
+	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
+		breakerCalls++
+		return breaking(ctx, fullMethod, req, resp, conn, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+			downstreamCalls++
+			return nil
+		}, opts...)
+	}
+	err = retrying(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 1, breakerCalls)
+	require.Equal(t, 0, downstreamCalls)
+}
+
+func TestRetryPreservesRemoteResourceExhausted(t *testing.T) {
+	clientLimiter, err := grpclimiter.NewClientLimiter(
+		test.NoopLifecycle{},
+		limiter.NewKeyMap(),
+		test.NewLimiterConfig("user-agent", "1m", 2),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientLimiter.Close(t.Context())) })
+
+	limiting := grpclimiter.UnaryClientInterceptor(clientLimiter)
+	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted))
+	limiterCalls := 0
+	downstreamCalls := 0
+	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
+		limiterCalls++
+		return limiting(ctx, fullMethod, req, resp, conn, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+			downstreamCalls++
+			if downstreamCalls == 1 {
+				return status.Error(codes.ResourceExhausted, "remote resource exhausted")
+			}
+
+			return nil
+		}, opts...)
+	}
+	err = retrying(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, limiterCalls)
+	require.Equal(t, 2, downstreamCalls)
 }

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -121,6 +121,7 @@ func TestBreakerUnary(t *testing.T) {
 	require.Equal(t, codes.Internal, status.Code(err))
 
 	_, err = client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
+	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 

--- a/transport/grpc/limiter/client.go
+++ b/transport/grpc/limiter/client.go
@@ -4,6 +4,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
 
@@ -36,7 +37,7 @@ type Client struct {
 // The interceptor calls `limiter.TakeDecision(ctx)` before invoking the RPC:
 //
 //   - If `TakeDecision` returns an error, it returns [codes.Internal].
-//   - If the request is not allowed, it returns [codes.ResourceExhausted].
+//   - If the request is not allowed, it returns a locally marked [codes.ResourceExhausted].
 //   - Otherwise, it invokes the underlying `invoker`.
 //
 // Callers should only install this interceptor when limiter is non-nil.
@@ -48,7 +49,7 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 		}
 
 		if !decision.Allowed() {
-			return limitError()
+			return status.LocalError(limitError())
 		}
 
 		return invoker(ctx, fullMethod, req, resp, conn, opts...)
@@ -61,7 +62,7 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 // stream message:
 //
 //   - If `TakeDecision` returns an error, it returns [codes.Internal].
-//   - If the stream is not allowed, it returns [codes.ResourceExhausted].
+//   - If the stream is not allowed, it returns a locally marked [codes.ResourceExhausted].
 //   - Otherwise, it invokes the underlying `streamer`.
 //
 // Callers should only install this interceptor when limiter is non-nil.
@@ -73,7 +74,7 @@ func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
 		}
 
 		if !decision.Allowed() {
-			return nil, limitError()
+			return nil, status.LocalError(limitError())
 		}
 
 		stream, err := streamer(ctx, desc, conn, fullMethod, opts...)
@@ -102,7 +103,7 @@ func (s *clientStream) RecvMsg(m any) error {
 	}
 
 	if !decision.Allowed() {
-		return limitError()
+		return status.LocalError(limitError())
 	}
 
 	return nil
@@ -115,7 +116,7 @@ func (s *clientStream) SendMsg(m any) error {
 	}
 
 	if !decision.Allowed() {
-		return limitError()
+		return status.LocalError(limitError())
 	}
 
 	return s.ClientStream.SendMsg(m)

--- a/transport/grpc/limiter/doc.go
+++ b/transport/grpc/limiter/doc.go
@@ -17,6 +17,9 @@
 //
 // Streaming interceptors take one token when a stream opens and also meter
 // each RecvMsg and SendMsg operation. Unary interceptors take one token per RPC.
+// Client-side denials are locally marked so retry middleware returns them
+// terminally. Server-side denials remain ordinary remote ResourceExhausted
+// statuses and may be retried by configured clients.
 //
 // Start with [UnaryServerInterceptor] or [StreamServerInterceptor] for server-side limiting and
 // [UnaryClientInterceptor] or [StreamClientInterceptor] for client-side limiting.

--- a/transport/grpc/limiter/limiter.go
+++ b/transport/grpc/limiter/limiter.go
@@ -23,9 +23,9 @@ func take(ctx context.Context, rateLimiter *limiter.Limiter) (limiter.Decision, 
 	return decision, nil
 }
 
-// limitError returns the terminal ResourceExhausted error used when a limiter
-// rejects a request. Client-side local rejections use this bare form, matching
-// the HTTP client limiter's local 429.
+// limitError returns the ResourceExhausted error used when a limiter rejects a
+// request. Client interceptors wrap it with status.LocalError; server
+// interceptors leave it unmarked so remote retry configuration still applies.
 func limitError() error {
 	return status.Error(codes.ResourceExhausted, grpc.StatusText(codes.ResourceExhausted))
 }

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -35,6 +35,7 @@ func TestServerLimiterUnary(t *testing.T) {
 	rejectedHeader := grpcmeta.Map{}
 	_, err = client.SayHello(t.Context(), req, grpc.Header(&rejectedHeader))
 	require.Error(t, err)
+	require.False(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 	require.NotEmpty(t, rejectedHeader.Get("ratelimit"))
 	require.NotEmpty(t, rejectedHeader.Get("ratelimit-policy"))
@@ -52,6 +53,7 @@ func TestServerLimiterStream(t *testing.T) {
 	require.NoError(t, sayStreamHello(t, client))
 	err := sayStreamHello(t, client)
 	require.Error(t, err)
+	require.False(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 	requireRetryInfo(t, err)
 }
@@ -75,6 +77,7 @@ func TestServerLimiterStreamHeader(t *testing.T) {
 		return nil
 	})
 	require.Error(t, err)
+	require.False(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 	require.NotEmpty(t, rejected.Header.Get("ratelimit"))
 	require.NotEmpty(t, rejected.Header.Get("ratelimit-policy"))
@@ -113,6 +116,7 @@ func TestClientLimiterUnary(t *testing.T) {
 	_, _ = client.SayHello(t.Context(), req)
 	_, err := client.SayHello(t.Context(), req)
 	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
@@ -127,6 +131,7 @@ func TestClientLimiterStream(t *testing.T) {
 	_ = sayStreamHello(t, client)
 	err := sayStreamHello(t, client)
 	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
@@ -143,6 +148,7 @@ func TestClientLimiterStreamRecvRejected(t *testing.T) {
 
 	_, err = stream.Recv()
 	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
@@ -158,6 +164,7 @@ func TestClientLimiterStreamSendRejected(t *testing.T) {
 
 	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
 	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -13,5 +13,9 @@
 // greater than the minimum jittered backoff, the error is returned without another attempt. Missing, zero, or
 // shorter retry_delay values do not suppress a retry.
 //
+// Locally produced client-control errors marked by `net/grpc/status.LocalError` are
+// terminal. An unmarked response with the same gRPC code remains governed by
+// the configured retry codes.
+//
 // Start with [Config] and [UnaryClientInterceptor].
 package retry

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -53,6 +53,7 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 //
 // Failure classification:
 // Retries are only attempted for configured gRPC status codes. The default is [codes.Unavailable].
+// Errors marked by [status.LocalError] are terminal even when their status code is configured as retryable.
 //
 // Policy behavior:
 // When no policy is provided, only side-effect-safe unary RPCs are eligible for retry: AIP-style read methods,
@@ -81,7 +82,10 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 		retries = retry.WithMaxRetries(maxAttempts-1, retries)
 		return retry.Do(ctx, retries, func(ctx context.Context) error {
 			err := attempt(ctx)
-			if err == nil || !isRetryableCode(status.Code(err), codes) {
+			if err == nil || status.IsLocalError(err) {
+				return err
+			}
+			if !isRetryableCode(status.Code(err), codes) {
 				return err
 			}
 			if retryInfoDelayExceedsBackoff(err, backoff) {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -103,6 +103,22 @@ func TestUnaryClientInterceptorRetriesConfiguredCode(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestUnaryClientInterceptorDoesNotRetryLocalStatusError(t *testing.T) {
+	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted))
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.LocalError(status.SafeError(codes.ResourceExhausted, test.ErrInvalid))
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrInvalid)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 1, calls)
+}
+
 func TestUnaryClientInterceptorConfiguredCodesReplaceDefaults(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted))
 

--- a/transport/http/recovery.go
+++ b/transport/http/recovery.go
@@ -15,8 +15,11 @@ func (*recoveryHandler) ServeHTTP(res http.ResponseWriter, req *http.Request, ne
 	hooks := snoop.Hooks{
 		WriteHeader: func(writeHeader snoop.WriteHeaderFunc) snoop.WriteHeaderFunc {
 			return func(code int) {
-				committed = true
 				writeHeader(code)
+				// Informational responses do not commit the final response, except 101 switches protocols.
+				if code == http.StatusSwitchingProtocols || code >= http.StatusOK {
+					committed = true
+				}
 			}
 		},
 		Write: func(write snoop.WriteFunc) snoop.WriteFunc {

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -3,6 +3,7 @@ package retry
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/body"
@@ -13,6 +14,8 @@ import (
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
 	retryable "github.com/hashicorp/go-retryablehttp"
 )
+
+const maxResponseDrainBytes int64 = 4096
 
 // Policy decides whether req is eligible for retry.
 //
@@ -225,7 +228,7 @@ func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *ht
 		return nil
 	}
 
-	closeResponse(res)
+	discardResponse(res)
 	a.attempt++
 	return retryErr
 }
@@ -316,10 +319,17 @@ func statusError(retryErr, err error) error {
 	return ErrInvalidStatusCode
 }
 
-func closeResponse(res *http.Response) {
-	if res != nil {
-		body.Close(res.Body)
+func discardResponse(res *http.Response) {
+	if res.Body == nil {
+		return
 	}
+
+	// Drain a bounded prefix so small HTTP/1.x responses can reach EOF and keep the connection reusable
+	// without fully consuming large or streaming responses. Disposal remains best-effort so a read
+	// failure does not replace the retry result. The cap bounds bytes, not time; request cancellation
+	// or http.Client.Timeout remains responsible for limiting slow reads.
+	_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, maxResponseDrainBytes))
+	body.Close(res.Body)
 }
 
 func composePolicy(policies []Policy) Policy {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -337,10 +337,12 @@ func TestRoundTripperReturnsFinalRetryableResponseWhenExhausted(t *testing.T) {
 	require.Equal(t, 2, rt.Calls)
 }
 
-func TestRoundTripperClosesRetryableResponseBeforeNextAttempt(t *testing.T) {
+func TestRoundTripperReusesConnectionWhenRetryingResponse(t *testing.T) {
 	var calls int
-	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	var remoteAddresses []string
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		calls++
+		remoteAddresses = append(remoteAddresses, req.RemoteAddr)
 		if calls == 1 {
 			res.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = res.Write([]byte("first failure"))
@@ -359,6 +361,60 @@ func TestRoundTripperClosesRetryableResponseBeforeNextAttempt(t *testing.T) {
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
 	require.NoError(t, err)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 1, res.ProtoMajor, "connection reuse regression is HTTP/1.x-specific")
+	require.NoError(t, res.Body.Close())
+	require.Equal(t, 2, calls)
+	require.Len(t, remoteAddresses, 2)
+	require.Equal(t, remoteAddresses[0], remoteAddresses[1])
+}
+
+func TestRoundTripperBoundsDiscardedResponseDrain(t *testing.T) {
+	const drainSize = 4096
+
+	reader := strings.NewReader(strings.Repeat("a", drainSize*2))
+	retryBody := &test.TrackedBody{Reader: reader}
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			res := test.ResponseWithStatus(http.StatusServiceUnavailable)
+			res.Body = retryBody
+			res.ProtoMajor = 1
+
+			return res, nil
+		}
+
+		return test.ResponseWithStatus(http.StatusOK), nil
+	})
+	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, time.Millisecond), rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.NoError(t, res.Body.Close())
+	require.True(t, retryBody.Closed, "discarded response body should be closed")
+	require.Equal(t, drainSize, reader.Len(), "discarded response drain should remain byte-bounded")
+}
+
+func TestRoundTripperRetriesResponseWithNilBody(t *testing.T) {
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{StatusCode: http.StatusServiceUnavailable}, nil
+		}
+
+		return test.ResponseWithStatus(http.StatusOK), nil
+	})
+	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, time.Millisecond), rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
 
 	res, err := retrying.RoundTrip(req)
 	require.NoError(t, err)

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -7,47 +7,48 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/alexfalkowski/go-service/v2/transport/http"
+	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidServer(t *testing.T) {
-	http.Register(test.FS)
+	transporthttp.Register(test.FS)
 
-	cfg := &http.Config{
+	cfg := &transporthttp.Config{
 		Config: &server.Config{
 			Timeout: 5 * time.Second,
 			TLS:     test.NewTLSConfig("certs/client-cert.pem", "secrets/none"),
 		},
 	}
-	params := http.ServerParams{
+	params := transporthttp.ServerParams{
 		Shutdowner: test.NewShutdowner(),
 		Config:     cfg,
 	}
 
-	_, err := http.NewServer(params)
+	_, err := transporthttp.NewServer(params)
 	require.Error(t, err)
 }
 
 func TestServerRejectsCAOnlyTLS(t *testing.T) {
-	http.Register(test.FS)
+	transporthttp.Register(test.FS)
 
-	cfg := &http.Config{
+	cfg := &transporthttp.Config{
 		Config: &server.Config{
 			Timeout: 5 * time.Second,
 			TLS:     &tls.Config{CA: test.FilePath("certs/rootCA.pem")},
 		},
 	}
-	params := http.ServerParams{
+	params := transporthttp.ServerParams{
 		Shutdowner: test.NewShutdowner(),
 		Config:     cfg,
 	}
 
-	_, err := http.NewServer(params)
+	_, err := transporthttp.NewServer(params)
 	require.ErrorIs(t, err, server.ErrMissingKeyPair)
 }
 
@@ -104,16 +105,26 @@ func TestServerRecoversPanic(t *testing.T) {
 	world.Handle("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test panic")
 	}))
+	world.Handle("GET /panic-after-informational", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.WriteHeader(http.StatusEarlyHints)
+		panic("test panic after informational response")
+	}))
 	world.Handle("GET /panic-after-write", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		res.WriteHeader(http.StatusOK)
 		_, _ = res.Write([]byte("partial"))
 		res.(interface{ Flush() }).Flush()
+		res.WriteHeader(http.StatusEarlyHints)
 		panic("test panic after commit")
 	}))
 	world.HandleHello()
 	world.Start()
 
 	res, body, err := world.GetBody(t.Context(), world.PathServerURL("http", "panic"), http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "http: internal server error", body)
+
+	res, body, err = world.GetBody(t.Context(), world.PathServerURL("http", "panic-after-informational"), http.Header{})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	require.Equal(t, "http: internal server error", body)


### PR DESCRIPTION
## What

- Drain a bounded prefix of retryable HTTP responses before closing them so small HTTP/1.x responses can preserve connection reuse without fully consuming large or streaming bodies.
- Keep panic recovery available after informational HTTP responses while treating protocol switches and final responses as committed.
- Mark local gRPC limiter and breaker rejections transparently so retry middleware returns them terminally while remote `ResourceExhausted` responses remain configurable for retry.
- Preserve gRPC status codes, messages, details, and wrapped causes through the local-error marker, with package documentation and caller-visible regression coverage.

## Why

- Retrying discarded HTTP responses without draining them creates avoidable connection churn, and treating informational responses as final prevents safe panic rendering before a final response is committed.
- Retrying local load-control rejections can wait through limiter refills or breaker transitions, adding latency and weakening overload protection.

## Testing

- `make specs` - passed (2,306 race/coverage tests)
- `make lint` - passed (0 issues; existing gomodguard deprecation warning)
- `make sec` - passed (no reachable vulnerabilities; Trivy reported 0 vulnerabilities)
- CI will additionally run generated-output freshness, bounded fuzz, benchmark, and coverage publication targets.

AI-assisted-by: [Codex](https://openai.com/codex/)
