### PR TITLE
docs(agents): clarify mvc encoded path handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,6 +481,12 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   `fs.FS` can return partial data after successful `Open`/`Stat`; report only
   concrete supported filesystem paths where static reads can fail mid-stream
   and operators need different behavior.
+- `mvc.StaticPathValue` intentionally treats the decoded
+  `Request.PathValue` as an `fs.FS` path beneath the configured prefix. Go's
+  `ServeMux` can decode `%2F` inside a single wildcard to `/`, so a pattern such
+  as `/{file}` can resolve descendants under that prefix. Do not flag this
+  solely as path traversal; report only a concrete prefix escape, a supported
+  top-level-only contract, or unintended exposure of a non-public asset.
 - MVC static serving intentionally does not generate `ETag`, `Last-Modified`,
   or conditional 304 responses. The supported embedded filesystem path has no
   reliable content identity, so do not propose reintroducing validators unless


### PR DESCRIPTION
## What

- Document that `mvc.StaticPathValue` treats decoded path values as filesystem paths beneath the configured prefix, including `%2F` decoded within a single `ServeMux` wildcard.
- Keep reviews focused on concrete prefix escapes, supported top-level-only contracts, or unintended exposure of non-public assets.

## Why

- Prevent future audits from misclassifying intentional Go `ServeMux` decoding and prefix-contained asset resolution as path traversal while preserving scrutiny of genuine exposure.

## Testing

- `git diff --check` - passed
- `make lint` - passed; 0 issues
- `make package=net/http/mvc specs` - passed; 38 tests and examples

AI-assisted-by: [Codex](https://openai.com/codex/)
