### PR TITLE
feat(mvc): remove the concurrency-unsafe safeShuffle template function

### DIFF
--- a/net/http/mvc/funcs.go
+++ b/net/http/mvc/funcs.go
@@ -45,8 +45,10 @@ func NewFunctionMap(params FunctionMapParams) sprout.FunctionMap {
 	runtime.Must(handler.AddRegistry(time.NewRegistry()))
 
 	functionMap := handler.Build()
-	// Sprout's shuffle uses a package-global math/rand.Source, which races during concurrent template renders.
+	// Sprout's shuffle (and its WithSafeFuncs twin safeShuffle) uses a package-global
+	// math/rand.Source, which races during concurrent template renders.
 	delete(functionMap, "shuffle")
+	delete(functionMap, "safeShuffle")
 
 	return functionMap
 }

--- a/net/http/mvc/funcs_test.go
+++ b/net/http/mvc/funcs_test.go
@@ -1,0 +1,16 @@
+package mvc_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFunctionMapRemovesUnsafeShuffle(t *testing.T) {
+	fmap := mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()})
+
+	require.NotContains(t, fmap, "shuffle")
+	require.NotContains(t, fmap, "safeShuffle")
+}


### PR DESCRIPTION
## What

- Removed the `safeShuffle` entry from the function map returned by `NewFunctionMap`, alongside the existing `shuffle` removal, and updated the comment to note the `WithSafeFuncs` twin.
- Templates can no longer call `{{ safeShuffle }}`; a template that references it now fails to parse at view construction instead of racing at render time. No public API or signature change.

## Why

- `sprout.WithSafeFuncs(true)` registers a `safe`-prefixed twin of every function, so `handler.Build()` returned both `shuffle` and `safeShuffle`. Deleting only `shuffle` left `safeShuffle`, which reflectively invokes the same `Shuffle` on sprout's package-global `math/rand.Source`. Because MVC views render concurrently across HTTP requests, a template using `safeShuffle` is a data race — undefined behavior (corrupted output or panic) — which defeats the mitigation the original `delete` intended. Reproduced with `go test -race`: the map contained `safeShuffle`, and concurrent renders reported `WARNING: DATA RACE` through `html/template` into `math/rand`.

## Testing

- `make specs package=net/http/mvc` - passed (38 tests, race + coverage), including the new `TestNewFunctionMapRemovesUnsafeShuffle` asserting both `shuffle` and `safeShuffle` are absent from the map.
- `make golangci-lint package=net/http/mvc` - passed (0 issues).
- `make sec` - not run locally; the change removes a map key and adds a test with no dependency, auth, filesystem, or network surface change, so CI's security suite provides that coverage.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
