### PR TITLE
feat(events): log cloud processor panics safely

### DIFF
--- a/net/http/status/context.go
+++ b/net/http/status/context.go
@@ -27,3 +27,13 @@ func RequestError(ctx context.Context) error {
 
 	return state.err
 }
+
+// RecordError captures err for request-scoped operator diagnostics without writing a response.
+//
+// It retains the first error recorded through ctx and does nothing when ctx was not prepared with
+// [WithRequestError].
+func RecordError(ctx context.Context, err error) {
+	if state, _ := ctx.Value(requestErrorKey).(*requestError); state != nil && state.err == nil {
+		state.err = err
+	}
+}

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -23,9 +23,7 @@ var (
 // code. Use [SafeError] to retain an internal cause without exposing it to the client. WriteError returns a
 // body-write failure without attempting a secondary response.
 func WriteError(ctx context.Context, res http.ResponseWriter, err error) error {
-	if state, _ := ctx.Value(requestErrorKey).(*requestError); state != nil && state.err == nil {
-		state.err = err
-	}
+	RecordError(ctx, err)
 
 	header := res.Header()
 	header.Del("Content-Length")

--- a/transport/http/events/doc.go
+++ b/transport/http/events/doc.go
@@ -5,5 +5,10 @@
 //   - register unauthenticated HTTP transport routes that receive CloudEvents and dispatch to a ReceiverFunc, and
 //   - create CloudEvents HTTP clients that send events using an HTTP RoundTripper and configured encoding.
 //
+// Receiver panics are recovered at the CloudEvents callback boundary. The CloudEvents SDK otherwise recovers
+// callback panics internally, before go-service's transport recovery middleware can write its safe response or
+// emit its request log. A recovered panic becomes a safe HTTP 500/NACK response, and its diagnostic error is
+// recorded for the standard HTTP logger without being exposed to the sender.
+//
 // Start with [NewReceiver] / [Receiver.Register] for receiving and [NewSender] for sending.
 package events

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -1,6 +1,7 @@
 package events_test
 
 import (
+	"log/slog"
 	"net/http/httptest"
 	"testing"
 
@@ -12,7 +13,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/events"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
 	transportevents "github.com/alexfalkowski/go-service/v2/transport/http/events"
 	httphooks "github.com/alexfalkowski/go-service/v2/transport/http/hooks"
@@ -124,6 +127,50 @@ func TestReceiveCanReportProcessingFailure(t *testing.T) {
 	result := world.Sender.Send(ctx, e)
 	test.RequireNACK(t, result)
 	require.Nil(t, world.Event)
+}
+
+func TestReceiveLogsPanickingProcessor(t *testing.T) {
+	capture := &test.CaptureHandler{}
+	world := test.NewWorld(t,
+		test.WithWorldHTTP(),
+		test.WithWorldLogger(&logger.Logger{Logger: slog.New(capture)}),
+	)
+	world.Receiver.Register(t.Context(), "/events", func(context.Context, events.Event) events.Result {
+		panic("processor exploded")
+	})
+	world.Start()
+
+	e := events.NewEvent()
+	e.SetSource("example/uri")
+	e.SetType("example.type")
+	require.NoError(t, e.SetData(events.TextPlain, "test"))
+
+	result := world.Sender.Send(world.EventsContext(t.Context()), e)
+	test.RequireNACK(t, result)
+	require.Contains(t, result.Error(), "500")
+	require.NotContains(t, result.Error(), "processor exploded")
+
+	panicLogs := 0
+	for _, record := range capture.Snapshot() {
+		if record.Message != "http: panic" {
+			continue
+		}
+
+		panicLogs++
+		err, ok := record.Attrs["error"].Any().(error)
+		require.True(t, ok)
+		require.ErrorIs(t, err, runtime.ErrRecovered)
+		require.Contains(t, err.Error(), "processor exploded")
+		require.Equal(t, slog.LevelError, record.Level)
+		require.Equal(t, "http", record.Attrs["system"].String())
+		require.Equal(t, "events", record.Attrs["service"].String())
+		require.Equal(t, "post", record.Attrs["method"].String())
+		require.Equal(t, int64(http.StatusInternalServerError), record.Attrs["code"].Int64())
+		require.NotEmpty(t, record.Attrs["duration"].String())
+		require.NotEmpty(t, record.Attrs["requestId"].String())
+	}
+
+	require.Equal(t, 1, panicLogs)
 }
 
 func TestReceiveBypassesTransportTokenAuth(t *testing.T) {

--- a/transport/http/events/receiver.go
+++ b/transport/http/events/receiver.go
@@ -4,6 +4,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/events"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/events/hooks"
 )
@@ -42,7 +44,18 @@ func NewReceiver(router *http.Router, hook *hooks.Webhook) *Receiver {
 // structured HTTP encoding only; binary-mode CloudEvents with ce-* headers are rejected before signature
 // verification.
 func (r *Receiver) Register(ctx context.Context, path string, receiver ReceiverFunc) {
-	handler := events.NewReceiveHandler(ctx, receiver)
+	handler := events.NewReceiveHandler(ctx, func(ctx context.Context, event events.Event) (result events.Result) {
+		defer func() {
+			if value := recover(); value != nil {
+				// CloudEvents recovers callback panics internally, so recover here to preserve
+				// go-service's safe response and request-log diagnostics.
+				status.RecordError(ctx, runtime.ConvertRecover(value))
+				result = events.NewHTTPResult(http.StatusInternalServerError, "")
+			}
+		}()
+
+		return receiver(ctx, event)
+	})
 	handler = hooks.NewHandler(r.hook, handler)
 
 	r.router.HandleUnauthenticated(strings.Join(strings.Space, http.MethodPost, path), handler)


### PR DESCRIPTION
## What

- Return a safe HTTP 500 for CloudEvents receiver processor panics and retain the recovered error for request-scoped diagnostics.
- Add end-to-end coverage that verifies the sender receives no panic detail while the HTTP logger records the recovered processor failure.

## Why

- Processor panics should fail event delivery predictably and remain visible to operators without leaking implementation details to event senders.

## Testing

- `make package=transport/http/events specs` - passed
- `make package=net/http/status specs` - passed
- `make lint` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
