### PR TITLE
feat(limiter): amortize full key-map cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ transport-diagram:
 	@$(MAKE) package=transport create-diagram
 
 # Run all the benchmarks.
-benchmarks: http-benchmarks grpc-benchmarks sql-benchmarks cache-benchmarks bytes-benchmarks \
+benchmarks: http-benchmarks grpc-benchmarks limiter-benchmarks sql-benchmarks cache-benchmarks bytes-benchmarks \
 	strings-benchmarks id-benchmarks net-http-benchmarks http-content-benchmarks
 
 http-benchmarks:
@@ -30,6 +30,9 @@ http-benchmarks:
 
 grpc-benchmarks:
 	@$(MAKE) package=transport/grpc benchtime=100x benchmark
+
+limiter-benchmarks:
+	@$(MAKE) package=transport/limiter benchtime=100x benchmark
 
 sql-benchmarks:
 	@$(MAKE) package=database/sql/driver benchtime=100x benchmark

--- a/README.md
+++ b/README.md
@@ -1600,6 +1600,7 @@ make sec
 make benchmarks
 make http-benchmarks
 make grpc-benchmarks
+make limiter-benchmarks
 make sql-benchmarks
 make cache-benchmarks
 make bytes-benchmarks

--- a/transport/limiter/benchmark_test.go
+++ b/transport/limiter/benchmark_test.go
@@ -1,0 +1,44 @@
+package limiter_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+// BenchmarkLimiterManyDistinctKeys measures limiter behavior after its independent-key cap is reached.
+func BenchmarkLimiterManyDistinctKeys(b *testing.B) {
+	lc := fxtest.NewLifecycle(b)
+	lim, err := limiter.NewLimiter(lc, limiter.KeyMap{"user-agent": meta.UserAgent}, &limiter.Config{
+		Kind:     "user-agent",
+		Tokens:   1,
+		Interval: time.Second,
+		MaxKeys:  limiter.DefaultMaxKeys,
+	})
+	require.NoError(b, err)
+	defer func() {
+		b.StopTimer()
+		require.NoError(b, lim.Close(b.Context()))
+	}()
+
+	b.ReportAllocs()
+	for i := range limiter.DefaultMaxKeys {
+		ctx := meta.WithAttributes(b.Context(), meta.WithUserAgent(meta.String(strconv.FormatUint(i, 10))))
+		_, _, err := lim.Take(ctx)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	for i := int(limiter.DefaultMaxKeys); b.Loop(); i++ {
+		ctx := meta.WithAttributes(b.Context(), meta.WithUserAgent(meta.String(strconv.Itoa(i))))
+		_, _, err := lim.Take(ctx)
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+}

--- a/transport/limiter/keys.go
+++ b/transport/limiter/keys.go
@@ -57,10 +57,12 @@ type KeyFunc func(context.Context) meta.Value
 type KeyMap map[string]KeyFunc
 
 type keys struct {
-	values  map[string]time.Time
-	lock    sync.Mutex
-	ttl     time.Duration
-	maxKeys uint64
+	values        map[string]time.Time
+	lastSweep     time.Time
+	lock          sync.Mutex
+	ttl           time.Duration
+	sweepInterval time.Duration
+	maxKeys       uint64
 }
 
 func (k *keys) storeKey(value meta.Value) string {
@@ -75,7 +77,17 @@ func (k *keys) storeKey(value meta.Value) string {
 		return key
 	}
 
-	k.deleteExpired(now)
+	if uint64(len(k.values)) < k.maxKeys {
+		k.values[key] = now
+		return key
+	}
+
+	// Match the store's sweep cadence so full-map expiry cleanup is amortized during key floods.
+	if k.lastSweep.IsZero() || now.Sub(k.lastSweep) >= k.sweepInterval.Duration() {
+		k.deleteExpired(now)
+		k.lastSweep = now
+	}
+
 	if uint64(len(k.values)) < k.maxKeys {
 		k.values[key] = now
 		return key

--- a/transport/limiter/limiter.go
+++ b/transport/limiter/limiter.go
@@ -70,9 +70,10 @@ func NewLimiter(lc di.Lifecycle, keyMap KeyMap, cfg *Config) (*Limiter, error) {
 		key:    k,
 		window: limiterWindow(cfg.Interval),
 		keys: &keys{
-			values:  map[string]time.Time{},
-			ttl:     time.Duration(sweepMinTTL + sweepInterval),
-			maxKeys: cfg.GetMaxKeys(),
+			values:        map[string]time.Time{},
+			ttl:           time.Duration(sweepMinTTL + sweepInterval),
+			sweepInterval: time.Duration(sweepInterval),
+			maxKeys:       cfg.GetMaxKeys(),
 		},
 	}
 


### PR DESCRIPTION
## What

- Amortize expired key cleanup after the independent-key cap is reached, add a benchmark for high-cardinality traffic, and expose the benchmark through the documented Make commands.

## Why

- Sustained traffic with new caller keys should not require a full active-key scan on every overflow request, while keeping independent bucket capacity and cleanup behavior intact.

## Testing

- `make lint` - passed
- `make sec` - passed; no reachable dependency vulnerabilities or repository secrets were reported.
- `make specs` - passed
- `make benchmarks` - passed, including `BenchmarkLimiterManyDistinctKeys`.

AI-assisted-by: [Codex](https://openai.com/codex/)
