### PR TITLE
feat(transport): add retry max-backoff cap, failure-ratio breaker, and grpc server option escape hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,23 @@ closed-state count reset window. `timeout` controls how long the breaker stays
 open before allowing half-open probes. `consecutive_failures` controls when the
 breaker opens. Zero values keep the package defaults.
 
+Instead of (or alongside) `consecutive_failures`, `failure_ratio` and
+`min_requests` open the breaker on a sustained error rate rather than an
+unbroken run of failures:
+
+```yaml
+feature:
+  address: localhost:9000
+  breaker:
+    failure_ratio: 0.5
+    min_requests: 10
+```
+
+`failure_ratio` is the fraction of failed requests (0 < r <= 1) within the
+current `interval` that opens the breaker, evaluated only once `min_requests`
+requests have been observed. When `failure_ratio` is set, it takes precedence
+over `consecutive_failures`.
+
 HTTP `StatusCodes` and gRPC `Codes` are optional replacement lists for failure
 classification. When omitted, the default lists above apply. When set, only the
 configured values count as breaker failures, so include the defaults as well
@@ -1300,6 +1317,21 @@ total elapsed time can include multiple attempt timeouts plus backoff unless the
 caller context ends first. HTTP retries do not create a retry-owned per-attempt
 timeout; bound outbound HTTP calls with the request context or
 `http.Client.Timeout`.
+
+`max_backoff` caps the per-attempt backoff duration, applied before jitter. It
+is most useful with `exponential` and `fibonacci` growth, which otherwise grow
+unbounded across attempts. A zero value (the default) leaves backoff
+uncapped:
+
+```yaml
+feature:
+  address: localhost:9000
+  retry:
+    backoff: 1s
+    strategy: exponential
+    attempts: 10
+    max_backoff: 30s
+```
 
 HTTP `StatusCodes` and gRPC `Codes` are optional replacement lists for failure
 classification. When omitted, the default lists below apply. When set, only the

--- a/compress/zstd/zstd_test.go
+++ b/compress/zstd/zstd_test.go
@@ -79,7 +79,9 @@ func TestDecompressAllowsWindowLargerThanOutputLimit(t *testing.T) {
 	data := make([]byte, 64<<10)
 	encoder, err := compress.NewWriter(nil, compress.WithWindowSize(128<<10), compress.WithSingleSegment(false))
 	require.NoError(t, err)
-	defer encoder.Close()
+	t.Cleanup(func() {
+		require.NoError(t, encoder.Close())
+	})
 
 	encoded := encoder.EncodeAll(data, nil)
 	decoded, err := cmp.Decompress(encoded, bytes.Size(len(data)))

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -25,10 +25,12 @@ func TestConfigRejectsNegativeTimeout(t *testing.T) {
 }
 
 func TestConfigRejectsNegativeBreakerDurations(t *testing.T) {
-	cfg := &client.Config{Breaker: &breaker.Config{Interval: -time.Second}}
+	breakerConfig := &breaker.Config{Interval: -time.Second}
+	cfg := &client.Config{Breaker: breakerConfig}
 	require.Error(t, test.Validator.Struct(cfg))
 
-	cfg = &client.Config{Breaker: &breaker.Config{Timeout: -time.Second}}
+	breakerConfig = &breaker.Config{Timeout: -time.Second}
+	cfg = &client.Config{Breaker: breakerConfig}
 	require.Error(t, test.Validator.Struct(cfg))
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -340,9 +340,12 @@ func verifyFeatureConfig(t *testing.T, cfg *config.Config) {
 	require.Equal(t, 15*time.Second, cfg.Feature.Breaker.Interval)
 	require.Equal(t, 5*time.Second, cfg.Feature.Breaker.Timeout)
 	require.Equal(t, uint32(4), cfg.Feature.Breaker.ConsecutiveFailures)
+	require.InDelta(t, 0.5, cfg.Feature.Breaker.FailureRatio, 0)
+	require.Equal(t, uint32(10), cfg.Feature.Breaker.MinRequests)
 	require.Equal(t, 100*time.Millisecond, cfg.Feature.Retry.Backoff)
 	require.Equal(t, time.Second, cfg.Feature.Retry.Timeout)
 	require.Equal(t, uint64(3), cfg.Feature.Retry.Attempts)
+	require.Equal(t, 5*time.Second, cfg.Feature.Retry.MaxBackoff)
 }
 
 func verifyIDConfig(t *testing.T, cfg *config.Config) {

--- a/database/sql/driver/driver_test.go
+++ b/database/sql/driver/driver_test.go
@@ -91,7 +91,9 @@ func TestRegisterWrapsDriverWhenTelemetryIsEnabled(t *testing.T) {
 
 	db, err := sql.Open(driverName, "benchmark")
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	rows, err := db.QueryContext(t.Context(), "SELECT register-telemetry")
 	require.NoError(t, err)

--- a/database/sql/telemetry/telemetry_test.go
+++ b/database/sql/telemetry/telemetry_test.go
@@ -24,7 +24,9 @@ func TestOpenDisablesRawQueryTextByDefault(t *testing.T) {
 
 	db, err := telemetry.Open(driverName, "benchmark")
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	test.RequireSQLQueryRows(t, db, query)
 
@@ -41,7 +43,9 @@ func TestWrapDriverDisablesRawQueryTextByDefault(t *testing.T) {
 
 	db, err := sql.Open(driverName, "benchmark")
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	test.RequireSQLQueryRows(t, db, query)
 
@@ -58,7 +62,9 @@ func TestWithSpanOptionsCanEnableRawQueryText(t *testing.T) {
 
 	db, err := telemetry.Open(driverName, "benchmark", telemetry.WithSpanOptions(telemetry.SpanOptions{}))
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	test.RequireSQLQueryRows(t, db, query)
 

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -94,7 +94,9 @@ func TestMaxReceiveSize(t *testing.T) {
 
 	res, err := http.NewClient(http.DefaultTransport, time.DefaultTimeout).Do(req)
 	require.NoError(t, err)
-	defer res.Body.Close()
+	t.Cleanup(func() {
+		require.NoError(t, res.Body.Close())
+	})
 
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.StatusCode)
 }

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -9,8 +9,8 @@
 //   - type aliases for commonly used gRPC types such as CallOption, DialOption,
 //     ServerOption, Server, ClientConn, interceptors, and stream interfaces
 //   - thin helper functions that forward to common constructors and options
-//     such as StatsHandler, Header, ChainUnaryInterceptor, Creds, NewTLS,
-//     NewInsecureCredentials, and UseCompressor
+//     such as StatsHandler, InTapHandle, Header, ChainUnaryInterceptor, Creds,
+//     NewTLS, NewInsecureCredentials, and UseCompressor
 //   - ParseServiceMethod for deriving service/method names from gRPC full method strings
 //   - a convenience NewServer constructor that applies standard server-side
 //     keepalive configuration and registers gRPC reflection

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/tap"
 )
 
 // CallOption is an alias of [grpc.CallOption].
@@ -148,6 +149,19 @@ type UnaryServerInterceptor = grpc.UnaryServerInterceptor
 // TransportCredentials is an alias of [credentials.TransportCredentials].
 type TransportCredentials = credentials.TransportCredentials
 
+// TapInfo is an alias of [tap.Info].
+//
+// It carries per-RPC metadata (method name, wire byte count) available to a
+// TapHandle before the request is read or dispatched to a handler.
+type TapInfo = tap.Info
+
+// TapHandle is an alias of [tap.ServerInHandle].
+//
+// It runs for every RPC as the connection accepts it, before message
+// decoding or interceptors, and can reject the call by returning a non-nil
+// error.
+type TapHandle = tap.ServerInHandle
+
 // ErrServerStopped is an alias for [grpc.ErrServerStopped].
 var ErrServerStopped = grpc.ErrServerStopped
 
@@ -185,6 +199,16 @@ func ParseServiceMethod(name string) (string, string) {
 // server runtime.
 func StatsHandler(h stats.Handler) ServerOption {
 	return grpc.StatsHandler(h)
+}
+
+// InTapHandle returns a ServerOption that installs h as the server's tap handle.
+//
+// This is a thin wrapper around [grpc.InTapHandle]. A tap handle runs for every
+// RPC as the connection accepts it, before message decoding or interceptors,
+// and can reject the call early (for example for connection-level admission
+// control or overload shedding) by returning a non-nil error.
+func InTapHandle(h TapHandle) ServerOption {
+	return grpc.InTapHandle(h)
 }
 
 // WithStatsHandler returns a DialOption that installs h as the client stats handler.

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -21,7 +21,7 @@ func TestDoAllowsResponseAtMaxResponseSize(t *testing.T) {
 		res.Header().Set(content.TypeKey, media.Text)
 		_, _ = io.WriteString(res, "hello")
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(5))
 
@@ -34,7 +34,7 @@ func TestDoRejectsResponseOverMaxResponseSize(t *testing.T) {
 		res.Header().Set(content.TypeKey, media.Text)
 		_, _ = io.WriteString(res, "hello!")
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(5))
 
@@ -50,7 +50,7 @@ func TestDoRejectsErrorResponseOverMaxResponseSize(t *testing.T) {
 		res.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(res, "too large")
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(5))
 
@@ -66,7 +66,7 @@ func TestDoPreservesErrorMediaStatusCode(t *testing.T) {
 		res.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(res, "bad request")
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := client.NewClient(test.Content, test.Pool)
 
@@ -81,7 +81,7 @@ func TestDoUsesDefaultMessageForNonstandardErrorStatus(t *testing.T) {
 		res.Header().Set(content.TypeKey, media.Text)
 		res.WriteHeader(http.StatusClientClosedRequest)
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := client.NewClient(test.Content, test.Pool)
 
@@ -107,7 +107,7 @@ func TestDoNormalizesErrorMediaSuccessStatusCode(t *testing.T) {
 				res.WriteHeader(tt.code)
 				_, _ = io.WriteString(res, "upstream error")
 			}))
-			defer server.Close()
+			t.Cleanup(server.Close)
 
 			c := client.NewClient(test.Content, test.Pool)
 
@@ -124,7 +124,7 @@ func TestDoUsesDefaultMaxResponseSize(t *testing.T) {
 		res.Header().Set(content.TypeKey, media.Text)
 		_, _ = io.WriteString(res, "hello")
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(0))
 
@@ -141,7 +141,7 @@ func TestDoUsesMsgPack(t *testing.T) {
 		res.Header().Set(content.TypeKey, media.MessagePack+"; profile=test")
 		require.NoError(t, test.Encoder.Get("msgpack").Encode(res, &test.Response{Greeting: "Hello " + request.Name}))
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	var response test.Response
 	c := client.NewClient(test.Content, test.Pool)

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -52,7 +52,7 @@ func TestPostUsesAccept(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := rpc.NewClient(server.URL,
 		rpc.WithClientContentType(media.JSON),

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -53,6 +53,14 @@ func WithMaxRetries(attempts uint64, next Backoff) Backoff {
 	return retry.WithMaxRetries(attempts, next)
 }
 
+// WithCappedDuration wraps next so each returned backoff duration is capped at maxDuration.
+//
+// This bounds only the per-attempt duration, not the total backoff time; combine it with
+// [WithMaxRetries] or [Do]'s context to bound overall retry time.
+func WithCappedDuration(maxDuration time.Duration, next Backoff) Backoff {
+	return retry.WithCappedDuration(maxDuration.Duration(), next)
+}
+
 // Do wraps f with b and retries errors marked by [RetryableError].
 //
 // It forwards ctx to each call of f. If ctx is canceled before or during a

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -37,6 +37,18 @@ func TestNewBackoffProducesStrategyDelays(t *testing.T) {
 	}
 }
 
+func TestWithCappedDurationBoundsGrowingBackoff(t *testing.T) {
+	backoff := retry.WithCappedDuration(4*time.Millisecond, retry.NewBackoff("exponential", time.Millisecond))
+
+	want := []time.Duration{time.Millisecond, 2 * time.Millisecond, 4 * time.Millisecond, 4 * time.Millisecond}
+	for _, w := range want {
+		next, stop := backoff.Next()
+
+		require.False(t, stop, "capped backoff should not stop before max retries")
+		require.Equal(t, w, time.Duration(next))
+	}
+}
+
 func TestWithJitterPercentBoundsBackoff(t *testing.T) {
 	backoff := retry.WithJitterPercent(20, retry.NewBackoff("constant", 100*time.Millisecond))
 

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -42,11 +42,14 @@
       interval: "15s"
       timeout: "5s"
       consecutive_failures: 4
+      failure_ratio: 0.5
+      min_requests: 10
     }
     retry: {
       backoff: "100ms"
       timeout: "1s"
       attempts: 3
+      max_backoff: "5s"
     }
     timeout: "10s"
   }

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -40,11 +40,14 @@ max_requests = 2
 interval = "15s"
 timeout = "5s"
 consecutive_failures = 4
+failure_ratio = 0.5
+min_requests = 10
 
 [feature.retry]
 backoff = "100ms"
 timeout = "1s"
 attempts = 3
+max_backoff = "5s"
 
 [hooks]
 key = "current"

--- a/test/configs/config.yml
+++ b/test/configs/config.yml
@@ -31,10 +31,13 @@ feature:
     interval: 15s
     timeout: 5s
     consecutive_failures: 4
+    failure_ratio: 0.5
+    min_requests: 10
   retry:
     backoff: 100ms
     timeout: 1s
     attempts: 3
+    max_backoff: 5s
   timeout: 10s
 hooks:
   key: current

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -10,7 +10,9 @@ import (
 func TestNewTimer(t *testing.T) {
 	timer := time.NewTimer(time.Nanosecond)
 	require.NotNil(t, timer)
-	defer timer.Stop()
+	t.Cleanup(func() {
+		timer.Stop()
+	})
 
 	select {
 	case tm := <-timer.C:

--- a/transport/breaker/breaker_test.go
+++ b/transport/breaker/breaker_test.go
@@ -55,18 +55,72 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigSettings(t *testing.T) {
-	settings := (&breaker.Config{
+	cfg := &breaker.Config{
 		MaxRequests:         2,
 		Interval:            15 * time.Second,
 		Timeout:             5 * time.Second,
 		ConsecutiveFailures: 4,
-	}).Settings()
+	}
+	settings := cfg.Settings()
 
 	require.Equal(t, uint32(2), settings.MaxRequests)
 	require.Equal(t, (15 * time.Second).Duration(), settings.Interval)
 	require.Equal(t, (5 * time.Second).Duration(), settings.Timeout)
 	require.False(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 3}))
 	require.True(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 4}))
+}
+
+func TestConfigSettingsFailureRatio(t *testing.T) {
+	cfg := &breaker.Config{
+		FailureRatio: 0.5,
+		MinRequests:  10,
+	}
+	settings := cfg.Settings()
+
+	tests := []struct {
+		name   string
+		counts breaker.Counts
+		want   bool
+	}{
+		{
+			name:   "ratio reached at minimum requests",
+			counts: breaker.Counts{Requests: 10, TotalFailures: 5},
+			want:   true,
+		},
+		{
+			name:   "ratio below threshold",
+			counts: breaker.Counts{Requests: 10, TotalFailures: 4},
+			want:   false,
+		},
+		{
+			name:   "ratio exceeded but below minimum requests",
+			counts: breaker.Counts{Requests: 9, TotalFailures: 9},
+			want:   false,
+		},
+		{
+			name:   "zero requests does not panic or trip",
+			counts: breaker.Counts{Requests: 0, TotalFailures: 0},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, settings.ReadyToTrip(tt.counts))
+		})
+	}
+}
+
+func TestConfigSettingsFailureRatioTakesPrecedence(t *testing.T) {
+	cfg := &breaker.Config{
+		FailureRatio:        0.5,
+		MinRequests:         10,
+		ConsecutiveFailures: 1,
+	}
+	settings := cfg.Settings()
+
+	require.False(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 4}), "consecutive failures should be ignored when FailureRatio is set")
+	require.True(t, settings.ReadyToTrip(breaker.Counts{Requests: 10, TotalFailures: 5}))
 }
 
 func TestConfigSettingsDefaults(t *testing.T) {

--- a/transport/breaker/config.go
+++ b/transport/breaker/config.go
@@ -32,6 +32,16 @@ type Config struct {
 	//
 	// A zero value keeps the default.
 	ConsecutiveFailures uint32 `yaml:"consecutive_failures,omitempty" json:"consecutive_failures,omitempty" toml:"consecutive_failures,omitempty"`
+
+	// FailureRatio is the failure ratio (0 < r <= 1) that opens the breaker once MinRequests is reached.
+	//
+	// A zero value keeps ConsecutiveFailures-based tripping. When set, it takes precedence over ConsecutiveFailures.
+	FailureRatio float64 `yaml:"failure_ratio,omitempty" json:"failure_ratio,omitempty" toml:"failure_ratio,omitempty" validate:"omitempty,gt=0,lte=1"`
+
+	// MinRequests is the minimum request volume within the interval before FailureRatio is evaluated.
+	//
+	// A zero value means any request volume is eligible once FailureRatio is set.
+	MinRequests uint32 `yaml:"min_requests,omitempty" json:"min_requests,omitempty" toml:"min_requests,omitempty"`
 }
 
 // IsEnabled reports whether breaker configuration is present.
@@ -55,7 +65,13 @@ func (c *Config) Settings() Settings {
 	if c.Timeout > 0 {
 		settings.Timeout = c.Timeout.Duration()
 	}
-	if c.ConsecutiveFailures > 0 {
+	if c.FailureRatio > 0 {
+		ratio := c.FailureRatio
+		minRequests := c.MinRequests
+		settings.ReadyToTrip = func(counts Counts) bool {
+			return counts.Requests > 0 && counts.Requests >= minRequests && float64(counts.TotalFailures)/float64(counts.Requests) >= ratio
+		}
+	} else if c.ConsecutiveFailures > 0 {
 		failures := c.ConsecutiveFailures
 		settings.ReadyToTrip = func(counts Counts) bool {
 			return counts.ConsecutiveFailures >= failures

--- a/transport/breaker/doc.go
+++ b/transport/breaker/doc.go
@@ -9,4 +9,9 @@
 //
 // go-service transport packages (for example the HTTP RoundTripper wrapper and the gRPC unary
 // client interceptor) compose these settings to build per-destination circuit breakers.
+//
+// Config.Settings builds ReadyToTrip from either ConsecutiveFailures (an unbroken run of
+// failures) or FailureRatio plus MinRequests (a sustained failure rate over the rolling
+// interval, evaluated only once MinRequests requests have been observed). FailureRatio
+// takes precedence over ConsecutiveFailures when both are set.
 package breaker

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -24,7 +24,9 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -41,7 +43,9 @@ func TestEmptyAuthUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -54,7 +58,9 @@ func TestMissingClientAuthUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -75,7 +81,9 @@ func TestInvalidAuthUnary(t *testing.T) {
 	ctx = meta.AppendToOutgoingContext(ctx, "geolocation", "geo:47,11")
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -91,7 +99,9 @@ func TestAuthUnaryWithAppend(t *testing.T) {
 	ctx = meta.AppendToOutgoingContext(ctx, "authorization", "What Invalid")
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -107,7 +117,9 @@ func TestAuthStreamWithAppend(t *testing.T) {
 	ctx = meta.AppendToOutgoingContext(ctx, "authorization", "What Invalid")
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -125,7 +137,9 @@ func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
 	ctx = meta.AppendToOutgoingContext(ctx, "authorization", "bearer test")
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -145,7 +159,9 @@ func TestValidAuthUnary(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(tkn, tkn), test.WithWorldGRPC())
 
 			conn := test.RequireGRPCConn(t, world)
-			defer conn.Close()
+			t.Cleanup(func() {
+				require.NoError(t, conn.Close())
+			})
 
 			client := v1.NewGreeterServiceClient(conn)
 			req := &v1.SayHelloRequest{Name: "test"}
@@ -172,7 +188,9 @@ func TestAccessDeniedUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -188,7 +206,9 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(test.NewGenerator("test", nil), tkn), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -206,7 +226,9 @@ func TestValidAuthStream(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -227,7 +249,9 @@ func TestInvalidAuthStream(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -246,7 +270,9 @@ func TestEmptyAuthStream(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -262,7 +288,9 @@ func TestMissingClientAuthStream(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -281,7 +309,9 @@ func TestTokenErrorAuthStream(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -37,7 +37,9 @@ func TestClientEmptyTLSConfigUsesTLS(t *testing.T) {
 
 	conn, err := transportgrpc.NewClient(target, transportgrpc.WithClientTLS(&tls.Config{}))
 	require.NoError(t, err)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	_, err = client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -26,7 +26,9 @@ func TestInsecureUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -45,7 +47,9 @@ func TestCompressionUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldGRPC(), test.WithWorldCompression())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -61,7 +65,9 @@ func TestSecureUnary(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(), meta.NewPair("ip", meta.ToIgnored(net.ParseIP("192.168.8.0"))))
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -77,7 +83,9 @@ func TestStream(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(), test.WithTest(meta.Redacted("test")))
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -95,7 +103,9 @@ func TestStream(t *testing.T) {
 func TestServerRecoversUnaryPanic(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldGRPC())
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -113,7 +123,9 @@ func TestBreakerUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldGRPC(), test.WithWorldBreaker(test.NewBreaker(1)))
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -128,7 +140,9 @@ func TestBreakerUnary(t *testing.T) {
 func TestServerRecoversStreamPanic(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldGRPC())
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -150,7 +164,9 @@ func TestServerRecoversStreamPanic(t *testing.T) {
 func TestUnaryMaxReceiveSize(t *testing.T) {
 	world := newStartedGRPCWorld(t, 64)
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -162,7 +178,9 @@ func TestUnaryMaxReceiveSize(t *testing.T) {
 func TestStreamMaxReceiveSize(t *testing.T) {
 	world := newStartedGRPCWorld(t, 64)
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	stream, err := client.SayStreamHello(t.Context())
@@ -176,7 +194,9 @@ func TestStreamMaxReceiveSize(t *testing.T) {
 func TestUnaryMaxSendSize(t *testing.T) {
 	world := newStartedGRPCWorldWithOptions(t, 0, map[string]string{"max_send_msg_size": "64B"})
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -188,7 +208,9 @@ func TestUnaryMaxSendSize(t *testing.T) {
 func TestStreamMaxSendSize(t *testing.T) {
 	world := newStartedGRPCWorldWithOptions(t, 0, map[string]string{"max_send_msg_size": "64B"})
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	stream, err := client.SayStreamHello(t.Context())

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -32,7 +32,9 @@ func TestCheck(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -51,7 +53,9 @@ func TestCheckBypassesServerLimiter(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -71,7 +75,9 @@ func TestInvalidCheck(t *testing.T) {
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -108,7 +114,9 @@ func TestOverallCheck(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 
@@ -124,7 +132,9 @@ func TestInvalidOverallCheck(t *testing.T) {
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 
@@ -139,7 +149,9 @@ func TestNotFoundCheck(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: "bob"}
@@ -160,7 +172,9 @@ func TestIgnoreAuthCheck(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -184,7 +198,9 @@ func TestList(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.ListRequest{}
@@ -224,7 +240,9 @@ func TestWatch(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -252,7 +270,9 @@ func TestWatchStaysOpenPastServerTimeout(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -280,7 +300,9 @@ func TestWatchServerLimiter(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -313,7 +335,9 @@ func TestWatchServerLimiterStatusSend(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -332,7 +356,9 @@ func TestInvalidWatch(t *testing.T) {
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -355,7 +381,9 @@ func TestOverallWatch(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -377,7 +405,9 @@ func TestInvalidOverallWatch(t *testing.T) {
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -401,7 +431,9 @@ func TestUnknownOverallWatch(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -421,7 +453,9 @@ func TestNotFoundWatch(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: "bob"}
@@ -477,7 +511,9 @@ func TestIgnoreAuthWatch(t *testing.T) {
 	requireGRPCReady(t, world)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := health.NewClient(conn)
 	req := &health.Request{Service: test.Name.String()}
@@ -505,7 +541,7 @@ func TestWatchStatusChanges(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer probe.Close()
+	t.Cleanup(probe.Close)
 
 	world := newGRPCHealthWorld(t, probe.URL, test.WithWorldTelemetry("otlp"))
 

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -21,7 +21,9 @@ func TestServerLimiterUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -46,7 +48,9 @@ func TestServerLimiterStream(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 3)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -88,7 +92,9 @@ func TestServerLimiterStreamHeaderNotDuplicated(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 10)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -108,7 +114,9 @@ func TestClientLimiterUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -124,7 +132,9 @@ func TestClientLimiterStream(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 3)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -139,7 +149,9 @@ func TestClientLimiterStreamRecvRejected(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 2)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	stream, err := client.SayStreamHello(t.Context())
@@ -156,7 +168,9 @@ func TestClientLimiterStreamSendRejected(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 1)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	stream, err := client.SayStreamHello(t.Context())
@@ -177,7 +191,9 @@ func TestServerLimiterUsesVerifiedUserIDUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -199,7 +215,9 @@ func TestServerLimiterUsesVerifiedUserIDStream(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 
@@ -219,7 +237,9 @@ func TestLimiterUnlimitedUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -237,7 +257,9 @@ func TestLimiterAuthUnary(t *testing.T) {
 	)
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -257,7 +279,9 @@ func TestServerClosedLimiterUnary(t *testing.T) {
 	require.NoError(t, world.Server.GRPCLimiter.Close(t.Context()))
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}
@@ -271,7 +295,9 @@ func TestClientClosedLimiterUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 10)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
-	defer conn.Close()
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := v1.NewGreeterServiceClient(conn)
 	req := &v1.SayHelloRequest{Name: "test"}

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -70,6 +70,7 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 	maxAttempts := cfg.MaxAttempts()
 	timeout := cfg.GetTimeout()
 	backoff := cfg.GetBackoff()
+	maxBackoff := cfg.GetMaxBackoff()
 	strategy := cfg.GetStrategy()
 	codes := retryableCodes(cfg)
 
@@ -78,7 +79,12 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 			return attempt(ctx)
 		}
 
-		retries := retry.WithJitterPercent(config.DefaultJitterPercent, retry.NewBackoff(strategy, backoff))
+		strategyBackoff := retry.NewBackoff(strategy, backoff)
+		if maxBackoff > 0 {
+			strategyBackoff = retry.WithCappedDuration(maxBackoff, strategyBackoff)
+		}
+
+		retries := retry.WithJitterPercent(config.DefaultJitterPercent, strategyBackoff)
 		retries = retry.WithMaxRetries(maxAttempts-1, retries)
 		return retry.Do(ctx, retries, func(ctx context.Context) error {
 			err := attempt(ctx)

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -132,6 +132,26 @@ func TestUnaryClientInterceptorConfiguredCodesReplaceDefaults(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+func TestUnaryClientInterceptorCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
+	cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Timeout: time.Second, Attempts: config.MaxAttempts}
+	interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+
+	calls := 0
+	start := time.Now()
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.Unavailable, "unavailable")
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Equal(t, int(config.MaxAttempts), calls)
+	// Uncapped exponential growth from a 2ms base across 9 retries sums to ~1022ms; capping
+	// at 10ms bounds the same schedule to well under that, so a generous bound below the
+	// uncapped total still proves the cap is applied.
+	require.Less(t, elapsed, 400*time.Millisecond)
+}
+
 func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {
 	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 0))
 

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -39,6 +39,8 @@ import (
 //   - `Verifier`: enables server-side token verification when non-nil.
 //   - `Access`: enables server-side access control when non-nil.
 //   - `Unary`/`Stream`: allow callers to inject additional interceptors (and are optional in DI).
+//   - `Options`: allow callers to pass additional raw [grpc.ServerOption] values not modeled by this
+//     package (and is optional in DI).
 type ServerParams struct {
 	di.In
 
@@ -80,6 +82,12 @@ type ServerParams struct {
 
 	// Stream are additional stream server interceptors to append after the standard chain.
 	Stream []grpc.StreamServerInterceptor `optional:"true"`
+
+	// Options are additional gRPC server options appended after the built option list.
+	//
+	// This is an escape hatch for passing options not modeled by this package, such as
+	// grpc.InTapHandle, a second grpc.StatsHandler, or grpc.UnknownServiceHandler.
+	Options []grpc.ServerOption `optional:"true"`
 }
 
 // NewServer constructs a gRPC transport [Server] when the transport is enabled.
@@ -95,6 +103,7 @@ type ServerParams struct {
 //     followed by any user-provided interceptors.
 //   - A stream interceptor chain that performs metadata extraction/injection, and optionally logging,
 //     token verification, rate limiting, and access control, followed by any user-provided interceptors.
+//   - Any params.Options appended last, after the built option list.
 //
 // TLS:
 // If TLS is enabled in config, server credentials are built from `params.Config.TLS`. Certificate/key
@@ -126,6 +135,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	if metrics.IsEnabled() || tracer.IsEnabled() {
 		options = append(options, grpc.StatsHandler(telemetry.NewServerHandler()))
 	}
+	options = append(options, params.Options...)
 
 	grpcServer := grpc.NewServer(params.Config.Options, params.Config.GetTimeout(), options...)
 	cfg := &config.Config{Address: cmp.Or(params.Config.Address, net.DefaultAddress("9090"))}

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/config/server"
+	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	netgrpc "github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -78,4 +82,39 @@ func TestServerRejectsCAOnlyTLS(t *testing.T) {
 
 	_, err := grpc.NewServer(params)
 	require.ErrorIs(t, err, server.ErrMissingKeyPair)
+}
+
+func TestServerAppliesCallerServerOption(t *testing.T) {
+	rejected := errors.New("rejected by tap handle")
+	tapHandle := func(ctx context.Context, _ *netgrpc.TapInfo) (context.Context, error) {
+		return ctx, rejected
+	}
+
+	cfg := test.NewInsecureTransportConfig().GRPC
+	params := grpc.ServerParams{
+		Shutdowner:   test.NewShutdowner(),
+		Config:       cfg,
+		MethodPolicy: grpc.NewMethodPolicy(),
+		Options:      []netgrpc.ServerOption{netgrpc.InTapHandle(tapHandle)},
+	}
+
+	srv, err := grpc.NewServer(params)
+	require.NoError(t, err)
+
+	v1.RegisterGreeterServiceServer(srv.ServiceRegistrar(), test.NewService())
+	srv.GetService().Start()
+	t.Cleanup(func() {
+		require.NoError(t, srv.GetService().Stop(context.Background()))
+	})
+
+	conn, err := netgrpc.NewClient(srv.GetService().String(), netgrpc.WithTransportCredentials(netgrpc.NewInsecureCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	_, err = v1.NewGreeterServiceClient(conn).SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, rejected.Error())
 }

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -19,7 +19,9 @@ func TestSecure(t *testing.T) {
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -91,6 +91,7 @@ func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *Ro
 	return &RoundTripper{
 		RoundTripper: hrt,
 		backoff:      cfg.GetBackoff(),
+		maxBackoff:   cfg.GetMaxBackoff(),
 		strategy:     cfg.GetStrategy(),
 		policy:       composePolicy(policies),
 		maxRetries:   cfg.MaxRetries(),
@@ -115,6 +116,7 @@ type RoundTripper struct {
 	strategy    string
 	statusCodes []int
 	backoff     time.Duration
+	maxBackoff  time.Duration
 	maxRetries  uint64
 }
 
@@ -181,7 +183,12 @@ func (r *RoundTripper) retry(ctx context.Context, req *http.Request, attempt *ro
 		return res, err
 	}
 
-	backoff := retry.WithJitterPercent(config.DefaultJitterPercent, retry.NewBackoff(r.strategy, attempt.backoff))
+	strategyBackoff := retry.NewBackoff(r.strategy, attempt.backoff)
+	if r.maxBackoff > 0 {
+		strategyBackoff = retry.WithCappedDuration(r.maxBackoff, strategyBackoff)
+	}
+
+	backoff := retry.WithJitterPercent(config.DefaultJitterPercent, strategyBackoff)
 	backoff = retry.WithMaxRetries(attempt.maxRetries, backoff)
 	return retry.DoValue(ctx, backoff, operation)
 }

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -132,6 +132,30 @@ func TestRoundTripperClampsAttemptsAboveMax(t *testing.T) {
 	require.Equal(t, int(config.MaxAttempts), calls)
 }
 
+func TestRoundTripperCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return test.ResponseWithStatus(http.StatusTooManyRequests), nil
+	})
+	cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Attempts: config.MaxAttempts}
+	retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	start := time.Now()
+	res, err := retrying.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+	require.Equal(t, int(config.MaxAttempts), calls)
+	// Uncapped exponential growth from a 2ms base across 9 retries sums to ~1022ms; capping
+	// at 10ms bounds the same schedule to well under that, so a generous bound below the
+	// uncapped total still proves the cap is applied.
+	require.Less(t, elapsed, 400*time.Millisecond)
+}
+
 func TestRoundTripperDoesNotPanicWithOmittedBackoff(t *testing.T) {
 	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
 	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(1, 0), rt)

--- a/transport/retry/config.go
+++ b/transport/retry/config.go
@@ -53,6 +53,15 @@ type Config struct {
 	// A zero value applies DefaultBackoff. Negative values are invalid.
 	Backoff time.Duration `yaml:"backoff,omitempty" json:"backoff,omitempty" toml:"backoff,omitempty" validate:"gte=0"`
 
+	// MaxBackoff caps the per-attempt backoff duration for the exponential and fibonacci
+	// strategies. Without a cap, those strategies grow the wait between attempts
+	// unboundedly (aside from any overall context or client timeout).
+	//
+	// Value encoding: Go duration string (for example "5s", "30s").
+	// A zero value leaves backoff growth uncapped, preserving today's behavior. Negative
+	// values are invalid.
+	MaxBackoff time.Duration `yaml:"max_backoff,omitempty" json:"max_backoff,omitempty" toml:"max_backoff,omitempty" validate:"gte=0"`
+
 	// Attempts is the maximum number of attempts, including the initial attempt.
 	//
 	// The go-service transport convention is:
@@ -100,6 +109,17 @@ func (c *Config) GetBackoff() time.Duration {
 	}
 
 	return c.Backoff
+}
+
+// GetMaxBackoff returns the configured maximum backoff duration.
+//
+// A nil receiver or a non-positive value returns zero, meaning backoff growth is uncapped.
+func (c *Config) GetMaxBackoff() time.Duration {
+	if c == nil || c.MaxBackoff <= 0 {
+		return 0
+	}
+
+	return c.MaxBackoff
 }
 
 // GetStrategy returns the configured retry backoff strategy.

--- a/transport/retry/config_test.go
+++ b/transport/retry/config_test.go
@@ -16,6 +16,7 @@ func TestConfigRejectsNegativeDurations(t *testing.T) {
 	}{
 		{name: "timeout", cfg: &retry.Config{Timeout: -time.Second}},
 		{name: "backoff", cfg: &retry.Config{Backoff: -time.Second}},
+		{name: "max backoff", cfg: &retry.Config{MaxBackoff: -time.Second}},
 	}
 
 	for _, tt := range tests {
@@ -64,6 +65,25 @@ func TestConfigGetBackoff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, tt.cfg.GetBackoff())
+		})
+	}
+}
+
+func TestConfigGetMaxBackoff(t *testing.T) {
+	tests := []struct {
+		cfg  *retry.Config
+		name string
+		want time.Duration
+	}{
+		{name: "nil", want: 0},
+		{name: "zero", cfg: &retry.Config{}, want: 0},
+		{name: "negative", cfg: &retry.Config{MaxBackoff: -time.Second}, want: 0},
+		{name: "explicit", cfg: &retry.Config{MaxBackoff: time.Second}, want: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.cfg.GetMaxBackoff())
 		})
 	}
 }

--- a/transport/retry/doc.go
+++ b/transport/retry/doc.go
@@ -17,6 +17,10 @@
 // Timeout and Backoff are typed durations. In config files they are encoded as
 // Go duration strings (see [time.ParseDuration]), such as "250ms", "5s", or "1m".
 //
+// Strategy selects how Backoff grows across attempts ("constant", "exponential", or
+// "fibonacci"), and MaxBackoff optionally caps that growth so exponential/fibonacci
+// backoff plateaus instead of growing unbounded. A zero MaxBackoff leaves growth uncapped.
+//
 // # Transport interpretation
 //
 // Because this package does not implement retries directly, the exact semantics depend on


### PR DESCRIPTION
## What

- gRPC server: new optional `ServerParams.Options []grpc.ServerOption` escape hatch to install options this package does not model (for example `grpc.InTapHandle` for admission/overload rejection, a second stats handler, or an unknown-service handler), appended after the built option list. Adds `net/grpc.InTapHandle` plus `TapInfo`/`TapHandle` aliases. Mirrors the existing client `WithClientDialOption`.
- Retry: new `transport/retry.Config.MaxBackoff` (plus `GetMaxBackoff` and `retry.WithCappedDuration`) caps per-attempt backoff for the `exponential`/`fibonacci` strategies, applied before jitter in both the HTTP and gRPC retry paths. A zero value leaves backoff uncapped, preserving current behavior.
- Breaker: new `transport/breaker.Config.FailureRatio` and `MinRequests` open the breaker on a sustained error rate over the rolling interval; `FailureRatio` takes precedence over `ConsecutiveFailures` when set, and a zero value keeps today's consecutive-failure tripping.
- Docs/config: README and the hjson/toml/yml config fixtures document and exercise the three new fields.
- Test maintenance: converted teardown `defer`s (`Close`/`Stop`/`cleanup`) to `t.Cleanup` in `Test*` functions across the touched packages. Intentionally excluded `database/sql/pg` (context-dependent teardown must remain `defer`), example/benchmark functions (no `testing.T`), and non-teardown defers such as `cancel`, `tx.Rollback`, and `span.End`.
- All changes are additive; no existing public API, default, or behavior changes.

## Why

- Service authors on the standard `module.Server` wiring had no supported way to install a `grpc.ServerOption` the package does not model (admission control, overload shedding, a parallel stats backend, unknown-service proxying); the client already had this via `WithClientDialOption`.
- Exponential/fibonacci retry backoff grew without bound (limited only by the overall context/client timeout); an initial-plus-maximum backoff is the standard retry-policy shape and makes the schedule predictable.
- Consecutive-only breaker tripping never opens for a partially degraded upstream (failures interleaved with occasional successes); failure-rate tripping is the industry-standard mode and closes that gap.
- The `t.Cleanup` pass modernizes teardown and now asserts closer errors that the old `defer`s silently ignored.

## Testing

- `make specs` - passed (2331 tests, race + coverage)
- `make lint` - passed (0 issues)
- `make sec` - passed (0 vulnerabilities, 0 secrets; the pre-existing transitive `x/crypto/openpgp` advisory is unchanged and uncalled)
- New tests: a deterministic backoff-cap test; a failure-ratio table covering the minimum-request floor, the zero-request division guard, and precedence over consecutive failures; an end-to-end gRPC server test where a caller-supplied `InTapHandle` rejects a real client call; config-decode fixtures for the new fields; and negative-duration validation for `MaxBackoff`.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
