### PR TITLE
feat(grpc): contain metadata interceptor panics

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -180,6 +180,7 @@ func (s *Server) GetService() *grpcserver.Service {
 
 func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInterceptor) grpc.ServerOption {
 	uis := []grpc.UnaryServerInterceptor{
+		recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)),
 		meta.UnaryServerInterceptor(params.MethodPolicy, params.UserAgent, params.Version, params.ID),
 		grpc.TimeoutUnaryServerInterceptor(params.Config.GetTimeout()),
 	}
@@ -208,7 +209,10 @@ func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInte
 }
 
 func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerInterceptor) grpc.ServerOption {
-	sis := []grpc.StreamServerInterceptor{meta.StreamServerInterceptor(params.MethodPolicy, params.UserAgent, params.Version, params.ID)}
+	sis := []grpc.StreamServerInterceptor{
+		recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)),
+		meta.StreamServerInterceptor(params.MethodPolicy, params.UserAgent, params.Version, params.ID),
+	}
 
 	if params.Logger != nil {
 		sis = append(sis, logger.StreamServerInterceptor(params.MethodPolicy, params.Logger))

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -7,13 +7,17 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	netgrpc "github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -118,4 +122,76 @@ func TestServerAppliesCallerServerOption(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, rejected.Error())
+}
+
+func TestServerRecoversUnaryMetadataPanic(t *testing.T) {
+	client := newPanicMetadataServerClient(t)
+
+	_, err := client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "panic"})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	resp, err := client.SayHello(t.Context(), &v1.SayHelloRequest{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "Hello test", resp.GetMessage())
+}
+
+func TestServerRecoversStreamMetadataPanic(t *testing.T) {
+	client := newPanicMetadataServerClient(t)
+
+	stream, err := client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	_, err = test.SendStreamHello(t, stream, "panic")
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	stream, err = client.SayStreamHello(t.Context())
+	require.NoError(t, err)
+
+	resp, err := test.SendStreamHello(t, stream, "test")
+	require.NoError(t, err)
+	require.Equal(t, "Hello test", resp.GetMessage())
+}
+
+func newPanicMetadataServerClient(t *testing.T) v1.GreeterServiceClient {
+	t.Helper()
+
+	params := grpc.ServerParams{
+		Shutdowner:   test.NewShutdowner(),
+		Config:       test.NewInsecureTransportConfig().GRPC,
+		ID:           &panicOnceIDGenerator{},
+		MethodPolicy: grpc.NewMethodPolicy(),
+	}
+
+	srv, err := grpc.NewServer(params)
+	require.NoError(t, err)
+
+	v1.RegisterGreeterServiceServer(srv.ServiceRegistrar(), test.NewService())
+	srv.GetService().Start()
+	t.Cleanup(func() {
+		require.NoError(t, srv.GetService().Stop(context.Background()))
+	})
+
+	conn, err := netgrpc.NewClient(srv.GetService().String(), netgrpc.WithTransportCredentials(netgrpc.NewInsecureCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	return v1.NewGreeterServiceClient(conn)
+}
+
+var _ id.Generator = (*panicOnceIDGenerator)(nil)
+
+type panicOnceIDGenerator struct {
+	once sync.Once
+}
+
+func (g *panicOnceIDGenerator) Generate() string {
+	g.once.Do(func() {
+		panic("metadata panic")
+	})
+
+	return "request-id"
 }


### PR DESCRIPTION
## What

- Convert panics raised while gRPC server metadata is prepared into safe internal responses for unary and streaming RPCs.
- Preserve the existing later recovery interceptor so panics from logging, authorization, limiting, custom interceptors, and handlers retain their established containment and logging path.

## Why

- Request metadata runs before the former recovery boundary, so a failing request-ID generator or similar metadata dependency could terminate the serving goroutine instead of returning a controlled RPC error.

## Testing

- `make package=transport/grpc specs` - passed
- `make lint` - passed
- `make sec` - passed; the scanner reported no reachable vulnerabilities.
- `make specs` - passed
- Added unary and stream integration coverage for a metadata panic and a succeeding follow-up request.

AI-assisted-by: [Codex](https://openai.com/codex/)
