### PR TITLE
feat(hooks): retain webhook id across cloudevents retries

### DIFF
--- a/net/http/events/events.go
+++ b/net/http/events/events.go
@@ -25,6 +25,9 @@ type ReceiverFunc func(context.Context, Event) Result
 // Client sends CloudEvents.
 type Client = client.Client
 
+// ContextWithRetriesConstantBackoff aliases the CloudEvents retry-context helper.
+var ContextWithRetriesConstantBackoff = cloudevents.ContextWithRetriesConstantBackoff
+
 // NewEvent constructs an empty CloudEvent.
 func NewEvent() Event {
 	return cloudevents.NewEvent()

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -111,6 +111,45 @@ func TestReceiveAcceptsPreviousWebhookSecret(t *testing.T) {
 	require.Equal(t, "test", bytes.String(received.Data()))
 }
 
+func TestSenderReusesWebhookIDAcrossRetries(t *testing.T) {
+	receiver := httphooks.NewWebhook(newSingleHook(t, webhookSecret("dGVzdA==")), nil)
+	ids := make(chan string, 2)
+	verificationErrors := make(chan error, 2)
+	attempt := 0
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		verificationErrors <- receiver.Verify(req)
+		ids <- req.Header.Get(webhooks.HeaderWebhookID)
+
+		if attempt == 0 {
+			attempt++
+			res.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		res.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	sender := transportevents.NewSender(
+		httphooks.NewWebhook(newSingleHook(t, webhookSecret("dGVzdA==")), &test.IDSequenceGenerator{IDs: []string{"id-1", "id-2"}}),
+	)
+	e := events.NewEvent()
+	e.SetID("event-1")
+	e.SetSource("example/uri")
+	e.SetType("example.type")
+	require.NoError(t, e.SetData(events.TextPlain, "test"))
+
+	ctx := events.ContextWithTarget(t.Context(), server.URL+"/events")
+	ctx = events.ContextWithRetriesConstantBackoff(ctx, time.Nanosecond.Duration(), 1)
+	result := sender.Send(ctx, e)
+
+	test.RequireACK(t, result)
+	require.NoError(t, <-verificationErrors)
+	require.NoError(t, <-verificationErrors)
+	require.Equal(t, "id-1", <-ids)
+	require.Equal(t, "id-1", <-ids)
+}
+
 func TestReceiveCanReportProcessingFailure(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 	world.Receiver.Register(t.Context(), "/events", func(_ context.Context, _ events.Event) events.Result {

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -11,8 +11,9 @@ import (
 //
 // The constructed client uses the go-service CloudEvents HTTP transport. Outbound requests are wrapped with the
 // webhook signing RoundTripper (see [github.com/alexfalkowski/go-service/v2/transport/http/hooks]) so each request is signed before being sent
-// when hook is non-nil. When hook is nil, the signing RoundTripper behaves as a pass-through wrapper and
-// requests are sent unsigned.
+// when hook is non-nil. Each Send uses one generated Webhook-Id so retries retain the same id while refreshing
+// their timestamp and signature. When hook is nil, the signing RoundTripper behaves as a pass-through wrapper
+// and requests are sent unsigned.
 //
 // If no round tripper is configured via [WithSenderRoundTripper], it uses the default HTTP transport.
 //
@@ -31,17 +32,22 @@ func NewSender(hook *hooks.Webhook, opts ...SenderOption) *Sender {
 	httpClient.CheckRedirect = http.SameOriginRedirect
 
 	sender := events.NewClient(*httpClient)
-	return &Sender{client: sender, encoding: resolved.encoding}
+	return &Sender{client: sender, encoding: resolved.encoding, hook: hook}
 }
 
 // Sender wraps a CloudEvents client and sends outbound events using its configured HTTP encoding.
 type Sender struct {
 	client   events.Client
+	hook     *hooks.Webhook
 	encoding SenderEncoding
 }
 
 // Send transmits event using the configured CloudEvents HTTP encoding.
 func (s *Sender) Send(ctx context.Context, event events.Event) events.Result {
+	if s.hook != nil {
+		ctx = hooks.WithWebhookID(ctx, s.hook.GenerateID())
+	}
+
 	if s.encoding == SenderEncodingBinary {
 		return events.SendBinary(ctx, s.client, event)
 	}

--- a/transport/http/hooks/context.go
+++ b/transport/http/hooks/context.go
@@ -1,0 +1,16 @@
+package hooks
+
+import "github.com/alexfalkowski/go-service/v2/context"
+
+const webhookIDKey = context.Key("webhook-id")
+
+// WithWebhookID returns ctx with the webhook id for one logical delivery.
+func WithWebhookID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, webhookIDKey, id)
+}
+
+// WebhookID returns the webhook id from ctx.
+func WebhookID(ctx context.Context) string {
+	id, _ := ctx.Value(webhookIDKey).(string)
+	return id
+}

--- a/transport/http/hooks/hooks.go
+++ b/transport/http/hooks/hooks.go
@@ -22,7 +22,7 @@ import (
 // on top of the underlying Standard Webhooks signer/verifier.
 //
 // Signing requires a non-nil generator. Passing a nil generator is valid for verification-only use, but
-// calling [Webhook.Sign] or using the signing [RoundTripper] with a nil generator will panic.
+// calling [Webhook.Sign], [Webhook.GenerateID], or using the signing [RoundTripper] with a nil generator will panic.
 func NewWebhook(hook *hooks.Hook, generator id.Generator) *Webhook {
 	if hook == nil {
 		return nil
@@ -43,6 +43,13 @@ func NewWebhook(hook *hooks.Hook, generator id.Generator) *Webhook {
 type Webhook struct {
 	hook      *hooks.Hook
 	generator id.Generator
+}
+
+// GenerateID returns an id from the configured generator.
+//
+// A non-nil generator is required; calling GenerateID with a nil generator will panic.
+func (h *Webhook) GenerateID() string {
+	return h.generator.Generate()
 }
 
 // Sign signs an outbound webhook request.
@@ -81,8 +88,14 @@ func (h *Webhook) Sign(req *http.Request) error {
 	if req.Header == nil {
 		req.Header = http.Header{}
 	}
+
+	id := WebhookID(req.Context())
+	if id == "" {
+		id = h.generator.Generate()
+	}
+
 	now := time.Now()
-	id := h.generator.Generate()
+
 	signature, err := h.hook.Sign(id, now, payload)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

- `transport/http/events.Sender.Send` now generates one `Webhook-Id` per logical event delivery and carries it through the request context, so every CloudEvents retry attempt for that same `Send` call reuses the same id while its timestamp and signature are still refreshed on each attempt.
- `transport/http/hooks.Webhook.Sign` prefers an id found on the request context and only falls back to generating a fresh one when the context has none, so direct `RoundTripper`/`Sign` callers that don't set a context id keep their previous per-request id behavior.
- Adds `transport/http/hooks.Webhook.GenerateID` (exported, panics on a nil generator, documented alongside `Sign`'s existing panic contract) and a small `transport/http/hooks/context.go` helper pair, `WithWebhookID`/`WebhookID`, following this package's existing unexported `context.Key` pattern.
- Adds `net/http/events.ContextWithRetriesConstantBackoff`, a var alias to the CloudEvents SDK's constant-backoff retry helper, so tests and callers can configure CloudEvents client-side retries through this package's existing `net/http/events` surface.

## Why

- Standard Webhooks receivers are expected to deduplicate deliveries by `Webhook-Id`. Before this change, each CloudEvents retry attempt minted a brand-new id inside `Sign`, so a receiver that saw three delivery attempts for one logical send would see three different ids and could not tell they were the same event, defeating idempotent processing.
- Generating the id once per `Send` call and threading it through the context makes the id a stable idempotency key across an event's retries, matching this repository's existing convention for other logical-request identifiers.

## Testing

- `make golangci-lint package=transport/http/events`, `package=transport/http/hooks`, and `package=net/http/events` - passed
- `make specs package=transport/http/events`, `package=transport/http/hooks`, and `package=net/http/events` - passed
- `make field-alignment` and `make sec` - passed (the one reported `golang.org/x/crypto` advisory is an unaffected transitive module, not code this change touches)
- New test `TestSenderReusesWebhookIDAcrossRetries` drives a real CloudEvents retry (503 then success) through `Sender.Send` and asserts both delivery attempts verify successfully and carry the same `Webhook-Id`, while only one id is consumed from the configured generator.
- An independent agent review pass flagged one low-severity doc gap (`GenerateID`'s nil-generator panic contract wasn't documented); fixed by documenting the panic on `GenerateID` and listing it alongside `Sign` in `NewWebhook`'s panic note. No other findings.
