### PR TITLE
feat(transport): bound redirect loops and honor retry hints

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http/telemetry"
 	"github.com/alexfalkowski/go-service/v2/net/url"
@@ -197,7 +198,7 @@ func IsCrossOriginRedirect(req *Request) bool {
 	return !SameOrigin(req.Response.Request.URL, req.URL)
 }
 
-// SameOriginRedirect allows redirects only when the next request stays on the same scheme and host.
+// SameOriginRedirect limits same-origin redirect chains to the standard Go limit of ten requests.
 //
 // It is intended for clients that add credentials or signatures in RoundTripper middleware, where Go's
 // default cross-origin sensitive-header stripping is not enough because middleware may mint fresh credentials
@@ -209,11 +210,15 @@ func SameOriginRedirect(req *Request, via []*Request) error {
 
 	prev := via[len(via)-1].URL
 	next := req.URL
-	if SameOrigin(prev, next) {
-		return nil
+	if !SameOrigin(prev, next) {
+		return ErrUseLastResponse
 	}
 
-	return ErrUseLastResponse
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+
+	return nil
 }
 
 // NewRequestWithContext constructs a new outgoing HTTP request with ctx.

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -145,6 +145,31 @@ func TestSameOriginRedirect(t *testing.T) {
 	}
 }
 
+func TestSameOriginRedirectStopsAfterTenRedirects(t *testing.T) {
+	t.Parallel()
+
+	via := make([]*http.Request, 10)
+	for i := range via {
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/redirect", http.NoBody)
+		require.NoError(t, err)
+
+		via[i] = request
+	}
+
+	next, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/redirect", http.NoBody)
+	require.NoError(t, err)
+
+	require.NoError(t, http.SameOriginRedirect(next, via[:9]))
+
+	err = http.SameOriginRedirect(next, via)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, http.ErrUseLastResponse)
+
+	crossOrigin, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://other.example.com/redirect", http.NoBody)
+	require.NoError(t, err)
+	require.ErrorIs(t, http.SameOriginRedirect(crossOrigin, via), http.ErrUseLastResponse)
+}
+
 func TestSameOrigin(t *testing.T) {
 	t.Parallel()
 

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -144,6 +144,42 @@ func TestInvalidOverallCheck(t *testing.T) {
 	require.Equal(t, health.NotServing, resp.GetStatus())
 }
 
+func TestInvalidOverallList(t *testing.T) {
+	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
+	requireGRPCReady(t, world)
+	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
+
+	conn := test.RequireGRPCConn(t, world)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := health.NewClient(conn)
+
+	resp, err := client.List(t.Context(), &health.ListRequest{})
+	require.NoError(t, err)
+	require.Equal(t, health.NotServing, resp.GetStatuses()[""].GetStatus())
+}
+
+func TestUnknownOverallCheck(t *testing.T) {
+	world := test.NewStartedWorld(t,
+		test.WithWorldGRPCHealth(test.Name.String(), test.StatusURL("200")),
+		test.WithWorldTelemetry("otlp"),
+	)
+	requireGRPCReady(t, world)
+
+	conn := test.RequireGRPCConn(t, world)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := health.NewClient(conn)
+
+	_, err := client.Check(t.Context(), &health.Request{})
+	require.Error(t, err)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
 func TestNotFoundCheck(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
@@ -209,6 +245,7 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := map[string]*health.Response{
+		"":                 {Status: health.Serving},
 		test.Name.String(): {Status: health.Serving},
 	}
 	require.Equal(t, expected, resp.GetStatuses())
@@ -223,12 +260,14 @@ func TestListDrains(t *testing.T) {
 
 	resp, err := server.List(t.Context(), &health.ListRequest{})
 	require.NoError(t, err)
+	require.Equal(t, health.Serving, resp.GetStatuses()[""].GetStatus())
 	require.Equal(t, health.Serving, resp.GetStatuses()[test.Name.String()].GetStatus())
 
 	drain.Start()
 
 	resp, err = server.List(t.Context(), &health.ListRequest{})
 	require.NoError(t, err)
+	require.Equal(t, health.NotServing, resp.GetStatuses()[""].GetStatus())
 	require.Equal(t, health.NotServing, resp.GetStatuses()[test.Name.String()].GetStatus())
 }
 

--- a/transport/grpc/health/server.go
+++ b/transport/grpc/health/server.go
@@ -60,7 +60,12 @@ type Server struct {
 func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response, error) {
 	service := req.GetService()
 	if strings.IsEmpty(service) {
-		return &health.Response{Status: s.healthStatus(s.server.Error("grpc"))}, nil
+		err := s.server.Error("grpc")
+		if errors.Is(err, healthserver.ErrObserverNotFound) {
+			return nil, status.SafeError(codes.NotFound, err)
+		}
+
+		return &health.Response{Status: s.healthStatus(err)}, nil
 	}
 
 	observer, err := s.server.Observer(service, "grpc")
@@ -77,6 +82,10 @@ func (s *Server) Check(_ context.Context, req *health.Request) (*health.Response
 // statuses.
 func (s *Server) List(_ context.Context, _ *health.ListRequest) (*health.ListResponse, error) {
 	res := &health.ListResponse{Statuses: map[string]*health.Response{}}
+	if err := s.server.Error("grpc"); !errors.Is(err, healthserver.ErrObserverNotFound) {
+		res.Statuses[""] = &health.Response{Status: s.healthStatus(err)}
+	}
+
 	for name, observer := range s.server.Observers("grpc") {
 		res.Statuses[name] = &health.Response{Status: s.healthStatus(observer.Error())}
 	}

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -71,6 +71,9 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 	timeout := cfg.GetTimeout()
 	backoff := cfg.GetBackoff()
 	maxBackoff := cfg.GetMaxBackoff()
+	if maxBackoff > 0 && maxBackoff < backoff {
+		backoff = maxBackoff
+	}
 	strategy := cfg.GetStrategy()
 	codes := retryableCodes(cfg)
 

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -182,6 +182,20 @@ func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsMinimumBacko
 	require.Equal(t, 1, calls)
 }
 
+func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsCappedBackoff(t *testing.T) {
+	cfg := config.Config{Strategy: "exponential", Backoff: 100 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Timeout: time.Second, Attempts: 2}
+	interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+
+	calls := 0
+	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return retryInfoError(t, codes.Unavailable, 20*time.Millisecond)
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
 func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *testing.T) {
 	tests := map[string]time.Duration{
 		"minimum": 8 * time.Millisecond,

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -88,10 +88,16 @@ var ErrInvalidStatusCode = errors.New("retry: invalid status code")
 // retry and return the current response to the caller. Invalid, absent, elapsed, or smaller Retry-After values
 // do not suppress a retry.
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
+	backoff := cfg.GetBackoff()
+	maxBackoff := cfg.GetMaxBackoff()
+	if maxBackoff > 0 && maxBackoff < backoff {
+		backoff = maxBackoff
+	}
+
 	return &RoundTripper{
 		RoundTripper: hrt,
-		backoff:      cfg.GetBackoff(),
-		maxBackoff:   cfg.GetMaxBackoff(),
+		backoff:      backoff,
+		maxBackoff:   maxBackoff,
 		strategy:     cfg.GetStrategy(),
 		policy:       composePolicy(policies),
 		maxRetries:   cfg.MaxRetries(),

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -218,6 +218,26 @@ func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsMinimumBackoff(t *testing.
 	}
 }
 
+func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsCappedBackoff(t *testing.T) {
+	calls := 0
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		res := test.ResponseWithStatus(http.StatusTooManyRequests)
+		res.Header.Set("Retry-After", "1")
+
+		return res, nil
+	})
+	cfg := config.Config{Strategy: "exponential", Backoff: 10 * time.Second, MaxBackoff: 100 * time.Millisecond, Attempts: 2}
+	retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+	res, err := retrying.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+	require.Equal(t, 1, calls)
+}
+
 func TestRoundTripperRetriesWhenRetryAfterDoesNotExceedBackoff(t *testing.T) {
 	calls := 0
 	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
## What

- Limits same-origin redirect chains while preserving cross-origin response handling.
- Applies the effective capped backoff when HTTP and gRPC clients evaluate server retry hints.
- Aligns aggregate gRPC health behavior across `Check` and `List`.

## Why

- Prevents redirect loops and premature retries that can amplify upstream overload, while making aggregate health discovery consistent for probes and control-plane clients.

## Testing

- `make specs` - passed
- `make lint` - passed
- `make sec` - passed
- Added focused regression coverage for redirect boundaries, capped retry hints, and aggregate health states.

AI-assisted-by: [Codex](https://openai.com/codex/)
