### PR TITLE
feat(net): correct media negotiation and lifecycle behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   calling constructors with nil filesystem dependencies unless a public API
   explicitly promises nil-FS tolerance or a supported path can provide nil.
 
+## Compatibility
+
+- Treat compatibility-affecting changes that have landed in repository history
+  as accepted decisions, even when they appear semver-incompatible or require
+  downstream source changes. Do not flag or reopen them solely by comparing
+  current code with older tags, releases, documentation, examples, or exported
+  surfaces. Review current code against the current supported behavior, and
+  revisit a landed compatibility decision only when the user explicitly asks.
+
 ## Gotchas
 
 - Manual transport TLS setup must call the HTTP and gRPC transport register functions; `transport.Module` does this on the normal path.
@@ -472,6 +481,11 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   `fs.FS` can return partial data after successful `Open`/`Stat`; report only
   concrete supported filesystem paths where static reads can fail mid-stream
   and operators need different behavior.
+- MVC static serving intentionally does not generate `ETag`, `Last-Modified`,
+  or conditional 304 responses. The supported embedded filesystem path has no
+  reliable content identity, so do not propose reintroducing validators unless
+  the supported Go toolchain provides a trustworthy constant-time content hash
+  or MVC gains explicit, reliable build metadata.
 - MVC not-found handling intentionally uses a simple `Accept` header check for
   `text/html` and does not fully evaluate quality weights such as
   `text/html;q=0`. Do not flag this unless there is concrete evidence of a

--- a/net/grpc/errors/doc.go
+++ b/net/grpc/errors/doc.go
@@ -1,0 +1,4 @@
+// Package errors provides gRPC-specific error helpers for go-service.
+//
+// This package contains small helpers for classifying and normalizing gRPC-related errors.
+package errors

--- a/net/grpc/errors/errors.go
+++ b/net/grpc/errors/errors.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+)
+
+// ServerError normalizes expected gRPC server shutdown errors.
+//
+// gRPC returns [grpc.ErrServerStopped] when (*[grpc.Server]).Serve is called
+// after Stop or GracefulStop. That order can occur during normal asynchronous
+// lifecycle shutdown, so it is not considered a serve failure.
+//
+// ServerError returns nil when err is [grpc.ErrServerStopped], otherwise it
+// returns err unchanged.
+func ServerError(err error) error {
+	if errors.Is(err, grpc.ErrServerStopped) {
+		return nil
+	}
+
+	return err
+}

--- a/net/grpc/errors/errors_test.go
+++ b/net/grpc/errors/errors_test.go
@@ -1,0 +1,20 @@
+package errors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerError(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, errors.ServerError(fmt.Errorf("server stopped: %w", grpc.ErrServerStopped)))
+
+	err := errors.ServerError(test.ErrFailed)
+	require.Same(t, test.ErrFailed, err)
+}

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -148,6 +148,9 @@ type UnaryServerInterceptor = grpc.UnaryServerInterceptor
 // TransportCredentials is an alias of [credentials.TransportCredentials].
 type TransportCredentials = credentials.TransportCredentials
 
+// ErrServerStopped is an alias for [grpc.ErrServerStopped].
+var ErrServerStopped = grpc.ErrServerStopped
+
 // MethodPolicy is an alias of [method.Policy].
 //
 // It stores gRPC method behavior used by server middleware.

--- a/net/grpc/server/server.go
+++ b/net/grpc/server/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/errors"
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 )
@@ -74,10 +75,12 @@ type Server struct {
 
 // Serve starts serving requests on the configured listener.
 //
-// This delegates to (*[grpc.Server]).Serve. It will return an error if the server
-// cannot begin serving, or if the underlying listener encounters an error.
+// Serve normalizes [grpc.ErrServerStopped] through
+// [github.com/alexfalkowski/go-service/v2/net/grpc/errors.ServerError], so a
+// graceful shutdown that occurs before serving is treated as normal completion.
+// Other errors, including listener failures, are returned unchanged.
 func (s *Server) Serve() error {
-	return s.server.Serve(s.listener)
+	return errors.ServerError(s.server.Serve(s.listener))
 }
 
 // Shutdown gracefully stops the gRPC server while respecting ctx.

--- a/net/grpc/server/server_test.go
+++ b/net/grpc/server/server_test.go
@@ -43,6 +43,14 @@ func TestShutdownClosesUnservedListener(t *testing.T) {
 	require.Nil(t, conn)
 }
 
+func TestServeReturnsNilAfterShutdownBeforeServe(t *testing.T) {
+	srv, err := server.NewServer(grpc.NewServer(test.ConfigOptions, time.Second), &config.Config{Address: ":0"})
+	require.NoError(t, err)
+
+	require.NoError(t, srv.Shutdown(context.Background()))
+	require.NoError(t, srv.Serve())
+}
+
 func TestShutdownStopsServerWhenContextCanceled(t *testing.T) {
 	srv, blocking := newServerWithBlockingGreeter(t)
 	serveErrCh := serve(srv)

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -97,8 +97,36 @@ func (c *Content) NewFromMedia(mediaType string) Media {
 }
 
 func firstMediaType(value string) string {
-	mediaType, _, _ := strings.Cut(value, ",")
-	return strings.TrimSpace(mediaType)
+	quoted := false
+	escaped := false
+
+	for index := range value {
+		if escaped {
+			// The preceding backslash quotes this character, so it cannot change the list state.
+			escaped = false
+			continue
+		}
+
+		if quoted && value[index] == '\\' {
+			// A quoted-pair protects the next character, including a quote or comma.
+			escaped = true
+			continue
+		}
+
+		if value[index] == '"' {
+			// Only an unescaped quote can enter or leave a quoted parameter value.
+			quoted = !quoted
+			continue
+		}
+
+		if value[index] == ',' && !quoted {
+			// An HTTP list comma ends the first media range only outside a quoted string.
+			return strings.TrimSpace(value[:index])
+		}
+	}
+
+	// Leave a single or malformed range intact so the media parser can accept or reject it.
+	return strings.TrimSpace(value)
 }
 
 func (c *Content) newRequestMedia(mediaType string) Media {

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -58,6 +58,32 @@ func TestNewFromAcceptPrefersAccept(t *testing.T) {
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
 }
 
+func TestNewFromAcceptUsesFirstCompleteMediaRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		accept  string
+		subtype string
+		kind    string
+	}{
+		{name: "quoted comma", accept: `application/yaml; profile="a,b", application/toml`, subtype: "yaml", kind: "yaml"},
+		{name: "escaped quoted comma", accept: `application/yaml; profile="a\",b", application/toml`, subtype: "yaml", kind: "yaml"},
+		{name: "list", accept: "application/yaml, application/toml", subtype: "yaml", kind: "yaml"},
+		{name: "malformed quoted parameter", accept: `application/yaml; profile="a,b`, subtype: "json", kind: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+			req.Header.Set(content.AcceptKey, tt.accept)
+
+			media := test.Content.NewFromAccept(req)
+
+			require.Equal(t, tt.subtype, media.Subtype())
+			require.Same(t, test.Encoder.Get(tt.kind), media.Encoder)
+		})
+	}
+}
+
 func TestNewFromAcceptFallsBackToContentType(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 	req.Header.Set(content.TypeKey, media.TOML)
@@ -70,7 +96,7 @@ func TestNewFromAcceptFallsBackToContentType(t *testing.T) {
 
 func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.AcceptKey, "application/yaml, application/toml")
+	req.Header.Set(content.AcceptKey, `application/yaml; profile="a,b", application/toml`)
 
 	media := test.Content.NewFromRequest(req)
 

--- a/net/http/mvc/example_test.go
+++ b/net/http/mvc/example_test.go
@@ -83,7 +83,6 @@ func ExampleStaticFile() {
 		"/asset.txt",
 		"static/asset.txt",
 		mvc.WithCacheControl("public, max-age=60"),
-		mvc.WithCacheValidators(),
 	)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
@@ -91,25 +90,13 @@ func ExampleStaticFile() {
 
 	mux.ServeHTTP(res, req)
 
-	etag := res.Header().Get("ETag")
 	fmt.Println(res.Code)
 	fmt.Println(res.Header().Get("Cache-Control"))
-	fmt.Println(etag != "")
-
-	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
-	req.Header.Set("If-None-Match", etag)
-	res = httptest.NewRecorder()
-
-	mux.ServeHTTP(res, req)
-
-	fmt.Println(res.Code)
-	fmt.Println(res.Body.Len())
+	fmt.Println(res.Body.String())
 	// Output:
 	// 200
 	// public, max-age=60
-	// true
-	// 304
-	// 0
+	// hello
 }
 
 func ExampleStaticPathValue() {
@@ -123,25 +110,18 @@ func ExampleStaticPathValue() {
 		Layout:      mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
 	})
 
-	mvc.StaticPathValue("/{file...}", "file", "static", mvc.WithCacheValidators())
+	mvc.StaticPathValue("/{file...}", "file", "static")
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
-	etag := res.Header().Get("ETag")
-	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/asset.txt", http.NoBody)
-	req.Header.Set("If-None-Match", etag)
-	res = httptest.NewRecorder()
-
-	mux.ServeHTTP(res, req)
-
 	fmt.Println(res.Code)
-	fmt.Println(res.Body.Len())
+	fmt.Println(res.Body.String())
 	// Output:
-	// 304
-	// 0
+	// 200
+	// hello
 }
 
 type examplePage struct {

--- a/net/http/mvc/options.go
+++ b/net/http/mvc/options.go
@@ -4,27 +4,13 @@ package mvc
 type StaticOption func(*staticOptions)
 
 type staticOptions struct {
-	cacheControl    string
-	cacheValidators bool
+	cacheControl string
 }
 
 // WithCacheControl sets the Cache-Control response header for a static route.
 func WithCacheControl(value string) StaticOption {
 	return func(options *staticOptions) {
 		options.cacheControl = value
-	}
-}
-
-// WithCacheValidators adds ETag and Last-Modified response headers for a static route.
-//
-// The ETag is a weak metadata validator derived from the file name, size, and modification time. It does not
-// hash file contents, so conditional requests can be answered without reading the file body.
-//
-// When a request's If-None-Match header matches the generated ETag, the route responds with
-// 304 Not Modified and no body.
-func WithCacheValidators() StaticOption {
-	return func(options *staticOptions) {
-		options.cacheValidators = true
 	}
 }
 

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,46 +167,26 @@ func TestStaticFileSetsCacheControl(t *testing.T) {
 	test.RequireResponseBody(t, res, "hello")
 }
 
-func TestStaticFileUsesETagValidator(t *testing.T) {
-	modified := time.Now().UTC()
+func TestStaticFileIgnoresConditionalRequestHeaders(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{
 		Router:      newTestRouter(mux),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
-		FileSystem: fstest.MapFS{
-			"static/asset.txt": &fstest.MapFile{Data: []byte("hello"), ModTime: modified},
-		},
-		Pool:   test.Pool,
-		Layout: test.Layout,
+		FileSystem:  test.FileSystem,
+		Pool:        test.Pool,
+		Layout:      test.Layout,
 	})
-	require.True(t, mvc.StaticFile("/asset.txt", "static/asset.txt", mvc.WithCacheValidators()))
-
-	firstReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
-	firstRes := httptest.NewRecorder()
-
-	mux.ServeHTTP(firstRes, firstReq)
-
-	etag := firstRes.Header().Get("ETag")
-	require.Equal(t, http.StatusOK, firstRes.Code)
-	require.NotEmpty(t, etag)
-	require.GreaterOrEqual(t, len(etag), 2)
-	require.Equal(t, "W/", etag[:2])
-	require.Equal(t, modified.Format(http.TimeFormat), firstRes.Header().Get("Last-Modified"))
-	test.RequireResponseBody(t, firstRes, "hello")
+	require.True(t, mvc.StaticFile("/robots.txt", "static/robots.txt"))
 
 	for _, tt := range []struct {
 		headers map[string]string
 		name    string
-		body    string
-		code    int
 	}{
-		{headers: map[string]string{"If-None-Match": etag}, name: "etag", code: http.StatusNotModified},
-		{headers: map[string]string{"If-None-Match": etag[2:]}, name: "strong-etag", code: http.StatusNotModified},
-		{headers: map[string]string{"If-Modified-Since": modified.Format(http.TimeFormat)}, name: "modified", code: http.StatusNotModified},
-		{headers: map[string]string{"If-Modified-Since": modified.AddDate(0, 0, -1).Format(http.TimeFormat)}, name: "stale", body: "hello", code: http.StatusOK},
+		{headers: map[string]string{"If-None-Match": `W/"asset"`}, name: "none match"},
+		{headers: map[string]string{"If-Modified-Since": "Sun, 06 Nov 1994 08:49:37 GMT"}, name: "modified since"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset.txt", http.NoBody)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/robots.txt", http.NoBody)
 			for key, value := range tt.headers {
 				req.Header.Set(key, value)
 			}
@@ -215,23 +194,23 @@ func TestStaticFileUsesETagValidator(t *testing.T) {
 
 			mux.ServeHTTP(res, req)
 
-			require.Equal(t, tt.code, res.Code)
-			if tt.body == "" {
-				test.RequireEmptyResponseBody(t, res)
-				return
-			}
-			test.RequireResponseBody(t, res, tt.body)
+			require.Equal(t, http.StatusOK, res.Code)
+			require.Empty(t, res.Header().Get("ETag"))
+			require.Empty(t, res.Header().Get("Last-Modified"))
+			test.RequireResponseBody(t, res, "User-agent: *\nAllow: /\n")
 		})
 	}
 }
 
-func TestStaticPathValueUsesETagValidator(t *testing.T) {
+func TestStaticPathValueIgnoresConditionalRequestHeaders(t *testing.T) {
 	for _, tt := range []struct {
-		name string
-		path string
+		value  string
+		header string
+		name   string
+		path   string
 	}{
-		{name: "simple", path: "/asset.txt"},
-		{name: "comma", path: "/a,b.txt"},
+		{header: "If-None-Match", name: "none match", path: "/asset.txt", value: `W/"asset"`},
+		{header: "If-Modified-Since", name: "modified since", path: "/a,b.txt", value: "Sun, 06 Nov 1994 08:49:37 GMT"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := http.NewServeMux()
@@ -245,26 +224,18 @@ func TestStaticPathValueUsesETagValidator(t *testing.T) {
 				Pool:   test.Pool,
 				Layout: test.Layout,
 			})
-			require.True(t, mvc.StaticPathValue("/{file...}", "file", "static", mvc.WithCacheValidators()))
+			require.True(t, mvc.StaticPathValue("/{file...}", "file", "static"))
 
-			firstReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
-			firstRes := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
+			req.Header.Set(tt.header, tt.value)
+			res := httptest.NewRecorder()
 
-			mux.ServeHTTP(firstRes, firstReq)
+			mux.ServeHTTP(res, req)
 
-			etag := firstRes.Header().Get("ETag")
-			require.Equal(t, http.StatusOK, firstRes.Code)
-			require.NotEmpty(t, etag)
-			test.RequireResponseBody(t, firstRes, "hello")
-
-			secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
-			secondReq.Header.Set("If-None-Match", etag)
-			secondRes := httptest.NewRecorder()
-
-			mux.ServeHTTP(secondRes, secondReq)
-
-			require.Equal(t, http.StatusNotModified, secondRes.Code)
-			test.RequireEmptyResponseBody(t, secondRes)
+			require.Equal(t, http.StatusOK, res.Code)
+			require.Empty(t, res.Header().Get("ETag"))
+			require.Empty(t, res.Header().Get("Last-Modified"))
+			test.RequireResponseBody(t, res, "hello")
 		})
 	}
 }

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -1,8 +1,6 @@
 package mvc
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"io/fs"
 	"path"
 	"strconv"
@@ -14,12 +12,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
-	"github.com/alexfalkowski/go-service/v2/time"
 )
-
-// staticETagSeparator is a NUL byte field separator for ETag hash input.
-// Static file names cannot contain NUL, so this keeps name/size/mod-time boundaries unambiguous.
-const staticETagSeparator = "\x00"
 
 // StaticFile registers an HTTP GET route that serves the named file from the registered filesystem.
 //
@@ -30,8 +23,8 @@ func StaticFile(pattern, name string, opts ...StaticOption) bool {
 	}
 
 	options := options(opts...)
-	handler := func(res http.ResponseWriter, req *http.Request) {
-		serveFile(res, req, name, options)
+	handler := func(res http.ResponseWriter, _ *http.Request) {
+		serveFile(res, name, options)
 	}
 
 	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
@@ -58,14 +51,14 @@ func StaticPathValue(pattern, value, prefix string, opts ...StaticOption) bool {
 		}
 
 		name := path.Join(prefix, cleaned)
-		serveFile(res, req, name, options)
+		serveFile(res, name, options)
 	}
 
 	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
 	return true
 }
 
-func serveFile(res http.ResponseWriter, req *http.Request, name string, options *staticOptions) {
+func serveFile(res http.ResponseWriter, name string, options *staticOptions) {
 	f, err := fileSystem.Open(name)
 	if err != nil {
 		res.WriteHeader(staticStatusCode(err))
@@ -84,26 +77,6 @@ func serveFile(res http.ResponseWriter, req *http.Request, name string, options 
 	}
 
 	setStaticCacheControl(res, options)
-	if options.cacheValidators {
-		serveFileWithCacheValidators(res, req, name, f, info)
-		return
-	}
-
-	writeStaticFile(res, name, f, info)
-}
-
-func serveFileWithCacheValidators(res http.ResponseWriter, req *http.Request, name string, f fs.File, info fs.FileInfo) {
-	etag := staticETag(name, info)
-	setStaticValidators(res, etag, info)
-	if staticETagMatches(req.Header.Get("If-None-Match"), etag) {
-		res.WriteHeader(http.StatusNotModified)
-		return
-	}
-	if strings.IsEmpty(req.Header.Get("If-None-Match")) && staticModifiedSinceMatches(req, info) {
-		res.WriteHeader(http.StatusNotModified)
-		return
-	}
-
 	writeStaticFile(res, name, f, info)
 }
 
@@ -137,77 +110,8 @@ func setStaticCacheControl(res http.ResponseWriter, options *staticOptions) {
 	}
 }
 
-func setStaticValidators(res http.ResponseWriter, etag string, info fs.FileInfo) {
-	res.Header().Set("ETag", etag)
-
-	modified := info.ModTime()
-	if !modified.IsZero() {
-		res.Header().Set("Last-Modified", modified.UTC().Format(http.TimeFormat))
-	}
-}
-
-func staticModifiedSinceMatches(req *http.Request, info fs.FileInfo) bool {
-	value := req.Header.Get("If-Modified-Since")
-	if strings.IsEmpty(value) {
-		return false
-	}
-
-	since, err := http.ParseTime(value)
-	if err != nil {
-		return false
-	}
-
-	modified := info.ModTime()
-	if modified.IsZero() {
-		return false
-	}
-
-	modified = modified.UTC().Truncate(time.Second.Duration())
-	return !modified.After(since)
-}
-
 func setStaticContentLength(res http.ResponseWriter, size int64) {
 	if size >= 0 {
 		res.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	}
-}
-
-func staticETag(name string, info fs.FileInfo) string {
-	sum := sha256.Sum256(strings.Bytes(strings.Join(
-		staticETagSeparator,
-		name,
-		strconv.FormatInt(info.Size(), 10),
-		strconv.FormatInt(info.ModTime().UTC().UnixNano(), 10),
-	)))
-
-	// W/ marks a weak ETag: metadata freshness, not byte-for-byte content identity.
-	return strings.Concat(
-		`W/"`,
-		hex.EncodeToString(sum[:]),
-		`"`,
-	)
-}
-
-func staticETagMatches(value, etag string) bool {
-	tag := staticETagOpaqueTag(etag)
-	for {
-		candidate, rest, found := strings.Cut(value, ",")
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "*" || staticETagOpaqueTag(candidate) == tag {
-			return true
-		}
-		if !found {
-			return false
-		}
-
-		value = rest
-	}
-}
-
-func staticETagOpaqueTag(value string) string {
-	if strings.HasPrefix(value, "W/") {
-		return value[2:]
-	}
-
-	return value
 }

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
+	grpcserver "github.com/alexfalkowski/go-service/v2/net/grpc/server"
 	"github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -164,6 +167,31 @@ func TestRegisterSnapshotsServices(t *testing.T) {
 	require.NoError(t, lc.Stop(t.Context()))
 	require.Equal(t, 1, original.Shutdowns, "original shutdowns")
 	require.Equal(t, 0, replacement.Shutdowns, "replacement shutdowns")
+}
+
+func TestRegisterImmediateGRPCStopDoesNotRequestShutdown(t *testing.T) {
+	for iteration := range 5_000 {
+		lc := fxtest.NewLifecycle(t)
+		sh := test.NewShutdowner()
+		service, err := grpcserver.NewService(
+			"grpc",
+			grpc.NewServer(test.ConfigOptions, time.Second),
+			&config.Config{Address: "tcp://127.0.0.1:0"},
+			nil,
+			sh,
+		)
+		require.NoError(t, err)
+
+		server.Register(server.RegisterParams{
+			Lifecycle: lc,
+			Drain:     server.NewDrain(),
+			Services:  []*server.Service{service},
+		})
+
+		require.NoError(t, lc.Start(t.Context()))
+		require.NoError(t, lc.Stop(t.Context()))
+		require.False(t, sh.Called(), "graceful lifecycle stop was reported as a serve failure at iteration %d", iteration)
+	}
 }
 
 func waitForRegisteredService(t *testing.T, done <-chan struct{}) {


### PR DESCRIPTION
## What

- Parse the first Accept media range without splitting commas inside quoted parameters, including escaped quotes.
- Remove MVC-generated ETag, Last-Modified, and conditional 304 behavior, along with WithCacheValidators; callers should delete that option and may continue using Cache-Control.
- Normalize gRPC's expected stopped-server sentinel like HTTP so shutdown-before-Serve does not request a failure exit code.
- Record accepted compatibility and static-validator boundaries in AGENTS guidance.

## Why

- Valid parameterized media ranges must select the requested encoder, static assets must not return false 304 responses without reliable content identity, and normal lifecycle rollback must not be reported as a server failure.

## Testing

- `make package=net/http/content specs` - passed
- `make package=net/http/mvc specs` - passed
- `make package=net/grpc/errors specs` - passed
- `make package=net/grpc/server specs` - passed
- `make package=net/server specs` - passed
- `make specs` - passed; 2,314 tests
- `make lint` - passed
- `make sec` - passed; no called vulnerabilities, findings, or secrets
- `make fuzzes` - passed
- `make generate-stale` - could not produce a clean result because its repository-wide dirty-tree check detects the intended changes; no `internal/test` paths changed

AI-assisted-by: [Codex](https://openai.com/codex/)
