### PR TITLE
refactor(content): move accept list-item parsing into its own file

### DIFF
--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -47,7 +47,7 @@ type Content struct {
 func (c *Content) NewFromRequest(req *http.Request) Media {
 	mediaType := req.Header.Get(TypeKey)
 	if strings.IsEmpty(mediaType) {
-		mediaType = firstMediaType(req.Header.Get(AcceptKey))
+		mediaType = firstListItem(req.Header.Get(AcceptKey))
 	}
 
 	return c.newRequestMedia(mediaType)
@@ -60,7 +60,7 @@ func (c *Content) NewFromRequest(req *http.Request) Media {
 // If parsing fails, it falls back to JSON.
 // If the internal error media type is selected, it falls back to plain text.
 func (c *Content) NewFromAccept(req *http.Request) Media {
-	mediaType := firstMediaType(req.Header.Get(AcceptKey))
+	mediaType := firstListItem(req.Header.Get(AcceptKey))
 	if strings.IsEmpty(mediaType) {
 		mediaType = req.Header.Get(TypeKey)
 	}
@@ -94,39 +94,6 @@ func (c *Content) NewFromRequestBody(req *http.Request) (Media, error) {
 // If parsing fails, it falls back to JSON.
 func (c *Content) NewFromMedia(mediaType string) Media {
 	return NewMedia(mediaType, c.enc)
-}
-
-func firstMediaType(value string) string {
-	quoted := false
-	escaped := false
-
-	for index := range value {
-		if escaped {
-			// The preceding backslash quotes this character, so it cannot change the list state.
-			escaped = false
-			continue
-		}
-
-		if quoted && value[index] == '\\' {
-			// A quoted-pair protects the next character, including a quote or comma.
-			escaped = true
-			continue
-		}
-
-		if value[index] == '"' {
-			// Only an unescaped quote can enter or leave a quoted parameter value.
-			quoted = !quoted
-			continue
-		}
-
-		if value[index] == ',' && !quoted {
-			// An HTTP list comma ends the first media range only outside a quoted string.
-			return strings.TrimSpace(value[:index])
-		}
-	}
-
-	// Leave a single or malformed range intact so the media parser can accept or reject it.
-	return strings.TrimSpace(value)
 }
 
 func (c *Content) newRequestMedia(mediaType string) Media {

--- a/net/http/content/header.go
+++ b/net/http/content/header.go
@@ -1,0 +1,51 @@
+package content
+
+import "github.com/alexfalkowski/go-service/v2/strings"
+
+// firstListItem returns the first item of an HTTP list-valued header value.
+//
+// It splits on the first unquoted comma per RFC 9110 list syntax (https://www.rfc-editor.org/rfc/rfc9110#section-5.6.1),
+// so a comma inside a quoted parameter value does not end the first item. A backslash inside a quoted value
+// escapes the next character, including a quote or comma, per the quoted-pair rule.
+//
+// Surrounding whitespace around the returned item is trimmed.
+//
+// Examples:
+//
+//	firstListItem(`application/json`)                                  // "application/json"
+//	firstListItem(`application/json, text/html`)                       // "application/json"
+//	firstListItem(`application/yaml; profile="a,b", application/toml`) // `application/yaml; profile="a,b"`
+//	firstListItem(`application/yaml; profile="a\",b", application/toml`) // `application/yaml; profile="a\",b"`
+//	firstListItem(`application/yaml; profile="a,b`)                    // `application/yaml; profile="a,b` (malformed, returned as-is)
+func firstListItem(value string) string {
+	quoted := false
+	escaped := false
+
+	for index := range value {
+		if escaped {
+			// The preceding backslash quotes this character, so it cannot change the list state.
+			escaped = false
+			continue
+		}
+
+		if quoted && value[index] == '\\' {
+			// A quoted-pair protects the next character, including a quote or comma.
+			escaped = true
+			continue
+		}
+
+		if value[index] == '"' {
+			// Only an unescaped quote can enter or leave a quoted parameter value.
+			quoted = !quoted
+			continue
+		}
+
+		if value[index] == ',' && !quoted {
+			// An HTTP list comma ends the first item only outside a quoted string.
+			return strings.TrimSpace(value[:index])
+		}
+	}
+
+	// Leave a single or malformed item intact so the caller can accept or reject it.
+	return strings.TrimSpace(value)
+}


### PR DESCRIPTION
## What

- Moved the unexported first-item-of-an-HTTP-list helper out of `content.go` into a new `header.go` file in the same package, and renamed it from `firstMediaType` to `firstListItem`.
- Added a GoDoc comment describing the RFC 9110 list-syntax splitting behavior, with worked examples covering a plain list, a quoted comma inside a parameter, an escaped quote followed by a comma, and the malformed/unterminated-quote fallback.
- Call sites in `NewFromRequest` and `NewFromAccept` now use the renamed helper; there is no behavior change.

## Why

- The helper's algorithm (quote-aware first-item split of a comma-separated header value) is generic HTTP list syntax, not media-type-specific — it would apply equally to any list-valued header. Keeping it named and filed as a media concern conflated two different responsibilities inside `content.go`: content negotiation and generic header-list parsing.
- Giving it its own file, a name that describes what it actually does, and documented examples makes the quoting edge cases (already covered by tests) discoverable without reading the implementation line by line.

## Testing

- `make specs package=net/http/content` - passed (99 tests, including existing quoted-comma and malformed-quote fixtures exercised through the renamed helper)
- `make lint package=net/http/content` - passed, 0 issues
- `make sec` - passed, no vulnerabilities found in this code
- No new tests were added; this is a non-behavioral move/rename, and the pre-existing fixture coverage in `content_test.go` continues to pass unchanged.
