### PR TITLE
docs(readme): describe webhook timestamp leeway option

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ hooks:
   secrets:
     current: env:WEBHOOK_SECRET_CURRENT
     previous: env:WEBHOOK_SECRET_PREVIOUS
+  leeway: 30s
 ```
 
 Each `secrets` value is a source string. The resolved value must be accepted by the
@@ -397,6 +398,14 @@ Signing uses the active `key`. Verification accepts signatures from every
 configured secret, trying the active secret first. Standard Webhooks includes a
 message id (`Webhook-Id`) but not a signing key id, so go-service does not extend
 the protocol with a custom selector header.
+
+`leeway` is optional clock-skew tolerance applied to the `Webhook-Timestamp`
+freshness check during verification. A zero value (the default) keeps the
+Standard Webhooks library's fixed 5-minute freshness window; a non-zero value
+replaces that fixed window with this configured tolerance, matching the
+clock-skew `leeway` already exposed by the JWT, PASETO, and SSH token
+verifiers. Like those, `leeway` is a Go duration string and must be a positive
+whole-second duration.
 
 Inbound verification checks Standard Webhooks signatures and timestamps, but
 does not store or reject previously seen webhook ids. Receivers that perform


### PR DESCRIPTION
## What

- Documented the `hooks.Config.Leeway` field in the README's Webhooks (Standard Webhooks) section: added a `leeway: 30s` line to the example YAML and an explanatory paragraph describing the behavior.
- The paragraph covers the zero-value default (keeps the vendored Standard Webhooks library's fixed 5-minute `Webhook-Timestamp` freshness window), the non-zero-value override behavior, and the duration format constraint (positive whole-second Go duration string), matching how the JWT/PASETO/SSH `leeway` fields are already documented.
- No code changes; this closes a documentation gap left by #3038 (`feat(hooks): add configurable webhook timestamp leeway`), which added the config field and its behavior but did not update the README.

## Why

- The Webhooks section of the README is the primary operator-facing reference for `hooks.Config`. Without this update, operators had no discoverable documentation for the new `leeway` knob even though the equivalent JWT/PASETO/SSH `leeway` fields are already documented there, so the new tuning option would go unnoticed.

## Testing

- Manually verified the added text against `hooks/config.go` (field name, YAML key, `validate:"omitempty,duration_second_precision"` tag) and `hooks/hooks.go` (`Hook.Verify`/`verifyTimestamp` zero-value vs. non-zero-value behavior).
- Not run: no markdown/doc-lint make target exists in this repository for a docs-only change; reviewed the rendered Markdown diff directly instead.
- Not run: `make specs`, `make lint` — no Go files changed in this PR.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
