### PR TITLE
feat(hooks): add configurable webhook timestamp leeway

### DIFF
--- a/hooks/config.go
+++ b/hooks/config.go
@@ -1,5 +1,7 @@
 package hooks
 
+import "github.com/alexfalkowski/go-service/v2/time"
+
 // Config configures Standard Webhooks secret loading.
 type Config struct {
 	// Secrets contains named Standard Webhooks secrets trusted for verification.
@@ -12,6 +14,15 @@ type Config struct {
 	//
 	// The selected entry must exist in Secrets.
 	Key string `yaml:"key,omitempty" json:"key,omitempty" toml:"key,omitempty"`
+
+	// Leeway is the optional clock-skew tolerance applied to the Webhook-Timestamp
+	// freshness check during verification.
+	//
+	// A zero value keeps the Standard Webhooks library's fixed 5-minute freshness
+	// window. A non-zero value replaces that fixed window with this configured
+	// tolerance, matching the clock-skew Leeway already exposed by the JWT,
+	// PASETO, and SSH token verifiers.
+	Leeway time.Duration `yaml:"leeway,omitempty" json:"leeway,omitempty" toml:"leeway,omitempty" validate:"omitempty,duration_second_precision"`
 }
 
 // IsEnabled reports whether hooks configuration is present.

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"maps"
+	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/crypto/rand"
@@ -50,6 +51,7 @@ func (g *Generator) Generate() (string, error) {
 type Hook struct {
 	signer    *webhooks.Webhook
 	verifiers []*webhooks.Webhook
+	leeway    time.Duration
 }
 
 // Sign computes a Standard Webhooks signature with the active secret.
@@ -58,13 +60,24 @@ func (h *Hook) Sign(id string, timestamp time.Time, payload []byte) (string, err
 }
 
 // Verify verifies payload and headers against the configured trusted secrets.
+//
+// When [Config.Leeway] is zero, the Webhook-Timestamp freshness check uses the
+// Standard Webhooks library's fixed 5-minute window. When [Config.Leeway] is
+// non-zero, Verify checks Webhook-Timestamp against that configured window
+// itself, then verifies the signature ignoring the library's own timestamp check.
 func (h *Hook) Verify(payload []byte, headers http.Header) error {
+	if h.leeway != 0 {
+		if err := verifyTimestamp(headers, h.leeway); err != nil {
+			return err
+		}
+	}
+
 	// Standard Webhooks signs the message id, timestamp, and payload, but it does
 	// not include a signing key id. During rotation we therefore verify against the
 	// configured trusted secrets in order and accept the first match.
 	err := ErrInvalidConfig
 	for _, verifier := range h.verifiers {
-		if verifyErr := verifier.Verify(payload, headers); verifyErr != nil {
+		if verifyErr := h.verifySignature(verifier, payload, headers); verifyErr != nil {
 			err = verifyErr
 		} else {
 			return nil
@@ -72,6 +85,46 @@ func (h *Hook) Verify(payload []byte, headers http.Header) error {
 	}
 
 	return err
+}
+
+func (h *Hook) verifySignature(verifier *webhooks.Webhook, payload []byte, headers http.Header) error {
+	if h.leeway != 0 {
+		return verifier.VerifyIgnoringTimestamp(payload, headers)
+	}
+
+	return verifier.Verify(payload, headers)
+}
+
+// verifyTimestamp checks the Webhook-Timestamp header against a configured leeway window.
+//
+// A missing or unparsable header is left for the downstream Standard Webhooks verifier to reject with its
+// own required/invalid header error, so this check only reports freshness failures.
+func verifyTimestamp(headers http.Header, leeway time.Duration) error {
+	ts, ok := parseWebhookTimestamp(headers)
+	if !ok {
+		return nil
+	}
+
+	now := time.Now()
+
+	if now.Sub(ts) > leeway.Duration() {
+		return webhooks.ErrMessageTooOld
+	}
+
+	if ts.After(now.Add(leeway.Duration())) {
+		return webhooks.ErrMessageTooNew
+	}
+
+	return nil
+}
+
+func parseWebhookTimestamp(headers http.Header) (time.Time, bool) {
+	sec, err := strconv.ParseInt(headers.Get(webhooks.HeaderWebhookTimestamp), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return time.Unix(sec), true
 }
 
 // NewHook constructs a Standard Webhooks hook from cfg.
@@ -123,7 +176,7 @@ func newRotatingHook(fs *os.FS, cfg *Config) (*Hook, error) {
 		verifiers = append(verifiers, verifier)
 	}
 
-	return &Hook{signer: signer, verifiers: verifiers}, nil
+	return &Hook{signer: signer, verifiers: verifiers, leeway: cfg.Leeway}, nil
 }
 
 func newWebhook(fs *os.FS, secret string) (*webhooks.Webhook, error) {

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -39,7 +39,7 @@ func TestNewHookSignsWithActiveSecret(t *testing.T) {
 	signature, err := hook.Sign("id-1", timestamp, payload)
 	require.NoError(t, err)
 
-	headers := signedHeaders("id-1", timestamp, signature)
+	headers := signedHeaders(timestamp, signature)
 	require.NoError(t, newSingleHook(t, webhookSecret("dGVzdA==")).Verify(payload, headers))
 	require.Error(t, newSingleHook(t, webhookSecret("b3RoZXI=")).Verify(payload, headers))
 }
@@ -56,12 +56,73 @@ func TestNewHookVerifiesTrustedSecrets(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			signature, timestamp := sign(t, newSingleHook(t, secret), payload)
 
-			require.NoError(t, hook.Verify(payload, signedHeaders("id-1", timestamp, signature)))
+			require.NoError(t, hook.Verify(payload, signedHeaders(timestamp, signature)))
 		})
 	}
 
 	signature, timestamp := sign(t, newSingleHook(t, webhookSecret("YmFk")), payload)
-	require.Error(t, hook.Verify(payload, signedHeaders("id-1", timestamp, signature)))
+	require.Error(t, hook.Verify(payload, signedHeaders(timestamp, signature)))
+}
+
+func TestNewHookVerifiesWithLeeway(t *testing.T) {
+	secret := webhookSecret("dGVzdA==")
+
+	hook, err := hooks.NewHook(test.FS, &hooks.Config{
+		Key:     "current",
+		Secrets: hooks.Secrets{"current": secret},
+		Leeway:  10 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	signer := newSingleHook(t, secret)
+	payload := []byte("body")
+
+	tests := map[string]struct {
+		delta   time.Duration
+		wantErr bool
+	}{
+		"too old within leeway": {delta: -7 * time.Minute, wantErr: false},
+		"too old beyond leeway": {delta: -11 * time.Minute, wantErr: true},
+		"too new within leeway": {delta: 7 * time.Minute, wantErr: false},
+		"too new beyond leeway": {delta: 11 * time.Minute, wantErr: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			timestamp := time.Now().Add(tt.delta.Duration())
+			signature, err := signer.Sign("id-1", timestamp, payload)
+			require.NoError(t, err)
+
+			err = hook.Verify(payload, signedHeaders(timestamp, signature))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewHookVerifiesWithLeewayRejectsMalformedTimestamp(t *testing.T) {
+	secret := webhookSecret("dGVzdA==")
+
+	hook, err := hooks.NewHook(test.FS, &hooks.Config{
+		Key:     "current",
+		Secrets: hooks.Secrets{"current": secret},
+		Leeway:  10 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	signer := newSingleHook(t, secret)
+	payload := []byte("body")
+	timestamp := time.Now()
+	signature, err := signer.Sign("id-1", timestamp, payload)
+	require.NoError(t, err)
+
+	headers := signedHeaders(timestamp, signature)
+	headers.Set(webhooks.HeaderWebhookTimestamp, "not-a-number")
+
+	require.Error(t, hook.Verify(payload, headers))
 }
 
 func TestNewHookReturnsInvalidConfigForMissingActiveSecret(t *testing.T) {
@@ -136,9 +197,9 @@ func sign(t *testing.T, hook *hooks.Hook, payload []byte) (string, time.Time) {
 	return signature, timestamp
 }
 
-func signedHeaders(id string, timestamp time.Time, signature string) http.Header {
+func signedHeaders(timestamp time.Time, signature string) http.Header {
 	header := http.Header{}
-	header.Set(webhooks.HeaderWebhookID, id)
+	header.Set(webhooks.HeaderWebhookID, "id-1")
 	header.Set(webhooks.HeaderWebhookSignature, signature)
 	header.Set(webhooks.HeaderWebhookTimestamp, strconv.FormatInt(timestamp.Unix(), 10))
 

--- a/time/time.go
+++ b/time/time.go
@@ -56,6 +56,13 @@ func Now() Time {
 	return time.Now()
 }
 
+// Unix returns the local Time corresponding to the given Unix time, sec seconds since January 1, 1970 UTC.
+//
+// This is a thin wrapper around [time.Unix] and does not change semantics.
+func Unix(sec int64) Time {
+	return time.Unix(sec, 0)
+}
+
 // Since returns the time elapsed since t.
 //
 // This is a thin wrapper around [time.Since] and does not change semantics.


### PR DESCRIPTION
## What

- Adds an optional `hooks.Config.Leeway` (`time.Duration`) so operators can widen or narrow the `Webhook-Timestamp` freshness window enforced during Standard Webhooks verification.
- Zero-value (default) behavior is unchanged: verification still uses the vendored Standard Webhooks library's fixed 5-minute window.
- When `Leeway` is non-zero, `Hook.Verify` checks `Webhook-Timestamp` against that configured window itself, then verifies the signature via the library's `VerifyIgnoringTimestamp`, mirroring the clock-skew `Leeway` already exposed by the JWT, PASETO, and SSH token verifiers.
- Adds a small `time.Unix(sec int64) Time` wrapper to the shared `time` package (whole-second precision, matching the only need here) so `hooks` doesn't need to import the standard library `time` package directly.
- Non-goal: no replay/idempotency protection is added; receivers must still dedupe by `Webhook-Id` as already documented.

## Why

- Operators can now tune webhook clock-skew/delivery-latency tolerance the same way they already can for JWT, PASETO, and SSH tokens, instead of being stuck with a hardcoded 5-minute window with no adjustment path short of forking the vendored library.
- Widening the window is an explicit, opt-in operator choice: the zero-value default keeps today's strict behavior, so nobody's security posture changes unless they configure it.

## Testing

- `make specs package=hooks` - passed (17 tests, including 4 leeway boundary cases covering too-old/too-new inside and outside the configured window, and a malformed-`Webhook-Timestamp`-header case)
- `make lint package=hooks` - passed
- `make lint package=time` - passed
- `make field-alignment package=hooks` / `package=time` - passed
- `go build ./...` - passed
- `go vet ./hooks/... ./time/...` - passed
- New tests cover the previously-uncovered error branches added by this change (verified via `go test ./hooks/... -cover`: both new helpers reached 100% statement coverage after adding the malformed-timestamp test).
- Not run: repo-wide `make specs`, `govulncheck`, and `trivy-repo` — left to CI.
