### PR TITLE
feat(encoding): drop markdown media support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,10 @@ Encoding kinds used by subsystems that support encoding:
 - `protojson`, `pbjson`
 - `prototext`, `prototxt`, `pbtxt`
 - `gob`
-- `plain`, `octet-stream`, `markdown`
+- `plain`, `octet-stream`
 
 > [!NOTE]
-> - `plain`, `octet-stream`, and `markdown` all map to the bytes passthrough encoder.
+> - `plain` and `octet-stream` map to the bytes passthrough encoder.
 > - Protobuf binary/text/JSON kinds have multiple aliases; the list above reflects the built-in registry.
 
 ---
@@ -1094,7 +1094,7 @@ Built-in text/object payload media types include:
 - `application/hjson`
 - `application/yaml`, `application/yml`
 - `application/toml`
-- `application/octet-stream`, `text/plain`, `text/markdown`
+- `application/octet-stream`, `text/plain`
 
 Internal binary payload media types include:
 

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -30,7 +30,7 @@ import (
 //
 //   - gob: "gob"
 //
-//   - bytes/plain passthrough: "plain", "octet-stream", "markdown"
+//   - bytes/plain passthrough: "plain", "octet-stream"
 //
 // Callers can add additional kinds or override existing kinds via [Map.Register].
 func NewMap() *Map {
@@ -64,7 +64,6 @@ func NewMap() *Map {
 			"protojson":    protoJSON,
 			"pbjson":       protoJSON,
 			"gob":          gobEncoder,
-			"markdown":     bytesEncoder,
 			"octet-stream": bytesEncoder,
 			"plain":        bytesEncoder,
 		},

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -52,7 +52,6 @@ func TestNewMapRegistersDefaultEncoders(t *testing.T) {
 		"protojson":    proto.NewJSON(),
 		"pbjson":       proto.NewJSON(),
 		"gob":          gob.NewEncoder(),
-		"markdown":     bytes.NewEncoder(),
 		"octet-stream": bytes.NewEncoder(),
 		"plain":        bytes.NewEncoder(),
 	}

--- a/net/http/content/content_test.go
+++ b/net/http/content/content_test.go
@@ -239,7 +239,6 @@ func mediaTests() []mediaTest {
 		{name: "gob", mediaType: "application/gob", subtype: "gob", kind: "gob"},
 		{name: "plain", mediaType: media.Text, subtype: "plain", kind: "plain"},
 		{name: "octet-stream", mediaType: "application/octet-stream", subtype: "octet-stream", kind: "octet-stream"},
-		{name: "markdown", mediaType: media.Markdown, subtype: "markdown", kind: "markdown"},
 		{name: "invalid", mediaType: "test", subtype: "json", kind: "json"},
 		{name: "unknown", mediaType: "application/test", subtype: "json", kind: "json"},
 	}

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -33,9 +33,6 @@ const JSON = "application/json"
 // This is commonly used as the Content-Type for HumanJSON request/response bodies.
 const HumanJSON = "application/hjson"
 
-// Markdown is the media type for Markdown documents.
-const Markdown = "text/markdown"
-
 // MessagePack is the vendor media type for MessagePack payloads.
 const MessagePack = "application/vnd.msgpack"
 


### PR DESCRIPTION
## What

- Remove the unused Markdown encoder alias and the exported `media.Markdown` constant.
- Stop advertising Markdown as a built-in HTTP payload type while retaining the supported `plain` and `octet-stream` passthrough kinds.
- This is an intentional breaking change: callers using the removed encoder key or constant must migrate.

## Why

- Public dependent projects do not use the Markdown encoder or media constant, so removing the unsupported surface reduces the default registry and media API to the formats the framework maintains.

## Testing

- `make specs` - passed
- `make lint` - passed
- Existing encoder, HTTP content, and media package tests cover the remaining registry and media-type behavior; unknown media continues to use the JSON fallback.

AI-assisted-by: [Codex](https://openai.com/codex/)
