### PR TITLE
feat(telemetry): make environment and localhost matching case-insensitive, tighten grpc port validation, and fix doubled sampler error prefix

### DIFF
--- a/telemetry/attributes/attributes.go
+++ b/telemetry/attributes/attributes.go
@@ -2,6 +2,7 @@ package attributes
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
@@ -154,7 +155,7 @@ func ServiceVersion(version string) attribute.KeyValue {
 
 // DeploymentEnvironmentName returns a deployment.environment.name attribute for env.
 //
-// It maps common environment names onto the stable OpenTelemetry enum values:
+// It case-insensitively maps common environment names onto the stable OpenTelemetry enum values:
 // "prod" and "production" become "production"; "stage" and "staging" become
 // "staging"; "qa", "test", and "testing" become "test"; "dev" and
 // "development" become "development". Unknown or empty values default to
@@ -166,7 +167,7 @@ func ServiceVersion(version string) attribute.KeyValue {
 // Parameters:
 //   - env: the deployment environment name, such as "prod" or "staging"
 func DeploymentEnvironmentName(env string) attribute.KeyValue {
-	switch env {
+	switch strings.ToLower(env) {
 	case "prod", "production":
 		return semconv.DeploymentEnvironmentNameProduction
 	case "stage", "staging":

--- a/telemetry/attributes/attributes_test.go
+++ b/telemetry/attributes/attributes_test.go
@@ -64,9 +64,12 @@ func TestDeploymentEnvironmentName(t *testing.T) {
 		expected string
 	}{
 		{name: "prod alias", value: "prod", expected: "production"},
+		{name: "prod alias uppercase", value: "PROD", expected: "production"},
 		{name: "production", value: "production", expected: "production"},
+		{name: "production mixed case", value: "Production", expected: "production"},
 		{name: "stage alias", value: "stage", expected: "staging"},
 		{name: "staging", value: "staging", expected: "staging"},
+		{name: "staging uppercase", value: "STAGING", expected: "staging"},
 		{name: "qa alias", value: "qa", expected: "test"},
 		{name: "test", value: "test", expected: "test"},
 		{name: "testing alias", value: "testing", expected: "test"},

--- a/telemetry/internal/otlp/endpoint.go
+++ b/telemetry/internal/otlp/endpoint.go
@@ -83,10 +83,11 @@ func validateHTTP(endpoint Endpoint) error {
 
 func validateGRPC(endpoint Endpoint) error {
 	host, port, err := net.SplitHostPort(endpoint.Address)
-	if err != nil || strings.IsEmpty(host) {
+	if err != nil || strings.IsEmpty(host) || strings.IsEmpty(port) {
 		return ErrInvalidEndpoint
 	}
-	if _, err := net.LookupPort(context.Background(), "tcp", port); err != nil {
+	portNumber, err := net.LookupPort(context.Background(), "tcp", port)
+	if err != nil || portNumber == 0 {
 		return ErrInvalidEndpoint
 	}
 
@@ -98,7 +99,7 @@ func validateGRPC(endpoint Endpoint) error {
 }
 
 func isLoopback(host string) bool {
-	if host == "localhost" {
+	if strings.ToLower(host) == "localhost" {
 		return true
 	}
 

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -11,19 +11,36 @@ import (
 func TestValidateEndpoint(t *testing.T) {
 	headers := map[string]string{"Authorization": "Bearer token"}
 
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "https://collector.example.com/v1/traces", Headers: headers}))
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://localhost:4318/v1/traces", Headers: headers}))
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://127.0.0.1:4318/v1/traces", Headers: headers}))
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces"}))
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "localhost:4317", Headers: headers}))
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317"}))
-	require.NoError(t, otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers, TLS: &tls.Config{}}))
+	tests := []struct {
+		endpoint otlp.Endpoint
+		wantErr  error
+		name     string
+	}{
+		{name: "secure HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "https://collector.example.com/v1/traces", Headers: headers}},
+		{name: "lowercase localhost HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://localhost:4318/v1/traces", Headers: headers}},
+		{name: "mixed case localhost HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://Localhost:4318/v1/traces", Headers: headers}},
+		{name: "uppercase localhost HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://LOCALHOST:4318/v1/traces", Headers: headers}},
+		{name: "loopback IP HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://127.0.0.1:4318/v1/traces", Headers: headers}},
+		{name: "headerless HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces"}},
+		{name: "loopback gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "localhost:4317", Headers: headers}},
+		{name: "mixed case localhost gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "Localhost:4317", Headers: headers}},
+		{name: "headerless gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317"}},
+		{name: "TLS gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers, TLS: &tls.Config{}}},
+		{name: "insecure HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces", Headers: headers}, wantErr: otlp.ErrInsecureEndpoint},
+		{name: "insecure gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers}, wantErr: otlp.ErrInsecureEndpoint},
+	}
 
-	err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces", Headers: headers})
-	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := otlp.ValidateEndpoint(tt.endpoint)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
 
-	err = otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers})
-	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestValidateEndpointInvalidURL(t *testing.T) {
@@ -52,6 +69,8 @@ func TestValidateEndpointRejectsInvalidEndpoint(t *testing.T) {
 	for _, address := range []string{
 		"https://collector.example.com:4317",
 		"collector.example.com",
+		"collector.example.com:",
+		"collector.example.com:0",
 		"collector.example.com:4317/v1/traces",
 	} {
 		t.Run(address, func(t *testing.T) {

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -177,7 +177,7 @@ func Register(params TracerParams) error {
 		providerOpts := []sdk.TracerProviderOption{sdk.WithResource(attrs), sdk.WithBatcher(exporter, batchSpanProcessorOptions(params.Config)...)}
 		sampler, err := newSampler(params.Config.Sampler)
 		if err != nil {
-			return prefix(err)
+			return err
 		}
 		if sampler != nil {
 			providerOpts = append(providerOpts, sdk.WithSampler(sampler))

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -211,6 +211,7 @@ func TestRegisterInvalidSampler(t *testing.T) {
 			})
 
 			require.ErrorIs(t, err, tracer.ErrInvalidSampler)
+			require.EqualError(t, err, "tracer: invalid sampler")
 		})
 	}
 }


### PR DESCRIPTION
## What

- `attributes.DeploymentEnvironmentName` now matches known environment aliases ("prod", "staging", "qa", "dev", etc.) case-insensitively, so values like "PROD" or "Production" map onto the correct OpenTelemetry `deployment.environment.name` enum instead of falling back to "development".
- OTLP gRPC endpoint validation (`telemetry/internal/otlp`) now rejects addresses with an empty or zero port, such as `collector.example.com:` or `collector.example.com:0`; these previously passed validation silently because `net.LookupPort` returns `0, nil` for an empty port string.
- Loopback host detection (`isLoopback`) is now case-insensitive, so `LOCALHOST`/`Localhost` are treated as loopback for both the HTTP insecure-endpoint check and the gRPC insecure-endpoint check, matching `localhost`.
- `tracer.Register` no longer double-prefixes the sampler configuration error; `ErrInvalidSampler` already reads `"tracer: invalid sampler"`, so the returned error message is now correct instead of `"tracer: tracer: invalid sampler"`.

## Why

- Deployment environment names and OTLP endpoint hosts are administrator-supplied configuration and commonly vary in case; the previous case-sensitive checks caused correctly configured environments/hosts to be silently treated as unknown or non-loopback.
- A gRPC endpoint with a missing or `0` port is not usable and should fail fast at startup rather than being accepted and failing later at the transport layer.
- The doubled error prefix on invalid-sampler configuration made the returned error message misleading for anyone reading logs or debugging config.

## Testing

- `make specs package=telemetry/attributes` - passed
- `make specs package=telemetry/internal/otlp` - passed
- `make specs package=telemetry/tracer` - passed
- `make golangci-lint package=telemetry/attributes` - passed
- `make golangci-lint package=telemetry/internal/otlp` - passed
- `make golangci-lint package=telemetry/tracer` - passed
- `make field-alignment` - passed
- `make sec` - passed (0 vulnerabilities affecting this code; one pre-existing unmaintained-package advisory for a transitive `golang.org/x/crypto` dependency, unrelated to this change)
- Added test cases cover uppercase/mixed-case environment names, uppercase/mixed-case `localhost` for both HTTP and gRPC endpoint validation, and empty/zero-port gRPC addresses. An independent review pass flagged that the gRPC loopback branch (which gates whether secret headers are allowed over cleartext) had no case-insensitivity coverage; added a "mixed case localhost gRPC" case to close that gap.
