### PR TITLE
feat(token): cache resolved key material per process and drop the unused facade name parameter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,16 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   compatibility. Report only concrete bugs where repository-generated RSA keys
   fail to load, weak keys are accepted, secrets leak, or the documented support
   boundary changes.
+- Crypto key generation is intentionally not a `crypto`-package product surface.
+  The `crypto/{aes,hmac,ed25519,rsa,ssh}` `Generator` types exist to produce
+  config-compatible key material, but a runnable, user-facing generation entry
+  point (CLI command, aggregating facade, make target, or shipped example) is
+  intentionally out of scope for this repository; key generation lives in a
+  dedicated CLI. Do not flag the absence of a runnable crypto key-generation
+  command/facade/recipe, or the fact that the `Generator` types have only test
+  callers, as a feature or DX gap. Report only concrete bugs where a generator
+  emits material that its own matching `Config` loader rejects, or where
+  documented generation behavior is wrong.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
 - `net/header.ForwardedIPs` is intentionally an exported mutable list, similar

--- a/token/errors/errors.go
+++ b/token/errors/errors.go
@@ -18,13 +18,19 @@ var (
 	// ErrInvalidIssuer is a sentinel error indicating the issuer claim is invalid.
 	//
 	// For claim-based token formats, this commonly corresponds to an "iss" claim
-	// mismatch. Implementations should wrap this error to preserve additional context.
+	// mismatch. The JWT verifier returns this sentinel on issuer mismatch, so callers
+	// can detect it with errors.Is. The PASETO verifier instead surfaces issuer rule
+	// failures as an upstream [github.com/alexfalkowski/go-service/v2/token/paseto.RuleError],
+	// which does not match this sentinel; SSH tokens do not carry an issuer.
 	ErrInvalidIssuer = errors.New("token: invalid issuer")
 
 	// ErrInvalidAudience is a sentinel error indicating the audience claim is invalid.
 	//
 	// For claim-based token formats, this commonly corresponds to an "aud" claim
-	// mismatch. Implementations should wrap this error to preserve additional context.
+	// mismatch. The JWT and SSH verifiers return this sentinel on audience mismatch, so
+	// callers can detect it with errors.Is. The PASETO verifier instead surfaces audience
+	// rule failures as an upstream [github.com/alexfalkowski/go-service/v2/token/paseto.RuleError],
+	// which does not match this sentinel.
 	ErrInvalidAudience = errors.New("token: invalid audience")
 
 	// ErrInvalidSubject is a sentinel error indicating the subject claim is invalid.

--- a/token/keys/keys.go
+++ b/token/keys/keys.go
@@ -4,6 +4,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
+	"github.com/alexfalkowski/go-sync"
 )
 
 // Map maps key ids to Ed25519 token key material.
@@ -22,9 +23,16 @@ func (m Map) Get(id string) *Config {
 type Config struct {
 	// Config contains the Ed25519 public/private key sources.
 	*ed25519.Config `yaml:",inline" json:",inline" toml:",inline"`
+
+	signer   sync.Pointer[ed25519.Signer]
+	verifier sync.Pointer[ed25519.Verifier]
 }
 
 // Signer loads an Ed25519 signer for k.
+//
+// The signer is resolved at most once per process lifetime and reused for
+// subsequent calls. Only a successful load is cached, so a transient read or
+// parse failure is retried on the next call rather than being cached forever.
 //
 // It returns [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig]
 // when k is nil, its embedded key config is nil, or decoder is nil.
@@ -33,10 +41,27 @@ func (k *Config) Signer(decoder *pem.Decoder) (*ed25519.Signer, error) {
 		return nil, errors.ErrInvalidConfig
 	}
 
-	return ed25519.NewSigner(decoder, k.Config)
+	if s := k.signer.Load(); s != nil {
+		return s, nil
+	}
+
+	s, err := ed25519.NewSigner(decoder, k.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	if !k.signer.CompareAndSwap(nil, s) {
+		s = k.signer.Load()
+	}
+
+	return s, nil
 }
 
 // Verifier loads an Ed25519 verifier for k.
+//
+// The verifier is resolved at most once per process lifetime and reused for
+// subsequent calls. Only a successful load is cached, so a transient read or
+// parse failure is retried on the next call rather than being cached forever.
 //
 // It returns [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig]
 // when k is nil, its embedded key config is nil, or decoder is nil.
@@ -45,5 +70,18 @@ func (k *Config) Verifier(decoder *pem.Decoder) (*ed25519.Verifier, error) {
 		return nil, errors.ErrInvalidConfig
 	}
 
-	return ed25519.NewVerifier(decoder, k.Config)
+	if v := k.verifier.Load(); v != nil {
+		return v, nil
+	}
+
+	v, err := ed25519.NewVerifier(decoder, k.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	if !k.verifier.CompareAndSwap(nil, v) {
+		v = k.verifier.Load()
+	}
+
+	return v, nil
 }

--- a/token/keys/keys_test.go
+++ b/token/keys/keys_test.go
@@ -3,10 +3,12 @@ package keys_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/keys"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,9 +67,86 @@ func TestConfigLoaders(t *testing.T) {
 				})
 			}
 
-			key, err := loader.load(&keys.Config{Config: test.NewEd25519()}, test.PEM)
+			cfg := &keys.Config{Config: test.NewEd25519()}
+
+			key, err := loader.load(cfg, test.PEM)
 			require.NoError(t, err)
 			require.NotNil(t, key)
+
+			again, err := loader.load(cfg, test.PEM)
+			require.NoError(t, err)
+			require.Same(t, key, again)
+		})
+	}
+}
+
+func TestConfigLoaderRetriesAfterFailure(t *testing.T) {
+	loaders := []struct {
+		load func(*keys.Config, *pem.Decoder) (any, error)
+		name string
+	}{
+		{name: "signer", load: func(cfg *keys.Config, decoder *pem.Decoder) (any, error) {
+			return cfg.Signer(decoder)
+		}},
+		{name: "verifier", load: func(cfg *keys.Config, decoder *pem.Decoder) (any, error) {
+			return cfg.Verifier(decoder)
+		}},
+	}
+
+	for _, loader := range loaders {
+		t.Run(loader.name, func(t *testing.T) {
+			cfg := &keys.Config{Config: &ed25519.Config{}}
+
+			_, err := loader.load(cfg, test.PEM)
+			require.Error(t, err)
+
+			cfg.Config = test.NewEd25519()
+
+			key, err := loader.load(cfg, test.PEM)
+			require.NoError(t, err)
+			require.NotNil(t, key)
+		})
+	}
+}
+
+func TestConfigLoaderConcurrentAccessReturnsSameInstance(t *testing.T) {
+	loaders := []struct {
+		load func(*keys.Config, *pem.Decoder) (any, error)
+		name string
+	}{
+		{name: "signer", load: func(cfg *keys.Config, decoder *pem.Decoder) (any, error) {
+			return cfg.Signer(decoder)
+		}},
+		{name: "verifier", load: func(cfg *keys.Config, decoder *pem.Decoder) (any, error) {
+			return cfg.Verifier(decoder)
+		}},
+	}
+
+	for _, loader := range loaders {
+		t.Run(loader.name, func(t *testing.T) {
+			cfg := &keys.Config{Config: test.NewEd25519()}
+
+			const goroutines = 16
+
+			var group sync.WaitGroup
+
+			results := make([]any, goroutines)
+			errs := make([]error, goroutines)
+
+			group.Add(goroutines)
+			for i := range goroutines {
+				go func(i int) {
+					defer group.Done()
+
+					results[i], errs[i] = loader.load(cfg, test.PEM)
+				}(i)
+			}
+			group.Wait()
+
+			for i := range goroutines {
+				require.NoError(t, errs[i])
+				require.Same(t, results[0], results[i])
+			}
 		})
 	}
 }

--- a/token/ssh/config.go
+++ b/token/ssh/config.go
@@ -2,8 +2,11 @@ package ssh
 
 import (
 	"github.com/alexfalkowski/go-service/v2/crypto/ssh"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
+	token "github.com/alexfalkowski/go-service/v2/token/errors"
+	"github.com/alexfalkowski/go-sync"
 )
 
 // Config configures the SSH-style token implementation.
@@ -78,6 +81,67 @@ func (c *Config) IsEnabled() bool {
 type Key struct {
 	// Config contains the SSH key material configuration (public/private key sources).
 	*ssh.Config `yaml:",inline" json:",inline" toml:",inline"`
+
+	signer   sync.Pointer[ssh.Signer]
+	verifier sync.Pointer[ssh.Verifier]
+}
+
+// Signer loads an SSH signer for k.
+//
+// The signer is resolved at most once per process lifetime and reused for
+// subsequent calls. Only a successful load is cached, so a transient read or
+// parse failure is retried on the next call rather than being cached forever.
+//
+// It returns [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig]
+// when k is nil, its embedded key config is nil, or fs is nil.
+func (k *Key) Signer(fs *os.FS) (*ssh.Signer, error) {
+	if k == nil || k.Config == nil || fs == nil {
+		return nil, token.ErrInvalidConfig
+	}
+
+	if s := k.signer.Load(); s != nil {
+		return s, nil
+	}
+
+	s, err := ssh.NewSigner(fs, k.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	if !k.signer.CompareAndSwap(nil, s) {
+		s = k.signer.Load()
+	}
+
+	return s, nil
+}
+
+// Verifier loads an SSH verifier for k.
+//
+// The verifier is resolved at most once per process lifetime and reused for
+// subsequent calls. Only a successful load is cached, so a transient read or
+// parse failure is retried on the next call rather than being cached forever.
+//
+// It returns [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig]
+// when k is nil, its embedded key config is nil, or fs is nil.
+func (k *Key) Verifier(fs *os.FS) (*ssh.Verifier, error) {
+	if k == nil || k.Config == nil || fs == nil {
+		return nil, token.ErrInvalidConfig
+	}
+
+	if v := k.verifier.Load(); v != nil {
+		return v, nil
+	}
+
+	v, err := ssh.NewVerifier(fs, k.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	if !k.verifier.CompareAndSwap(nil, v) {
+		v = k.verifier.Load()
+	}
+
+	return v, nil
 }
 
 // Keys maps key ids to SSH key material.

--- a/token/ssh/ssh.go
+++ b/token/ssh/ssh.go
@@ -92,7 +92,7 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 		return strings.Empty, token.ErrInvalidConfig
 	}
 
-	sig, err := ssh.NewSigner(t.fs, key.Config)
+	sig, err := key.Signer(t.fs)
 	if err != nil {
 		return strings.Empty, err
 	}
@@ -170,7 +170,7 @@ func (t *Token) Verify(tkn, aud string) (string, error) {
 		return strings.Empty, token.ErrInvalidConfig
 	}
 
-	verifier, err := ssh.NewVerifier(t.fs, cfg.Config)
+	verifier, err := cfg.Verifier(t.fs)
 	if err != nil {
 		return strings.Empty, err
 	}

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/token/errors"
 	"github.com/alexfalkowski/go-service/v2/token/ssh"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -560,6 +562,123 @@ func TestKeysGet(t *testing.T) {
 	require.Nil(t, keys.Get("missing"))
 	require.Nil(t, ssh.Keys{}.Get("missing"))
 	require.Nil(t, ssh.Keys(nil).Get("missing"))
+}
+
+func TestKeyLoaders(t *testing.T) {
+	loaders := []struct {
+		load func(*ssh.Key, *os.FS) (any, error)
+		name string
+	}{
+		{name: "signer", load: func(key *ssh.Key, fs *os.FS) (any, error) {
+			return key.Signer(fs)
+		}},
+		{name: "verifier", load: func(key *ssh.Key, fs *os.FS) (any, error) {
+			return key.Verifier(fs)
+		}},
+	}
+
+	invalid := []struct {
+		key  *ssh.Key
+		fs   *os.FS
+		name string
+	}{
+		{name: "nil key", fs: test.FS},
+		{name: "missing key config", key: &ssh.Key{}, fs: test.FS},
+		{name: "missing fs", key: &ssh.Key{Config: test.NewSSH("secrets/ssh_public", "secrets/ssh_private")}},
+	}
+
+	for _, loader := range loaders {
+		t.Run(loader.name, func(t *testing.T) {
+			for _, tt := range invalid {
+				t.Run(tt.name, func(t *testing.T) {
+					key, err := loader.load(tt.key, tt.fs)
+					require.Nil(t, key)
+					require.ErrorIs(t, err, errors.ErrInvalidConfig)
+				})
+			}
+
+			cfg := &ssh.Key{Config: test.NewSSH("secrets/ssh_public", "secrets/ssh_private")}
+
+			key, err := loader.load(cfg, test.FS)
+			require.NoError(t, err)
+			require.NotNil(t, key)
+
+			again, err := loader.load(cfg, test.FS)
+			require.NoError(t, err)
+			require.Same(t, key, again)
+		})
+	}
+}
+
+func TestKeyLoaderRetriesAfterFailure(t *testing.T) {
+	loaders := []struct {
+		load func(*ssh.Key, *os.FS) (any, error)
+		name string
+	}{
+		{name: "signer", load: func(key *ssh.Key, fs *os.FS) (any, error) {
+			return key.Signer(fs)
+		}},
+		{name: "verifier", load: func(key *ssh.Key, fs *os.FS) (any, error) {
+			return key.Verifier(fs)
+		}},
+	}
+
+	for _, loader := range loaders {
+		t.Run(loader.name, func(t *testing.T) {
+			key := &ssh.Key{Config: test.NewSSH("secrets/none", "secrets/none")}
+
+			_, err := loader.load(key, test.FS)
+			require.Error(t, err)
+
+			key.Config = test.NewSSH("secrets/ssh_public", "secrets/ssh_private")
+
+			k, err := loader.load(key, test.FS)
+			require.NoError(t, err)
+			require.NotNil(t, k)
+		})
+	}
+}
+
+func TestKeyLoaderConcurrentAccessReturnsSameInstance(t *testing.T) {
+	loaders := []struct {
+		load func(*ssh.Key, *os.FS) (any, error)
+		name string
+	}{
+		{name: "signer", load: func(key *ssh.Key, fs *os.FS) (any, error) {
+			return key.Signer(fs)
+		}},
+		{name: "verifier", load: func(key *ssh.Key, fs *os.FS) (any, error) {
+			return key.Verifier(fs)
+		}},
+	}
+
+	for _, loader := range loaders {
+		t.Run(loader.name, func(t *testing.T) {
+			key := &ssh.Key{Config: test.NewSSH("secrets/ssh_public", "secrets/ssh_private")}
+
+			const goroutines = 16
+
+			var group sync.WaitGroup
+
+			results := make([]any, goroutines)
+			errs := make([]error, goroutines)
+
+			group.Add(goroutines)
+			for i := range goroutines {
+				go func(i int) {
+					defer group.Done()
+
+					results[i], errs[i] = loader.load(key, test.FS)
+				}(i)
+			}
+			group.Wait()
+
+			for i := range goroutines {
+				require.NoError(t, errs[i])
+				require.Same(t, results[0], results[i])
+			}
+		})
+	}
 }
 
 func sshClaims(cfg *ssh.Config, issuedAt, expiresAt time.Time) map[string]any {

--- a/token/token.go
+++ b/token/token.go
@@ -2,7 +2,6 @@ package token
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/os"
@@ -30,13 +29,13 @@ import (
 //
 // Unknown kinds are treated as invalid configuration by the facade methods: Generate and Verify
 // return [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidConfig].
-func NewToken(name env.Name, cfg *Config, fs *os.FS, gen id.Generator) *Token {
+func NewToken(cfg *Config, fs *os.FS, gen id.Generator) *Token {
 	if !cfg.IsEnabled() {
 		return nil
 	}
 
 	return &Token{
-		name: name, cfg: cfg,
+		cfg:    cfg,
 		jwt:    jwt.NewToken(cfg.JWT, fs, gen),
 		paseto: paseto.NewToken(cfg.Paseto, fs, gen),
 		ssh:    ssh.NewToken(cfg.SSH, fs),
@@ -52,7 +51,6 @@ type Token struct {
 	jwt    *jwt.Token
 	paseto *paseto.Token
 	ssh    *ssh.Token
-	name   env.Name
 }
 
 // Generate creates a token for the configured kind.

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -20,7 +20,7 @@ func TestGenerate(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
 			gen := uuid.NewGenerator()
-			tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+			tkn := token.NewToken(cfg, test.FS, gen)
 
 			_, err := tkn.Generate("hello", test.UserID.String())
 			require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestVerify(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
 			gen := uuid.NewGenerator()
-			tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+			tkn := token.NewToken(cfg, test.FS, gen)
 
 			token, err := tkn.Generate("hello", test.UserID.String())
 			require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestVerify(t *testing.T) {
 
 	t.Run("ssh", func(t *testing.T) {
 		cfg := test.NewToken("ssh")
-		tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+		tkn := token.NewToken(cfg, test.FS, nil)
 
 		gen, err := tkn.Generate("hello", strings.Empty)
 		require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestVerify(t *testing.T) {
 func TestVerifyDispatchesJWTToConcreteImplementation(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
-	tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+	tkn := token.NewToken(cfg, test.FS, gen)
 
 	raw, err := tkn.Generate("hello", test.UserID.String())
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestVerifyDispatchesJWTToConcreteImplementation(t *testing.T) {
 func TestVerifyDispatchesPasetoToConcreteImplementation(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
-	tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+	tkn := token.NewToken(cfg, test.FS, gen)
 
 	raw, err := tkn.Generate("hello", test.UserID.String())
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestVerifyDispatchesPasetoToConcreteImplementation(t *testing.T) {
 
 func TestVerifyDispatchesSSHToConcreteImplementation(t *testing.T) {
 	cfg := test.NewToken("ssh")
-	tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+	tkn := token.NewToken(cfg, test.FS, nil)
 
 	raw, err := tkn.Generate("hello", strings.Empty)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestVerifyDispatchesSSHToConcreteImplementation(t *testing.T) {
 func TestVerifyRejectsPasetoEmptySubject(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
-	tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+	tkn := token.NewToken(cfg, test.FS, gen)
 
 	raw, err := tkn.Generate("hello", strings.Empty)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestVerifyRejectsPasetoEmptySubject(t *testing.T) {
 func TestVerifyRejectsJWTEmptySubject(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
-	tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+	tkn := token.NewToken(cfg, test.FS, gen)
 
 	raw, err := tkn.Generate("hello", strings.Empty)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestVerifyRejectsJWTEmptySubject(t *testing.T) {
 
 func TestSSHSubjectMatchesActiveKey(t *testing.T) {
 	cfg := test.NewToken("ssh")
-	tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+	tkn := token.NewToken(cfg, test.FS, nil)
 
 	raw, err := tkn.Generate("hello", "ignored-subject")
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 
 func TestUnknownKindConfig(t *testing.T) {
 	cfg := test.NewToken("none")
-	tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+	tkn := token.NewToken(cfg, test.FS, nil)
 
 	gen, err := tkn.Generate("hello", test.UserID.String())
 	require.Nil(t, gen)
@@ -204,7 +204,7 @@ func TestUnknownKindConfig(t *testing.T) {
 }
 
 func TestNewTokenWithNilConfig(t *testing.T) {
-	tkn := token.NewToken(test.Name, nil, test.FS, nil)
+	tkn := token.NewToken(nil, test.FS, nil)
 	require.Nil(t, tkn)
 }
 
@@ -212,7 +212,7 @@ func TestInvalidKindConfig(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto", "ssh"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := &token.Config{Kind: kind}
-			tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+			tkn := token.NewToken(cfg, test.FS, nil)
 
 			gen, err := tkn.Generate("hello", test.UserID.String())
 			require.Nil(t, gen)
@@ -229,7 +229,7 @@ func TestInvalidDependenciesDoNotPanic(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
-			tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+			tkn := token.NewToken(cfg, test.FS, nil)
 
 			gen, err := tkn.Generate("hello", test.UserID.String())
 			require.Nil(t, gen)
@@ -244,7 +244,7 @@ func TestInvalidMatchClassification(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
-			tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+			tkn := token.NewToken(cfg, test.FS, gen)
 
 			sub, err := tkn.Verify([]byte("test"), "hello")
 			require.Equal(t, strings.Empty, sub)
@@ -254,7 +254,7 @@ func TestInvalidMatchClassification(t *testing.T) {
 
 	t.Run("ssh", func(t *testing.T) {
 		cfg := test.NewToken("ssh")
-		tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+		tkn := token.NewToken(cfg, test.FS, nil)
 
 		sub, err := tkn.Verify([]byte("test"), "hello")
 		require.Equal(t, strings.Empty, sub)

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -154,7 +154,7 @@ func TestValidAuthUnary(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
 			gen := uuid.NewGenerator()
-			tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+			tkn := token.NewToken(cfg, test.FS, gen)
 
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(tkn, tkn), test.WithWorldGRPC())
 
@@ -201,7 +201,7 @@ func TestAccessDeniedUnary(t *testing.T) {
 
 func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	cfg := test.NewToken("none")
-	tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+	tkn := token.NewToken(cfg, test.FS, nil)
 
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(test.NewGenerator("test", nil), tkn), test.WithWorldGRPC())
 

--- a/transport/grpc/token.go
+++ b/transport/grpc/token.go
@@ -1,7 +1,6 @@
 package grpc
 
 import (
-	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
@@ -14,9 +13,9 @@ import (
 //
 // If cfg is disabled or cfg.Token is omitted, it returns nil so downstream wiring can treat token auth
 // as not configured.
-func NewToken(name env.Name, cfg *Config, fs *os.FS, gen id.Generator) *token.Token {
+func NewToken(cfg *Config, fs *os.FS, gen id.Generator) *token.Token {
 	if !cfg.IsEnabled() || !cfg.Token.IsEnabled() {
 		return nil
 	}
-	return token.NewToken(name, cfg.Token, fs, gen)
+	return token.NewToken(cfg.Token, fs, gen)
 }

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -24,11 +24,11 @@ import (
 // JWT/PASETO/SSH token kinds as configured by the underlying token package).
 //
 // If cfg is disabled, it returns nil so callers can treat token auth as not configured.
-func NewToken(name env.Name, cfg *token.Config, fs *os.FS, gen id.Generator) *Token {
+func NewToken(cfg *token.Config, fs *os.FS, gen id.Generator) *Token {
 	if !cfg.IsEnabled() {
 		return nil
 	}
-	return &Token{Token: token.NewToken(name, cfg, fs, gen)}
+	return &Token{Token: token.NewToken(cfg, fs, gen)}
 }
 
 // Token wraps *[github.com/alexfalkowski/go-service/v2/token.Token] for gRPC transport integration.

--- a/transport/grpc/token_test.go
+++ b/transport/grpc/token_test.go
@@ -9,6 +9,6 @@ import (
 )
 
 func TestNewTokenWithoutTokenConfig(t *testing.T) {
-	tkn := grpc.NewToken(test.Name, test.NewGRPCTransportConfig(), nil, nil)
+	tkn := grpc.NewToken(test.NewGRPCTransportConfig(), nil, nil)
 	require.Nil(t, tkn)
 }

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -22,7 +22,7 @@ func TestTokenAuthUnary(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
 			gen := uuid.NewGenerator()
-			tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+			tkn := token.NewToken(cfg, test.FS, gen)
 
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(tkn, tkn), test.WithWorldHTTP())
 
@@ -46,7 +46,7 @@ func TestTokenAuthUnary(t *testing.T) {
 
 func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	cfg := test.NewToken("none")
-	tkn := token.NewToken(test.Name, cfg, test.FS, nil)
+	tkn := token.NewToken(cfg, test.FS, nil)
 
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(test.NewGenerator("test", nil), tkn), test.WithWorldHTTP())
 

--- a/transport/http/metrics_test.go
+++ b/transport/http/metrics_test.go
@@ -40,7 +40,7 @@ func TestPrometheusHTTP(t *testing.T) {
 func TestPrometheusAuthHTTP(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
-	tkn := token.NewToken(test.Name, cfg, test.FS, gen)
+	tkn := token.NewToken(cfg, test.FS, gen)
 
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("prometheus"),

--- a/transport/http/token.go
+++ b/transport/http/token.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
@@ -14,9 +13,9 @@ import (
 //
 // If cfg is disabled or cfg.Token is omitted, it returns nil so downstream wiring can treat token auth
 // as not configured.
-func NewToken(name env.Name, cfg *Config, fs *os.FS, gen id.Generator) *token.Token {
+func NewToken(cfg *Config, fs *os.FS, gen id.Generator) *token.Token {
 	if !cfg.IsEnabled() || !cfg.Token.IsEnabled() {
 		return nil
 	}
-	return token.NewToken(name, cfg.Token, fs, gen)
+	return token.NewToken(cfg.Token, fs, gen)
 }

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -20,11 +20,11 @@ import (
 // JWT/PASETO/SSH token kinds as configured by the underlying token package).
 //
 // If cfg is disabled, it returns nil so callers can treat token auth as not configured.
-func NewToken(name env.Name, cfg *token.Config, fs *os.FS, gen id.Generator) *Token {
+func NewToken(cfg *token.Config, fs *os.FS, gen id.Generator) *Token {
 	if !cfg.IsEnabled() {
 		return nil
 	}
-	return &Token{Token: token.NewToken(name, cfg, fs, gen)}
+	return &Token{Token: token.NewToken(cfg, fs, gen)}
 }
 
 // Token wraps *[github.com/alexfalkowski/go-service/v2/token.Token] for HTTP transport integration.

--- a/transport/http/token_test.go
+++ b/transport/http/token_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewTokenWithoutTokenConfig(t *testing.T) {
-	tkn := http.NewToken(test.Name, test.NewHTTPTransportConfig(), nil, nil)
+	tkn := http.NewToken(test.NewHTTPTransportConfig(), nil, nil)
 	require.Nil(t, tkn)
 }
 
@@ -22,7 +22,7 @@ func TestNewTokenWithTokenConfig(t *testing.T) {
 	cfg.Token = test.NewToken("jwt")
 	gen := uuid.NewGenerator()
 
-	tkn := http.NewToken(test.Name, cfg, test.FS, gen)
+	tkn := http.NewToken(cfg, test.FS, gen)
 
 	require.NotNil(t, tkn)
 	require.NotNil(t, token.NewGenerator(tkn))


### PR DESCRIPTION
## What

- Cache resolved key material per process: `token/keys.Config` (Ed25519) and `token/ssh.Key` (SSH) now resolve their signer/verifier at most once and reuse it, via a concurrency-safe `sync.Pointer` that caches only successful loads (a transient read/parse failure is retried, not cached forever). Token `Generate`/`Verify` no longer re-read the key source and re-parse PEM/SSH material on every request. Key rotation still requires a process restart, matching the existing pinned-material model.
- Remove the unused `name env.Name` argument from the token constructor chain: `token.NewToken` and the DI-wired transport constructors (`transport/grpc.NewToken`, `transport/http.NewToken`, `transport/grpc/token.NewToken`, `transport/http/token.NewToken`) no longer accept `name`. It was threaded through three layers and never used. This is a public API change, but every call site is wired by DI, so no external service call site is affected.
- Clarify `token/errors` sentinel docs: `ErrInvalidIssuer` and `ErrInvalidAudience` now state that the JWT verifier (and SSH, for audience) return these sentinels, while the PASETO verifier surfaces issuer/audience rule failures as an upstream `paseto.RuleError` that does not match them.
- Add an `AGENTS.md` note recording that a runnable crypto key-generation entry point is intentionally out of scope for the `crypto` package.

## Why

- Re-reading and re-parsing unchanging key material on every authenticated request added avoidable filesystem I/O and CPU on the auth hot path for `file:`-sourced keys, and coupled steady-state auth to the key file remaining continuously readable. Caching removes both while keeping fail-closed behavior and the restart-based rotation model. This addresses the REL-1 reliability finding recorded for this package.
- The `name` parameter was dead weight on the public constructor surface; removing it simplifies the facade and transport wiring with no behavioral loss.
- The previous sentinel docs implied issuer/audience mismatches surface uniformly across kinds, which is false for PASETO; the clarified docs stop consumers relying on `errors.Is` with those sentinels for the PASETO kind.

## Testing

- `make lint` - passed (0 issues)
- `go build ./...` - passed
- `go vet ./token/...` - passed
- `go test ./token/...` - passed (facade, access, jwt, paseto, keys, ssh)
- Transport integration tests (`make specs`) were not run locally: the sandbox cannot bind network listeners (`bind: operation not permitted` / `httptest` panic). CI exercises the HTTP/gRPC auth, token, and metrics integration paths.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
