### PR TITLE
feat(transport): avoid tripping breakers on cancellation and use grown retry backoff

### DIFF
--- a/transport/grpc/breaker/breaker_test.go
+++ b/transport/grpc/breaker/breaker_test.go
@@ -102,6 +102,38 @@ func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
 	}
 }
 
+func TestUnaryClientInterceptorDoesNotOpenOnCallerCancellation(t *testing.T) {
+	tests := map[string][]breaker.Option{
+		"canceled configured as a failure code": {
+			breaker.WithSettings(settings()),
+			breaker.WithFailureCodes(codes.Canceled),
+		},
+		"custom IsSuccessful treats canceled as a failure": {
+			breaker.WithSettings(settings(func(error) bool { return false })),
+		},
+	}
+
+	for name, opts := range tests {
+		t.Run(name, func(t *testing.T) {
+			interceptor := breaker.UnaryClientInterceptor(opts...)
+
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				return status.Error(codes.Canceled, "canceled")
+			}
+
+			err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+			require.Error(t, err)
+			require.Equal(t, codes.Canceled, status.Code(err))
+			require.False(t, status.IsLocalError(err))
+
+			err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+			require.Error(t, err)
+			require.Equal(t, codes.Canceled, status.Code(err))
+			require.False(t, status.IsLocalError(err))
+		})
+	}
+}
+
 func TestUnaryClientInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
 	interceptor := breaker.UnaryClientInterceptor(
 		breaker.WithSettings(settings()),

--- a/transport/grpc/breaker/config.go
+++ b/transport/grpc/breaker/config.go
@@ -30,7 +30,8 @@ type Config struct {
 	//
 	// When empty, gRPC breakers use their default failure classification. When set, only these configured
 	// non-OK status codes are counted as breaker failures; include the defaults here as well when custom
-	// configuration should extend rather than replace the default list.
+	// configuration should extend rather than replace the default list. [codes.Canceled] is always counted
+	// as a success even when included here, so a caller aborting an in-flight call never trips the breaker.
 	Codes []codes.Code `yaml:"codes,omitempty" json:"codes,omitempty" toml:"codes,omitempty" validate:"omitempty,dive,gt=0,lte=16"`
 }
 

--- a/transport/grpc/breaker/options.go
+++ b/transport/grpc/breaker/options.go
@@ -42,7 +42,9 @@ func WithSettings(s Settings) Option {
 // WithFailureCodes configures which gRPC status codes are treated as failures for breaker accounting.
 //
 // If an invocation returns an error whose status code is contained in this set, the breaker counts it as a
-// failure. Errors with status codes not in this set are counted as successes.
+// failure. Errors with status codes not in this set are counted as successes. [codes.Canceled] is always
+// counted as a success regardless of this set, matching the caller-cancellation handling in the HTTP client
+// breaker: a caller aborting an in-flight call should not trip the breaker against a healthy upstream.
 func WithFailureCodes(cs ...codes.Code) Option {
 	return optionFunc(func(o *opts) {
 		o.failureCodes = make(map[codes.Code]struct{}, len(cs))

--- a/transport/grpc/breaker/registry.go
+++ b/transport/grpc/breaker/registry.go
@@ -1,6 +1,7 @@
 package breaker
 
 import (
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/transport/breaker"
 	"github.com/alexfalkowski/go-sync"
@@ -23,6 +24,9 @@ func (r *registry) get(fullMethod string) *breaker.CircuitBreaker {
 	failureCodes := r.opts.failureCodes
 	s.IsSuccessful = func(err error) bool {
 		if err == nil {
+			return true
+		}
+		if status.Code(err) == codes.Canceled {
 			return true
 		}
 

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -180,7 +180,7 @@ func WithClientUnaryInterceptors(unary ...grpc.UnaryClientInterceptor) ClientOpt
 //
 // Metadata propagation runs first so custom interceptors see the resolved user-agent and request-id.
 // Interceptors provided here then run before the remaining standard interceptors added by this package
-// (logging, token injection, limiter, etc.).
+// (logging, limiter, token injection, etc.).
 //
 // Pass all custom stream interceptors for a client construction in one call. Repeating this option follows
 // the package's last-wins functional option convention and replaces earlier custom stream interceptors.

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -10,8 +10,9 @@
 // should deduplicate by request-id. Callers that need different retry eligibility can pass an explicit policy.
 //
 // RetryInfo handling: when a retryable gRPC status error includes google.rpc RetryInfo with a retry_delay
-// greater than the minimum jittered backoff, the error is returned without another attempt. Missing, zero, or
-// shorter retry_delay values do not suppress a retry.
+// greater than the minimum jittered backoff that will precede the next attempt, the error is returned without
+// another attempt. For exponential and fibonacci strategies this grows per attempt, matching the real backoff
+// schedule rather than the static base. Missing, zero, or shorter retry_delay values do not suppress a retry.
 //
 // Locally produced client-control errors marked by `net/grpc/status.LocalError` are
 // terminal. An unmarked response with the same gRPC code remains governed by

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/retry"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	config "github.com/alexfalkowski/go-service/v2/transport/retry"
 )
 
@@ -82,10 +83,12 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 			return attempt(ctx)
 		}
 
-		strategyBackoff := retry.NewBackoff(strategy, backoff)
-		if maxBackoff > 0 {
-			strategyBackoff = retry.WithCappedDuration(maxBackoff, strategyBackoff)
-		}
+		strategyBackoff := cappedBackoff(strategy, backoff, maxBackoff)
+
+		// growthBackoff mirrors strategyBackoff's construction so the RetryInfo gate can peek the
+		// backoff that will actually precede the next attempt, growing per attempt for exponential
+		// and fibonacci strategies rather than staying pinned to the static base.
+		growthBackoff := cappedBackoff(strategy, backoff, maxBackoff)
 
 		retries := retry.WithJitterPercent(config.DefaultJitterPercent, strategyBackoff)
 		retries = retry.WithMaxRetries(maxAttempts-1, retries)
@@ -97,7 +100,9 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 			if !isRetryableCode(status.Code(err), codes) {
 				return err
 			}
-			if retryInfoDelayExceedsBackoff(err, backoff) {
+
+			next, _ := growthBackoff.Next()
+			if retryInfoDelayExceedsBackoff(err, time.Duration(next)) {
 				return err
 			}
 
@@ -117,6 +122,16 @@ func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInt
 			return invoker(attemptCtx, fullMethod, req, resp, conn, opts...)
 		})
 	}
+}
+
+// cappedBackoff builds a backoff for strategy and base, capped at maxBackoff when positive.
+func cappedBackoff(strategy string, base, maxBackoff time.Duration) retry.Backoff {
+	backoff := retry.NewBackoff(strategy, base)
+	if maxBackoff > 0 {
+		backoff = retry.WithCappedDuration(maxBackoff, backoff)
+	}
+
+	return backoff
 }
 
 func retryableCodes(cfg *Config) []codes.Code {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -175,11 +175,52 @@ func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsMinimumBacko
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 		calls++
-		return retryInfoError(t, codes.Unavailable, 20*time.Millisecond)
+		return retryInfoError(t, 20*time.Millisecond)
 	})
 
 	require.Error(t, err)
 	require.Equal(t, 1, calls)
+}
+
+func TestUnaryClientInterceptorHonorsGrownBackoffForRetryInfo(t *testing.T) {
+	tests := []struct {
+		name  string
+		delay time.Duration
+		calls int
+		err   bool
+	}{
+		{name: "below the grown backoff retries", delay: 15 * time.Millisecond, calls: 3, err: false},
+		{name: "above the grown backoff still suppresses", delay: 25 * time.Millisecond, calls: 2, err: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Exponential growth from a 10ms base gives ~10ms before attempt 2 and ~20ms before
+			// attempt 3; the second attempt's gate must compare against the latter, not the base.
+			cfg := config.Config{Strategy: "exponential", Backoff: 10 * time.Millisecond, Attempts: 3}
+			interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+
+			calls := 0
+			err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				switch calls {
+				case 1:
+					return status.Error(codes.Unavailable, "unavailable")
+				case 2:
+					return retryInfoError(t, tt.delay)
+				default:
+					return nil
+				}
+			})
+
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.calls, calls)
+		})
+	}
 }
 
 func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsCappedBackoff(t *testing.T) {
@@ -189,7 +230,7 @@ func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsCappedBackof
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 		calls++
-		return retryInfoError(t, codes.Unavailable, 20*time.Millisecond)
+		return retryInfoError(t, 20*time.Millisecond)
 	})
 
 	require.Error(t, err)
@@ -211,7 +252,7 @@ func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *
 			err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 				calls++
 				if calls == 1 {
-					return retryInfoError(t, codes.Unavailable, delay)
+					return retryInfoError(t, delay)
 				}
 
 				return nil
@@ -409,10 +450,10 @@ func TestUnaryClientInterceptorRetriesWhenPolicyAllowsRequestID(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
-func retryInfoError(t *testing.T, code codes.Code, delay time.Duration) error {
+func retryInfoError(t *testing.T, delay time.Duration) error {
 	t.Helper()
 
-	grpcStatus, err := status.New(code, "retry later").WithDetails(&status.RetryInfo{
+	grpcStatus, err := status.New(codes.Unavailable, "retry later").WithDetails(&status.RetryInfo{
 		RetryDelay: status.NewDuration(delay),
 	})
 	require.NoError(t, err)

--- a/transport/http/retry/doc.go
+++ b/transport/http/retry/doc.go
@@ -11,8 +11,10 @@
 // all attempts fail. When retries are triggered by transport errors, the original error is preserved.
 //
 // Retry-After handling: when a retryable HTTP response includes a valid Retry-After seconds value or HTTP-date
-// whose delay is greater than the minimum jittered backoff, the response is returned without another attempt.
-// Invalid, absent, elapsed, or shorter Retry-After values do not suppress a retry.
+// whose delay is greater than the minimum jittered backoff that will precede the next attempt, the response is
+// returned without another attempt. For exponential and fibonacci strategies this grows per attempt, matching
+// the real backoff schedule rather than the static base. Invalid, absent, elapsed, or shorter Retry-After values
+// do not suppress a retry.
 //
 // Default policy: if no policy is passed to NewRoundTripper, only side-effect-safe requests are eligible for
 // retry. This includes safe HTTP methods and requests carrying a Request-Id. In go-service, Request-Id

--- a/transport/http/retry/retry.go
+++ b/transport/http/retry/retry.go
@@ -84,9 +84,10 @@ var ErrInvalidStatusCode = errors.New("retry: invalid status code")
 //   - If retries are exhausted after retryable transport errors, the original transport error is returned.
 //
 // Retry-After behavior:
-// Valid Retry-After seconds values or HTTP-date values greater than the minimum jittered backoff suppress the
-// retry and return the current response to the caller. Invalid, absent, elapsed, or smaller Retry-After values
-// do not suppress a retry.
+// Valid Retry-After seconds values or HTTP-date values greater than the minimum jittered backoff that will
+// precede the next attempt suppress the retry and return the current response to the caller. For exponential
+// and fibonacci strategies this grows per attempt, matching the real backoff schedule rather than the static
+// base. Invalid, absent, elapsed, or smaller Retry-After values do not suppress a retry.
 func NewRoundTripper(cfg *Config, hrt http.RoundTripper, policies ...Policy) *RoundTripper {
 	backoff := cfg.GetBackoff()
 	maxBackoff := cfg.GetMaxBackoff()
@@ -160,6 +161,8 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 
 	attempt := &roundTripAttempt{
 		backoff:     r.backoff,
+		maxBackoff:  r.maxBackoff,
+		strategy:    r.strategy,
 		maxRetries:  r.maxRetries,
 		statusCodes: r.statusCodes,
 	}
@@ -214,9 +217,12 @@ func (r *RoundTripper) attempt(ctx context.Context, req *http.Request, attempt *
 }
 
 type roundTripAttempt struct {
+	growth      retry.Backoff
+	strategy    string
 	statusCodes []int
 	attempt     uint64
 	backoff     time.Duration
+	maxBackoff  time.Duration
 	maxRetries  uint64
 }
 
@@ -232,18 +238,38 @@ func (a *roundTripAttempt) retry(ctx context.Context, req *http.Request, res *ht
 	retryErr = statusError(retryErr, err)
 	if res == nil {
 		a.attempt++
+		a.nextGrowth()
 		return retryErr
 	}
 	if a.attempt >= a.maxRetries {
 		return nil
 	}
-	if retryAfterDelayExceedsBackoff(res, a.backoff) {
+	if retryAfterDelayExceedsBackoff(res, a.nextGrowth()) {
 		return nil
 	}
 
 	discardResponse(res)
 	a.attempt++
 	return retryErr
+}
+
+// nextGrowth returns the backoff duration that will precede the next retry attempt.
+//
+// It mirrors the growth applied by the real backoff chain built from the same strategy, base, and
+// cap so the Retry-After gate compares against the wait that will actually happen, not the static
+// base backoff, for growing strategies such as exponential and fibonacci.
+func (a *roundTripAttempt) nextGrowth() time.Duration {
+	if a.growth == nil {
+		growth := retry.NewBackoff(a.strategy, a.backoff)
+		if a.maxBackoff > 0 {
+			growth = retry.WithCappedDuration(a.maxBackoff, growth)
+		}
+
+		a.growth = growth
+	}
+
+	next, _ := a.growth.Next()
+	return time.Duration(next)
 }
 
 func request(req *http.Request, ctx context.Context, attempt uint64) (*http.Request, error) {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -218,6 +218,50 @@ func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsMinimumBackoff(t *testing.
 	}
 }
 
+func TestRoundTripperHonorsGrownBackoffForRetryAfter(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		calls      int
+		finalCode  int
+	}{
+		{name: "below the grown backoff retries", retryAfter: "1", calls: 3, finalCode: http.StatusOK},
+		{name: "above the grown backoff still suppresses", retryAfter: "2", calls: 2, finalCode: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+				calls++
+				switch calls {
+				case 1:
+					return test.ResponseWithStatus(http.StatusTooManyRequests), nil
+				case 2:
+					res := test.ResponseWithStatus(http.StatusTooManyRequests)
+					res.Header.Set("Retry-After", tt.retryAfter)
+
+					return res, nil
+				default:
+					return test.ResponseWithStatus(http.StatusOK), nil
+				}
+			})
+
+			// Exponential growth from a 750ms base gives ~750ms before attempt 2 and ~1.5s before
+			// attempt 3; the second attempt's gate must compare against the latter, not the base.
+			cfg := config.Config{Strategy: "exponential", Backoff: 750 * time.Millisecond, Attempts: 3}
+			retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+			res, err := retrying.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, tt.finalCode, res.StatusCode)
+			require.Equal(t, tt.calls, calls)
+		})
+	}
+}
+
 func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsCappedBackoff(t *testing.T) {
 	calls := 0
 	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
## What

- gRPC client circuit breakers now always treat `codes.Canceled` as a success, even when a caller explicitly configures it as a failure code via `WithFailureCodes`/`Config.Codes`, or supplies a custom `IsSuccessful` that would otherwise call it a failure. This matches the caller-cancellation handling already in the HTTP client breaker.
- gRPC RetryInfo and HTTP Retry-After suppression now compare the server-requested delay against the backoff that will actually precede the next attempt, rather than the static base backoff. For exponential and fibonacci strategies this grows per attempt, so later retries are no longer gated against an unrealistically small threshold.
- Fixed a stale doc comment on the gRPC client's stream interceptor ordering (limiter runs before token injection, not after).
- Package-level doc comments in `transport/grpc/retry` and `transport/http/retry` now describe the grown-backoff comparison so they no longer contradict the constructor doc comments in the same packages.

## Why

- A caller aborting an in-flight gRPC call (context cancellation) is not evidence the upstream is unhealthy. Without this fix, a client that cancels many in-flight calls, for example during shutdown or user navigation, could trip its own breaker against a perfectly healthy service.
- The retry suppression gate previously compared every attempt's RetryInfo/Retry-After delay against the same static base backoff. For growing strategies this made the gate progressively too lenient: a delay that should have suppressed a later, larger-backoff retry was let through because it was compared against the smaller base value instead of the delay that would actually precede the next attempt.

## Testing

- `make specs package=transport/grpc/breaker` - passed
- `make specs package=transport/grpc/retry` - passed
- `make specs package=transport/http/retry` - passed
- `make specs package=transport/grpc` - passed
- `make golangci-lint package=transport/grpc/breaker` - passed
- `make golangci-lint package=transport/grpc/retry` - passed
- `make golangci-lint package=transport/http/retry` - passed
- `make golangci-lint package=transport/grpc` - passed
- `make field-alignment` - passed
- `make sec` - passed (the one flagged advisory is a pre-existing, unrelated `golang.org/x/crypto/openpgp` module advisory not reachable from this code)
- New tests cover the breaker not opening on repeated caller cancellation, both with `Canceled` configured as an explicit failure code and with a custom `IsSuccessful` that treats it as a failure, and the grown-backoff comparison on both gRPC RetryInfo and HTTP Retry-After suppression across a below/above-threshold pair of attempts.
- An independent review pass caught two stale package-doc comments (`doc.go` in both retry packages still describing the old static-backoff comparison); fixed before opening this PR.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
