### PR TITLE
feat(http): log request failures with their diagnostic errors

### DIFF
--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
+	"github.com/alexfalkowski/go-sync"
 )
 
 // CapturedRecord is a slog record captured by CaptureHandler.
@@ -20,6 +21,7 @@ type CapturedRecord struct {
 // CaptureHandler records slog records for tests.
 type CaptureHandler struct {
 	Records []CapturedRecord
+	mu      sync.RWMutex
 }
 
 // Enabled reports whether the handler accepts records at level.
@@ -36,12 +38,23 @@ func (h *CaptureHandler) Handle(_ context.Context, record slog.Record) error {
 		}
 		return true
 	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	h.Records = append(h.Records, CapturedRecord{
 		Level:   record.Level,
 		Message: record.Message,
 		Attrs:   attrs,
 	})
 	return nil
+}
+
+// Snapshot returns the captured records at the time of the call.
+func (h *CaptureHandler) Snapshot() []CapturedRecord {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return append([]CapturedRecord(nil), h.Records...)
 }
 
 // WithAttrs returns a handler with attrs.

--- a/net/http/body/body.go
+++ b/net/http/body/body.go
@@ -36,7 +36,7 @@ func Close(body io.ReadCloser) {
 func NewHandler(handler http.Handler, limit int64) http.Handler {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.ContentLength > limit {
-			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
+			_ = status.WriteError(req.Context(), res, &http.MaxBytesError{Limit: limit})
 			return
 		}
 
@@ -47,13 +47,13 @@ func NewHandler(handler http.Handler, limit int64) http.Handler {
 
 		data, body, err := io.ReadAll(io.LimitReader(req.Body, limit+1))
 		if err != nil {
-			_ = status.WriteError(res, status.BadRequestError(err))
+			_ = status.WriteError(req.Context(), res, status.BadRequestError(err))
 			return
 		}
 		defer Close(req.Body)
 
 		if int64(len(data)) > limit {
-			_ = status.WriteError(res, &http.MaxBytesError{Limit: limit})
+			_ = status.WriteError(req.Context(), res, &http.MaxBytesError{Limit: limit})
 			return
 		}
 

--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -70,9 +70,9 @@ func NewHandler[Res any](cont *Content, handler Handler[Res]) http.HandlerFunc {
 
 // NotFoundHandler returns a not-found handler that writes the standard content error response.
 func NotFoundHandler() http.NotFoundHandler {
-	return func(res http.ResponseWriter, _ *http.Request) bool {
+	return func(res http.ResponseWriter, req *http.Request) bool {
 		err := status.SafeError(http.StatusNotFound, nil)
-		_ = status.WriteError(res, err)
+		_ = status.WriteError(req.Context(), res, err)
 
 		return true
 	}
@@ -88,7 +88,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 
 		data, err := handler(ctx)
 		if err != nil {
-			_ = status.WriteError(res, err)
+			_ = status.WriteError(ctx, res, err)
 
 			return
 		}
@@ -97,7 +97,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 		defer cont.pool.Put(buffer)
 
 		if err := mediaType.Encoder.Encode(buffer, data); err != nil {
-			_ = status.WriteError(res, err)
+			_ = status.WriteError(ctx, res, err)
 
 			return
 		}

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -69,7 +69,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 
 	auth, err := serverAuthorization(req)
 	if err != nil {
-		_ = status.WriteError(res, status.BadRequestError(err))
+		_ = status.WriteError(ctx, res, status.BadRequestError(err))
 		return
 	}
 	ctx = meta.WithAttributes(ctx,

--- a/net/http/status/context.go
+++ b/net/http/status/context.go
@@ -1,0 +1,29 @@
+package status
+
+import "github.com/alexfalkowski/go-service/v2/context"
+
+const requestErrorKey = context.Key("http-status-request-error")
+
+type requestError struct {
+	err error
+}
+
+// WithRequestError returns a context that captures the request diagnostic error.
+//
+// HTTP logging middleware uses the captured error to attach operator diagnostics to the request log while
+// [WriteError] continues to render only the safe client message.
+func WithRequestError(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestErrorKey, &requestError{})
+}
+
+// RequestError returns the captured request diagnostic error for ctx.
+//
+// It returns nil when ctx was not prepared with [WithRequestError] or no error was written.
+func RequestError(ctx context.Context) error {
+	state, _ := ctx.Value(requestErrorKey).(*requestError)
+	if state == nil {
+		return nil
+	}
+
+	return state.err
+}

--- a/net/http/status/doc.go
+++ b/net/http/status/doc.go
@@ -5,5 +5,6 @@
 //
 // Status error messages created with Error/Errorf are client-visible when passed to WriteError. Wrapped
 // internal failures created with FromError or SafeError keep their diagnostic Error text, but WriteError
-// sends a lowercase "http: " prefixed status message instead.
+// sends a lowercase "http: " prefixed status message instead. HTTP logging middleware can prepare the request
+// context with WithRequestError to attach that diagnostic error to its access log without exposing it to clients.
 package status

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -3,6 +3,7 @@ package status
 import (
 	"fmt"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -13,29 +14,19 @@ var (
 	textContentType  = media.MustParse(media.Text).WithUTF8()
 )
 
-// WriteError writes an error response to res.
+// WriteError records err for request-scoped operator diagnostics, then writes its safe response to res.
 //
-// Content-Type:
-// WriteError always writes the response as a plain-text error payload using the go-service specific
-// error media type "text/error; charset=utf-8" and sets "X-Content-Type-Options: nosniff".
-//
-// Status code selection:
-// The HTTP status code is derived from err using Code(err), which understands:
-//   - errors implementing Coder,
-//   - errors created by this package, and
-//   - raw *[http.MaxBytesError] values mapped to 413 Request Entity Too Large, and
-//   - gRPC status errors mapped to HTTP codes.
-//
-// Write behavior:
-// The error message is written as a single line (via [fmt.Fprintln]) containing the first SafeMessage in
-// err's chain. If no safe message is available, WriteError uses the default safe HTTP status message for Code(err).
-// Use SafeError to preserve an internal cause while returning the default safe HTTP status message to the client.
-// If writing the body fails, WriteError returns the write error and does not attempt to write a
-// secondary error response.
-//
-// This helper is conceptually similar to [net/http.Error] but uses go-service status code extraction
-// and the dedicated error media type.
-func WriteError(res http.ResponseWriter, err error) error {
+// The first error written through ctx is retained because it determines the client response. The response
+// rendering and error-return behavior are otherwise identical to previous releases of WriteError. It writes a
+// plain-text `text/error; charset=utf-8` response with `X-Content-Type-Options: nosniff`. The status code is
+// derived with [Code]. The body contains the first safe message in err's chain, or the default message for that
+// code. Use [SafeError] to retain an internal cause without exposing it to the client. WriteError returns a
+// body-write failure without attempting a secondary response.
+func WriteError(ctx context.Context, res http.ResponseWriter, err error) error {
+	if state, _ := ctx.Value(requestErrorKey).(*requestError); state != nil && state.err == nil {
+		state.err = err
+	}
+
 	header := res.Header()
 	header.Del("Content-Length")
 	header.Set("Content-Type", errorContentType)

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -48,7 +48,7 @@ func TestFromErrorAllowsNil(t *testing.T) {
 func TestWriteErrorUsesSafeMessageForFromError(t *testing.T) {
 	res := httptest.NewRecorder()
 
-	err := httpstatus.WriteError(res, httpstatus.BadRequestError(test.ErrInvalid))
+	err := httpstatus.WriteError(t.Context(), res, httpstatus.BadRequestError(test.ErrInvalid))
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, res.Code)
@@ -58,7 +58,7 @@ func TestWriteErrorUsesSafeMessageForFromError(t *testing.T) {
 func TestWriteErrorUsesSafeMessage(t *testing.T) {
 	res := httptest.NewRecorder()
 
-	err := httpstatus.WriteError(res, httpstatus.SafeError(http.StatusUnauthorized, test.ErrInvalid))
+	err := httpstatus.WriteError(t.Context(), res, httpstatus.SafeError(http.StatusUnauthorized, test.ErrInvalid))
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.Code)
@@ -92,7 +92,7 @@ func TestSafeErrorf(t *testing.T) {
 	require.Contains(t, err.Error(), "load tenant tenant-1")
 
 	res := httptest.NewRecorder()
-	require.NoError(t, httpstatus.WriteError(res, err))
+	require.NoError(t, httpstatus.WriteError(t.Context(), res, err))
 	test.RequireTrimmedResponseBody(t, res, "http: unauthorized")
 }
 
@@ -103,7 +103,7 @@ func TestSafeErrorfWithoutCause(t *testing.T) {
 	require.Contains(t, err.Error(), "load tenant tenant-1")
 
 	res := httptest.NewRecorder()
-	require.NoError(t, httpstatus.WriteError(res, err))
+	require.NoError(t, httpstatus.WriteError(t.Context(), res, err))
 	test.RequireTrimmedResponseBody(t, res, "http: unauthorized")
 }
 
@@ -114,7 +114,7 @@ func TestSafeErrorfWithoutFormat(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, httpstatus.Code(err))
 
 	res := httptest.NewRecorder()
-	require.NoError(t, httpstatus.WriteError(res, err))
+	require.NoError(t, httpstatus.WriteError(t.Context(), res, err))
 	test.RequireTrimmedResponseBody(t, res, "http: unauthorized")
 }
 
@@ -142,7 +142,7 @@ func TestSafeErrorUsesRequestEntityTooLargeForMaxBytesError(t *testing.T) {
 func TestWriteErrorUsesDefaultSafeMessageForUnknownStatusCode(t *testing.T) {
 	res := httptest.NewRecorder()
 
-	err := httpstatus.WriteError(res, &test.CoderError{StatusCode: 999})
+	err := httpstatus.WriteError(t.Context(), res, &test.CoderError{StatusCode: 999})
 
 	require.NoError(t, err)
 	require.Equal(t, 999, res.Code)
@@ -154,7 +154,7 @@ func TestWriteErrorUsesClientClosedRequestMessageForCanceledGRPCStatus(t *testin
 	status, ok := grpcstatus.FromError(grpcstatus.Error(codes.Canceled, "client canceled"))
 	require.True(t, ok)
 
-	err := httpstatus.WriteError(res, status.Err())
+	err := httpstatus.WriteError(t.Context(), res, status.Err())
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusClientClosedRequest, res.Code)
@@ -239,7 +239,7 @@ func TestCodeMapsContextErrors(t *testing.T) {
 func TestWriteErrorReturnsWriteFailure(t *testing.T) {
 	res := &test.ErrResponseWriter{}
 
-	err := httpstatus.WriteError(res, httpstatus.BadRequestError(test.ErrInvalid))
+	err := httpstatus.WriteError(t.Context(), res, httpstatus.BadRequestError(test.ErrInvalid))
 
 	require.ErrorIs(t, err, test.ErrFailed)
 	require.Equal(t, http.StatusBadRequest, res.Code)

--- a/transport/http/events/hooks/hooks.go
+++ b/transport/http/events/hooks/hooks.go
@@ -67,7 +67,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	if hasBinaryHeaders(req.Header) {
-		_ = status.WriteError(resp, status.BadRequestError(ErrBinaryEncoding))
+		_ = status.WriteError(req.Context(), resp, status.BadRequestError(ErrBinaryEncoding))
 		return
 	}
 

--- a/transport/http/health/health.go
+++ b/transport/http/health/health.go
@@ -59,18 +59,18 @@ func resister(pattern string, params RegisterParams) {
 	params.Router.HandleOperationFunc("GET "+http.Pattern(params.Name, pattern), func(res http.ResponseWriter, req *http.Request) {
 		if pattern == "/readyz" {
 			if err := params.Drain.Error(); err != nil {
-				_ = status.WriteError(res, status.ServiceUnavailableError(err))
+				_ = status.WriteError(req.Context(), res, status.ServiceUnavailableError(err))
 				return
 			}
 		}
 
 		observer, err := params.Server.Observer(params.Name.String(), pattern[1:])
 		if err != nil {
-			_ = status.WriteError(res, status.ServiceUnavailableError(err))
+			_ = status.WriteError(req.Context(), res, status.ServiceUnavailableError(err))
 			return
 		}
 		if err := observer.Error(); err != nil {
-			_ = status.WriteError(res, status.ServiceUnavailableError(err))
+			_ = status.WriteError(req.Context(), res, status.ServiceUnavailableError(err))
 			return
 		}
 

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -170,7 +170,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	}
 
 	if err := h.hook.Verify(req); err != nil {
-		_ = status.WriteError(res, status.BadRequestError(err))
+		_ = status.WriteError(req.Context(), res, status.BadRequestError(err))
 
 		return
 	}

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -71,7 +71,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 
 	decision, err := h.limiter.TakeDecision(ctx)
 	if err != nil {
-		_ = status.WriteError(res, status.InternalServerError(err))
+		_ = status.WriteError(req.Context(), res, status.InternalServerError(err))
 		return
 	}
 
@@ -83,7 +83,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 			res.Header().Set("Retry-After", strconv.FormatUint(resetAfter, 10))
 		}
 
-		_ = status.WriteError(res, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests)))
+		_ = status.WriteError(req.Context(), res, status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests)))
 		return
 	}
 

--- a/transport/http/recovery.go
+++ b/transport/http/recovery.go
@@ -61,8 +61,8 @@ func (*recoveryHandler) ServeHTTP(res http.ResponseWriter, req *http.Request, ne
 				panic(value)
 			}
 
-			err := status.SafeError(http.StatusInternalServerError, runtime.ConvertRecover(value))
-			_ = status.WriteError(res, err)
+			err := runtime.ConvertRecover(value)
+			_ = status.WriteError(req.Context(), res, status.SafeError(http.StatusInternalServerError, err))
 		}
 	}()
 

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -1,16 +1,21 @@
 package http_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
 	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/stretchr/testify/require"
@@ -101,7 +106,8 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 }
 
 func TestServerRecoversPanic(t *testing.T) {
-	world := test.NewWorld(t, test.WithWorldHTTP())
+	capture := &test.CaptureHandler{}
+	world := test.NewWorld(t, test.WithWorldHTTP(), test.WithWorldLogger(&logger.Logger{Logger: slog.New(capture)}))
 	world.Handle("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test panic")
 	}))
@@ -116,6 +122,14 @@ func TestServerRecoversPanic(t *testing.T) {
 		res.WriteHeader(http.StatusEarlyHints)
 		panic("test panic after commit")
 	}))
+	world.HandleOperationFunc("GET /panic-operation", func(http.ResponseWriter, *http.Request) {
+		panic("test operation panic")
+	})
+	world.Handle("GET /panic-after-error", http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		_ = status.WriteError(req.Context(), res, status.BadRequestError(test.ErrInvalid))
+		res.(interface{ Flush() }).Flush()
+		panic("test panic after error")
+	}))
 	world.HandleHello()
 	world.Start()
 
@@ -123,17 +137,55 @@ func TestServerRecoversPanic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	require.Equal(t, "http: internal server error", body)
+	requirePanicLog(t, capture, "test panic", "panic")
 
 	res, body, err = world.GetBody(t.Context(), world.PathServerURL("http", "panic-after-informational"), http.Header{})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	require.Equal(t, "http: internal server error", body)
+	requirePanicLog(t, capture, "test panic after informational response", "panic-after-informational")
 
 	_, _, err = world.GetBody(t.Context(), world.PathServerURL("http", "panic-after-write"), http.Header{"Accept-Encoding": {"identity"}})
 	require.Error(t, err)
+	requirePanicLog(t, capture, "test panic after commit", "panic-after-write")
+
+	res, body, err = world.GetBody(t.Context(), world.PathServerURL("http", "panic-operation"), http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "http: internal server error", body)
+	requirePanicLog(t, capture, "test operation panic", "panic-operation")
+
+	_, _, err = world.GetBody(t.Context(), world.PathServerURL("http", "panic-after-error"), http.Header{"Accept-Encoding": {"identity"}})
+	require.Error(t, err)
+	requirePanicLog(t, capture, "test panic after error", "panic-after-error")
 
 	res, body, err = world.GetBody(t.Context(), world.PathServerURL("http", "hello"), http.Header{})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, "hello!", body)
+}
+
+func requirePanicLog(t *testing.T, capture *test.CaptureHandler, panicMessage, service string) {
+	t.Helper()
+
+	for _, record := range capture.Snapshot() {
+		if record.Message != "http: panic" {
+			continue
+		}
+
+		err, ok := record.Attrs["error"].Any().(error)
+		if !ok || !errors.Is(err, runtime.ErrRecovered) || !strings.Contains(err.Error(), panicMessage) {
+			continue
+		}
+
+		require.Equal(t, slog.LevelError, record.Level)
+		require.Equal(t, "http", record.Attrs["system"].String())
+		require.Equal(t, service, record.Attrs["service"].String())
+		require.Equal(t, "get", record.Attrs["method"].String())
+		require.NotEmpty(t, record.Attrs["requestId"].String())
+
+		return
+	}
+
+	require.Failf(t, "panic log not found", "panic message: %q", panicMessage)
 }

--- a/transport/http/telemetry/logger/logger.go
+++ b/transport/http/telemetry/logger/logger.go
@@ -1,9 +1,12 @@
 package logger
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -19,7 +22,8 @@ type Logger = logger.Logger
 // NewHandler constructs HTTP server logging middleware.
 //
 // The returned handler logs the outcome of each request after next has completed, including duration and
-// response status code. Registered operation paths (health/metrics/etc.) are skipped.
+// response status code. Registered operation paths (health/metrics/etc.) skip ordinary access logs but still
+// log recovered panics.
 func NewHandler(routePolicy *http.RoutePolicy, logger *Logger) *Handler {
 	return &Handler{routePolicy: routePolicy, logger: logger}
 }
@@ -32,37 +36,64 @@ type Handler struct {
 
 // ServeHTTP logs the request outcome after next completes.
 //
-// Registered operation paths (health/metrics/etc.) bypass logging.
+// Registered operation paths (health/metrics/etc.) bypass ordinary access logging but retain recovered-panic
+// logging.
 //
 // Logged attributes include:
 //   - system: "http"
 //   - service/method: derived from the request (see [http.ParseServiceMethod])
 //   - duration: wall-clock elapsed time
 //   - code: HTTP response status code
+//   - error: the request diagnostic error, when present
+//
+// Recovered panics are logged at error level with their original diagnostic error.
 //
 // Log level is derived from the status code:
 //   - 4xx → warn
 //   - 5xx → error
 //   - otherwise → info
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	if h.routePolicy.IsOperation(req) {
-		next(res, req)
-		return
-	}
-
 	service, method := http.ParseServiceMethod(req)
-	ctx := req.Context()
+	ctx := status.WithRequestError(req.Context())
+	start := time.Now()
 
 	attrs := make([]logger.Attr, 0, 5)
 	attrs = append(attrs, logger.String(meta.SystemKey, "http"))
 	attrs = append(attrs, logger.String(meta.ServiceKey, service))
 	attrs = append(attrs, logger.String(meta.MethodKey, method))
+	defer func() {
+		if value := recover(); value != nil {
+			h.logPanic(ctx, attrs, runtime.ConvertRecover(value), time.Since(start).String())
+			panic(value)
+		}
+	}()
+	if h.routePolicy.IsOperation(req) {
+		next(res, req.WithContext(ctx))
+		if err := status.RequestError(ctx); errors.Is(err, runtime.ErrRecovered) {
+			h.logPanic(ctx, attrs, err, time.Since(start).String())
+		}
+
+		return
+	}
 
 	m := snoop.CaptureMetricsFn(res, func(res http.ResponseWriter) { next(res, req.WithContext(ctx)) })
 	attrs = append(attrs, logger.String(meta.DurationKey, m.Duration.String()), logger.Int(meta.CodeKey, m.Code))
-	message := logger.NewText(httpMessage(strings.Join(strings.Space, method, service)))
+	if err := status.RequestError(ctx); errors.Is(err, runtime.ErrRecovered) {
+		h.logPanic(ctx, attrs, err, "")
+		return
+	}
+
+	message := logger.NewMessage(httpMessage(strings.Join(strings.Space, method, service)), status.RequestError(ctx))
 
 	h.logger.LogAttrs(ctx, codeToLevel(m.Code), message, attrs...)
+}
+
+func (h *Handler) logPanic(ctx context.Context, attrs []logger.Attr, err error, duration string) {
+	if duration != "" {
+		attrs = append(attrs, logger.String(meta.DurationKey, duration))
+	}
+
+	h.logger.LogAttrs(ctx, logger.LevelError, logger.NewMessage("http: panic", err), attrs...)
 }
 
 // NewRoundTripper constructs HTTP client logging middleware.

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -49,6 +49,23 @@ func TestHandlerLogsResponse(t *testing.T) {
 	}
 }
 
+func TestHandlerLogsStatusError(t *testing.T) {
+	var logs bytes.Buffer
+	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+	handler := httplogger.NewHandler(http.NewRoutePolicy(), &logger.Logger{Logger: slogLogger})
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/greeter/say-hello", http.NoBody)
+
+	handler.ServeHTTP(res, req, func(res http.ResponseWriter, req *http.Request) {
+		require.NoError(t, status.WriteError(req.Context(), res, status.BadRequestError(test.ErrInvalid)))
+	})
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	test.RequireTrimmedResponseBody(t, res, "http: bad request")
+	require.Contains(t, logs.String(), `"level":"WARN"`)
+	require.Contains(t, logs.String(), `"error":"`+test.ErrInvalid.Error()+`"`)
+}
+
 func TestHandlerSkipsOperationPath(t *testing.T) {
 	var logs bytes.Buffer
 	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))

--- a/transport/http/token/token.go
+++ b/transport/http/token/token.go
@@ -88,7 +88,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 
 	sub, err := h.verifier.Verify(strings.Bytes(auth), audience(req))
 	if err != nil {
-		_ = status.WriteError(res, status.UnauthorizedError(err))
+		_ = status.WriteError(req.Context(), res, status.UnauthorizedError(err))
 		return
 	}
 
@@ -122,17 +122,17 @@ func (h *AccessHandler) ServeHTTP(res http.ResponseWriter, req *http.Request, ne
 
 	ctx := req.Context()
 	if meta.UserID(ctx).IsEmpty() {
-		_ = status.WriteError(res, status.UnauthorizedError(header.ErrInvalidAuthorization))
+		_ = status.WriteError(req.Context(), res, status.UnauthorizedError(header.ErrInvalidAuthorization))
 		return
 	}
 
 	ok, err := h.controller.HasAccess(ctx)
 	if err != nil {
-		_ = status.WriteError(res, status.InternalServerError(err))
+		_ = status.WriteError(req.Context(), res, status.InternalServerError(err))
 		return
 	}
 	if !ok {
-		_ = status.WriteError(res, status.SafeError(http.StatusForbidden, access.ErrAccessDenied))
+		_ = status.WriteError(req.Context(), res, status.SafeError(http.StatusForbidden, access.ErrAccessDenied))
 		return
 	}
 


### PR DESCRIPTION
## What

- Adds request-scoped diagnostic error capture so HTTP access logs include safe-response failures without exposing their causes to clients.
- Emits error-level panic logs for ordinary and operation routes, including panics after a response is committed.
- Changes `status.WriteError` to require the request context that carries the diagnostic state.

## Why

- Operators need the underlying failure and recovered panic in request logs to diagnose failed HTTP requests while clients continue receiving safe error responses.
- The API change is intentional: request-scoped diagnostics require the request context at every error-response boundary.

## Testing

- `make specs package=net/http/status` - passed
- `make specs package=transport/http` - passed
- `make lint` - passed
- `make sec` - passed
- `make specs` - passed
- Extended HTTP server coverage for recovered panics across regular, operation, committed-response, and prior-error paths.

AI-assisted-by: [Codex](https://openai.com/codex/)
