### PR TITLE
feat(compress): construct default implementations internally

### DIFF
--- a/compress/compress.go
+++ b/compress/compress.go
@@ -5,33 +5,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/compress/s2"
 	"github.com/alexfalkowski/go-service/v2/compress/snappy"
 	"github.com/alexfalkowski/go-service/v2/compress/zstd"
-	"github.com/alexfalkowski/go-service/v2/di"
 )
 
-// MapParams defines dependencies used to construct a Map.
-//
-// It is intended for dependency injection ([go.uber.org/fx]/[go.uber.org/dig]). The default wiring is provided by [Module].
-type MapParams struct {
-	di.In
-
-	// Zstd is the Zstandard compressor implementation registered under kind "zstd".
-	Zstd *zstd.Compressor
-
-	// S2 is the S2 compressor implementation registered under kind "s2".
-	S2 *s2.Compressor
-
-	// Snappy is the Snappy compressor implementation registered under kind "snappy".
-	Snappy *snappy.Compressor
-
-	// None is the no-op compressor implementation registered under kind "none".
-	None *none.Compressor
-}
-
-// NewMap constructs a Map pre-populated with the default compressors keyed by kind.
-//
-// The standard [Module] supplies non-nil default compressor implementations. Direct
-// calls use the [MapParams] values exactly, so zero-value params register nil
-// implementations for the built-in keys.
+// NewMap constructs a Map with the default compressors.
 //
 // The returned map includes these kinds:
 //
@@ -41,13 +17,13 @@ type MapParams struct {
 //   - "none"
 //
 // Callers can add additional implementations or override existing kinds via [Map.Register].
-func NewMap(params MapParams) *Map {
+func NewMap() *Map {
 	return &Map{
 		compressors: map[string]Compressor{
-			"zstd":   params.Zstd,
-			"s2":     params.S2,
-			"snappy": params.Snappy,
-			"none":   params.None,
+			"zstd":   zstd.NewCompressor(),
+			"s2":     s2.NewCompressor(),
+			"snappy": snappy.NewCompressor(),
+			"none":   none.NewCompressor(),
 		},
 	}
 }

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -41,34 +41,24 @@ func TestMap(t *testing.T) {
 }
 
 func TestNewMapRegistersDefaultCompressors(t *testing.T) {
-	zstdCompressor := zstd.NewCompressor()
-	s2Compressor := s2.NewCompressor()
-	snappyCompressor := snappy.NewCompressor()
-	noneCompressor := none.NewCompressor()
-
-	compressors := compress.NewMap(compress.MapParams{
-		Zstd:   zstdCompressor,
-		S2:     s2Compressor,
-		Snappy: snappyCompressor,
-		None:   noneCompressor,
-	})
+	compressors := compress.NewMap()
 
 	expected := map[string]compress.Compressor{
-		"zstd":   zstdCompressor,
-		"s2":     s2Compressor,
-		"snappy": snappyCompressor,
-		"none":   noneCompressor,
+		"zstd":   zstd.NewCompressor(),
+		"s2":     s2.NewCompressor(),
+		"snappy": snappy.NewCompressor(),
+		"none":   none.NewCompressor(),
 	}
 
 	for kind, expectedCompressor := range expected {
 		t.Run(kind, func(t *testing.T) {
-			require.Same(t, expectedCompressor, compressors.Get(kind))
+			require.IsType(t, expectedCompressor, compressors.Get(kind))
 		})
 	}
 }
 
 func TestMapRegister(t *testing.T) {
-	compressors := compress.NewMap(compress.MapParams{})
+	compressors := compress.NewMap()
 	custom := test.NewCompressor(test.ErrFailed)
 	replacement := none.NewCompressor()
 
@@ -94,4 +84,16 @@ func TestModuleProvidesDefaultCompressors(t *testing.T) {
 			require.NotNil(t, compressors.Get(kind))
 		})
 	}
+}
+
+func TestModuleDoesNotProvideZstdCompressor(t *testing.T) {
+	var compressor *zstd.Compressor
+
+	app := fx.New(
+		compress.Module,
+		fx.Populate(&compressor),
+		fx.NopLogger,
+	)
+
+	require.Error(t, app.Err())
 }

--- a/compress/doc.go
+++ b/compress/doc.go
@@ -17,12 +17,14 @@
 //
 // # Wiring
 //
-// [Module] wires the default compressor implementations and provides a *[Map] pre-populated with:
+// [NewMap] constructs a *[Map] with the default compressors:
 //
 //   - "zstd"
 //   - "s2"
 //   - "snappy"
 //   - "none"
+//
+// [Module] provides the default *[Map] for Fx applications.
 //
 // You can extend or override supported kinds by calling [Map.Register] after construction.
 //

--- a/compress/module.go
+++ b/compress/module.go
@@ -1,31 +1,8 @@
 package compress
 
-import (
-	"github.com/alexfalkowski/go-service/v2/compress/none"
-	"github.com/alexfalkowski/go-service/v2/compress/s2"
-	"github.com/alexfalkowski/go-service/v2/compress/snappy"
-	"github.com/alexfalkowski/go-service/v2/compress/zstd"
-	"github.com/alexfalkowski/go-service/v2/di"
-)
+import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module wires the default compressor implementations and the compressor registry into [go.uber.org/fx].
-//
-// It provides constructors for:
-//   - [snappy.NewCompressor] (kind "snappy")
-//   - [s2.NewCompressor] (kind "s2")
-//   - [zstd.NewCompressor] (kind "zstd")
-//   - [none.NewCompressor] (kind "none")
-//
-// And then constructs a *[Map] via [NewMap], pre-populated with those implementations.
-//
-// # Extending / overriding
-//
-// If you want to support additional kinds (or override a default), register them on the *[Map] after
-// construction by calling [Map.Register] during initialization.
+// Module provides the default compressor registry as a *[Map].
 var Module = di.Module(
-	di.Constructor(snappy.NewCompressor),
-	di.Constructor(s2.NewCompressor),
-	di.Constructor(zstd.NewCompressor),
-	di.Constructor(none.NewCompressor),
 	di.Constructor(NewMap),
 )

--- a/internal/test/compress.go
+++ b/internal/test/compress.go
@@ -3,19 +3,10 @@ package test
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/compress"
-	"github.com/alexfalkowski/go-service/v2/compress/none"
-	"github.com/alexfalkowski/go-service/v2/compress/s2"
-	"github.com/alexfalkowski/go-service/v2/compress/snappy"
-	"github.com/alexfalkowski/go-service/v2/compress/zstd"
 )
 
 // Compressor contains the real compressor implementations exercised by tests.
-var Compressor = compress.NewMap(compress.MapParams{
-	Zstd:   zstd.NewCompressor(),
-	S2:     s2.NewCompressor(),
-	Snappy: snappy.NewCompressor(),
-	None:   none.NewCompressor(),
-})
+var Compressor = compress.NewMap()
 
 // NewCompressor returns a compressor test double whose Compress and Decompress methods fail with err.
 func NewCompressor(err error) compress.Compressor {


### PR DESCRIPTION
## What

- Construct and register the default Zstandard, S2, Snappy, and no-op implementations inside `compress.NewMap`.
- Make `compress.Module` provide the default `*compress.Map` registry without exposing individual compressor implementations through Fx.
- **Breaking change:** replace `compress.NewMap(compress.MapParams{...})` with `compress.NewMap()`; consumers that need a concrete implementation directly should construct it from its algorithm package.

## Why

- Keep the default registry self-contained and remove low-level DI dependencies that callers do not need to configure.
- Align the registry construction model with the framework's other default registries.

## Testing

- `make lint` - passed
- `make specs` - passed (2,410 tests)
- `make coverage` - passed (96.8% overall; changed registry functions are fully covered)
- `make generate-stale` - not applicable before commit because it compares the entire dirty worktree; CI runs it from a clean checkout.

AI-assisted-by: [Codex](https://openai.com/codex/)
