### PR TITLE
feat(grpc): treat client limiter failures as local so retries don't re-enter it

### DIFF
--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -88,7 +88,7 @@ func (s *Server) Register() error {
 			Logger:   s.Logger,
 			Limiter:  s.HTTPLimiter,
 			Handlers: []http.ChainedHandler{&EmptyHandler{}},
-			Verifier: s.Verifier, Access: s.Access, ID: s.Generator, UserID: UserID,
+			Verifier: s.Verifier, Access: s.Access, ID: s.Generator,
 			UserAgent: UserAgent, Version: Version,
 			RoutePolicy: s.RoutePolicy,
 		}
@@ -108,7 +108,7 @@ func (s *Server) Register() error {
 			Shutdowner: sh,
 			Config:     s.TransportConfig.GRPC,
 			Logger:     s.Logger,
-			Verifier:   s.Verifier, Access: s.Access, ID: s.Generator, UserID: UserID,
+			Verifier:   s.Verifier, Access: s.Access, ID: s.Generator,
 			UserAgent: UserAgent, Version: Version,
 			Limiter:      s.GRPCLimiter,
 			MethodPolicy: s.GRPCMethodPolicy,

--- a/net/grpc/status/status.go
+++ b/net/grpc/status/status.go
@@ -102,11 +102,11 @@ func SafeError(c codes.Code, err error) error {
 // LocalError marks err as produced by this client's own load-control middleware —
 // the client circuit breaker or rate limiter — rather than returned by the upstream server.
 //
-// "Local" contrasts with an upstream response. A breaker-open or limiter-exhausted rejection surfaces
-// the same ResourceExhausted code an upstream server could return, so the status code alone cannot tell
-// the two apart. Retry middleware treats a local rejection as terminal: retrying a request the client
-// just shed is futile and only amplifies load, whereas an upstream status with the same code may be
-// worth retrying. If err is not a gRPC status error, it is represented with [codes.Unknown].
+// "Local" contrasts with an upstream response. A breaker-open or limiter outcome can surface the same
+// status code an upstream server could return, so the status code alone cannot tell the two apart. Retry
+// middleware treats a local outcome as terminal: retrying a request the client just rejected or cannot
+// process is futile and only amplifies load, whereas an upstream status with the same code may be worth
+// retrying. If err is not a gRPC status error, it is represented with [codes.Unknown].
 func LocalError(err error) error {
 	if err == nil {
 		return nil
@@ -115,8 +115,8 @@ func LocalError(err error) error {
 	return &localError{err: err}
 }
 
-// IsLocalError reports whether err was wrapped by LocalError, identifying a local load-control
-// rejection as opposed to an upstream status response.
+// IsLocalError reports whether err was wrapped by LocalError, identifying a local load-control outcome
+// as opposed to an upstream status response.
 func IsLocalError(err error) bool {
 	_, ok := errors.AsType[*localError](err)
 	return ok

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -80,6 +80,35 @@ func TestRetryDoesNotReenterClientLimiter(t *testing.T) {
 	require.Equal(t, 0, downstreamCalls)
 }
 
+func TestRetryDoesNotReenterClosedClientLimiter(t *testing.T) {
+	clientLimiter, err := grpclimiter.NewClientLimiter(
+		test.NoopLifecycle{},
+		limiter.NewKeyMap(),
+		test.NewLimiterConfig("user-agent", "1m", 10),
+	)
+	require.NoError(t, err)
+	require.NoError(t, clientLimiter.Close(t.Context()))
+
+	limiting := grpclimiter.UnaryClientInterceptor(clientLimiter)
+	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.Internal))
+	limiterCalls := 0
+	downstreamCalls := 0
+	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
+		limiterCalls++
+		return limiting(ctx, fullMethod, req, resp, conn, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+			downstreamCalls++
+			return nil
+		}, opts...)
+	}
+	err = retrying(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Equal(t, 1, limiterCalls)
+	require.Equal(t, 0, downstreamCalls)
+}
+
 func TestRetryDoesNotReenterClientBreaker(t *testing.T) {
 	breaking := grpcbreaker.UnaryClientInterceptor(
 		grpcbreaker.NewConfig(test.NewBreaker(1), codes.Unavailable).Options()...,

--- a/transport/grpc/limiter/client.go
+++ b/transport/grpc/limiter/client.go
@@ -36,7 +36,7 @@ type Client struct {
 //
 // The interceptor calls `limiter.TakeDecision(ctx)` before invoking the RPC:
 //
-//   - If `TakeDecision` returns an error, it returns [codes.Internal].
+//   - If `TakeDecision` returns an error, it returns a locally marked [codes.Internal].
 //   - If the request is not allowed, it returns a locally marked [codes.ResourceExhausted].
 //   - Otherwise, it invokes the underlying `invoker`.
 //
@@ -45,7 +45,7 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		decision, err := take(ctx, limiter.Limiter)
 		if err != nil {
-			return err
+			return status.LocalError(err)
 		}
 
 		if !decision.Allowed() {
@@ -61,7 +61,7 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 // The interceptor calls `limiter.TakeDecision(ctx)` before opening the stream, then meters each sent and received
 // stream message:
 //
-//   - If `TakeDecision` returns an error, it returns [codes.Internal].
+//   - If `TakeDecision` returns an error, it returns a locally marked [codes.Internal].
 //   - If the stream is not allowed, it returns a locally marked [codes.ResourceExhausted].
 //   - Otherwise, it invokes the underlying `streamer`.
 //
@@ -70,7 +70,7 @@ func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		decision, err := take(ctx, limiter.Limiter)
 		if err != nil {
-			return nil, err
+			return nil, status.LocalError(err)
 		}
 
 		if !decision.Allowed() {
@@ -99,7 +99,7 @@ func (s *clientStream) RecvMsg(m any) error {
 
 	decision, err := take(s.ctx, s.limiter)
 	if err != nil {
-		return err
+		return status.LocalError(err)
 	}
 
 	if !decision.Allowed() {
@@ -112,7 +112,7 @@ func (s *clientStream) RecvMsg(m any) error {
 func (s *clientStream) SendMsg(m any) error {
 	decision, err := take(s.ctx, s.limiter)
 	if err != nil {
-		return err
+		return status.LocalError(err)
 	}
 
 	if !decision.Allowed() {

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -309,6 +309,65 @@ func TestClientClosedLimiterUnary(t *testing.T) {
 	require.Equal(t, codes.Internal, status.Code(err))
 }
 
+func TestClientClosedLimiterStreamOpen(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 10)), test.WithWorldGRPC())
+
+	conn := test.RequireGRPCConn(t, world)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := v1.NewGreeterServiceClient(conn)
+
+	require.NoError(t, world.Client.GRPCLimiter.Close(t.Context()))
+
+	_, err := client.SayStreamHello(t.Context())
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestClientClosedLimiterStreamSend(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 10)), test.WithWorldGRPC())
+
+	conn := test.RequireGRPCConn(t, world)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := v1.NewGreeterServiceClient(conn)
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, world.Client.GRPCLimiter.Close(t.Context()))
+
+	err = stream.Send(&v1.SayStreamHelloRequest{Name: "test"})
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestClientClosedLimiterStreamRecv(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 10)), test.WithWorldGRPC())
+
+	conn := test.RequireGRPCConn(t, world)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := v1.NewGreeterServiceClient(conn)
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&v1.SayStreamHelloRequest{Name: "test"}))
+
+	require.NoError(t, world.Client.GRPCLimiter.Close(t.Context()))
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.Internal, status.Code(err))
+}
+
 func requireRetryInfo(t *testing.T, err error) {
 	t.Helper()
 

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -59,9 +59,6 @@ type ServerParams struct {
 	// Version is the service version reported via metadata interceptors.
 	Version env.Version
 
-	// UserID identifies the metadata key used for injecting authenticated subjects into context.
-	UserID env.UserID
-
 	// ID generates request IDs when one is not already present.
 	ID id.Generator
 
@@ -194,7 +191,7 @@ func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInte
 	uis = append(uis, recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)))
 
 	if params.Verifier != nil {
-		uis = append(uis, token.UnaryServerInterceptor(params.MethodPolicy, params.UserID, params.Verifier))
+		uis = append(uis, token.UnaryServerInterceptor(params.MethodPolicy, params.Verifier))
 	}
 
 	if params.Limiter != nil {
@@ -220,7 +217,7 @@ func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerIn
 	sis = append(sis, recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)))
 
 	if params.Verifier != nil {
-		sis = append(sis, token.StreamServerInterceptor(params.MethodPolicy, params.UserID, params.Verifier))
+		sis = append(sis, token.StreamServerInterceptor(params.MethodPolicy, params.Verifier))
 	}
 
 	if params.Limiter != nil {
@@ -253,7 +250,7 @@ func credsServerOption(fs *os.FS, cfg *Config) (grpc.ServerOption, error) {
 
 	conf, err := server.NewConfig(fs, cfg.TLS)
 	if err != nil {
-		return grpc.EmptyServerOption{}, prefix(err)
+		return grpc.EmptyServerOption{}, err
 	}
 
 	return grpc.Creds(grpc.NewTLS(conf)), nil

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -82,6 +82,7 @@ func TestServerRejectsCAOnlyTLS(t *testing.T) {
 
 	_, err := grpc.NewServer(params)
 	require.ErrorIs(t, err, server.ErrMissingKeyPair)
+	require.EqualError(t, err, "grpc: server: missing tls key pair")
 }
 
 func TestServerAppliesCallerServerOption(t *testing.T) {

--- a/transport/grpc/telemetry/logger/server.go
+++ b/transport/grpc/telemetry/logger/server.go
@@ -21,7 +21,7 @@ import (
 //   - code: gRPC status code as a string
 //
 // Log level is derived from the status code (see [CodeToLevel]). The log message includes the full
-// method name and, when present, error details.
+// method name.
 //
 // Operator diagnostics:
 // The raw error is intentionally attached to the log record for backend observability. Client-facing
@@ -63,7 +63,7 @@ func UnaryServerInterceptor(policy *method.Policy, log *Logger) grpc.UnaryServer
 //   - code: gRPC status code as a string
 //
 // Log level is derived from the status code (see [CodeToLevel]). The log message includes the full
-// method name and, when present, error details.
+// method name.
 //
 // Operator diagnostics:
 // The raw error is intentionally attached to the log record for backend observability. Client-facing

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -70,7 +70,7 @@ type Verifier token.Verifier
 //     the handler.
 //
 // Callers should only install this interceptor when verifier is non-nil.
-func UnaryServerInterceptor(policy *method.Policy, id env.UserID, verifier Verifier) grpc.UnaryServerInterceptor {
+func UnaryServerInterceptor(policy *method.Policy, verifier Verifier) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if bypassAuth(policy, info.FullMethod) {
 			return handler(ctx, req)
@@ -102,7 +102,7 @@ func UnaryServerInterceptor(policy *method.Policy, id env.UserID, verifier Verif
 //     invokes the handler using a wrapped stream (`go-grpc-middleware` wrapper) that carries the new context.
 //
 // Callers should only install this interceptor when verifier is non-nil.
-func StreamServerInterceptor(policy *method.Policy, id env.UserID, verifier Verifier) grpc.StreamServerInterceptor {
+func StreamServerInterceptor(policy *method.Policy, verifier Verifier) grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if bypassAuth(policy, info.FullMethod) {
 			return handler(srv, stream)

--- a/transport/grpc/token/token_test.go
+++ b/transport/grpc/token/token_test.go
@@ -52,7 +52,7 @@ func TestStreamClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 func TestUnaryServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 	policy := method.NewPolicy()
 	policy.AllowUnauthenticated("/events.v1.EventsService/Receive")
-	interceptor := token.UnaryServerInterceptor(policy, env.UserID("service-user"), &test.Verifier{})
+	interceptor := token.UnaryServerInterceptor(policy, &test.Verifier{})
 	called := false
 
 	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/events.v1.EventsService/Receive"}, func(context.Context, any) (any, error) {
@@ -67,7 +67,7 @@ func TestUnaryServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 func TestStreamServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 	policy := method.NewPolicy()
 	policy.AllowUnauthenticated("/events.v1.EventsService/Subscribe")
-	interceptor := token.StreamServerInterceptor(policy, env.UserID("service-user"), &test.Verifier{})
+	interceptor := token.StreamServerInterceptor(policy, &test.Verifier{})
 	stream := &test.MetaServerStream{Ctx: t.Context()}
 	called := false
 

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -60,9 +60,6 @@ type ServerParams struct {
 	// Version is the service version reported via response headers and/or request context metadata.
 	Version env.Version
 
-	// UserID identifies the metadata key used for injecting authenticated subjects into context.
-	UserID env.UserID
-
 	// ID generates request IDs when one is not already present.
 	ID id.Generator
 
@@ -141,7 +138,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	neg.Use(&recoveryHandler{})
 
 	if params.Verifier != nil {
-		neg.Use(token.NewHandler(params.RoutePolicy, params.UserID, params.Verifier))
+		neg.Use(token.NewHandler(params.RoutePolicy, params.Verifier))
 	}
 
 	if params.Limiter != nil {

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -55,15 +55,14 @@ type Verifier token.Verifier
 // NewHandler constructs server-side token verification middleware.
 //
 // Callers should only install this handler when verifier is non-nil.
-func NewHandler(routePolicy *http.RoutePolicy, id env.UserID, verifier Verifier) *Handler {
-	return &Handler{routePolicy: routePolicy, id: id, verifier: verifier}
+func NewHandler(routePolicy *http.RoutePolicy, verifier Verifier) *Handler {
+	return &Handler{routePolicy: routePolicy, verifier: verifier}
 }
 
 // Handler verifies Authorization headers and injects the verified subject into request metadata.
 type Handler struct {
 	verifier    Verifier
 	routePolicy *http.RoutePolicy
-	id          env.UserID
 }
 
 // ServeHTTP verifies the request Authorization token and stores the verified subject in the context.

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -77,7 +77,7 @@ func TestRoundTripperGeneratesTokenForMethodPath(t *testing.T) {
 
 func TestHandlerVerifiesTokenForMethodPath(t *testing.T) {
 	verifier := &audienceVerifier{token: "fresh-token"}
-	handler := token.NewHandler(http.NewRoutePolicy(), env.UserID("user-id"), verifier)
+	handler := token.NewHandler(http.NewRoutePolicy(), verifier)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPatch, "/users/123", http.NoBody)
 	require.NoError(t, err)
 	req = req.WithContext(meta.WithAttributes(req.Context(), meta.WithAuthorization(meta.String("fresh-token"))))


### PR DESCRIPTION
## What

- gRPC client rate limiter interceptors (unary, stream open, `RecvMsg`, `SendMsg`) now wrap `TakeDecision` failures with `status.LocalError`, matching the local-rejection marking already used for limiter-denied requests.
- Removed the unused `id env.UserID` parameter from `token.UnaryServerInterceptor`/`token.StreamServerInterceptor` (gRPC) and from `token.NewHandler`/`Handler` (HTTP), and the now-dead `UserID` field from both `transport/grpc.ServerParams` and `transport/http.ServerParams` and their callers in `internal/test`.
- Fixed a double `"grpc: grpc: ..."` error prefix from `credsServerOption`'s TLS config error path; it now returns the raw error so the caller's single `prefix()` wrap applies once.
- Minor doc-comment accuracy fixes in `net/grpc/status` and the gRPC telemetry logger describing local-error semantics and log message contents.

## Why

- `TakeDecision` errors were previously returned unmarked, so retry middleware could not tell them apart from a genuine upstream failure and could retry a request the client had already rejected locally. Marking them local makes retry treat them as terminal, consistent with limiter-denied requests.
- `UserID` was threaded through both the gRPC and HTTP token verification middleware and their transport `ServerParams`, but never read in either handler body; removing it from both transports keeps their dependency surfaces consistent and clarifies what these handlers actually need. The HTTP side's client-facing `token.NewRoundTripper`/`RoundTripper.id`, which does use the configured user id to generate outbound tokens, is unaffected.
- The doubled TLS error prefix made `NewServer`'s CA-only-config error message misleading; fixing it keeps error text accurate for operators.

## Testing

- `make specs package=transport/grpc` (69 tests, incl. 4 new closed-limiter/retry tests), `transport/grpc/token`, `transport/grpc/limiter`, `net/grpc/status`, `transport/grpc/telemetry/logger` - all passed
- `make specs package=transport/http` (168 tests), `transport/http/token` - all passed
- `go build ./...` / `go vet ./...` - passed
- `make golangci-lint` on each changed package - 0 issues
- `make field-alignment` - passed
- Independent fresh-context code review found no blocking issues; confirmed the removed parameter/field was genuinely dead in both handler bodies and had exactly one construction site each.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
