### PR TITLE
feat(encoding): simplify default codec construction

### DIFF
--- a/config/example_test.go
+++ b/config/example_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/config"
 	"github.com/alexfalkowski/go-service/v2/encoding"
-	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/flag"
 	"github.com/alexfalkowski/go-service/v2/os"
@@ -37,12 +36,10 @@ func ExampleNewConfig() {
 	flags.AddConfig("file:" + path)
 
 	decoder := config.NewDecoder(config.DecoderParams{
-		Flags: flags,
-		Encoder: encoding.NewMap(encoding.MapParams{
-			YAML: yaml.NewEncoder(),
-		}),
-		FS:   fs,
-		Name: env.Name("payments"),
+		Flags:   flags,
+		Encoder: encoding.NewMap(),
+		FS:      fs,
+		Name:    env.Name("payments"),
 	})
 
 	cfg, err := config.NewConfig[exampleConfig](decoder, config.NewValidator())

--- a/encoding/doc.go
+++ b/encoding/doc.go
@@ -15,12 +15,14 @@
 //
 // # Wiring
 //
-// Module wires the default encoder implementations and provides a *[Map] that registers the supplied
-// encoders under common kinds used throughout go-service, including:
+// NewMap constructs a *[Map] that registers default encoders under common kinds used throughout
+// go-service, including:
 //   - JSON, HJSON, YAML, TOML, MessagePack
 //   - protobuf binary/text/JSON variants
 //   - gob
 //   - "plain"/bytes passthrough for [io.ReaderFrom]/[io.WriterTo] payloads
+//
+// Module provides the default *[Map] for Fx applications.
 //
 // Start with [Encoder], [Map], [NewMap], and [Module].
 package encoding

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -3,7 +3,6 @@ package encoding
 import (
 	"maps"
 
-	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/encoding/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding/gob"
 	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
@@ -15,53 +14,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/slices"
 )
 
-// MapParams defines the dependencies used to construct an encoding Map.
+// NewMap constructs a Map with the default encoders.
 //
-// It is intended for dependency injection ([go.uber.org/fx]/[go.uber.org/dig]). The default wiring is provided by [Module].
-// [NewMap] registers these values as supplied; direct callers that leave a field nil will get a nil
-// encoder for that field's registered kind aliases.
-type MapParams struct {
-	di.In
-
-	// JSON is the encoder implementation registered under kind "json".
-	JSON *json.Encoder
-
-	// HumanJSON is the encoder implementation registered under kind "hjson".
-	HumanJSON *hjson.Encoder
-
-	// YAML is the encoder implementation registered under kinds "yaml" and "yml".
-	YAML *yaml.Encoder
-
-	// TOML is the encoder implementation registered under kind "toml".
-	TOML *toml.Encoder
-
-	// MessagePack is the encoder implementation registered under kind "msgpack".
-	MessagePack *msgpack.Encoder `optional:"true"`
-
-	// ProtoBinary is the encoder implementation registered under common binary kinds
-	// (e.g. "proto", "protobuf", "pb", etc.).
-	ProtoBinary *proto.Binary
-
-	// ProtoText is the encoder implementation registered under common text kinds
-	// (e.g. "prototext", "prototxt", "pbtxt").
-	ProtoText *proto.Text
-
-	// ProtoJSON is the encoder implementation registered under common JSON kinds
-	// (e.g. "protojson", "pbjson").
-	ProtoJSON *proto.JSON
-
-	// GOB is the encoder implementation registered under kind "gob".
-	GOB *gob.Encoder
-
-	// Bytes is the passthrough encoder for [io.ReaderFrom]/[io.WriterTo] payloads, registered under kinds
-	// like "plain", "octet-stream", and "markdown".
-	Bytes *bytes.Encoder
-}
-
-// NewMap constructs a Map from the supplied encoder dependencies.
-//
-// The returned registry includes common kinds used throughout go-service, mapped to the corresponding
-// fields from params:
+// The returned registry includes these kinds:
 //
 //   - Structured config formats: "json", "hjson", "yaml", "yml", "toml", "msgpack"
 //
@@ -77,31 +32,41 @@ type MapParams struct {
 //
 //   - bytes/plain passthrough: "plain", "octet-stream", "markdown"
 //
-// Callers can add additional kinds or override existing kinds via [Map.Register]. NewMap does not
-// synthesize encoders; if a params field is nil, its registered kind aliases resolve to nil.
-func NewMap(params MapParams) *Map {
+// Callers can add additional kinds or override existing kinds via [Map.Register].
+func NewMap() *Map {
+	jsonEncoder := json.NewEncoder()
+	hjsonEncoder := hjson.NewEncoder()
+	yamlEncoder := yaml.NewEncoder()
+	tomlEncoder := toml.NewEncoder()
+	msgpackEncoder := msgpack.NewEncoder()
+	protoBinary := proto.NewBinary()
+	protoText := proto.NewText()
+	protoJSON := proto.NewJSON()
+	gobEncoder := gob.NewEncoder()
+	bytesEncoder := bytes.NewEncoder()
+
 	return &Map{
 		encoders: map[string]Encoder{
-			"json":         params.JSON,
-			"hjson":        params.HumanJSON,
-			"yaml":         params.YAML,
-			"yml":          params.YAML,
-			"toml":         params.TOML,
-			"msgpack":      params.MessagePack,
-			"pb":           params.ProtoBinary,
-			"pbbin":        params.ProtoBinary,
-			"proto":        params.ProtoBinary,
-			"protobin":     params.ProtoBinary,
-			"protobuf":     params.ProtoBinary,
-			"pbtxt":        params.ProtoText,
-			"prototext":    params.ProtoText,
-			"prototxt":     params.ProtoText,
-			"protojson":    params.ProtoJSON,
-			"pbjson":       params.ProtoJSON,
-			"gob":          params.GOB,
-			"markdown":     params.Bytes,
-			"octet-stream": params.Bytes,
-			"plain":        params.Bytes,
+			"json":         jsonEncoder,
+			"hjson":        hjsonEncoder,
+			"yaml":         yamlEncoder,
+			"yml":          yamlEncoder,
+			"toml":         tomlEncoder,
+			"msgpack":      msgpackEncoder,
+			"pb":           protoBinary,
+			"pbbin":        protoBinary,
+			"proto":        protoBinary,
+			"protobin":     protoBinary,
+			"protobuf":     protoBinary,
+			"pbtxt":        protoText,
+			"prototext":    protoText,
+			"prototxt":     protoText,
+			"protojson":    protoJSON,
+			"pbjson":       protoJSON,
+			"gob":          gobEncoder,
+			"markdown":     bytesEncoder,
+			"octet-stream": bytesEncoder,
+			"plain":        bytesEncoder,
 		},
 	}
 }

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -32,62 +32,40 @@ func TestEncoder(t *testing.T) {
 }
 
 func TestNewMapRegistersDefaultEncoders(t *testing.T) {
-	jsonEncoder := json.NewEncoder()
-	hjsonEncoder := hjson.NewEncoder()
-	yamlEncoder := yaml.NewEncoder()
-	tomlEncoder := toml.NewEncoder()
-	msgpackEncoder := msgpack.NewEncoder()
-	protoBinary := proto.NewBinary()
-	protoText := proto.NewText()
-	protoJSON := proto.NewJSON()
-	gobEncoder := gob.NewEncoder()
-	bytesEncoder := bytes.NewEncoder()
-
-	encoders := encoding.NewMap(encoding.MapParams{
-		JSON:        jsonEncoder,
-		HumanJSON:   hjsonEncoder,
-		YAML:        yamlEncoder,
-		TOML:        tomlEncoder,
-		MessagePack: msgpackEncoder,
-		ProtoBinary: protoBinary,
-		ProtoText:   protoText,
-		ProtoJSON:   protoJSON,
-		GOB:         gobEncoder,
-		Bytes:       bytesEncoder,
-	})
+	encoders := encoding.NewMap()
 
 	expected := map[string]encoding.Encoder{
-		"json":         jsonEncoder,
-		"hjson":        hjsonEncoder,
-		"yaml":         yamlEncoder,
-		"yml":          yamlEncoder,
-		"toml":         tomlEncoder,
-		"msgpack":      msgpackEncoder,
-		"pb":           protoBinary,
-		"pbbin":        protoBinary,
-		"proto":        protoBinary,
-		"protobin":     protoBinary,
-		"protobuf":     protoBinary,
-		"pbtxt":        protoText,
-		"prototext":    protoText,
-		"prototxt":     protoText,
-		"protojson":    protoJSON,
-		"pbjson":       protoJSON,
-		"gob":          gobEncoder,
-		"markdown":     bytesEncoder,
-		"octet-stream": bytesEncoder,
-		"plain":        bytesEncoder,
+		"json":         json.NewEncoder(),
+		"hjson":        hjson.NewEncoder(),
+		"yaml":         yaml.NewEncoder(),
+		"yml":          yaml.NewEncoder(),
+		"toml":         toml.NewEncoder(),
+		"msgpack":      msgpack.NewEncoder(),
+		"pb":           proto.NewBinary(),
+		"pbbin":        proto.NewBinary(),
+		"proto":        proto.NewBinary(),
+		"protobin":     proto.NewBinary(),
+		"protobuf":     proto.NewBinary(),
+		"pbtxt":        proto.NewText(),
+		"prototext":    proto.NewText(),
+		"prototxt":     proto.NewText(),
+		"protojson":    proto.NewJSON(),
+		"pbjson":       proto.NewJSON(),
+		"gob":          gob.NewEncoder(),
+		"markdown":     bytes.NewEncoder(),
+		"octet-stream": bytes.NewEncoder(),
+		"plain":        bytes.NewEncoder(),
 	}
 
 	for kind, expectedEncoder := range expected {
 		t.Run(kind, func(t *testing.T) {
-			require.Same(t, expectedEncoder, encoders.Get(kind))
+			require.IsType(t, expectedEncoder, encoders.Get(kind))
 		})
 	}
 }
 
 func TestMapRegister(t *testing.T) {
-	encoders := encoding.NewMap(encoding.MapParams{})
+	encoders := encoding.NewMap()
 	custom := test.NewEncoder(test.ErrFailed)
 	replacement := bytes.NewEncoder()
 
@@ -113,4 +91,16 @@ func TestModuleProvidesDefaultEncoders(t *testing.T) {
 			require.NotNil(t, encoders.Get(kind))
 		})
 	}
+}
+
+func TestModuleDoesNotProvideJSONEncoder(t *testing.T) {
+	var encoder *json.Encoder
+
+	app := fx.New(
+		encoding.Module,
+		fx.Populate(&encoder),
+		fx.NopLogger,
+	)
+
+	require.Error(t, app.Err())
 }

--- a/encoding/module.go
+++ b/encoding/module.go
@@ -1,37 +1,8 @@
 package encoding
 
-import (
-	"github.com/alexfalkowski/go-service/v2/di"
-	"github.com/alexfalkowski/go-service/v2/encoding/bytes"
-	"github.com/alexfalkowski/go-service/v2/encoding/gob"
-	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
-	"github.com/alexfalkowski/go-service/v2/encoding/json"
-	"github.com/alexfalkowski/go-service/v2/encoding/msgpack"
-	"github.com/alexfalkowski/go-service/v2/encoding/proto"
-	"github.com/alexfalkowski/go-service/v2/encoding/toml"
-	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
-)
+import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module wires the default encoder implementations and the encoder registry into [go.uber.org/fx]/[go.uber.org/dig].
-//
-// It provides protobuf encoders (*[proto.Binary], *[proto.Text], *[proto.JSON]),
-// structured config encoders (*[json.Encoder], *[hjson.Encoder], *[toml.Encoder],
-// *[yaml.Encoder], *[msgpack.Encoder]), and passthrough/specialized encoders
-// (*[gob.Encoder] and *[bytes.Encoder]).
-//
-// Finally, it constructs a *[Map] via [NewMap], registering the provided
-// encoders under common kind aliases (for example "yaml"/"yml", protobuf kind
-// synonyms, and "plain"/"octet-stream" passthrough kinds).
+// Module provides the default encoder registry as a *[Map].
 var Module = di.Module(
-	di.Constructor(proto.NewBinary),
-	di.Constructor(proto.NewText),
-	di.Constructor(proto.NewJSON),
-	di.Constructor(json.NewEncoder),
-	di.Constructor(hjson.NewEncoder),
-	di.Constructor(toml.NewEncoder),
-	di.Constructor(yaml.NewEncoder),
-	di.Constructor(msgpack.NewEncoder),
-	di.Constructor(gob.NewEncoder),
-	di.Constructor(bytes.NewEncoder),
 	di.Constructor(NewMap),
 )

--- a/internal/test/encoding.go
+++ b/internal/test/encoding.go
@@ -2,31 +2,12 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
-	"github.com/alexfalkowski/go-service/v2/encoding/bytes"
-	"github.com/alexfalkowski/go-service/v2/encoding/gob"
-	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
-	"github.com/alexfalkowski/go-service/v2/encoding/json"
-	"github.com/alexfalkowski/go-service/v2/encoding/msgpack"
-	"github.com/alexfalkowski/go-service/v2/encoding/proto"
-	"github.com/alexfalkowski/go-service/v2/encoding/toml"
-	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 )
 
 // Encoder contains the real encoders exercised by config, cache, and transport tests.
-var Encoder = encoding.NewMap(encoding.MapParams{
-	JSON:        json.NewEncoder(),
-	HumanJSON:   hjson.NewEncoder(),
-	YAML:        yaml.NewEncoder(),
-	TOML:        toml.NewEncoder(),
-	MessagePack: msgpack.NewEncoder(),
-	ProtoBinary: proto.NewBinary(),
-	ProtoText:   proto.NewText(),
-	ProtoJSON:   proto.NewJSON(),
-	GOB:         gob.NewEncoder(),
-	Bytes:       bytes.NewEncoder(),
-})
+var Encoder = encoding.NewMap()
 
 // Content is the shared HTTP content registry backed by Encoder.
 var Content = content.NewContent(Encoder, Pool)

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -114,7 +114,7 @@ func TestNewHandlerReplacesExistingContentType(t *testing.T) {
 }
 
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
-	enc := encoding.NewMap(encoding.MapParams{})
+	enc := encoding.NewMap()
 	enc.Register("json", test.PartialEncoder{})
 	cont := content.NewContent(enc, test.Pool)
 

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
-	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
@@ -20,7 +19,7 @@ func ExampleGet() {
 	rest.Register(rest.RegisterParams{
 		Router: router,
 		Content: content.NewContent(
-			encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
+			encoding.NewMap(),
 			pool,
 		),
 		Pool: pool,

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
-	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
@@ -20,7 +19,7 @@ func ExampleClient_Post() {
 	rpc.Register(rpc.RegisterParams{
 		Router: router,
 		Content: content.NewContent(
-			encoding.NewMap(encoding.MapParams{JSON: json.NewEncoder()}),
+			encoding.NewMap(),
 			pool,
 		),
 		Pool: pool,


### PR DESCRIPTION
## What

- Make `encoding.NewMap` build and register the default codecs directly, and make `encoding.Module` provide only the resulting registry.
- Update config and HTTP examples, shared test setup, and package documentation to use the simplified registry boundary.

## Why

- Reduce the DI surface for default codecs while preserving the standard registry kinds used by configuration, cache, and HTTP flows.
- This intentionally removes `encoding.MapParams` and direct individual codec providers from the public API; consumers should construct or depend on `*encoding.Map`.

## Testing

- `make specs` - passed
- `make lint` - passed
- Updated coverage verifies the default registry kinds and that Fx exposes the registry rather than individual codecs.

AI-assisted-by: [Codex](https://openai.com/codex/)
