### PR TITLE
feat(http): stop double-prefixing tls config errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ DOCS.md
 FEATURES.md
 PROJECTS.md
 RELIABILITY.md
+PLAN.md
 vendor/
 test/reports/*
 !test/reports/.keep

--- a/debug/server.go
+++ b/debug/server.go
@@ -107,7 +107,7 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 
 	tlsConfig, err := server.NewConfig(fs, cfg.TLS)
 	if err != nil {
-		return nil, prefix(err)
+		return nil, err
 	}
 
 	serverConfig.TLS = tlsConfig

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -204,7 +204,7 @@ func newConfig(fs *os.FS, cfg *Config) (*config.Config, error) {
 
 	tlsConfig, err := server.NewConfig(fs, cfg.TLS)
 	if err != nil {
-		return nil, prefix(err)
+		return nil, err
 	}
 
 	config.TLS = tlsConfig


### PR DESCRIPTION
## What

- Remove the redundant inner `prefix(err)` call in `debug.newConfig` and `transport/http.newConfig` so a TLS configuration failure is no longer wrapped twice (e.g. `debug: debug: <cause>` / `http: http: <cause>`). Both `newConfig` helpers are only ever called from their package's `NewServer`, which already applies `prefix(err)` to whatever `newConfig` returns, so the inner wrap was pure duplication.
- Add `PLAN.md` to `.gitignore`, alongside the existing repo-root scratch/doc entries (`DOCS.md`, `FEATURES.md`, `PROJECTS.md`, `RELIABILITY.md`), so a local design-notes file with that name is not tracked.

## Why

- A double-prefixed error message is misleading and harder to grep for during triage, exactly at the moment (server startup with bad TLS config) when a clear, single-prefixed error matters most. Removing the redundant wrap restores the existing single `<package>: <cause>` error contract that the rest of the codebase relies on.

## Testing

- `make package=debug specs` - passed (`TestInvalidServer` exercises the `newConfig` TLS error path)
- `make package=transport/http specs` - passed, 168 tests (including `TestInvalidServer`, `TestServerRejectsCAOnlyTLS`)
- `make package=debug lint` - passed, 0 issues
- `make package=transport/http lint` - passed, 0 issues
- `make sec` - passed; the one reported advisory (`golang.org/x/crypto/openpgp`, GO-2026-5932) is a pre-existing, unrelated transitive finding not triggered by this change
- Independent review confirmed `newConfig` has exactly one call site per package, no test asserts the exact error-prefix string/count, and the `.gitignore` addition matches the existing naming convention
