### PR TITLE
docs(agents): record accepted-design http operation and client media contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,27 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   valid custom codes such as `499`. Do not flag hypothetical invalid
   `WriteHeader` panics from manually constructed bogus codes unless a concrete
   public API path accepts untrusted status codes or starts promising validation.
+- HTTP operation route patterns registered through
+  `net/http.Router.HandleOperation`/`HandleOperationFunc` and
+  `net/http.RoutePolicy.Operation` are expected to include an HTTP method
+  prefix, such as `"GET /<name>/metrics"`, matching the supported callers in
+  `transport/http/health` and `transport/http/telemetry/metrics`.
+  `RoutePolicy.Operation` stores only the path portion, so a bare method-less
+  pattern registers under the empty key and never matches; operation matching is
+  intentionally path-only so method mismatches still reach the mux for normal
+  method handling. Do not flag method-less operation patterns failing to match,
+  or the `Operation`-versus-`AllowUnauthenticated` handling asymmetry, as a bug;
+  method-prefixing is the supported registration form. Report only concrete bugs
+  where a method-prefixed operation pattern fails to match or the supported
+  callers stop prefixing.
+- HTTP `net/http/client.Options.ContentType` is expected to be a real encodable
+  request media type. Error media types (`text/error` and other `*/error`
+  subtypes) are internal error-response media with no encoder, so `Client.Do`
+  panics if one is supplied together with a request body. This is intentional:
+  error media are not valid request content types and callers control
+  `ContentType`. Do not flag the missing nil-encoder guard in `Client.Do` as a
+  bug based on supplying an error media type as a request content type; report
+  only concrete bugs where a valid request media type panics or fails to encode.
 - gRPC client constructor options use the package's last-wins functional option
   convention. `WithClientDialOption`, `WithClientUnaryInterceptors`, and
   `WithClientStreamInterceptors` expect all custom values for one client


### PR DESCRIPTION
## What

- Add two accepted-design entries to the repository review guidance (`AGENTS.md`) so review passes and agents stop flagging two caller-misuse behaviors in `net` as bugs. Documentation-only change; no code, command, or configuration behavior changes.
- HTTP operation route patterns are expected to include an HTTP method prefix (e.g. `"GET /<name>/metrics"`, as `transport/http/health` and `transport/http/telemetry/metrics` register them). `RoutePolicy.Operation` stores only the path portion, so a bare method-less pattern registers under the empty key and never matches, and this path-only matching is intentional so method mismatches still reach the mux for normal method handling.
- `net/http/client.Options.ContentType` is expected to be a real encodable request media type. Supplying an internal error media type (`text/error` or another `*/error` subtype) together with a request body makes `Client.Do` panic, and this is treated as caller misuse rather than a framework defect.

## Why

- A scoped code-issue review of `net` surfaced these two behaviors as candidate defects. The maintainer classified both as caller/user-misuse issues, not framework bugs, so recording them as intentional in `AGENTS.md` prevents repeated re-triage and keeps future reviews focused on real defects.
- The second entry documents a live panic on invalid caller input as accepted design. It is recorded transparently so reviewers understand the behavior is known and intentional, not hidden; a defensive nil-encoder guard in `Client.Do` remains available later if the maintainer changes that stance.

## Testing

- `go test ./net/http/ -run TestProbeMethodlessOperationNeverMatches` - passed (run earlier this session with a throwaway test, since removed): confirmed a method-less operation pattern never matches while a method-prefixed one does, and `AllowUnauthenticated` handles a bare path.
- `go test ./net/http/client/ -run TestProbeErrorContentTypeRequestPanics` - passed (run earlier this session with a throwaway test, since removed): confirmed `Client.Do` panics on an error media type supplied with a request body (`runtime error: invalid memory address or nil pointer dereference`).
- No code changed, so Go lint/test/security targets do not apply to this diff. The documented claims were verified against current source in `net/http/routes.go`, `net/http/client/client.go`, `net/http/content/media.go`, and the operation callers in `transport/http/health` and `transport/http/telemetry/metrics`.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
