### PR TITLE
feat(http): add ndjson streaming routes with reliable deadlines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
       - sync-submodules
 
 executors:
-  go-with-postgres-valkey-status-mimir:
+  go-with-postgres-valkey-status-observability:
     docker:
       - image: alexfalkowski/go:4.31
       - image: postgres:18-trixie
@@ -25,8 +25,7 @@ executors:
         command: server -config env:CONFIG
         environment:
           CONFIG: yml:ZW52aXJvbm1lbnQ6IGRldmVsb3BtZW50CmhlYWx0aDoKICBkdXJhdGlvbjogMXMKICB0aW1lb3V0OiAxcwppZDoKICBraW5kOiB1dWlkCnRlbGVtZXRyeToKICBsb2dnZXI6CiAgICBraW5kOiB0ZXh0CiAgICBsZXZlbDogaW5mbwp0cmFuc3BvcnQ6CiAgaHR0cDoKICAgIGFkZHJlc3M6IHRjcDovLzo2MDAwCiAgICB0aW1lb3V0OiAxMHMK
-      - image: grafana/mimir:latest
-        command: -server.http-listen-port=9009 -auth.multitenancy-enabled=false -ingester.ring.replication-factor=1
+      - image: grafana/otel-lgtm:latest
   release:
     docker:
       - image: alexfalkowski/release:8.27
@@ -36,14 +35,14 @@ executors:
 
 jobs:
   build:
-    executor: go-with-postgres-valkey-status-mimir
+    executor: go-with-postgres-valkey-status-observability
     working_directory: ~/go-service
     steps:
       - checkout-submodules
       - run: make source-key
       - run: mkcert -install
       - run: make create-certs
-      - run: dockerize -wait tcp://localhost:5432 -wait tcp://localhost:6379 -wait tcp://localhost:6000 -wait tcp://localhost:9009 -timeout 1m
+      - run: dockerize -wait tcp://localhost:5432 -wait tcp://localhost:6379 -wait tcp://localhost:6000 -wait tcp://localhost:4318 -timeout 1m
       - restore_cache:
           name: restore go cache
           keys:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,59 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   accidental double-counting; report only concrete bugs such as missing message
   limiting, ignored explicit limiter config, or incorrect status/header
   behavior.
+- HTTP streaming routes (`net/http/content.Stream`/`RequestStream`) mirror the
+  gRPC stream limiter behavior above: `transport/http/limiter.Handler` still
+  charges one token when the request/stream opens (its existing single
+  `TakeDecision` call, unchanged for every route), and on top of that it stores
+  the underlying `*transport/limiter.Limiter` on the request context via
+  `net/http/meta.WithLimiter` when the request is allowed. `Stream.Send` and
+  `RequestStream.Recv` retrieve it via `net/http/meta.Limiter` and each charge
+  one additional token per message, so a streaming route pays the same
+  stream-open-plus-per-message cost gRPC streams do; non-streaming routes never
+  read that context value, so it is harmless overhead for them. A denial
+  discovered by `Send`/`Recv` before the first successful `Send` is an ordinary
+  pre-commit `429` through `status.Error`, matching the middleware's own
+  rejection; a denial discovered after the response is committed cannot be a
+  `429` (headers are already sent), so it aborts the response like any other
+  post-commit streaming error. The
+  `RateLimit`/`RateLimit-Policy` response headers are set once, from the
+  stream-open decision only, and are not re-emitted per message, since HTTP
+  headers cannot change after a streaming response is committed — unlike
+  gRPC, which can fall back to trailers. Do not flag the missing per-message
+  header updates or the context-value plumbing as bugs; report only concrete
+  issues such as a streaming route never being charged, a charge applied
+  without a captured limiter, or a mid-stream denial incorrectly writing a
+  status after commit.
+- HTTP streaming responses (`net/http/content.NewStreamHandler`,
+  `NewRequestStreamHandler`) intentionally opt out of gzip by setting
+  `gzhttp.HeaderNoCompression` before the first byte is written. This is a
+  deliberate cost/interop decision, not an oversight: per-value flush emits a
+  separate gzip flush block per message (poor value for small NDJSON records),
+  and `gzhttp`'s deferred `Close` on an aborted stream can still emit a
+  complete, valid gzip footer, which is a residual interop risk for a client
+  whose gzip reader stops at that footer rather than reading ahead into the
+  truncated chunked stream (Go's own client does read ahead and still observes
+  the abort). Do not flag the missing compression for streaming responses as a
+  performance regression; report only concrete bugs such as the header not
+  being set before commit, or a streaming route that is compressed despite it.
+- Bidirectional HTTP streaming routes (`net/http/content.NewRequestStreamHandler`,
+  and the route helpers that use it: `net/http/rest`'s `StreamRouteRequest`,
+  `StreamPost`, `StreamPut`, `StreamPatch`, and `net/http/rpc.StreamRoute`)
+  require HTTP/2 (including h2c). `NewRequestStreamHandler` rejects a request
+  with `req.ProtoMajor < 2` with `505 HTTP Version Not Supported` before the
+  handler runs. This is intentional and measured, not a missing feature: an
+  HTTP/1.x request body is buffered ahead of the handler by intermediaries and
+  the Go transport, so a bidi handler that both reads the request stream and
+  writes the response stream hangs rather than failing outright over h1 — the
+  pre-handler rejection is what turns that hang into an immediate, diagnosable
+  error. Send-only streaming routes (`net/http/content.NewStreamHandler`, and
+  `net/http/rest`'s `StreamRoute`/`StreamGet`, `net/http/rpc` has no send-only
+  helper) have no such requirement and stay fully supported on HTTP/1.1
+  chunked responses, since only the bidi handle interleaves reads and writes.
+  Do not flag the 505 rejection, or the asymmetry between the bidi and
+  send-only helpers, as a bug; report only concrete issues such as the gate
+  firing for a send-only route, failing to fire for a bidi route, or an h2/h2c
+  deployment still hanging instead of failing.
 - HTTP telemetry logger service/method derivation may include request URL path
   segments for non-canonical HTTP routes. This is intentional for client and
   server debugging because HTTP clients can call arbitrary paths and route
@@ -640,3 +693,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   perform internet/network time queries. Report only concrete breakage such as
   all configured providers currently failing in CI, ignored timeouts, removed
   provider redundancy, or a documented promise of hermetic/offline specs.
+- Agents verifying changes in a sandboxed shell should run `make specs`
+  (optionally `package=<path>` to scope it) rather than a raw `go test`
+  invocation, especially for anything touching or depending on the `time`
+  package. In at least one sandboxed agent environment, raw `go test` against
+  `time`'s NTP/NTS tests failed reproducibly (`dial udp/tcp ...: operation not
+  permitted`) while `package=time make specs` passed reproducibly for the same
+  code, same machine, same session — `make specs` wraps the same `go test`
+  invocation (see `bin/build/go/test`), so the difference is in how that
+  sandbox's tooling permission/network layer treats the two invocations, not
+  in what the repo's tests do. Do not conclude live NTP/NTS coverage is broken
+  from a raw `go test` failure alone; reproduce through `make specs` before
+  treating it as a real breakage.

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ encoding-fuzz:
 	@$(MAKE) package=encoding/hjson name=FuzzUnmarshal fuzz
 	@$(MAKE) package=encoding/json name=FuzzUnmarshal fuzz
 	@$(MAKE) package=encoding/msgpack name=FuzzUnmarshal fuzz
+	@$(MAKE) package=encoding/stream/gob name=FuzzUnmarshal fuzz
+	@$(MAKE) package=encoding/stream/json name=FuzzUnmarshal fuzz
+	@$(MAKE) package=encoding/stream/msgpack name=FuzzUnmarshal fuzz
+	@$(MAKE) package=encoding/stream/yaml name=FuzzUnmarshal fuzz
 	@$(MAKE) package=encoding/toml name=FuzzUnmarshal fuzz
 	@$(MAKE) package=encoding/yaml name=FuzzUnmarshal fuzz
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ Encoding kinds used by subsystems that support encoding:
 > [!NOTE]
 > - `plain` and `octet-stream` map to the bytes passthrough encoder.
 > - Protobuf binary/text/JSON kinds have multiple aliases; the list above reflects the built-in registry.
+> - `encoding/stream.Map` is a separate registry for streaming (multi-value) encoding — `json`, `msgpack`,
+>   `gob`, `yaml` — used by [HTTP streaming (NDJSON)](#http-streaming-ndjson), not by this single-value
+>   registry.
 
 ---
 
@@ -1114,6 +1117,40 @@ Built-in protobuf-oriented media type aliases include:
 >
 > `application/vnd.msgpack` and `application/gob` can be resolved as media types, but REST/RPC request-body decoding rejects them with HTTP 415.
 
+### HTTP streaming (NDJSON)
+
+REST and RPC support streaming routes alongside the single-value helpers above, for responses (and,
+over HTTP/2, requests) that arrive as a sequence of values instead of one buffered payload:
+
+| single-value | streaming | direction | HTTP/2 required |
+| --- | --- | --- | --- |
+| `rest.Get`/`rest.Route` | `rest.StreamGet`/`rest.StreamRoute` | send-only | no |
+| `rest.Post`/`rest.Put`/`rest.Patch`/`rest.RouteRequest` | `rest.StreamPost`/`rest.StreamPut`/`rest.StreamPatch`/`rest.StreamRouteRequest` | bidirectional | yes |
+| `rpc.Route` | `rpc.StreamRoute` | bidirectional | yes |
+
+A send-only streaming handler gets a `*content.Stream[Res]` with `Send`; a bidirectional streaming
+handler gets a `*content.RequestStream[Req, Res]` with both `Send` and `Recv`. Client calls use the
+matching `client.Stream`/`client.RequestStream` functions, which take the same kind of callback.
+See `net/http/client`'s `ExampleClient_RequestStream` for a complete HTTP/2 bidirectional client call.
+
+The initial wire format is NDJSON (`application/x-ndjson`), newline-delimited JSON values, resolved
+through a separate streaming encoder/decoder registry (`encoding/stream.Map`) from the single-value one
+above — an unregistered or unparseable streaming media type is rejected outright rather than falling
+back to JSON, unlike single-value negotiation.
+
+> [!NOTE]
+> - Bidirectional streaming routes require HTTP/2 (including h2c); a request over HTTP/1.x is rejected
+>   with `505 HTTP Version Not Supported` before the handler runs. Send-only streaming routes have no
+>   such requirement and stay fully supported on HTTP/1.1 chunked responses.
+> - Streaming responses are not gzip-compressed, regardless of the client's `Accept-Encoding`.
+> - `max_receive_size` applies per decoded value on a streaming request body, not as a cumulative total
+>   across the whole stream; overall stream volume is controlled by the configured rate limiter instead,
+>   which charges one token per streamed message in addition to the token charged when the stream opens.
+> - A successful `Send` extends the HTTP server's configured write timeout, so a slow-but-active stream
+>   is not severed by a whole-stream deadline; bound a client-side streaming call with the request
+>   context instead of the client's overall request timeout.
+> - Streaming requests are never retried by the client's retry middleware.
+
 ### HTTP route misses
 
 The HTTP transport wraps the mux with `net/http.NewNotFoundHandler` so generated 404 responses can be rendered consistently while preserving other mux responses such as 405 Method Not Allowed.
@@ -1152,7 +1189,7 @@ transport:
 > - If address is omitted, defaults are `tcp://:8080` (HTTP) and `tcp://:9090` (gRPC).
 > - `transport.grpc.timeout` bounds unary RPC handlers and feeds gRPC server keepalive/connection defaults; it does not cap stream lifetime. Long-lived streams remain open until client cancellation or stream-specific controls apply.
 > - `max_receive_size` limits inbound payload size. A zero value uses the default `4MB`.
-> - For HTTP, `max_receive_size` applies per request body. For gRPC, it applies per inbound unary request and per inbound stream message.
+> - For HTTP, `max_receive_size` applies per request body, except for bidirectional streaming routes (see [HTTP streaming (NDJSON)](#http-streaming-ndjson)), where it applies per decoded value instead, with no cumulative total. For gRPC, it applies per inbound unary request and per inbound stream message.
 > - MVC does not enforce its own body-size caps; supported HTTP server wiring applies `max_receive_size` before MVC handlers run, and go-service HTTP clients apply their configured response-size cap when reading responses.
 
 Receive-limit example:

--- a/bytes/bytes.go
+++ b/bytes/bytes.go
@@ -11,6 +11,12 @@ import (
 // standard library implementation.
 type Buffer = bytes.Buffer
 
+// Reader is an alias for [bytes.Reader].
+//
+// It is provided so go-service code can depend on a consistent import path while still using the
+// standard library implementation.
+type Reader = bytes.Reader
+
 // NewBuffer returns a new Buffer initialized with buf's contents.
 //
 // This is a thin wrapper around [bytes.NewBuffer]. The returned buffer uses buf as its initial

--- a/encoding/stream/doc.go
+++ b/encoding/stream/doc.go
@@ -1,0 +1,19 @@
+// Package stream provides streaming (multi-value) encode/decode interfaces used by go-service.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding], which models exactly one value per
+// Encode/Decode call against a writer/reader supplied per call, this package models a sequence of
+// values written to, or read from, one writer or reader bound at construction time. [Encoder] and
+// [Decoder] are separate interfaces, rather than one combined interface, because the underlying
+// per-kind codecs construct distinct encoder and decoder types that are each bound to a single
+// direction.
+//
+// Per-kind implementations live in sibling packages
+// (github.com/alexfalkowski/go-service/v2/encoding/stream/json, .../msgpack, .../gob, .../yaml), each
+// exporting NewEncoder(io.Writer) [Encoder] and NewDecoder(io.Reader) [Decoder]. They wrap the same
+// underlying libraries as the sibling encoding/<kind> packages, carrying over the same policy with two
+// exceptions needed for multi-value streams: no output indentation (which would break newline-delimited
+// framing) and no trailing-data rejection (a stream is expected to contain many values). Strict/unknown-
+// field decoding is preserved.
+//
+// Start with [Encoder] and [Decoder].
+package stream

--- a/encoding/stream/gob/doc.go
+++ b/encoding/stream/gob/doc.go
@@ -1,0 +1,10 @@
+// Package gob provides a streaming gob [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder]/
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] pair used by go-service.
+//
+// It wraps the standard library [encoding/gob] package's own NewEncoder/NewDecoder types with one
+// persistent encoder/decoder bound to the writer/reader for the lifetime of the stream, unlike
+// [github.com/alexfalkowski/go-service/v2/encoding/gob], which constructs and discards a fresh
+// encoder/decoder per call and rejects trailing values because it models exactly one value per call.
+//
+// Start with the package-level constructors.
+package gob

--- a/encoding/stream/gob/fuzz_test.go
+++ b/encoding/stream/gob/fuzz_test.go
@@ -1,0 +1,65 @@
+package gob_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/gob"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzUnmarshal explores the streaming gob decoder input space and verifies accepted map payloads
+// round-trip through the stream encoder/decoder pair.
+func FuzzUnmarshal(f *testing.F) {
+	for _, msg := range []map[string]string{
+		{},
+		{"test": "test"},
+		{"test": ""},
+	} {
+		buffer := &bytes.Buffer{}
+		encoder := gob.NewEncoder(buffer)
+		require.NoError(f, encoder.Encode(msg))
+		f.Add(buffer.Bytes())
+	}
+	f.Add([]byte("junk"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		decoder := gob.NewDecoder(bytes.NewReader(data))
+
+		var msgs []map[string]string
+		for {
+			var msg map[string]string
+			if err := decoder.Decode(&msg); err != nil {
+				break
+			}
+			msgs = append(msgs, msg)
+		}
+		require.NoError(t, decoder.Close())
+
+		if len(msgs) == 0 {
+			return
+		}
+
+		buffer := &bytes.Buffer{}
+		encoder := gob.NewEncoder(buffer)
+		for _, msg := range msgs {
+			require.NoError(t, encoder.Encode(msg))
+		}
+		require.NoError(t, encoder.Close())
+
+		decoded := gob.NewDecoder(buffer)
+		for _, msg := range msgs {
+			var actual map[string]string
+			require.NoError(t, decoded.Decode(&actual))
+			require.Len(t, actual, len(msg))
+			for key, value := range msg {
+				require.Equal(t, value, actual[key])
+			}
+		}
+		require.NoError(t, decoded.Close())
+	})
+}

--- a/encoding/stream/gob/gob.go
+++ b/encoding/stream/gob/gob.go
@@ -1,0 +1,58 @@
+package gob
+
+import (
+	"encoding/gob"
+
+	"github.com/alexfalkowski/go-service/v2/io"
+)
+
+// Encoder streams gob values to a writer bound at construction.
+//
+// Encoder embeds the standard library's [encoding/gob.Encoder], so [Encoder.Encode] is the embedded
+// encoder's own method. Encoder satisfies
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder] structurally, without this
+// package importing that package: [github.com/alexfalkowski/go-service/v2/encoding/stream.NewMap]
+// imports this package to pre-register the default "gob" kind, and this package importing that one
+// back would be a compile-time import cycle.
+type Encoder struct {
+	*gob.Encoder
+}
+
+// NewEncoder constructs a streaming gob [Encoder] bound to w.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding/gob.Encoder], which constructs a fresh
+// standard library encoder per Encode call, the returned encoder wraps one persistent
+// [encoding/gob.Encoder] bound to w for the lifetime of the stream — the intended way to use gob for
+// more than one value on the same connection.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{Encoder: gob.NewEncoder(w)}
+}
+
+// Close is a no-op: the standard library gob encoder has no finalization state to flush.
+func (e *Encoder) Close() error {
+	return nil
+}
+
+// Decoder streams gob values from a reader bound at construction.
+//
+// Decoder embeds the standard library's [encoding/gob.Decoder], so [Decoder.Decode] is the embedded
+// decoder's own method. Decoder satisfies
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] structurally, without this
+// package importing that package.
+type Decoder struct {
+	*gob.Decoder
+}
+
+// NewDecoder constructs a streaming gob [Decoder] bound to r.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding/gob.Encoder]'s Decode, the returned decoder
+// allows additional gob values after the first: it does not enforce single-value trailing-data
+// rejection, since a stream is expected to carry many values.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{Decoder: gob.NewDecoder(r)}
+}
+
+// Close is a no-op: the standard library gob decoder has no finalization state to flush.
+func (d *Decoder) Close() error {
+	return nil
+}

--- a/encoding/stream/gob/gob_test.go
+++ b/encoding/stream/gob/gob_test.go
@@ -1,0 +1,97 @@
+package gob_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/gob"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := gob.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "one"}))
+	require.NoError(t, encoder.Encode(map[string]string{"test": "two"}))
+	require.NoError(t, encoder.Close())
+
+	decoder := gob.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+
+	var third map[string]string
+	require.ErrorIs(t, decoder.Decode(&third), io.EOF)
+	require.NoError(t, decoder.Close())
+}
+
+func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	encoder := gob.NewEncoder(test.ErrWriter{})
+
+	require.Error(t, encoder.Encode(func() {}))
+}
+
+func TestDecodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	decoder := gob.NewDecoder(&test.ErrReaderCloser{})
+
+	var msg map[string]string
+	require.Error(t, decoder.Decode(&msg))
+}
+
+func TestDecodeAllowsTrailingValues(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := gob.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "one"}))
+	require.NoError(t, encoder.Encode(map[string]string{"test": "two"}))
+
+	decoder := gob.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+}
+
+func TestEncoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := gob.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Close())
+	require.NoError(t, encoder.Close())
+}
+
+func TestDecoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	decoder := gob.NewDecoder(buffer)
+	require.NoError(t, decoder.Close())
+	require.NoError(t, decoder.Close())
+}

--- a/encoding/stream/json/doc.go
+++ b/encoding/stream/json/doc.go
@@ -1,0 +1,11 @@
+// Package json provides a streaming JSON [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder]/
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] pair used by go-service.
+//
+// It wraps the standard library [encoding/json] package's own NewEncoder/NewDecoder types, which are
+// each bound to one writer/reader for many Encode/Decode calls. It carries over the strict decoding
+// policy of [github.com/alexfalkowski/go-service/v2/encoding/json] (unknown fields rejected), but
+// drops that package's indentation (which would break newline-delimited framing) and trailing-data
+// rejection (a stream is expected to contain many values).
+//
+// Start with the package-level constructors.
+package json

--- a/encoding/stream/json/fuzz_test.go
+++ b/encoding/stream/json/fuzz_test.go
@@ -1,0 +1,59 @@
+package json_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzUnmarshal explores the strict streaming JSON decoder surface and verifies accepted map
+// payloads round-trip through the stream encoder/decoder pair.
+func FuzzUnmarshal(f *testing.F) {
+	f.Add([]byte(`{"test":"test"}`))
+	f.Add([]byte(`{"test":""}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"test":"test"}{"extra":"value"}`))
+	f.Add([]byte(`{`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		decoder := json.NewDecoder(bytes.NewReader(data))
+
+		var msgs []map[string]string
+		for {
+			var msg map[string]string
+			if err := decoder.Decode(&msg); err != nil {
+				break
+			}
+			msgs = append(msgs, msg)
+		}
+		require.NoError(t, decoder.Close())
+
+		if len(msgs) == 0 {
+			return
+		}
+
+		buffer := &bytes.Buffer{}
+		encoder := json.NewEncoder(buffer)
+		for _, msg := range msgs {
+			require.NoError(t, encoder.Encode(msg))
+		}
+		require.NoError(t, encoder.Close())
+
+		decoded := json.NewDecoder(buffer)
+		for _, msg := range msgs {
+			var actual map[string]string
+			require.NoError(t, decoded.Decode(&actual))
+			require.Len(t, actual, len(msg))
+			for key, value := range msg {
+				require.Equal(t, value, actual[key])
+			}
+		}
+		require.NoError(t, decoded.Close())
+	})
+}

--- a/encoding/stream/json/json.go
+++ b/encoding/stream/json/json.go
@@ -1,0 +1,61 @@
+package json
+
+import (
+	"encoding/json"
+
+	"github.com/alexfalkowski/go-service/v2/io"
+)
+
+// Encoder streams JSON values to a writer bound at construction.
+//
+// Encoder embeds the standard library's [encoding/json.Encoder], so [Encoder.Encode] is the embedded
+// encoder's own method. Encoder satisfies
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder] structurally, without this
+// package importing that package: [github.com/alexfalkowski/go-service/v2/encoding/stream.NewMap]
+// imports this package to pre-register the default "json" kind, and this package importing that one
+// back would be a compile-time import cycle.
+type Encoder struct {
+	*json.Encoder
+}
+
+// NewEncoder constructs a streaming JSON [Encoder] bound to w.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding/json.Encoder], the returned encoder writes
+// no indentation, so consecutive values stay newline-delimited (NDJSON) instead of each spanning
+// multiple lines.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{Encoder: json.NewEncoder(w)}
+}
+
+// Close is a no-op: the standard library JSON encoder has no finalization state to flush.
+func (e *Encoder) Close() error {
+	return nil
+}
+
+// Decoder streams JSON values from a reader bound at construction.
+//
+// Decoder embeds the standard library's [encoding/json.Decoder], so [Decoder.Decode] is the embedded
+// decoder's own method. Decoder satisfies
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] structurally, without this
+// package importing that package.
+type Decoder struct {
+	*json.Decoder
+}
+
+// NewDecoder constructs a streaming JSON [Decoder] bound to r.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding/json.Encoder]'s Decode, the returned
+// decoder allows additional JSON values after the first: it does not enforce single-value
+// trailing-data rejection, since a stream is expected to carry many values. Unknown fields remain
+// rejected.
+func NewDecoder(r io.Reader) *Decoder {
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+
+	return &Decoder{Decoder: decoder}
+}
+
+// Close is a no-op: the standard library JSON decoder has no finalization state to flush.
+func (d *Decoder) Close() error {
+	return nil
+}

--- a/encoding/stream/json/json_test.go
+++ b/encoding/stream/json/json_test.go
@@ -1,0 +1,120 @@
+package json_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := json.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "one"}))
+	require.NoError(t, encoder.Encode(map[string]string{"test": "two"}))
+	require.NoError(t, encoder.Close())
+
+	require.NotContains(t, buffer.String(), "  ")
+
+	decoder := json.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+
+	var third map[string]string
+	require.ErrorIs(t, decoder.Decode(&third), io.EOF)
+	require.NoError(t, decoder.Close())
+}
+
+func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	encoder := json.NewEncoder(test.ErrWriter{})
+
+	require.Error(t, encoder.Encode(map[string]string{"test": "test"}))
+}
+
+func TestDecodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	decoder := json.NewDecoder(&test.ErrReaderCloser{})
+
+	var msg map[string]string
+	require.Error(t, decoder.Decode(&msg))
+}
+
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	_, err := buffer.WriteString(`{"test":"test","extra":"ignored"}`)
+	require.NoError(t, err)
+
+	decoder := json.NewDecoder(buffer)
+	msg := &message{}
+
+	err = decoder.Decode(msg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeAllowsTrailingValues(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	_, err := buffer.WriteString(`{"test":"one"}{"test":"two"}`)
+	require.NoError(t, err)
+
+	decoder := json.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+}
+
+func TestEncoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := json.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Close())
+	require.NoError(t, encoder.Close())
+}
+
+func TestDecoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	decoder := json.NewDecoder(buffer)
+	require.NoError(t, decoder.Close())
+	require.NoError(t, decoder.Close())
+}
+
+type message struct {
+	Test string `json:"test"`
+}

--- a/encoding/stream/map.go
+++ b/encoding/stream/map.go
@@ -1,0 +1,120 @@
+package stream
+
+import (
+	"maps"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/gob"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/msgpack"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/yaml"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/slices"
+)
+
+// NewMap constructs a Map with the default streaming encoder/decoder constructors.
+//
+// The returned registry includes these kinds: "json", "msgpack", "gob", "yaml".
+//
+// Each per-kind package (encoding/stream/json, .../msgpack, .../gob, .../yaml) exports constructors
+// returning its own concrete [json.Encoder]/[json.Decoder]-shaped type rather than the
+// [Encoder]/[Decoder] interfaces, so those packages do not import this one back — avoiding a
+// compile-time import cycle, since this package imports them here to build the default registry. The
+// adapter closures below convert each concrete constructor to the registry's constructor-function
+// shape; the concrete types satisfy [Encoder]/[Decoder] structurally, so the conversion is just an
+// ordinary interface assignment on return.
+//
+// Callers can add additional kinds or override existing kinds via [Map.RegisterEncoder] and
+// [Map.RegisterDecoder].
+func NewMap() *Map {
+	return &Map{
+		encoders: map[string]EncoderFunc{
+			"json":    func(w io.Writer) Encoder { return json.NewEncoder(w) },
+			"msgpack": func(w io.Writer) Encoder { return msgpack.NewEncoder(w) },
+			"gob":     func(w io.Writer) Encoder { return gob.NewEncoder(w) },
+			"yaml":    func(w io.Writer) Encoder { return yaml.NewEncoder(w) },
+		},
+		decoders: map[string]DecoderFunc{
+			"json":    func(r io.Reader) Decoder { return json.NewDecoder(r) },
+			"msgpack": func(r io.Reader) Decoder { return msgpack.NewDecoder(r) },
+			"gob":     func(r io.Reader) Decoder { return gob.NewDecoder(r) },
+			"yaml":    func(r io.Reader) Decoder { return yaml.NewDecoder(r) },
+		},
+	}
+}
+
+// Map provides lookup and registration of streaming encoder/decoder constructors by kind.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding.Map], which registers ready-to-use
+// encoder instances, Map registers constructor functions. Each streaming Encode/Decode call needs a
+// fresh [Encoder] or [Decoder] bound to its own writer or reader, so the registry stores how to build
+// one rather than a shared instance.
+//
+// Map is not concurrency-safe. If you mutate it via RegisterEncoder or RegisterDecoder, do so during
+// initialization.
+type Map struct {
+	encoders map[string]EncoderFunc
+	decoders map[string]DecoderFunc
+}
+
+// RegisterEncoder associates kind with fn, overwriting any existing encoder constructor.
+//
+// If kind already exists, the previous encoder constructor is replaced.
+func (m *Map) RegisterEncoder(kind string, fn EncoderFunc) {
+	m.encoders[kind] = fn
+}
+
+// RegisterDecoder associates kind with fn, overwriting any existing decoder constructor.
+//
+// If kind already exists, the previous decoder constructor is replaced.
+func (m *Map) RegisterDecoder(kind string, fn DecoderFunc) {
+	m.decoders[kind] = fn
+}
+
+// GetEncoder returns the encoder constructor registered for kind.
+//
+// If no encoder constructor is registered for kind, or if kind was registered with a nil
+// constructor, GetEncoder returns nil. Callers typically treat nil as "unknown or unavailable kind"
+// and fail explicitly rather than falling back to a default encoder.
+//
+// GetEncoder is nil-safe: it returns nil for a nil m, so resolving against an unconfigured registry
+// fails the same way resolving an unregistered kind does, rather than panicking.
+func (m *Map) GetEncoder(kind string) EncoderFunc {
+	if m == nil {
+		return nil
+	}
+
+	return m.encoders[kind]
+}
+
+// GetDecoder returns the decoder constructor registered for kind.
+//
+// If no decoder constructor is registered for kind, or if kind was registered with a nil
+// constructor, GetDecoder returns nil. Callers typically treat nil as "unknown or unavailable kind"
+// and fail explicitly rather than falling back to a default decoder.
+//
+// GetDecoder is nil-safe: it returns nil for a nil m, so resolving against an unconfigured registry
+// fails the same way resolving an unregistered kind does, rather than panicking.
+func (m *Map) GetDecoder(kind string) DecoderFunc {
+	if m == nil {
+		return nil
+	}
+
+	return m.decoders[kind]
+}
+
+// Keys returns the union of registered encoder and decoder kinds.
+//
+// Keys includes kinds registered with nil constructors. The returned slice is not guaranteed to be
+// sorted.
+func (m *Map) Keys() []string {
+	keys := make(map[string]struct{}, len(m.encoders)+len(m.decoders))
+	for k := range m.encoders {
+		keys[k] = struct{}{}
+	}
+
+	for k := range m.decoders {
+		keys[k] = struct{}{}
+	}
+
+	return slices.Collect(maps.Keys(keys))
+}

--- a/encoding/stream/map_test.go
+++ b/encoding/stream/map_test.go
@@ -1,0 +1,133 @@
+package stream_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/gob"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/msgpack"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/yaml"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestNewMapRegistersDefaultEncodersAndDecoders(t *testing.T) {
+	t.Parallel()
+
+	expectedEncoders := map[string]stream.Encoder{
+		"json":    &json.Encoder{},
+		"msgpack": &msgpack.Encoder{},
+		"gob":     &gob.Encoder{},
+		"yaml":    &yaml.Encoder{},
+	}
+	expectedDecoders := map[string]stream.Decoder{
+		"json":    &json.Decoder{},
+		"msgpack": &msgpack.Decoder{},
+		"gob":     &gob.Decoder{},
+		"yaml":    &yaml.Decoder{},
+	}
+
+	m := stream.NewMap()
+
+	for _, kind := range []string{"json", "msgpack", "gob", "yaml"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			newEncoder := m.GetEncoder(kind)
+			newDecoder := m.GetDecoder(kind)
+			require.NotNil(t, newEncoder)
+			require.NotNil(t, newDecoder)
+
+			require.IsType(t, expectedEncoders[kind], newEncoder(io.Discard))
+			require.IsType(t, expectedDecoders[kind], newDecoder(strings.NewReader("")))
+		})
+	}
+}
+
+func TestMapGetIsNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var m *stream.Map
+
+	require.Nil(t, m.GetEncoder("json"))
+	require.Nil(t, m.GetDecoder("json"))
+}
+
+func TestMapGetReturnsNilForUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	m := stream.NewMap()
+
+	for _, kind := range []string{"test", "bob"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			require.Nil(t, m.GetEncoder(kind))
+			require.Nil(t, m.GetDecoder(kind))
+		})
+	}
+}
+
+func TestMapKeysIsUnionOfEncodersAndDecoders(t *testing.T) {
+	t.Parallel()
+
+	m := stream.NewMap()
+	m.RegisterEncoder("encode-only", func(w io.Writer) stream.Encoder { return json.NewEncoder(w) })
+	m.RegisterDecoder("decode-only", func(r io.Reader) stream.Decoder { return json.NewDecoder(r) })
+
+	require.ElementsMatch(t, []string{"json", "msgpack", "gob", "yaml", "encode-only", "decode-only"}, m.Keys())
+}
+
+func TestMapRegisterEncoder(t *testing.T) {
+	t.Parallel()
+
+	m := stream.NewMap()
+	custom := func(w io.Writer) stream.Encoder { return json.NewEncoder(w) }
+
+	m.RegisterEncoder("custom", custom)
+	require.Equal(t, reflect.ValueOf(custom).Pointer(), reflect.ValueOf(m.GetEncoder("custom")).Pointer())
+
+	replacement := func(w io.Writer) stream.Encoder { return msgpack.NewEncoder(w) }
+	m.RegisterEncoder("custom", replacement)
+	require.Equal(t, reflect.ValueOf(replacement).Pointer(), reflect.ValueOf(m.GetEncoder("custom")).Pointer())
+}
+
+func TestMapRegisterDecoder(t *testing.T) {
+	t.Parallel()
+
+	m := stream.NewMap()
+	custom := func(r io.Reader) stream.Decoder { return json.NewDecoder(r) }
+
+	m.RegisterDecoder("custom", custom)
+	require.Equal(t, reflect.ValueOf(custom).Pointer(), reflect.ValueOf(m.GetDecoder("custom")).Pointer())
+
+	replacement := func(r io.Reader) stream.Decoder { return yaml.NewDecoder(r) }
+	m.RegisterDecoder("custom", replacement)
+	require.Equal(t, reflect.ValueOf(replacement).Pointer(), reflect.ValueOf(m.GetDecoder("custom")).Pointer())
+}
+
+func TestModuleProvidesDefaultMap(t *testing.T) {
+	t.Parallel()
+
+	var m *stream.Map
+
+	app := fx.New(
+		stream.Module,
+		fx.Populate(&m),
+		fx.NopLogger,
+	)
+
+	require.NoError(t, app.Err())
+	for _, kind := range []string{"json", "msgpack", "gob", "yaml"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			require.NotNil(t, m.GetEncoder(kind))
+			require.NotNil(t, m.GetDecoder(kind))
+		})
+	}
+}

--- a/encoding/stream/module.go
+++ b/encoding/stream/module.go
@@ -1,0 +1,8 @@
+package stream
+
+import "github.com/alexfalkowski/go-service/v2/di"
+
+// Module provides the default streaming encoder/decoder registry as a *[Map].
+var Module = di.Module(
+	di.Constructor(NewMap),
+)

--- a/encoding/stream/msgpack/doc.go
+++ b/encoding/stream/msgpack/doc.go
@@ -1,0 +1,11 @@
+// Package msgpack provides a streaming MessagePack
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder]/
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] pair used by go-service.
+//
+// It wraps [github.com/Basekick-Labs/msgpack/v6]'s own NewEncoder/NewDecoder types, which are each
+// bound to one writer/reader for many Encode/Decode calls, unlike
+// [github.com/alexfalkowski/go-service/v2/encoding/msgpack]'s Decode, which rejects trailing values
+// because a stream is expected to contain many values.
+//
+// Start with the package-level constructors.
+package msgpack

--- a/encoding/stream/msgpack/fuzz_test.go
+++ b/encoding/stream/msgpack/fuzz_test.go
@@ -1,0 +1,65 @@
+package msgpack_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/msgpack"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzUnmarshal explores the streaming MessagePack decoder input space and verifies accepted map
+// payloads round-trip through the stream encoder/decoder pair.
+func FuzzUnmarshal(f *testing.F) {
+	for _, msg := range []map[string]string{
+		{},
+		{"test": "test"},
+		{"test": ""},
+	} {
+		buffer := &bytes.Buffer{}
+		encoder := msgpack.NewEncoder(buffer)
+		require.NoError(f, encoder.Encode(msg))
+		f.Add(buffer.Bytes())
+	}
+	f.Add([]byte("junk"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		decoder := msgpack.NewDecoder(bytes.NewReader(data))
+
+		var msgs []map[string]string
+		for {
+			var msg map[string]string
+			if err := decoder.Decode(&msg); err != nil {
+				break
+			}
+			msgs = append(msgs, msg)
+		}
+		require.NoError(t, decoder.Close())
+
+		if len(msgs) == 0 {
+			return
+		}
+
+		buffer := &bytes.Buffer{}
+		encoder := msgpack.NewEncoder(buffer)
+		for _, msg := range msgs {
+			require.NoError(t, encoder.Encode(msg))
+		}
+		require.NoError(t, encoder.Close())
+
+		decoded := msgpack.NewDecoder(buffer)
+		for _, msg := range msgs {
+			var actual map[string]string
+			require.NoError(t, decoded.Decode(&actual))
+			require.Len(t, actual, len(msg))
+			for key, value := range msg {
+				require.Equal(t, value, actual[key])
+			}
+		}
+		require.NoError(t, decoded.Close())
+	})
+}

--- a/encoding/stream/msgpack/msgpack.go
+++ b/encoding/stream/msgpack/msgpack.go
@@ -1,0 +1,52 @@
+package msgpack
+
+import (
+	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/alexfalkowski/go-service/v2/io"
+)
+
+// Encoder streams MessagePack values to a writer bound at construction.
+//
+// Encoder embeds the [github.com/Basekick-Labs/msgpack/v6.Encoder], so [Encoder.Encode] is the
+// embedded encoder's own method. Encoder satisfies
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder] structurally, without this
+// package importing that package: [github.com/alexfalkowski/go-service/v2/encoding/stream.NewMap]
+// imports this package to pre-register the default "msgpack" kind, and this package importing that
+// one back would be a compile-time import cycle.
+type Encoder struct {
+	*msgpack.Encoder
+}
+
+// NewEncoder constructs a streaming MessagePack [Encoder] bound to w.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{Encoder: msgpack.NewEncoder(w)}
+}
+
+// Close is a no-op: the underlying MessagePack encoder has no finalization state to flush.
+func (e *Encoder) Close() error {
+	return nil
+}
+
+// Decoder streams MessagePack values from a reader bound at construction.
+//
+// Decoder embeds the [github.com/Basekick-Labs/msgpack/v6.Decoder], so [Decoder.Decode] is the
+// embedded decoder's own method. Decoder satisfies
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] structurally, without this
+// package importing that package.
+type Decoder struct {
+	*msgpack.Decoder
+}
+
+// NewDecoder constructs a streaming MessagePack [Decoder] bound to r.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding/msgpack.Encoder]'s Decode, the returned
+// decoder allows additional MessagePack values after the first: it does not enforce single-value
+// trailing-data rejection, since a stream is expected to carry many values.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{Decoder: msgpack.NewDecoder(r)}
+}
+
+// Close is a no-op: the underlying MessagePack decoder has no finalization state to flush.
+func (d *Decoder) Close() error {
+	return nil
+}

--- a/encoding/stream/msgpack/msgpack_test.go
+++ b/encoding/stream/msgpack/msgpack_test.go
@@ -1,0 +1,97 @@
+package msgpack_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/msgpack"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "one"}))
+	require.NoError(t, encoder.Encode(map[string]string{"test": "two"}))
+	require.NoError(t, encoder.Close())
+
+	decoder := msgpack.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+
+	var third map[string]string
+	require.ErrorIs(t, decoder.Decode(&third), io.EOF)
+	require.NoError(t, decoder.Close())
+}
+
+func TestEncodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	encoder := msgpack.NewEncoder(test.ErrWriter{})
+
+	require.Error(t, encoder.Encode(map[string]string{"test": "test"}))
+}
+
+func TestDecodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	decoder := msgpack.NewDecoder(&test.ErrReaderCloser{})
+
+	var msg map[string]string
+	require.Error(t, decoder.Decode(&msg))
+}
+
+func TestDecodeAllowsTrailingValues(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "one"}))
+	require.NoError(t, encoder.Encode(map[string]string{"test": "two"}))
+
+	decoder := msgpack.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+}
+
+func TestEncoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := msgpack.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Close())
+	require.NoError(t, encoder.Close())
+}
+
+func TestDecoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	decoder := msgpack.NewDecoder(buffer)
+	require.NoError(t, decoder.Close())
+	require.NoError(t, decoder.Close())
+}

--- a/encoding/stream/stream.go
+++ b/encoding/stream/stream.go
@@ -1,0 +1,67 @@
+package stream
+
+import "github.com/alexfalkowski/go-service/v2/io"
+
+// Encoder encodes a sequence of values to a writer bound at construction.
+//
+// Encoder differs from [github.com/alexfalkowski/go-service/v2/encoding.Encoder] in two ways: it is
+// bound to one writer for its entire lifetime (constructed with the writer rather than given one per
+// call), and it is expected to serve many Encode calls rather than exactly one.
+//
+// # Encode contract
+//
+// Encode serializes v and writes it to the underlying writer. Implementations may require that v
+// satisfies additional interfaces or is of a particular shape, matching the wrapped codec's own
+// requirements. Callers may call Encode repeatedly to write multiple values to the same stream.
+//
+// # Close contract
+//
+// Close finalizes any codec-level state (for example a stream terminator or trailer). Close must
+// never close the underlying writer — the writer is owned by the caller, not the Encoder. Close is
+// called exactly once, at the true end of the stream: implementations are not required to tolerate a
+// second call (for example encoding/stream/yaml's Encoder is a direct alias of a non-idempotent
+// upstream Close), so callers must not both defer Close and call it explicitly on the success path.
+type Encoder interface {
+	// Encode writes a serialized representation of v to the underlying writer.
+	Encode(v any) error
+
+	// Close finalizes the encoder. Close never closes the underlying writer. Close is called exactly
+	// once; a second call is not guaranteed to be safe.
+	Close() error
+}
+
+// Decoder decodes a sequence of values from a reader bound at construction.
+//
+// Decoder differs from [github.com/alexfalkowski/go-service/v2/encoding.Encoder]'s Decode in two
+// ways: it is bound to one reader for its entire lifetime (constructed with the reader rather than
+// given one per call), and it is expected to serve many Decode calls rather than exactly one.
+//
+// # Decode contract
+//
+// Decode reads the next encoded value from the underlying reader and populates v. In most cases v
+// should be a pointer to the destination value (for example *MyStruct). Decode returns io.EOF once
+// the underlying stream is exhausted, matching the terminal behavior of the wrapped codec's own
+// decoder.
+//
+// # Close contract
+//
+// Close finalizes any codec-level state. Close must never close the underlying reader — the reader
+// is owned by the caller, not the Decoder. Close is called exactly once; implementations are not
+// required to tolerate a second call.
+type Decoder interface {
+	// Decode reads the next value from the underlying reader into v. Decode returns io.EOF once the
+	// stream is exhausted.
+	Decode(v any) error
+
+	// Close finalizes the decoder. Close never closes the underlying reader. Close is called exactly
+	// once; a second call is not guaranteed to be safe.
+	Close() error
+}
+
+// EncoderFunc constructs an [Encoder] bound to w. Registered in a [Map] by kind via
+// [Map.RegisterEncoder], and returned by [Map.GetEncoder].
+type EncoderFunc func(w io.Writer) Encoder
+
+// DecoderFunc constructs a [Decoder] bound to r. Registered in a [Map] by kind via
+// [Map.RegisterDecoder], and returned by [Map.GetDecoder].
+type DecoderFunc func(r io.Reader) Decoder

--- a/encoding/stream/yaml/doc.go
+++ b/encoding/stream/yaml/doc.go
@@ -1,0 +1,14 @@
+// Package yaml provides a streaming YAML [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder]/
+// [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] pair used by go-service.
+//
+// It wraps [go.yaml.in/yaml/v3]'s own NewEncoder/NewDecoder types, which are each bound to one
+// writer/reader for many Encode/Decode calls. It carries over the strict decoding policy of
+// [github.com/alexfalkowski/go-service/v2/encoding/yaml] (unknown fields rejected), but drops that
+// package's trailing-document rejection, since a stream is expected to contain many documents. Encoder
+// is a direct alias of the upstream type, so its Close is not idempotent — a second call surfaces
+// upstream's "expected nothing after STREAM-END" error; callers must call Close exactly once, at the
+// true end of the stream, per [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder]'s
+// contract. See [NewEncoder].
+//
+// Start with the package-level constructors.
+package yaml

--- a/encoding/stream/yaml/fuzz_test.go
+++ b/encoding/stream/yaml/fuzz_test.go
@@ -1,0 +1,59 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzUnmarshal explores the strict streaming YAML decoder surface and verifies accepted map
+// payloads round-trip through the stream encoder/decoder pair.
+func FuzzUnmarshal(f *testing.F) {
+	f.Add([]byte("test: test"))
+	f.Add([]byte("test: ''"))
+	f.Add([]byte("{}"))
+	f.Add([]byte("test: test\n---\ntest: other"))
+	f.Add([]byte(": invalid"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 16*1024 {
+			t.Skip()
+		}
+
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+
+		var msgs []map[string]string
+		for {
+			var msg map[string]string
+			if err := decoder.Decode(&msg); err != nil {
+				break
+			}
+			msgs = append(msgs, msg)
+		}
+		require.NoError(t, decoder.Close())
+
+		if len(msgs) == 0 {
+			return
+		}
+
+		buffer := &bytes.Buffer{}
+		encoder := yaml.NewEncoder(buffer)
+		for _, msg := range msgs {
+			require.NoError(t, encoder.Encode(msg))
+		}
+		require.NoError(t, encoder.Close())
+
+		decoded := yaml.NewDecoder(buffer)
+		for _, msg := range msgs {
+			var actual map[string]string
+			require.NoError(t, decoded.Decode(&actual))
+			require.Len(t, actual, len(msg))
+			for key, value := range msg {
+				require.Equal(t, value, actual[key])
+			}
+		}
+		require.NoError(t, decoded.Close())
+	})
+}

--- a/encoding/stream/yaml/yaml.go
+++ b/encoding/stream/yaml/yaml.go
@@ -1,0 +1,52 @@
+package yaml
+
+import (
+	"github.com/alexfalkowski/go-service/v2/io"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// Encoder is an alias of [go.yaml.in/yaml/v3.Encoder].
+//
+// Encoder already satisfies [github.com/alexfalkowski/go-service/v2/encoding/stream.Encoder]
+// structurally (Encode and Close), so no wrapper type is needed.
+//
+// Note: the underlying Close is not idempotent — a second call returns
+// "yaml: expected nothing after STREAM-END". Callers must call Close exactly once, at the end of the
+// stream.
+type Encoder = yaml.Encoder
+
+// NewEncoder constructs a streaming YAML [Encoder] bound to w.
+//
+// The underlying encoder separates successive documents with "---" and only finalizes the stream once
+// Close is called.
+func NewEncoder(w io.Writer) *Encoder {
+	return yaml.NewEncoder(w)
+}
+
+// Decoder streams YAML values from a reader bound at construction.
+//
+// Decoder embeds the [go.yaml.in/yaml/v3.Decoder], so [Decoder.Decode] is the embedded decoder's own
+// method. Decoder satisfies [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder]
+// structurally, without this package importing that package: the underlying decoder has no Close
+// method at all, so this thin wrapper exists only to add one.
+type Decoder struct {
+	*yaml.Decoder
+}
+
+// NewDecoder constructs a streaming YAML [Decoder] bound to r.
+//
+// Unlike [github.com/alexfalkowski/go-service/v2/encoding/yaml.Encoder]'s Decode, the returned
+// decoder allows additional YAML documents after the first: it does not enforce single-value
+// trailing-data rejection, since a stream is expected to carry many documents. Unknown fields remain
+// rejected.
+func NewDecoder(r io.Reader) *Decoder {
+	decoder := yaml.NewDecoder(r)
+	decoder.KnownFields(true)
+
+	return &Decoder{Decoder: decoder}
+}
+
+// Close is a no-op: [go.yaml.in/yaml/v3]'s Decoder has no Close method or finalization state.
+func (d *Decoder) Close() error {
+	return nil
+}

--- a/encoding/stream/yaml/yaml_test.go
+++ b/encoding/stream/yaml/yaml_test.go
@@ -1,0 +1,125 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/yaml"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := yaml.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "one"}))
+	require.NoError(t, encoder.Encode(map[string]string{"test": "two"}))
+	require.NoError(t, encoder.Close())
+
+	require.Contains(t, buffer.String(), "---")
+
+	decoder := yaml.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+
+	var third map[string]string
+	require.ErrorIs(t, decoder.Decode(&third), io.EOF)
+	require.NoError(t, decoder.Close())
+}
+
+func TestEncodeOrCloseReturnsError(t *testing.T) {
+	t.Parallel()
+
+	encoder := yaml.NewEncoder(test.ErrWriter{})
+
+	err := encoder.Encode(map[string]string{"test": "test"})
+	if err == nil {
+		err = encoder.Close()
+	}
+
+	require.Error(t, err)
+}
+
+func TestDecodeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	decoder := yaml.NewDecoder(&test.ErrReaderCloser{})
+
+	var msg map[string]string
+	require.Error(t, decoder.Decode(&msg))
+}
+
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	_, err := buffer.WriteString("test: test\nextra: ignored")
+	require.NoError(t, err)
+
+	decoder := yaml.NewDecoder(buffer)
+	msg := &message{}
+
+	err = decoder.Decode(msg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeAllowsTrailingDocuments(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	_, err := buffer.WriteString("test: one\n---\ntest: two")
+	require.NoError(t, err)
+
+	decoder := yaml.NewDecoder(buffer)
+
+	var first map[string]string
+	require.NoError(t, decoder.Decode(&first))
+	require.Equal(t, map[string]string{"test": "one"}, first)
+
+	var second map[string]string
+	require.NoError(t, decoder.Decode(&second))
+	require.Equal(t, map[string]string{"test": "two"}, second)
+}
+
+func TestEncoderCloseIsNotIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	encoder := yaml.NewEncoder(buffer)
+	require.NoError(t, encoder.Encode(map[string]string{"test": "test"}))
+	require.NoError(t, encoder.Close())
+	require.Error(t, encoder.Close())
+}
+
+func TestDecoderCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	decoder := yaml.NewDecoder(buffer)
+	require.NoError(t, decoder.Close())
+	require.NoError(t, decoder.Close())
+}
+
+type message struct {
+	Test string `yaml:"test"`
+}

--- a/internal/test/benchmark.go
+++ b/internal/test/benchmark.go
@@ -6,15 +6,14 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 // ResetTelemetry disables global telemetry state for benchmarks and tests.
 func ResetTelemetry(tb testing.TB) {
 	tb.Helper()
 
-	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(tb)}))
-	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(tb)})
+	require.NoError(tb, tracer.Register(tracer.TracerParams{Lifecycle: QuietLifecycle(tb)}))
+	metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: QuietLifecycle(tb)})
 }
 
 // EnableMetrics installs the shared test meter provider.
@@ -26,7 +25,7 @@ func EnableMetrics(tb testing.TB) {
 	tb.Helper()
 
 	metrics.NewMeterProvider(metrics.MeterProviderParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
+		Lifecycle:   QuietLifecycle(tb),
 		Config:      &metrics.Config{},
 		Reader:      metrics.NewManualReader(),
 		ID:          ID,
@@ -45,8 +44,8 @@ func EnableTracer(tb testing.TB) {
 	tb.Helper()
 
 	require.NoError(tb, tracer.Register(tracer.TracerParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
-		Config:      &tracer.Config{Kind: "otlp", URL: "https://localhost:4318/v1/traces"},
+		Lifecycle:   QuietLifecycle(tb),
+		Config:      &tracer.Config{Kind: "otlp", URL: otlpHTTPSURL + "/v1/traces"},
 		ID:          ID,
 		Name:        Name,
 		Version:     Version,

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -37,7 +37,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/retry"
 )
 
-const timeout = 2 * time.Second
+const (
+	timeout      = 2 * time.Second
+	otlpHTTPURL  = "http://localhost:4318"
+	otlpHTTPSURL = "https://localhost:4318"
+)
 
 // Validator is the shared config validator used by test helpers.
 var Validator = config.NewValidator()
@@ -262,7 +266,7 @@ func NewOTLPLoggerConfig() *logger.Config {
 	return &logger.Config{
 		Kind:  "otlp",
 		Level: "debug",
-		URL:   "http://localhost:3100/loki/api/v1/push",
+		URL:   otlpHTTPURL + "/v1/logs",
 		Headers: header.Map{
 			"Authorization": FilePath("secrets/telemetry"),
 		},
@@ -304,7 +308,7 @@ func NewPrometheusMetricsConfig() *metrics.Config {
 func NewOTLPMetricsConfig() *metrics.Config {
 	return &metrics.Config{
 		Kind: "otlp",
-		URL:  "http://localhost:9009/otlp/v1/metrics",
+		URL:  otlpHTTPURL + "/v1/metrics",
 		Headers: header.Map{
 			"Authorization": FilePath("secrets/telemetry"),
 		},
@@ -315,7 +319,7 @@ func NewOTLPMetricsConfig() *metrics.Config {
 func NewOTLPTracerConfig() *tracer.Config {
 	return &tracer.Config{
 		Kind: "otlp",
-		URL:  "http://localhost:4318/v1/traces",
+		URL:  otlpHTTPURL + "/v1/traces",
 		Headers: header.Map{
 			"Authorization": FilePath("secrets/telemetry"),
 		},

--- a/internal/test/encoding.go
+++ b/internal/test/encoding.go
@@ -2,15 +2,21 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // Encoder contains the real encoders exercised by config, cache, and transport tests.
 var Encoder = encoding.NewMap()
 
-// Content is the shared HTTP content registry backed by Encoder.
-var Content = content.NewContent(Encoder, Pool)
+// StreamEncoder contains the real streaming encoders/decoders exercised by content and transport tests.
+var StreamEncoder = stream.NewMap()
+
+// Content is the shared HTTP content registry backed by Encoder and StreamEncoder.
+var Content = content.NewContent(Encoder, StreamEncoder, Pool)
 
 // NewEncoder returns an encoder test double whose Encode and Decode methods fail with the supplied error.
 func NewEncoder(err error) encoding.Encoder {
@@ -43,4 +49,136 @@ func (PartialEncoder) Encode(w io.Writer, _ any) error {
 // Decode implements [encoding.Encoder] and always succeeds.
 func (PartialEncoder) Decode(io.Reader, any) error {
 	return nil
+}
+
+// Unencodable is a zero-field type whose MarshalJSON always fails with ErrFailed, letting tests force
+// a JSON encode failure without a real payload shape.
+type Unencodable struct{}
+
+// MarshalJSON returns ErrFailed so encoding/json's Encoder.Encode fails.
+func (Unencodable) MarshalJSON() ([]byte, error) {
+	return nil, ErrFailed
+}
+
+// OpaqueErrorDecoder is a [stream.Decoder] test double that reads R one byte at a time until a Read
+// error occurs, then returns a new error carrying only the original error's message — discarding its
+// type the way the standard library JSON decoder does under GOEXPERIMENT=jsonv2 when a mid-scan Read
+// fails. Used to prove a caller recovers a read-time sentinel error directly, rather than relying on
+// the decoder to return that error unwrapped.
+type OpaqueErrorDecoder struct {
+	R io.Reader
+}
+
+// Decode reads from R one byte at a time until a Read error occurs, then returns a new, differently
+// typed error carrying the same message.
+func (d *OpaqueErrorDecoder) Decode(_ any) error {
+	buf := make([]byte, 1)
+
+	for {
+		if _, err := d.R.Read(buf); err != nil {
+			return errors.New(err.Error())
+		}
+	}
+}
+
+// Close is a no-op.
+func (d *OpaqueErrorDecoder) Close() error {
+	return nil
+}
+
+// TripleReadDecoder is a [stream.Decoder] test double that reads R one byte at a time exactly three
+// times per Decode call, regardless of intervening errors, exercising a capReader's sticky repeat-Read
+// guard: a Read call made after the reader has already latched a size-limit error from a previous call.
+type TripleReadDecoder struct {
+	R io.Reader
+}
+
+// Decode reads from R exactly three times, returning the last call's error.
+func (d *TripleReadDecoder) Decode(_ any) error {
+	buf := make([]byte, 1)
+
+	var lastErr error
+
+	for range 3 {
+		_, lastErr = d.R.Read(buf)
+	}
+
+	return lastErr
+}
+
+// Close is a no-op.
+func (d *TripleReadDecoder) Close() error {
+	return nil
+}
+
+// SingleReadDecoder is a [stream.Decoder] test double that performs exactly one large Read against R
+// and always reports a successful decode, regardless of how many bytes that Read actually consumed.
+// A real streaming decoder's internal buffering strategy can vary by Go toolchain (for example under
+// GOEXPERIMENT=jsonv2), which can make it read incrementally and trip a capReader's live per-Read cap
+// check before Decode ever returns success. SingleReadDecoder bypasses that variability so a capReader
+// post-decode size check can be exercised deterministically.
+type SingleReadDecoder struct {
+	R io.Reader
+}
+
+// Decode performs one Read against R with a generous buffer and always reports success.
+func (d *SingleReadDecoder) Decode(_ any) error {
+	buf := make([]byte, 4096)
+	_, _ = d.R.Read(buf)
+
+	return nil
+}
+
+// Close is a no-op.
+func (d *SingleReadDecoder) Close() error {
+	return nil
+}
+
+// NoBufferedDecoder is a [stream.Decoder] test double that always decodes successfully and has no
+// Buffered method, exercising the no-correction fallback branch of a stream package's bufferedLen
+// helper.
+type NoBufferedDecoder struct{}
+
+// Decode always succeeds without consuming v.
+func (NoBufferedDecoder) Decode(_ any) error {
+	return nil
+}
+
+// Close is a no-op.
+func (NoBufferedDecoder) Close() error {
+	return nil
+}
+
+// WrongBufferedDecoder is a [stream.Decoder] test double that always decodes successfully and whose
+// Buffered method returns a reader that is not a *bytes.Reader, exercising the other no-correction
+// fallback branch of a stream package's bufferedLen helper.
+type WrongBufferedDecoder struct{}
+
+// Decode always succeeds without consuming v.
+func (WrongBufferedDecoder) Decode(_ any) error {
+	return nil
+}
+
+// Close is a no-op.
+func (WrongBufferedDecoder) Close() error {
+	return nil
+}
+
+// Buffered returns an empty reader that is not a *bytes.Reader.
+func (WrongBufferedDecoder) Buffered() io.Reader {
+	return strings.NewReader("")
+}
+
+// CloseErrEncoder is a [stream.Encoder] test double whose Encode always succeeds and whose Close
+// always fails with ErrFailed.
+type CloseErrEncoder struct{}
+
+// Encode always succeeds without writing v.
+func (CloseErrEncoder) Encode(_ any) error {
+	return nil
+}
+
+// Close returns ErrFailed.
+func (CloseErrEncoder) Close() error {
+	return ErrFailed
 }

--- a/internal/test/fxtest.go
+++ b/internal/test/fxtest.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"testing"
+
+	"go.uber.org/fx/fxtest"
+)
+
+// QuietLifecycle returns an [fxtest.Lifecycle] equivalent to [fxtest.NewLifecycle], except that its
+// default per-hook logging is discarded, so a benchmark or test run isn't dominated by "[Fx] HOOK
+// OnStart"/"OnStop" lines for every world or provider it starts. Errorf and FailNow are still
+// forwarded to tb, so a lifecycle that fails to start or stop cleanly still fails the test exactly as
+// fxtest.NewLifecycle would.
+func QuietLifecycle(tb testing.TB) *fxtest.Lifecycle {
+	tb.Helper()
+
+	return fxtest.NewLifecycle(quietTB{TB: tb})
+}
+
+// quietTB adapts a testing.TB to fxtest.TB, discarding Logf calls.
+type quietTB struct {
+	testing.TB
+}
+
+// Logf discards the message.
+func (quietTB) Logf(string, ...any) {}

--- a/internal/test/http.go
+++ b/internal/test/http.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -50,6 +51,29 @@ func (w *ErrResponseWriter) Write([]byte) (int, error) {
 
 // WriteHeader stores code in the Code field.
 func (w *ErrResponseWriter) WriteHeader(code int) {
+	w.Code = code
+}
+
+// NoFlushResponseWriter is an [http.ResponseWriter] test double whose writes succeed but which does
+// not implement [http.Flusher], so [http.ResponseController.Flush] reports
+// [http.ErrNotSupported] against it.
+type NoFlushResponseWriter struct {
+	Body bytes.Buffer
+	Code int
+}
+
+// Header is always empty.
+func (w *NoFlushResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+// Write appends p to Body.
+func (w *NoFlushResponseWriter) Write(p []byte) (int, error) {
+	return w.Body.Write(p)
+}
+
+// WriteHeader stores code in the Code field.
+func (w *NoFlushResponseWriter) WriteHeader(code int) {
 	w.Code = code
 }
 

--- a/internal/test/limiter.go
+++ b/internal/test/limiter.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	grpc "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	http "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
@@ -28,4 +29,40 @@ func NewGRPCClientLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *limiter.Con
 // NewGRPCServerLimiter returns a gRPC server limiter and any construction error.
 func NewGRPCServerLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *limiter.Config) (*grpc.Server, error) {
 	return grpc.NewServerLimiter(lc, keys, cfg)
+}
+
+// AllowAllLimiter is a [github.com/alexfalkowski/go-service/v2/net/http/meta.RateLimiter] test double
+// whose Take always allows.
+type AllowAllLimiter struct{}
+
+// Take always allows.
+func (*AllowAllLimiter) Take(context.Context) (bool, string, error) {
+	return true, "", nil
+}
+
+// CountingLimiter is a [github.com/alexfalkowski/go-service/v2/net/http/meta.RateLimiter] test double
+// that allows exactly Remaining Take calls before denying every call after, used to verify per-message
+// limiter charging deterministically without depending on transport/limiter's concrete type.
+type CountingLimiter struct {
+	Remaining int
+}
+
+// Take reports true and decrements Remaining while Remaining > 0, then reports false forever after.
+func (l *CountingLimiter) Take(context.Context) (bool, string, error) {
+	if l.Remaining <= 0 {
+		return false, "", nil
+	}
+
+	l.Remaining--
+
+	return true, "", nil
+}
+
+// ErrorLimiter is a [github.com/alexfalkowski/go-service/v2/net/http/meta.RateLimiter] test double
+// whose Take always fails with ErrFailed.
+type ErrorLimiter struct{}
+
+// Take always returns ErrFailed.
+func (ErrorLimiter) Take(context.Context) (bool, string, error) {
+	return false, "", ErrFailed
 }

--- a/internal/test/metrics.go
+++ b/internal/test/metrics.go
@@ -7,8 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
-	hm "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/metrics"
-	"go.uber.org/fx/fxtest"
+	httpmetrics "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/metrics"
 )
 
 var errInvalid = errors.New("invalid")
@@ -155,7 +154,7 @@ func EnableMetricsReader(tb testing.TB) metrics.Reader {
 
 	reader := metrics.NewManualReader()
 	metrics.NewMeterProvider(metrics.MeterProviderParams{
-		Lifecycle:   fxtest.NewLifecycle(tb),
+		Lifecycle:   QuietLifecycle(tb),
 		Config:      &metrics.Config{},
 		Reader:      reader,
 		ID:          ID,
@@ -173,7 +172,7 @@ func meter(lc di.Lifecycle, router *http.Router, os *worldOpts) (metrics.Meter, 
 	}
 
 	config := NewPrometheusMetricsConfig()
-	hm.Register(Name, config, router)
+	httpmetrics.Register(Name, config, router)
 
 	return NewMeter(lc, config)
 }

--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -87,18 +87,13 @@ func RestRequestError(_ context.Context, _ *Request) (*Response, error) {
 }
 
 func registerRest(router *http.Router) {
-	rest.Register(rest.RegisterParams{
-		Router:  router,
-		Pool:    Pool,
-		Content: Content,
-	})
+	rest.Register(router, Content, Pool, 0, 0)
 }
 
 func restClient(client *http.Client, os *worldOpts) *rest.Client {
 	if os.rest {
 		return rest.NewClient(
 			rest.WithClientRoundTripper(client.Transport),
-			rest.WithClientTimeout("10s"),
 		)
 	}
 

--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -70,9 +70,5 @@ func ErrorsInternalProtobufSayHello(_ context.Context, _ *v1.SayHelloRequest) (*
 }
 
 func (w *World) registerRPC() {
-	rpc.Register(rpc.RegisterParams{
-		Router:  w.Router,
-		Pool:    Pool,
-		Content: Content,
-	})
+	rpc.Register(w.Router, Content, Pool, 0, 0)
 }

--- a/internal/test/shutdowner.go
+++ b/internal/test/shutdowner.go
@@ -1,9 +1,8 @@
 package test
 
 import (
-	"sync"
-
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-sync"
 )
 
 // NewShutdowner returns a Shutdowner that records whether shutdown was requested.

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -60,7 +60,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
 	grpcPolicy := grpc.NewMethodPolicy()
-	lc := fxtest.NewLifecycle(tb)
+	lc := QuietLifecycle(tb)
 	tracer := NewOTLPTracerConfig()
 	generator := uuid.NewGenerator()
 	drain := server.NewDrain()

--- a/io/io.go
+++ b/io/io.go
@@ -59,6 +59,25 @@ func NopCloser(r Reader) ReadCloser {
 	return io.NopCloser(r)
 }
 
+// PipeReader is an alias for [io.PipeReader].
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type PipeReader = io.PipeReader
+
+// PipeWriter is an alias for [io.PipeWriter].
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type PipeWriter = io.PipeWriter
+
+// Pipe creates a synchronous in-memory pipe connecting a [PipeReader] and a [PipeWriter].
+//
+// This is a thin wrapper around [io.Pipe].
+func Pipe() (*PipeReader, *PipeWriter) {
+	return io.Pipe()
+}
+
 // LimitReader returns a [Reader] that reads from r but stops with [EOF] after n bytes.
 //
 // This is a thin wrapper around [io.LimitReader].

--- a/module/module.go
+++ b/module/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/debug"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/feature"
 	"github.com/alexfalkowski/go-service/v2/health"
@@ -27,6 +28,7 @@ import (
 //   - [env.Module] (ID/UserAgent/UserID constructors; Name and Version are supplied by CLI wiring or custom callers)
 //   - [compress.Module] (compression registry and default codecs)
 //   - [encoding.Module] (encoding registry and default encoders)
+//   - [stream.Module] (streaming encoding registry and default streaming encoders/decoders)
 //   - [crypto.Module] (crypto primitives and helpers)
 //   - [time.Module] (time providers/utilities)
 //   - [sync.Module] (shared buffer pool wiring)
@@ -38,6 +40,7 @@ var Library = di.Module(
 	env.Module,
 	compress.Module,
 	encoding.Module,
+	stream.Module,
 	crypto.Module,
 	time.Module,
 	sync.Module,

--- a/net/http/body/body.go
+++ b/net/http/body/body.go
@@ -61,3 +61,32 @@ func NewHandler(handler http.Handler, limit int64) http.Handler {
 		handler.ServeHTTP(res, req)
 	})
 }
+
+// NewLazyHandler wraps handler without buffering the request body.
+//
+// Unlike NewHandler, it never reads req.Body itself: handler reads the body directly, so handler can
+// begin processing before the full body has arrived. This suits routes whose body is read incrementally
+// (streaming routes) rather than decoded all at once.
+//
+// It rejects requests before calling handler when Content-Length is declared and greater than limit,
+// matching NewHandler's short-circuit for requests that announce their size upfront. Beyond that,
+// NewLazyHandler does not enforce limit itself: it does not wrap req.Body in a [http.MaxBytesReader] or
+// similar cumulative-total reader, because a streaming route has no meaningful cumulative body size to
+// cap (see the go-service streaming design's B18 decision) — a long-lived request stream with many
+// values is not bounded by a single byte ceiling the way a one-shot buffered body is. A chunked request
+// has no declared Content-Length, so for those requests this short-circuit cannot fire at all, and
+// nothing in this handler enforces a limit mid-read.
+//
+// Callers that need a per-decoded-value cap on a lazily-limited body must apply it themselves at the
+// point a value boundary is known, the way [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv]
+// does; that per-value cap produces a [http.MaxBytesError] from Recv, not from this handler.
+func NewLazyHandler(handler http.Handler, limit int64) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.ContentLength > limit {
+			_ = status.WriteError(req.Context(), res, &http.MaxBytesError{Limit: limit})
+			return
+		}
+
+		handler.ServeHTTP(res, req)
+	})
+}

--- a/net/http/body/body_test.go
+++ b/net/http/body/body_test.go
@@ -1,12 +1,16 @@
 package body_test
 
 import (
+	"bufio"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/body"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +43,109 @@ func TestCloseClosesBody(t *testing.T) {
 
 	body.Close(trackedBody)
 	require.True(t, trackedBody.Closed)
+}
+
+func TestNewLazyHandlerRejectsContentLengthOverLimit(t *testing.T) {
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", strings.NewReader(strings.Repeat("a", 100)))
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	handler := body.NewLazyHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		require.Fail(t, "next handler should not be called")
+	}), 64)
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+	test.RequireTrimmedResponseBody(t, res, "http: request entity too large")
+}
+
+func TestNewLazyHandlerSkipsEmptyBody(t *testing.T) {
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	handler := body.NewLazyHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, http.NoBody, req.Body)
+		res.WriteHeader(http.StatusOK)
+	}), 64)
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+}
+
+func TestNewLazyHandlerDoesNotEnforceLimitMidStream(t *testing.T) {
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", &test.UnknownLengthReader{Reader: strings.NewReader(strings.Repeat("a", 100))})
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	var data []byte
+	var readErr error
+	handler := body.NewLazyHandler(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		data, _, readErr = io.ReadAll(req.Body)
+	}), 64)
+
+	handler.ServeHTTP(res, req)
+
+	require.NoError(t, readErr)
+	require.Len(t, data, 100)
+}
+
+func TestNewLazyHandlerStreamsBodyIncrementally(t *testing.T) {
+	pipeReader, pipeWriter := io.Pipe()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", pipeReader)
+	require.NoError(t, err)
+	req.ContentLength = -1
+
+	res := httptest.NewRecorder()
+	lines := make(chan string, 2)
+	done := make(chan struct{})
+
+	handler := body.NewLazyHandler(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		reader := bufio.NewReader(req.Body)
+
+		for range 2 {
+			line, lineErr := reader.ReadString('\n')
+			require.NoError(t, lineErr)
+			lines <- line
+		}
+
+		close(done)
+	}), 1024)
+
+	go handler.ServeHTTP(res, req)
+
+	_, err = pipeWriter.Write([]byte("one\n"))
+	require.NoError(t, err)
+	requireLine(t, lines, "one\n")
+
+	_, err = pipeWriter.Write([]byte("two\n"))
+	require.NoError(t, err)
+	requireLine(t, lines, "two\n")
+
+	require.NoError(t, pipeWriter.Close())
+	requireDone(t, done)
+}
+
+func requireLine(tb testing.TB, lines chan string, want string) {
+	tb.Helper()
+
+	select {
+	case line := <-lines:
+		require.Equal(tb, want, line)
+	case <-time.After(2 * time.Second):
+		tb.Fatal("timed out waiting for line")
+	}
+}
+
+func requireDone(tb testing.TB, done chan struct{}) {
+	tb.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		tb.Fatal("timed out waiting for handler to finish")
+	}
 }

--- a/net/http/body/doc.go
+++ b/net/http/body/doc.go
@@ -1,2 +1,8 @@
 // Package body provides request-body handling helpers for HTTP handlers.
+//
+// [NewHandler] buffers the whole body and enforces a cumulative size limit before the handler runs.
+// [NewLazyHandler] never buffers and does not enforce that limit as the body is read; it only keeps
+// NewHandler's declared-Content-Length short-circuit, for routes that read their body incrementally as
+// it arrives (streaming routes) and cap individual decoded values themselves instead of a cumulative
+// total.
 package body

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -60,10 +60,11 @@ func WithRoundTripper(rt http.RoundTripper) ClientOption {
 	})
 }
 
-// WithTimeout sets the overall request timeout on the underlying [http.Client].
+// WithTimeout sets the overall timeout for unary [Client.Do] calls.
 //
-// The timeout value is assigned to [http.Client.Timeout] (total time limit for a request, including
-// connection time, redirects, and reading the response body).
+// The timeout includes connection time, redirects, and reading the response body. It is applied to
+// the request context rather than [http.Client.Timeout], so [Stream] and [RequestStream] remain
+// long-lived and are bounded only by their caller-provided contexts.
 //
 // If not provided, NewClient defaults to [time.DefaultTimeout].
 func WithTimeout(timeout time.Duration) ClientOption {
@@ -73,6 +74,13 @@ func WithTimeout(timeout time.Duration) ClientOption {
 }
 
 // WithMaxResponseSize sets the maximum response body size buffered by [Client.Do].
+//
+// For streaming calls made through [Stream] or [RequestStream], the same size instead bounds each
+// decoded value individually rather than the whole response: a stream has no natural total size, so a
+// cumulative cap would either be meaningless for a long-lived stream or reject a legitimately large
+// number of small values. This matches the inbound per-value cap applied to streaming request bodies
+// on the server (see the transport/http/body streaming middleware), so operators use one size
+// vocabulary for both directions.
 //
 // If not provided, NewClient defaults to [bytes.DefaultSize].
 func WithMaxResponseSize(size bytes.Size) ClientOption {
@@ -95,15 +103,19 @@ func WithRedirect(redirect Redirect) ClientOption {
 
 // NewClient constructs a Client that encodes requests and decodes responses using content.
 //
-// It reuses buffers from pool and applies the configured transport, timeout, and redirect policy.
+// It reuses buffers from pool and applies the configured transport, unary timeout, and redirect policy.
 //
-// The underlying *[http.Client] is constructed via [http.NewClient], which sets [http.Client.Timeout] and
-// instruments requests with OpenTelemetry when tracing or metrics are enabled.
+// The underlying *[http.Client] is constructed via [http.NewClient] with no timeout. [WithTimeout]
+// applies the configured deadline only to [Client.Do], preserving long-lived streaming calls.
+//
+// [Stream] and [RequestStream] resolve streaming media types through content (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.Content.NewStreamFromMedia]).
 //
 // Callers should treat the returned Client as safe for concurrent use.
 func NewClient(content *content.Content, pool *sync.BufferPool, opts ...ClientOption) *Client {
 	clientOptions := options(opts...)
-	client := http.NewClient(clientOptions.roundTripper, clientOptions.timeout)
+
+	client := http.NewClient(clientOptions.roundTripper, 0)
 
 	switch clientOptions.redirect {
 	case RedirectIgnore:
@@ -112,7 +124,13 @@ func NewClient(content *content.Content, pool *sync.BufferPool, opts ...ClientOp
 		client.CheckRedirect = http.SameOriginRedirect
 	}
 
-	return &Client{client: client, content: content, pool: pool, maxResponseSize: clientOptions.maxResponseSize.Bytes()}
+	return &Client{
+		client:          client,
+		content:         content,
+		pool:            pool,
+		timeout:         clientOptions.timeout,
+		maxResponseSize: clientOptions.maxResponseSize.Bytes(),
+	}
 }
 
 // Options describes the request/response payloads and media types for a single call.
@@ -159,6 +177,7 @@ type Client struct {
 	client          *http.Client
 	content         *content.Content
 	pool            *sync.BufferPool
+	timeout         time.Duration
 	maxResponseSize int64
 }
 
@@ -218,32 +237,15 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 // Notes:
 //   - Callers may pass the zero Options value when no request/response bodies are needed.
 //   - This method buffers response bodies in memory up to the configured limit.
-//
-//nolint:cyclop
 func (c *Client) Do(ctx context.Context, method, url string, opts Options) error {
-	requestMedia := c.content.NewFromMedia(opts.ContentType)
-
-	body := io.Reader(http.NoBody)
-	if opts.HasRequest() {
-		var requestBody bytes.Buffer
-		if err := requestMedia.Encoder.Encode(&requestBody, opts.Request); err != nil {
-			return errors.Prefix("http: encode", err)
-		}
-
-		// Do not use a pooled buffer for the request body: net/http may keep
-		// reading it from a transport goroutine after Do returns.
-		body = bytes.NewReader(requestBody.Bytes())
-	}
-
-	request, err := http.NewRequestWithContext(ctx, method, url, body)
+	request, err := c.newRequest(ctx, method, url, opts)
 	if err != nil {
-		return errors.Prefix("http: new request", err)
+		return err
 	}
 
-	request.Header.Set(content.TypeKey, requestMedia.String())
-	if !strings.IsEmpty(opts.Accept) {
-		request.Header.Set(content.AcceptKey, opts.Accept)
-	}
+	requestContext, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	request = request.WithContext(requestContext)
 
 	response, err := c.client.Do(request)
 	if err != nil {
@@ -261,23 +263,111 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 
 	// The server handlers return text/error to indicate an error.
 	responseMedia := c.content.NewFromMedia(responseContentType(response.Header, opts))
-	if responseMedia.IsError() {
-		code := response.StatusCode
-		if !isErrorStatus(code) {
-			code = http.StatusInternalServerError
-		}
-
-		return status.Error(code, strings.TrimSpace(responseBody.String()))
-	}
-
-	if isErrorStatus(response.StatusCode) {
-		return status.Error(response.StatusCode, defaultErrorMessage(response.StatusCode))
+	if err := mediaStatusError(response, responseMedia, responseBody.String()); err != nil {
+		return err
 	}
 
 	if opts.HasResponse() {
 		if err := responseMedia.Encoder.Decode(responseBody, opts.Response); err != nil {
 			return errors.Prefix("http: decode", err)
 		}
+	}
+
+	return nil
+}
+
+// newRequest builds an outgoing request for method/url, encoding opts.Request (if set) into the
+// request body using the encoder selected by opts.ContentType, and setting the Content-Type/Accept
+// headers.
+//
+// This is shared by Do and Stream; RequestStream builds its own pipe-backed request instead, since a
+// bidirectional streaming request has no single-value body to encode upfront.
+func (c *Client) newRequest(ctx context.Context, method, url string, opts Options) (*http.Request, error) {
+	requestMedia := c.content.NewFromMedia(opts.ContentType)
+
+	body := io.Reader(http.NoBody)
+	if opts.HasRequest() {
+		var requestBody bytes.Buffer
+		if err := requestMedia.Encoder.Encode(&requestBody, opts.Request); err != nil {
+			return nil, errors.Prefix("http: encode", err)
+		}
+
+		// Do not use a pooled buffer for the request body: net/http may keep
+		// reading it from a transport goroutine after Do returns.
+		body = bytes.NewReader(requestBody.Bytes())
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, errors.Prefix("http: new request", err)
+	}
+
+	request.Header.Set(content.TypeKey, requestMedia.String())
+	if !strings.IsEmpty(opts.Accept) {
+		request.Header.Set(content.AcceptKey, opts.Accept)
+	}
+
+	return request, nil
+}
+
+func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {
+	_, err := buffer.ReadFrom(io.LimitReader(body, c.maxResponseSize+1))
+	if err != nil {
+		return errors.Prefix("http: copy", err)
+	}
+
+	if int64(buffer.Len()) > c.maxResponseSize {
+		return status.SafeError(http.StatusRequestEntityTooLarge, nil)
+	}
+
+	return nil
+}
+
+// checkResponseStatus applies [mediaStatusError] to response, reading a bounded prefix of
+// response.Body into a pooled buffer only when the response uses the text/error media convention.
+//
+// Unlike Do, which always buffers the whole response body upfront, this only reads the body when the
+// error signal actually requires a message, so a non-error streaming response is left untouched for
+// the caller's decoder.
+func (c *Client) checkResponseStatus(response *http.Response, opts Options) error {
+	responseMedia := c.content.NewFromMedia(responseContentType(response.Header, opts))
+
+	message := strings.Empty
+	if responseMedia.IsError() {
+		buffer := c.pool.Get()
+		defer c.pool.Put(buffer)
+
+		if err := c.readResponse(buffer, response.Body); err != nil {
+			return err
+		}
+
+		message = buffer.String()
+	}
+
+	return mediaStatusError(response, responseMedia, message)
+}
+
+// mediaStatusError returns a [status.Error] when response indicates an error, either through the
+// text/error media convention (responseMedia.IsError(), using message as the trimmed error body text)
+// or a 4xx/5xx status code with no such convention. It returns nil when response is not an error by
+// either signal.
+//
+// This is the shared decision behind Do's response handling and the equivalent check applied to the
+// initial response of a [Stream] or [RequestStream] call, before either streams values from/to the
+// caller-supplied handler. Factoring it out keeps both paths honoring the same text/error and status
+// code contract instead of the streaming path silently dropping it (see [Client.checkResponseStatus]).
+func mediaStatusError(response *http.Response, responseMedia content.Media, message string) error {
+	if responseMedia.IsError() {
+		code := response.StatusCode
+		if !isErrorStatus(code) {
+			code = http.StatusInternalServerError
+		}
+
+		return status.Error(code, strings.TrimSpace(message))
+	}
+
+	if isErrorStatus(response.StatusCode) {
+		return status.Error(response.StatusCode, defaultErrorMessage(response.StatusCode))
 	}
 
 	return nil
@@ -303,31 +393,18 @@ func responseContentType(header http.Header, opts Options) string {
 	return opts.ContentType
 }
 
-func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {
-	_, err := buffer.ReadFrom(io.LimitReader(body, c.maxResponseSize+1))
-	if err != nil {
-		return errors.Prefix("http: copy", err)
-	}
-
-	if int64(buffer.Len()) > c.maxResponseSize {
-		return status.SafeError(http.StatusRequestEntityTooLarge, nil)
-	}
-
-	return nil
-}
-
 func options(opts ...ClientOption) *clientOpts {
 	clientOptions := &clientOpts{redirect: RedirectSameOrigin}
 	for _, o := range opts {
 		o.apply(clientOptions)
 	}
 
-	if clientOptions.timeout <= 0 {
-		clientOptions.timeout = time.DefaultTimeout
-	}
-
 	if clientOptions.maxResponseSize <= 0 {
 		clientOptions.maxResponseSize = bytes.DefaultSize
+	}
+
+	if clientOptions.timeout <= 0 {
+		clientOptions.timeout = time.DefaultTimeout
 	}
 
 	if clientOptions.roundTripper == nil {

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -13,6 +15,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,6 +30,22 @@ func TestDoAllowsResponseAtMaxResponseSize(t *testing.T) {
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.NoError(t, err)
+}
+
+func TestDoUsesConfiguredTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set(content.TypeKey, media.Text)
+		res.WriteHeader(http.StatusOK)
+		res.(http.Flusher).Flush()
+		<-req.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithTimeout(10*time.Millisecond))
+
+	err := c.Get(t.Context(), server.URL, client.Options{})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestDoRejectsResponseOverMaxResponseSize(t *testing.T) {
@@ -302,6 +321,94 @@ func TestDoRedirectIgnoreRejectsRedirectRoundTrip(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"https://example.com/start"}, urls)
+}
+
+func TestDoReturnsEncodeErrorFromNewRequest(t *testing.T) {
+	enc := encoding.NewMap()
+	enc.Register("json", test.NewEncoder(test.ErrFailed))
+	cont := content.NewContent(enc, test.StreamEncoder, test.Pool)
+
+	c := client.NewClient(cont, test.Pool)
+
+	err := c.Post(t.Context(), "http://example.com", client.Options{ContentType: media.JSON, Request: &test.Request{Name: "Bob"}})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestDoReturnsNewRequestError(t *testing.T) {
+	c := client.NewClient(test.Content, test.Pool)
+
+	err := c.Do(t.Context(), "BAD METHOD", "http://example.com", client.Options{})
+
+	require.Error(t, err)
+}
+
+func TestDoReturnsTransportError(t *testing.T) {
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, test.ErrFailed
+	})
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(rt))
+
+	err := c.Get(t.Context(), "http://example.com", client.Options{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestDoReturnsCopyErrorFromReadResponse(t *testing.T) {
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: &test.ErrReaderCloser{}, Request: req}, nil
+	})
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(rt))
+
+	err := c.Get(t.Context(), "http://example.com", client.Options{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestDoReturnsDecodeError(t *testing.T) {
+	enc := encoding.NewMap()
+	enc.Register("json", test.NewEncoder(test.ErrFailed))
+	cont := content.NewContent(enc, test.StreamEncoder, test.Pool)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.JSON)
+		_, _ = io.WriteString(res, "{}")
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(cont, test.Pool)
+
+	var res test.Response
+	err := c.Get(t.Context(), server.URL, client.Options{Response: &res})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestStreamReturnsCopyErrorFromCheckResponseStatus(t *testing.T) {
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{content.TypeKey: []string{media.Error}},
+			Body:       &test.ErrReaderCloser{},
+			Request:    req,
+		}, nil
+	})
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(rt))
+
+	err := c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{},
+		func(_ context.Context, _ *client.ResponseStream) error {
+			return nil
+		})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
 }
 
 type authRoundTripper struct {

--- a/net/http/client/example_test.go
+++ b/net/http/client/example_test.go
@@ -1,0 +1,58 @@
+package client_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/client"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-sync"
+)
+
+func ExampleClient_RequestStream() {
+	pool := sync.NewBufferPool()
+	cont := content.NewContent(encoding.NewMap(), stream.NewMap(), pool)
+	handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, stream *content.RequestStream[exampleRequest, exampleResponse]) error {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		return stream.Send(&exampleResponse{Greeting: "hello " + req.Name})
+	})
+
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	c := client.NewClient(cont, pool, client.WithRoundTripper(server.Client().Transport))
+	var response exampleResponse
+	err := c.RequestStream(context.Background(), http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			if err := stream.Send(&exampleRequest{Name: "Mira"}); err != nil {
+				return err
+			}
+
+			return stream.Recv(&response)
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(response.Greeting)
+	// Output: hello Mira
+}
+
+type exampleRequest struct {
+	Name string `json:"name"`
+}
+
+type exampleResponse struct {
+	Greeting string `json:"greeting"`
+}

--- a/net/http/client/stream.go
+++ b/net/http/client/stream.go
@@ -1,0 +1,585 @@
+package client
+
+import (
+	"bytes"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+// errHandlerPanicked stands in for a recovered [StreamHandler]/[RequestStreamHandler] panic when
+// [RequestResponseStream.finish] needs a non-nil handlerErr to close the pipe with CloseWithError
+// instead of the clean-success path (see [callHandler] and [Client.RequestStream]). It is never
+// returned to a caller: the original panic value is always re-raised after cleanup.
+var errHandlerPanicked = errors.New("client: handler panicked")
+
+// StreamHandler handles a client-side receive-only stream: the response streams, the request does
+// not. It is the client-side counterpart of a call to a send-only streaming route (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.StreamHandler]).
+//
+// Like [Options.Response], a streamed value has no static Go type known to this package: handle it by
+// calling [ResponseStream.Recv] with a pointer to whatever type the caller expects, the same way
+// [Client.Do] decodes into opts.Response.
+type StreamHandler func(ctx context.Context, stream *ResponseStream) error
+
+// RequestStreamHandler handles a client-side bidirectional stream: both the request and the response
+// stream. It is the client-side counterpart of a call to a bidirectional streaming route (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStreamHandler]).
+type RequestStreamHandler func(ctx context.Context, stream *RequestResponseStream) error
+
+// StreamGet issues a send-only streaming HTTP GET request to url using opts.
+//
+// It is a convenience wrapper around Stream.
+func (c *Client) StreamGet(ctx context.Context, url string, opts Options, handler StreamHandler) error {
+	return c.Stream(ctx, http.MethodGet, url, opts, handler)
+}
+
+// StreamPost issues a bidirectional streaming HTTP POST request to url using opts.
+//
+// It is a convenience wrapper around RequestStream.
+func (c *Client) StreamPost(ctx context.Context, url string, opts Options, handler RequestStreamHandler) error {
+	return c.RequestStream(ctx, http.MethodPost, url, opts, handler)
+}
+
+// StreamPut issues a bidirectional streaming HTTP PUT request to url using opts.
+//
+// It is a convenience wrapper around RequestStream.
+func (c *Client) StreamPut(ctx context.Context, url string, opts Options, handler RequestStreamHandler) error {
+	return c.RequestStream(ctx, http.MethodPut, url, opts, handler)
+}
+
+// StreamPatch issues a bidirectional streaming HTTP PATCH request to url using opts.
+//
+// It is a convenience wrapper around RequestStream.
+func (c *Client) StreamPatch(ctx context.Context, url string, opts Options, handler RequestStreamHandler) error {
+	return c.RequestStream(ctx, http.MethodPatch, url, opts, handler)
+}
+
+// Stream issues a request with method and url and drives handler over the streamed response.
+//
+// Unlike [Client.Do], the response is not buffered: values are decoded and delivered to handler as
+// they arrive on the wire. opts.Request/opts.ContentType are encoded into the request body exactly as
+// [Client.Do] would (Stream has no streamed request body; use RequestStream for that). opts.Response is
+// ignored.
+//
+// Content negotiation:
+// The response streaming decoder is resolved from the response Content-Type header, falling back to
+// opts.ContentType, via the same [content.Content] passed to [NewClient] (see
+// [content.Content.NewStreamFromMedia]). An unregistered or unparseable streaming media type, or a
+// Client whose Content has no streaming registry, is returned as an error and handler is never called —
+// but only once the response exists: unlike a media type Stream could reject before dialing at all,
+// there is no way to know the response's actual Content-Type without making the request first, so a
+// misconfigured Client still pays for one round trip before failing.
+//
+// Error contract:
+// Before handler is called, the initial response is checked exactly as [Client.Do] checks it: a
+// text/error response or a 4xx/5xx status code is returned as a [github.com/alexfalkowski/go-service/v2/net/http/status.Error]
+// and handler is never called (see [Client.checkResponseStatus]). Once handler is called, any error it
+// returns is returned as-is by Stream: there is no separate abort signal on the client side, since the
+// client is not committing an HTTP response of its own. The response body is always closed before
+// Stream returns, whether handler succeeds or fails.
+//
+// Retries:
+// Stream has no retry logic of its own, but its request is an ordinary [Client.Do]-shaped request with
+// no streamed body, so a retry-capable [http.RoundTripper] configured via [WithRoundTripper] (for
+// example [github.com/alexfalkowski/go-service/v2/transport/http/retry]) still governs whether the
+// initial request is retried, exactly as it would for Client.Do. There is no retry once handler starts
+// receiving values: a failure at that point is returned as-is, and it is the caller's responsibility to
+// retry the whole call if appropriate. Contrast [Client.RequestStream], whose pipe-backed request body
+// has no [http.Request.GetBody] and is therefore never retryable regardless of the configured
+// RoundTripper.
+//
+// Size limiting:
+// See [WithMaxResponseSize] for the per-value (not cumulative) response size cap applied to each
+// decoded value.
+//
+// Timeouts:
+// The underlying [http.Client] never has a [http.Client.Timeout] (see [NewClient]); bound the call
+// with ctx instead.
+func (c *Client) Stream(ctx context.Context, method, url string, opts Options, handler StreamHandler) error {
+	request, err := c.newRequest(ctx, method, url, opts)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.client.Do(request)
+	if err != nil {
+		return errors.Prefix("http: do", err)
+	}
+
+	ready := make(chan responseResult, 1)
+	ready <- responseResult{response: response}
+
+	stream := &ResponseStream{c: c, opts: opts, ready: ready}
+	if err := stream.ensure(); err != nil {
+		_ = stream.close()
+		return err
+	}
+
+	panicValue, handlerErr := callHandler(func() error { return handler(ctx, stream) })
+	closeErr := stream.close()
+
+	if panicValue != nil {
+		panic(panicValue)
+	}
+
+	if handlerErr != nil {
+		return handlerErr
+	}
+
+	return closeErr
+}
+
+// RequestStream issues a request with method and url over a pipe-backed, chunked request body and
+// drives handler over both directions: handler sends request values via
+// [RequestResponseStream.Send] and receives response values via [RequestResponseStream.Recv].
+//
+// Pipe lifecycle:
+// RequestStream owns the [io.Pipe] for the life of the call; handler never sees or controls it
+// directly. The underlying HTTP round trip is started on a separate goroutine as soon as the pipe and
+// request are built, so it can proceed concurrently with handler's Send calls — this allows genuine h2
+// bidi interleaving, where the server can respond to earlier values while the client is still writing
+// later ones. Once handler returns:
+//   - if handler returned an error, the pipe writer is closed with that error
+//     ([io.PipeWriter.CloseWithError]), so a transport still reading the request body observes a
+//     failure rather than a clean end of stream;
+//   - otherwise, the request stream encoder is finalized (Close), and the pipe writer is closed
+//     with that finalize error if it failed, or closed cleanly (EOF) if it succeeded.
+//
+// In every case RequestStream then waits for the underlying response to resolve (if handler never
+// called Recv, this is the first time the response is awaited) and closes the response body exactly
+// once before returning, so the connection is never leaked regardless of how handler exits.
+//
+// req.ContentLength is set to -1 so the transport uses chunked encoding for the pipe-backed body.
+//
+// HTTP/2 requirement:
+// This mirrors the server's bidirectional streaming requirement (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]): calling a bidi
+// route over HTTP/1.1 hangs rather than failing, because the h1 transport buffers the request body
+// ahead of the handler. Callers must dial an HTTP/2 (including h2c) endpoint.
+//
+// Content negotiation:
+// The request streaming encoder is resolved from opts.ContentType; the response streaming decoder is
+// resolved the same way [Client.Stream] resolves it. Both require the [content.Content] passed to
+// [NewClient] to have a streaming registry; an unregistered or unparseable streaming media type is
+// returned as an error before any request is sent.
+//
+// Error contract:
+// Unlike [Client.Stream], RequestStream cannot check the initial response before calling handler: the
+// response only exists once the server has read enough of the request stream to answer, so handler is
+// always called. A text/error response or a 4xx/5xx status code (see [Client.checkResponseStatus]) is
+// instead surfaced as the error returned by the first [RequestResponseStream.Recv] call, exactly like
+// any other Recv error; a handler that never calls Recv never observes it as a Recv error, but
+// RequestStream still resolves and closes the response before returning.
+//
+// Retries:
+// RequestStream's request body has no [http.Request.GetBody] (it is pipe-backed), so
+// [github.com/alexfalkowski/go-service/v2/transport/http/retry]'s canRetry check already excludes it —
+// streaming requests are never retried. This is a confirmed consequence, not a defect: retrying would
+// require replaying already-sent request values.
+//
+// Size limiting:
+// See [WithMaxResponseSize] for the per-value (not cumulative) response size cap applied to each
+// value received via Recv.
+//
+// Timeouts:
+// See [Client.Stream]: the underlying [http.Client] never has a [http.Client.Timeout].
+func (c *Client) RequestStream(ctx context.Context, method, url string, opts Options, handler RequestStreamHandler) error {
+	reqMedia, err := c.content.NewStreamFromMedia(opts.ContentType)
+	if err == nil && reqMedia.NewEncoder == nil {
+		err = content.ErrUnsupportedStreamMedia
+	}
+
+	if err != nil {
+		return errors.Prefix("http: stream media", err)
+	}
+
+	reader, writer := io.Pipe()
+
+	request, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		_ = writer.Close()
+		return errors.Prefix("http: new request", err)
+	}
+
+	// ContentLength = -1 forces chunked transfer encoding: the pipe has no known total length, and a
+	// declared Content-Length would make the transport try to read exactly that many bytes upfront.
+	request.ContentLength = -1
+	request.Header.Set(content.TypeKey, reqMedia.String())
+
+	if !strings.IsEmpty(opts.Accept) {
+		request.Header.Set(content.AcceptKey, opts.Accept)
+	}
+
+	ready := make(chan responseResult, 1)
+
+	go func() {
+		response, doErr := c.client.Do(request)
+		ready <- responseResult{response: response, err: doErr}
+	}()
+
+	stream := &RequestResponseStream{
+		ResponseStream: ResponseStream{c: c, opts: opts, ready: ready},
+		encoder:        reqMedia.NewEncoder(writer),
+		writer:         writer,
+	}
+
+	panicValue, handlerErr := callHandler(func() error { return handler(ctx, stream) })
+	if panicValue != nil && handlerErr == nil {
+		// finish branches on a nil handlerErr by finalizing the encoder and closing the pipe cleanly,
+		// as if the handler had succeeded. A panic is not success: force the error branch
+		// (CloseWithError) so a transport still reading the request body sees a failure, not a clean
+		// end of stream, matching how a returned handler error is already treated.
+		handlerErr = errHandlerPanicked
+	}
+
+	finishErr := stream.finish(handlerErr)
+
+	if panicValue != nil {
+		panic(panicValue)
+	}
+
+	return finishErr
+}
+
+// callHandler invokes fn, recovering a panic instead of letting it unwind immediately, so the caller can
+// still run its pipe/response cleanup (which only happens after the handler returns) before re-raising
+// the original panic. Without this, a panicking [StreamHandler] or [RequestStreamHandler] would skip
+// [ResponseStream.close]/[RequestResponseStream.finish] entirely, leaking the response body and, for
+// [Client.RequestStream], leaving its background [Client.client.Do] goroutine blocked on an unclosed
+// pipe.
+func callHandler(fn func() error) (panicValue any, err error) {
+	defer func() {
+		panicValue = recover()
+	}()
+
+	err = fn()
+
+	return nil, err
+}
+
+// responseResult carries the outcome of resolving the HTTP response for a streaming call: either a
+// response, or the error [Client.client.Do] returned instead of one.
+type responseResult struct {
+	response *http.Response
+	err      error
+}
+
+// ResponseStream is a client-side receive-only streaming handle: it decodes values from a streamed
+// response without writing a request body itself.
+//
+// ResponseStream is not safe for concurrent use: Recv is expected to be called from one goroutine at a
+// time, matching [github.com/alexfalkowski/go-service/v2/net/http/content.Stream]'s server-side
+// concurrency contract.
+//
+// The response is resolved lazily, on the first call to Recv (or, if Recv is never called, when the
+// driving [Client.Stream] or [Client.RequestStream] call finishes): this lets [Client.RequestStream]
+// hand a stream to handler immediately, before the response exists, while [Client.Stream] forces
+// resolution itself before calling handler so a known-bad response never reaches handler at all. See
+// [ResponseStream.ensure].
+type ResponseStream struct {
+	err      error
+	c        *Client
+	ready    <-chan responseResult
+	response *http.Response
+	dec      *responseDecoder
+	opts     Options
+}
+
+// ensure resolves the response exactly once: waiting for ready, applying the same status/media error
+// check [Client.Do] applies (see [Client.checkResponseStatus]), and selecting the streaming decoder.
+// Recv and close call it serially: ResponseStream is not safe for concurrent use.
+func (s *ResponseStream) ensure() error {
+	if s.ready == nil {
+		return s.err
+	}
+
+	result := <-s.ready
+	s.ready = nil
+	if result.err != nil {
+		s.err = errors.Prefix("http: do", result.err)
+		return s.err
+	}
+
+	s.response = result.response
+
+	if err := s.c.checkResponseStatus(s.response, s.opts); err != nil {
+		s.err = err
+		return err
+	}
+
+	dec, err := newResponseDecoder(s.c, s.response, s.opts)
+	if err != nil {
+		s.err = err
+		return err
+	}
+
+	s.dec = dec
+
+	return nil
+}
+
+// Recv decodes the next response value into v, a pointer to whatever type the caller expects — the
+// same convention [Client.Do] uses for opts.Response.
+//
+// Recv returns io.EOF once the response stream ends, matching
+// [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv]'s server-side terminal
+// behavior and the gRPC idiom. The first call to Recv resolves the underlying response if it has not
+// been resolved yet (see [ResponseStream.ensure]), including the text/error and status code checks
+// [Client.Do] applies to a non-streaming response; a response identified as an error surfaces here as
+// a [github.com/alexfalkowski/go-service/v2/net/http/status.Error], not as a decode failure.
+//
+// Each call to Recv is bounded independently by the size configured with [WithMaxResponseSize]: the
+// cap resets for every value rather than accumulating across the whole stream (see
+// [WithMaxResponseSize]).
+func (s *ResponseStream) Recv(v any) error {
+	if err := s.ensure(); err != nil {
+		return err
+	}
+
+	return s.dec.recv(v)
+}
+
+// IsFinished reports whether err is the terminal [io.EOF] Recv returns once the response stream ends,
+// letting a handler's Recv loop end cleanly without importing errors/io itself. IsFinished is promoted
+// to [RequestResponseStream] through the embedded ResponseStream.
+func (s *ResponseStream) IsFinished(err error) bool {
+	return errors.Is(err, io.EOF)
+}
+
+// close finalizes the decoder (if the response ever resolved to one) and closes the underlying
+// response body. It resolves the response first if that has not happened yet, so a call that never
+// invoked Recv still closes its connection instead of leaking it.
+func (s *ResponseStream) close() error {
+	err := s.ensure()
+
+	if s.dec != nil {
+		if closeErr := s.dec.close(); err == nil {
+			err = closeErr
+		}
+	}
+
+	if s.response != nil {
+		_ = s.response.Body.Close()
+	}
+
+	return err
+}
+
+// RequestResponseStream is a client-side bidirectional streaming handle: it both encodes values into
+// a pipe-backed request body via Send and decodes values from the response via the embedded
+// [ResponseStream.Recv].
+//
+// RequestResponseStream is not safe for arbitrary concurrent use. The supported pattern, matching
+// gRPC's bidi streaming convention and
+// [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream]'s server-side contract, is
+// one goroutine calling Send and one goroutine calling Recv.
+type RequestResponseStream struct {
+	encoder stream.Encoder
+	sendErr error
+	writer  *io.PipeWriter
+	ResponseStream
+}
+
+// Send encodes v, a pointer to whatever type the caller is sending, and writes it to the pipe-backed
+// request body.
+//
+// Send is sticky: once it returns a non-nil error, every later call returns that same error
+// immediately, matching
+// [github.com/alexfalkowski/go-service/v2/net/http/content.Stream.Send]'s server-side contract — a
+// handler that ignores the error degrades to a no-op rather than writing into a broken pipe forever.
+func (s *RequestResponseStream) Send(v any) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+
+	if err := s.encoder.Encode(v); err != nil {
+		s.sendErr = err
+		return err
+	}
+
+	return nil
+}
+
+// finish closes the request-side pipe according to handlerErr, then always resolves and closes the
+// response, returning the first of handlerErr, an encoder finalize error, or a response-resolution
+// error, in that priority order.
+func (s *RequestResponseStream) finish(handlerErr error) error {
+	if handlerErr != nil {
+		_ = s.writer.CloseWithError(handlerErr)
+	} else if closeErr := s.encoder.Close(); closeErr != nil {
+		_ = s.writer.CloseWithError(closeErr)
+		handlerErr = closeErr
+	} else {
+		_ = s.writer.Close()
+	}
+
+	closeErr := s.close()
+	if handlerErr != nil {
+		return handlerErr
+	}
+
+	return closeErr
+}
+
+// responseDecoder holds the resolved decode-side machinery shared by [Client.Stream] and
+// [Client.RequestStream] once a response is available: a streaming decoder bound to a per-value
+// size-capped reader over the response body.
+type responseDecoder struct {
+	decoder stream.Decoder
+	capped  *capReader
+}
+
+func newResponseDecoder(c *Client, response *http.Response, opts Options) (*responseDecoder, error) {
+	resMedia, err := c.content.NewStreamFromMedia(responseContentType(response.Header, opts))
+	if err == nil && resMedia.NewDecoder == nil {
+		err = content.ErrUnsupportedStreamMedia
+	}
+
+	if err != nil {
+		return nil, errors.Prefix("http: stream media", err)
+	}
+
+	capped := &capReader{r: response.Body, max: c.maxResponseSize}
+
+	return &responseDecoder{decoder: resMedia.NewDecoder(capped), capped: capped}, nil
+}
+
+// recv decodes the next value into v and, on success, checks it against the per-value cap. The check
+// runs after Decode returns (mirroring [Client.readResponse]'s read-then-check pattern) rather than
+// truncating capped's reads, because truncating mid-read would silently drop bytes the decoder never
+// asked to give back — those bytes belong to the underlying response body, not to this one value, and
+// dropping them would desynchronize every later value in the stream. See [capReader] for the read-time
+// half of the guard, which still bounds a single pathological value across repeated Read calls.
+//
+// A decoder is not guaranteed to return capped's Read-time error unwrapped: it may fold it into its own
+// error value instead (observed with the standard library JSON decoder under GOEXPERIMENT=jsonv2, which
+// wraps a mid-scan Read error into a *json.SyntaxError with no Unwrap method). recv therefore checks
+// capped's own latched error directly once Decode fails, rather than trusting Decode's returned error
+// to still be classifiable as the size-limit error.
+func (d *responseDecoder) recv(v any) error {
+	d.capped.resetValue(bufferedLen(d.decoder))
+
+	if err := d.decoder.Decode(v); err != nil {
+		if d.capped.err != nil {
+			return d.capped.err
+		}
+
+		return err
+	}
+
+	if d.capped.exceededBy(bufferedLen(d.decoder)) {
+		return entityTooLargeError()
+	}
+
+	return nil
+}
+
+func (d *responseDecoder) close() error {
+	return d.decoder.Close()
+}
+
+// capReader wraps an [io.Reader] with a byte counter that can be reset between decoded values, so a
+// streaming decoder bound to it for its whole lifetime (see [stream.Decoder]) gets a per-value cap
+// rather than a cumulative one (see [WithMaxResponseSize]).
+//
+// capReader never truncates or discards a Read call's data: every byte pulled from the underlying
+// reader is always returned to the caller, so a decoder's own internal buffering can never be
+// desynchronized by this guard (compare [http.MaxBytesReader], which truncates because it protects a
+// single one-shot body that is abandoned entirely once the limit is hit — this reader is reused across
+// many values, so "abandon the rest" is not an option). Read still refuses to pull more data once the
+// budget from a previous Read within the same value is already spent, which bounds a single
+// pathological value across repeated Read calls; [responseDecoder.recv] additionally checks the total
+// after each successful Decode, which catches a value whose entire content arrived in one Read call
+// that already exceeded the budget.
+//
+// Read-ahead correction: a decoder such as [encoding/stream/json.Decoder] fills its own internal buffer
+// in chunks, so one Decode call can pull bytes belonging to a later value out of the underlying reader
+// (confirmed by a direct repro: decoding the first of two small NDJSON lines read the whole remaining
+// buffer, attributing both lines' bytes to the first value and rejecting it as oversized even though
+// neither line alone was near the cap). [responseDecoder.recv] corrects for this via [bufferedLen],
+// which subtracts whatever the decoder still holds unconsumed in its own buffer (see [stream.Decoder]'s
+// wrapped [encoding/json.Decoder.Buffered]) from the raw bytes capReader counted for this call, so only
+// bytes actually consumed to produce the value just decoded count against its cap. This works for every
+// stream kind negotiable today (only "json"/NDJSON is registered for streaming); a decoder whose
+// Buffered method does not match gets no correction and falls back to a bound on reads attributed to
+// one value rather than a byte-exact boundary — still enough to prevent a single decoded value from
+// driving an unbounded read of the underlying stream, without the data-loss risk a truncating reader
+// would add.
+type capReader struct {
+	r    io.Reader
+	err  error
+	max  int64
+	read int64
+}
+
+// resetValue rearms the byte counter for the next decoded value, clearing any size-limit error latched
+// by the previous value's Read calls. bufferedAhead has already been read from the underlying stream by
+// the decoder while handling the previous value, so it starts this value's accounting rather than being
+// discarded when the counter resets.
+func (r *capReader) resetValue(bufferedAhead int64) {
+	r.read = bufferedAhead
+	r.err = nil
+}
+
+// exceededBy reports whether the bytes read since the last resetValue, minus bufferedAhead, exceed the
+// configured cap. bufferedAhead is the decoder's own read-ahead for a later value (see [bufferedLen]);
+// subtracting it corrects for a decoder that pulled more than one value's worth of bytes out of the
+// reader in a single underlying Read. The corrected count is clamped to zero.
+func (r *capReader) exceededBy(bufferedAhead int64) bool {
+	attributed := max(r.read-bufferedAhead, 0)
+
+	return attributed > r.max
+}
+
+// bufferedLen returns the number of bytes decoder has already pulled from its underlying reader for a
+// value it has not decoded yet, so a caller can subtract them from the raw bytes [capReader] counted for
+// the value it just decoded (see [capReader.exceededBy]).
+//
+// This only recognizes decoders whose Buffered method matches [encoding/json.Decoder.Buffered]'s shape
+// and returns a concrete [bytes.Reader]. It returns 0 for any decoder that does not match, which is
+// always safe: the correction is skipped, not a wrong non-zero answer.
+func bufferedLen(decoder stream.Decoder) int64 {
+	buffered, ok := decoder.(interface{ Buffered() io.Reader })
+	if !ok {
+		return 0
+	}
+
+	reader, ok := buffered.Buffered().(*bytes.Reader)
+	if !ok {
+		return 0
+	}
+
+	return int64(reader.Len())
+}
+
+// Read implements [io.Reader]. Once the bytes read since the last resetValue already reach the
+// configured cap, Read refuses to read more and returns
+// status.SafeError(http.StatusRequestEntityTooLarge, nil) — the same error [Client.readResponse] uses
+// for its non-streaming size limit — and every subsequent call returns that same error until
+// resetValue is called.
+func (r *capReader) Read(p []byte) (int, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	if r.read >= r.max {
+		r.err = entityTooLargeError()
+		return 0, r.err
+	}
+
+	n, err := r.r.Read(p)
+	r.read += int64(n)
+
+	return n, err
+}
+
+func entityTooLargeError() error {
+	return status.SafeError(http.StatusRequestEntityTooLarge, nil)
+}

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -1,0 +1,750 @@
+package client_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/client"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamRecvsValues(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool)
+
+	var greetings []string
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			for {
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					if stream.IsFinished(err) {
+						return nil
+					}
+
+					return err
+				}
+
+				greetings = append(greetings, res.Greeting)
+			}
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice"}, greetings)
+}
+
+func TestStreamGetIssuesGetRequest(t *testing.T) {
+	var method string
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "Hello Bob"})
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		method = req.Method
+		handler.ServeHTTP(res, req)
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool)
+
+	var greeting string
+	err := c.StreamGet(t.Context(), server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			var res test.Response
+			if err := stream.Recv(&res); err != nil {
+				return err
+			}
+
+			greeting = res.Greeting
+			return nil
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, http.MethodGet, method)
+	require.Equal(t, "Hello Bob", greeting)
+}
+
+func TestStreamPostPutPatchIssueBidiRequests(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		call   func(*client.Client, context.Context, string, client.Options, client.RequestStreamHandler) error
+	}{
+		{name: "post", method: http.MethodPost, call: (*client.Client).StreamPost},
+		{name: "put", method: http.MethodPut, call: (*client.Client).StreamPut},
+		{name: "patch", method: http.MethodPatch, call: (*client.Client).StreamPatch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var method string
+
+			handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+				req, err := stream.Recv()
+				if err != nil {
+					return err
+				}
+
+				return stream.Send(&test.Response{Greeting: "Hello " + req.Name})
+			})
+
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				method = req.Method
+				handler.ServeHTTP(res, req)
+			}))
+			server.EnableHTTP2 = true
+			server.StartTLS()
+			t.Cleanup(server.Close)
+
+			c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(server.Client().Transport))
+
+			var greeting string
+			err := tt.call(c, t.Context(), server.URL, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+				func(_ context.Context, stream *client.RequestResponseStream) error {
+					if err := stream.Send(&test.Request{Name: "Bob"}); err != nil {
+						return err
+					}
+
+					var res test.Response
+					if err := stream.Recv(&res); err != nil {
+						return err
+					}
+
+					greeting = res.Greeting
+					return nil
+				})
+
+			require.NoError(t, err)
+			require.Equal(t, tt.method, method)
+			require.Equal(t, "Hello Bob", greeting)
+		})
+	}
+}
+
+func TestStreamRequiresStreamMap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.NDJSON)
+		_, _ = io.WriteString(res, "{}\n")
+	}))
+	t.Cleanup(server.Close)
+
+	noStreamMap := content.NewContent(test.Encoder, nil, test.Pool)
+	c := client.NewClient(noStreamMap, test.Pool)
+
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON}, func(_ context.Context, stream *client.ResponseStream) error {
+		var res test.Response
+		return stream.Recv(&res)
+	})
+
+	require.ErrorIs(t, err, content.ErrUnsupportedStreamMedia)
+}
+
+func TestStreamRejectsUnsupportedResponseMedia(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.JSON)
+		_, _ = io.WriteString(res, "{}")
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool)
+
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{}, func(_ context.Context, _ *client.ResponseStream) error {
+		return nil
+	})
+
+	require.Error(t, err)
+}
+
+func TestStreamSurfacesErrorResponseBeforeCallingHandler(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.Error)
+		res.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(res, "bad request")
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool)
+
+	called := false
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{}, func(_ context.Context, _ *client.ResponseStream) error {
+		called = true
+		return nil
+	})
+
+	require.Error(t, err)
+	require.EqualError(t, err, "bad request")
+	require.Equal(t, http.StatusBadRequest, status.Code(err))
+	require.False(t, called)
+}
+
+func TestRequestStreamInterleavesOverHTTP2(t *testing.T) {
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+				return err
+			}
+		}
+	})
+
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(server.Client().Transport))
+
+	var greetings []string
+	err := c.RequestStream(ctx, http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			for _, name := range []string{"Bob", "Alice"} {
+				if err := stream.Send(&test.Request{Name: name}); err != nil {
+					return err
+				}
+
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					return err
+				}
+
+				greetings = append(greetings, res.Greeting)
+			}
+
+			return nil
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice"}, greetings)
+}
+
+func TestRequestStreamRejectsUnsupportedRequestMedia(t *testing.T) {
+	c := client.NewClient(test.Content, test.Pool)
+
+	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.invalid", client.Options{ContentType: media.JSON},
+		func(_ context.Context, _ *client.RequestResponseStream) error {
+			return nil
+		})
+
+	require.Error(t, err)
+}
+
+func TestRequestStreamRequiresStreamMap(t *testing.T) {
+	noStreamMap := content.NewContent(test.Encoder, nil, test.Pool)
+	c := client.NewClient(noStreamMap, test.Pool)
+
+	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.invalid", client.Options{},
+		func(_ context.Context, _ *client.RequestResponseStream) error {
+			return nil
+		})
+
+	require.ErrorIs(t, err, content.ErrUnsupportedStreamMedia)
+}
+
+func TestRequestStreamSurfacesErrorResponseViaRecv(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.Error)
+		res.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(res, "bad request")
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(server.Client().Transport))
+
+	sendErr := errors.New("unset")
+	err := c.RequestStream(ctx, http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			sendErr = stream.Send(&test.Request{Name: "Bob"})
+
+			var res test.Response
+			return stream.Recv(&res)
+		})
+
+	require.NoError(t, sendErr)
+	require.Error(t, err)
+	require.EqualError(t, err, "bad request")
+	require.Equal(t, http.StatusBadRequest, status.Code(err))
+}
+
+func TestRequestStreamSendIsSticky(t *testing.T) {
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			if _, err := stream.Recv(); err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+		}
+	})
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(server.Client().Transport))
+
+	var firstErr, secondErr error
+	err := c.RequestStream(ctx, http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			firstErr = stream.Send(&test.Unencodable{})
+			secondErr = stream.Send(&test.Unencodable{})
+			return firstErr
+		})
+
+	require.Error(t, firstErr)
+	require.Equal(t, firstErr, secondErr)
+	require.Equal(t, err, firstErr)
+}
+
+func TestStreamRejectsValueOverCap(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "a greeting far longer than the configured cap"})
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(8))
+
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			var res test.Response
+			return stream.Recv(&res)
+		})
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+}
+
+func TestStreamRejectsValueOverCapWhenDecodeSucceedsInOneRead(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "a greeting far longer than the configured cap"})
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	sm := stream.NewMap()
+	sm.RegisterDecoder("json", func(r io.Reader) stream.Decoder { return &test.SingleReadDecoder{R: r} })
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	c := client.NewClient(cont, test.Pool, client.WithMaxResponseSize(8))
+
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			var res test.Response
+			return stream.Recv(&res)
+		})
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+}
+
+func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
+	tests := []struct {
+		name     string
+		greeting string
+		maxSize  bytes.Size
+		decoder  func(io.Reader) stream.Decoder
+	}{
+		{
+			name:     "decoder discards the error's type",
+			greeting: "a greeting far longer than the configured cap",
+			maxSize:  8,
+			decoder:  func(r io.Reader) stream.Decoder { return &test.OpaqueErrorDecoder{R: r} },
+		},
+		{
+			name:     "decoder calls Read again after capReader already latched an error",
+			greeting: "ab",
+			maxSize:  1,
+			decoder:  func(r io.Reader) stream.Decoder { return &test.TripleReadDecoder{R: r} },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+				return stream.Send(&test.Response{Greeting: tt.greeting})
+			})
+
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+
+			sm := stream.NewMap()
+			sm.RegisterDecoder("json", tt.decoder)
+			cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+			c := client.NewClient(cont, test.Pool, client.WithMaxResponseSize(tt.maxSize))
+
+			err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+				func(_ context.Context, stream *client.ResponseStream) error {
+					var res test.Response
+					return stream.Recv(&res)
+				})
+
+			require.Error(t, err)
+			require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+		})
+	}
+}
+
+func TestStreamCapIsPerValueNotCumulative(t *testing.T) {
+	const values = 10
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		for range values {
+			if err := stream.Send(&test.Response{Greeting: "hi"}); err != nil {
+				return err
+			}
+
+			time.Sleep(3 * time.Millisecond)
+		}
+
+		return nil
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(200))
+
+	count := 0
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			for {
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					if stream.IsFinished(err) {
+						return nil
+					}
+
+					return err
+				}
+
+				count++
+			}
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, values, count)
+}
+
+func TestStreamRecvDoesNotFalsePositiveOnCoalescedReads(t *testing.T) {
+	handler := http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.NDJSON)
+		_, _ = res.Write([]byte("{\"Greeting\":\"Hello Bob\"}\n{\"Greeting\":\"Hello Alice\"}\n"))
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(32))
+
+	var greetings []string
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			for {
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					if stream.IsFinished(err) {
+						return nil
+					}
+
+					return err
+				}
+
+				greetings = append(greetings, res.Greeting)
+			}
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice"}, greetings)
+}
+
+func TestStreamRecvRejectsBufferedValueOverCap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.NDJSON)
+		_, _ = res.Write([]byte("{\"Greeting\":\"A\"}\n{\"Greeting\":\"a greeting far longer than the configured cap\"}\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithMaxResponseSize(20))
+
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+		func(_ context.Context, stream *client.ResponseStream) error {
+			var first test.Response
+			require.NoError(t, stream.Recv(&first))
+
+			var second test.Response
+			return stream.Recv(&second)
+		})
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+}
+
+func TestStreamClosesResponseBodyOnHandlerPanic(t *testing.T) {
+	body := &test.TrackedBody{Reader: strings.NewReader("{\"Greeting\":\"hi\"}\n")}
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{content.TypeKey: []string{media.NDJSON}},
+			Body:       body,
+			Request:    req,
+		}, nil
+	})
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(rt))
+
+	require.PanicsWithValue(t, "boom", func() {
+		_ = c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{Accept: media.NDJSON},
+			func(_ context.Context, _ *client.ResponseStream) error {
+				panic("boom")
+			})
+	})
+
+	require.True(t, body.Closed)
+}
+
+func TestRequestStreamClosesPipeOnHandlerPanic(t *testing.T) {
+	readDone := make(chan error, 1)
+
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		go func() {
+			_, _, err := io.ReadAll(req.Body)
+			readDone <- err
+		}()
+
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody, Request: req}, nil
+	})
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(rt))
+
+	require.PanicsWithValue(t, "boom", func() {
+		_ = c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
+			func(_ context.Context, _ *client.RequestResponseStream) error {
+				panic("boom")
+			})
+	})
+
+	select {
+	case <-readDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipe reader never unblocked after handler panic")
+	}
+}
+
+func TestStreamSurvivesSlowValuesWithConfiguredUnaryTimeout(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithTimeout(10*time.Millisecond))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	var greetings []string
+	err := c.Stream(ctx, http.MethodGet, server.URL, client.Options{Accept: media.NDJSON}, func(_ context.Context, stream *client.ResponseStream) error {
+		for {
+			var res test.Response
+			if err := stream.Recv(&res); err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			greetings = append(greetings, res.Greeting)
+		}
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice"}, greetings)
+}
+
+func TestStreamReturnsEncodeErrorFromNewRequest(t *testing.T) {
+	enc := encoding.NewMap()
+	enc.Register("json", test.NewEncoder(test.ErrFailed))
+	cont := content.NewContent(enc, test.StreamEncoder, test.Pool)
+
+	c := client.NewClient(cont, test.Pool)
+
+	err := c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{ContentType: media.JSON, Request: &test.Request{Name: "Bob"}},
+		func(_ context.Context, _ *client.ResponseStream) error {
+			return nil
+		})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestStreamReturnsTransportError(t *testing.T) {
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, test.ErrFailed
+	})
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(rt))
+
+	err := c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{}, func(_ context.Context, _ *client.ResponseStream) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestRequestStreamRejectsNilEncoderForRegisteredKind(t *testing.T) {
+	sm := stream.NewMap()
+	sm.RegisterEncoder("json", nil)
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	c := client.NewClient(cont, test.Pool)
+
+	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.invalid", client.Options{ContentType: media.NDJSON},
+		func(_ context.Context, _ *client.RequestResponseStream) error {
+			return nil
+		})
+
+	require.ErrorIs(t, err, content.ErrUnsupportedStreamMedia)
+}
+
+func TestRequestStreamReturnsNewRequestError(t *testing.T) {
+	c := client.NewClient(test.Content, test.Pool)
+
+	err := c.RequestStream(t.Context(), "BAD METHOD", "http://example.com", client.Options{ContentType: media.NDJSON},
+		func(_ context.Context, _ *client.RequestResponseStream) error {
+			return nil
+		})
+
+	require.Error(t, err)
+}
+
+func TestRequestStreamFinishReturnsEncoderCloseError(t *testing.T) {
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		go func() { _, _, _ = io.ReadAll(req.Body) }()
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody, Request: req}, nil
+	})
+
+	sm := stream.NewMap()
+	sm.RegisterEncoder("json", func(io.Writer) stream.Encoder { return test.CloseErrEncoder{} })
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	c := client.NewClient(cont, test.Pool, client.WithRoundTripper(rt))
+
+	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
+		func(_ context.Context, _ *client.RequestResponseStream) error {
+			return nil
+		})
+
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestNewResponseDecoderRejectsNilDecoderForRegisteredKind(t *testing.T) {
+	sm := stream.NewMap()
+	sm.RegisterDecoder("json", nil)
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(content.TypeKey, media.NDJSON)
+		_, _ = io.WriteString(res, "{}\n")
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(cont, test.Pool)
+
+	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON}, func(_ context.Context, stream *client.ResponseStream) error {
+		var res test.Response
+		return stream.Recv(&res)
+	})
+
+	require.ErrorIs(t, err, content.ErrUnsupportedStreamMedia)
+}
+
+func TestStreamRecvBufferedLenFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		decoder stream.Decoder
+	}{
+		{name: "no buffered method", decoder: test.NoBufferedDecoder{}},
+		{name: "wrong buffered type", decoder: test.WrongBufferedDecoder{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := stream.NewMap()
+			sm.RegisterDecoder("json", func(io.Reader) stream.Decoder { return tt.decoder })
+			cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+			server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+				res.Header().Set(content.TypeKey, media.NDJSON)
+				_, _ = io.WriteString(res, "{}\n")
+			}))
+			t.Cleanup(server.Close)
+
+			c := client.NewClient(cont, test.Pool)
+
+			err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+				func(_ context.Context, stream *client.ResponseStream) error {
+					var res test.Response
+					return stream.Recv(&res)
+				})
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/net/http/content/content.go
+++ b/net/http/content/content.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-sync"
@@ -13,14 +14,18 @@ const TypeKey = "Content-Type"
 // AcceptKey is the HTTP header key used for Accept.
 const AcceptKey = "Accept"
 
-// NewContent constructs a Content that resolves encoders from enc and buffers responses using pool.
-func NewContent(enc *encoding.Map, pool *sync.BufferPool) *Content {
-	return &Content{enc: enc, pool: pool}
+// NewContent constructs a Content that resolves single-value encoders from enc, streaming encoders/decoders
+// from sm, and buffers responses using pool.
+func NewContent(enc *encoding.Map, sm *stream.Map, pool *sync.BufferPool) *Content {
+	return &Content{enc: enc, sm: sm, pool: pool}
 }
 
 // Content resolves encoders from HTTP media types and provides helpers for content-aware request/response handling.
 //
-// It uses an [encoding.Map] registry to resolve an encoder by media subtype (e.g. "json", "hjson", "yaml", "toml").
+// It uses an [encoding.Map] registry to resolve a single-value encoder by media subtype (e.g. "json", "hjson",
+// "yaml", "toml"), and a [stream.Map] registry to resolve a streaming encoder/decoder by media subtype for
+// streaming routes (e.g. "x-ndjson"). The two registries are intentionally separate: an unregistered streaming
+// kind must fail explicitly rather than silently falling back to single-value JSON (see [NewStreamMedia]).
 //
 // Fallback behavior:
 //   - If media type parsing fails, Content falls back to JSON.
@@ -35,6 +40,7 @@ func NewContent(enc *encoding.Map, pool *sync.BufferPool) *Content {
 //     writing to the live response writer, so late encode failures do not commit partial success bodies.
 type Content struct {
 	enc  *encoding.Map
+	sm   *stream.Map
 	pool *sync.BufferPool
 }
 
@@ -94,6 +100,21 @@ func (c *Content) NewFromRequestBody(req *http.Request) (Media, error) {
 // If parsing fails, it falls back to JSON.
 func (c *Content) NewFromMedia(mediaType string) Media {
 	return NewMedia(mediaType, c.enc)
+}
+
+// NewStreamFromMedia parses mediaType and resolves a streaming encoder/decoder pair, the streaming
+// counterpart of NewFromMedia.
+//
+// Unlike NewFromMedia, there is no JSON fallback: an unparseable or unregistered streaming media type
+// returns [ErrUnsupportedStreamMedia] (see [NewStreamMedia]), including when c has no streaming
+// registry configured — that is indistinguishable from "this kind isn't registered" to the caller, and
+// is handled the same way rather than through a separate error.
+//
+// This is the entry point a caller without an *[http.Request] to negotiate from (for example
+// [github.com/alexfalkowski/go-service/v2/net/http/client.Client]) uses to resolve a streaming media
+// type directly, mirroring how [Content.NewFromMedia] already does this for single-value media.
+func (c *Content) NewStreamFromMedia(mediaType string) (StreamMedia, error) {
+	return NewStreamMedia(mediaType, c.sm)
 }
 
 func (c *Content) newRequestMedia(mediaType string) Media {

--- a/net/http/content/errors.go
+++ b/net/http/content/errors.go
@@ -5,3 +5,16 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // ErrUnsupportedRequestMedia is returned when a request body uses a media type
 // that is intentionally not decoded from public HTTP requests.
 var ErrUnsupportedRequestMedia = errors.New("content: unsupported request media")
+
+// ErrUnsupportedStreamMedia is returned when a media type has no streaming kind registered.
+//
+// Unlike single-value [Media] resolution, stream media resolution never falls back to JSON: silently
+// degrading a streaming route to a different wire format would hide the mismatch from the caller.
+var ErrUnsupportedStreamMedia = errors.New("content: unsupported stream media")
+
+// ErrBidiRequiresHTTP2 is returned when a bidirectional streaming route is called over HTTP/1.x.
+//
+// HTTP/1.1 request bodies are buffered by intermediaries and the Go client transport before the
+// response starts, so a handler that both reads the request stream and writes the response stream
+// hangs rather than failing outright. Bidirectional streaming routes require HTTP/2 (including h2c).
+var ErrBidiRequiresHTTP2 = errors.New("content: bidirectional streaming requires HTTP/2")

--- a/net/http/content/handler_test.go
+++ b/net/http/content/handler_test.go
@@ -116,7 +116,7 @@ func TestNewHandlerReplacesExistingContentType(t *testing.T) {
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	enc := encoding.NewMap()
 	enc.Register("json", test.PartialEncoder{})
-	cont := content.NewContent(enc, test.Pool)
+	cont := content.NewContent(enc, test.StreamEncoder, test.Pool)
 
 	handler := content.NewHandler(cont, func(_ context.Context) (*test.Response, error) {
 		return &test.Response{Greeting: "Hello Bob"}, nil

--- a/net/http/content/stream.go
+++ b/net/http/content/stream.go
@@ -1,0 +1,550 @@
+package content
+
+import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/ptr"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/klauspost/compress/gzhttp"
+)
+
+// StreamHandler handles a send-only stream: the response streams, the request does not.
+//
+// The handler must propagate a [Stream.Send] error by returning it (directly, or wrapped) rather than
+// ignoring it and continuing. Send is sticky — once it fails, every later call returns the same error
+// immediately — but only the handler returning that error triggers [finalizeStream]'s abort/HTTP-error
+// handling; a handler that swallows a Send error and returns nil degrades to a no-op loop over a dead
+// connection instead of ending the request.
+type StreamHandler[Res any] func(ctx context.Context, stream *Stream[Res]) error
+
+// RequestStreamHandler handles a bidirectional stream: both the request and the response stream.
+//
+// The handler must propagate a [Stream.Send] error the same way [StreamHandler] requires; the same
+// obligation applies to a [RequestStream.Recv] error other than the terminal io.EOF, since Recv errors
+// (an oversized value, a limiter denial, a decode failure) are likewise only acted on when the handler
+// returns them.
+type RequestStreamHandler[Req any, Res any] func(ctx context.Context, stream *RequestStream[Req, Res]) error
+
+// NewStreamHandler builds a handler for a send-only streaming response.
+//
+// Content negotiation:
+// The response encoder is resolved from the request Accept header, falling back to Content-Type,
+// using [Content.NewStreamFromAccept]. Unlike single-value handlers, an unregistered or unparseable
+// media type is rejected with 415 rather than falling back to JSON.
+//
+// Error contract:
+// A handler error returned before the first successful Send is an ordinary HTTP error rendered
+// through [status.WriteError]. A handler error returned after the first successful Send aborts the
+// response via panic([http.ErrAbortHandler]) instead, since the response is already committed — see
+// [Stream.Send] and [finalizeStream].
+//
+// timeout, when positive, is pushed forward as the response write deadline after every successful
+// Send (see [http.ResponseController.SetWriteDeadline]), turning a whole-stream write timeout into a
+// per-message inactivity budget. Pass zero to disable this.
+//
+// Load control:
+// If the request context carries a limiter (see [meta.WithLimiter], populated by
+// [github.com/alexfalkowski/go-service/v2/transport/http/limiter.Handler] for a request that was already
+// allowed to open the stream), every Send charges one additional token against that same limiter — see
+// [Stream.Send]. A route reached without that middleware, or with no limiter configured, sees no
+// per-message charging.
+func NewStreamHandler[Res any](cont *Content, timeout time.Duration, handler StreamHandler[Res]) http.HandlerFunc {
+	return func(res http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		limiter := meta.Limiter(ctx)
+
+		resMedia, err := cont.NewStreamFromAccept(req)
+		if err == nil && resMedia.NewEncoder == nil {
+			err = ErrUnsupportedStreamMedia
+		}
+
+		if err != nil {
+			_ = status.WriteError(ctx, res, status.SafeError(http.StatusUnsupportedMediaType, err))
+			return
+		}
+
+		ctx = meta.WithContent(ctx, req, res, nil)
+		res.Header().Set(TypeKey, resMedia.WithUTF8())
+		res.Header().Set(gzhttp.HeaderNoCompression, "1")
+
+		buffer := cont.pool.Get()
+		defer cont.pool.Put(buffer)
+
+		writer := &commitWriter{res: res, buffer: buffer}
+		st := &Stream[Res]{
+			ctx:        ctx,
+			writer:     writer,
+			encoder:    resMedia.NewEncoder(writer),
+			controller: http.NewResponseController(res),
+			timeout:    timeout,
+			limiter:    limiter,
+		}
+		finalizeStream(ctx, res, st, handler(ctx, st))
+	}
+}
+
+// NewRequestStreamHandler builds a handler for a bidirectional stream.
+//
+// HTTP/2 requirement:
+// Bidirectional streaming requires HTTP/2 (including h2c): an HTTP/1.x request body is buffered ahead
+// of the handler by intermediaries and the Go transport, so interleaving Recv/Send hangs rather than
+// failing. Requests with req.ProtoMajor < 2 are rejected with 505 before the handler runs.
+//
+// Content negotiation:
+// The request decoder is resolved from Content-Type via [Content.NewStreamFromContentType]; the
+// response encoder is resolved from Accept (falling back to Content-Type) via
+// [Content.NewStreamFromAccept]. Both reject an unregistered or unparseable media type with 415.
+//
+// Inbound size limiting:
+// maxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a whole
+// (see [capReader]): a request with many small values is never rejected for its cumulative size, only
+// for a single value that exceeds maxReceiveSize. A value at or under the limit is a normal terminal
+// [http.MaxBytesError] surfaced from Recv; the deviation is that no total byte ceiling exists for a
+// streaming route the way [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler]'s buffered
+// path enforces one. maxReceiveSize <= 0 disables the per-value cap entirely.
+//
+// Timeout:
+// When timeout is positive, every successful [RequestStream.Recv] extends the request read deadline
+// and every successful [Stream.Send] extends the response write deadline. This turns the server's
+// whole-request read and write timeouts into per-message inactivity budgets. Pass zero to disable this.
+//
+// See [NewStreamHandler] for the error contract and load control: Recv charges one token per successfully
+// decoded, in-cap value, the same way Send does, against the same request-scoped limiter.
+func NewRequestStreamHandler[Req any, Res any](cont *Content, timeout time.Duration, maxReceiveSize bytes.Size, handler RequestStreamHandler[Req, Res]) http.HandlerFunc {
+	return func(res http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		limiter := meta.Limiter(ctx)
+
+		if req.ProtoMajor < 2 {
+			_ = status.WriteError(ctx, res, status.SafeError(http.StatusHTTPVersionNotSupported, ErrBidiRequiresHTTP2))
+			return
+		}
+
+		reqMedia, err := cont.NewStreamFromContentType(req)
+		if err == nil && reqMedia.NewDecoder == nil {
+			err = ErrUnsupportedStreamMedia
+		}
+
+		if err != nil {
+			_ = status.WriteError(ctx, res, status.SafeError(http.StatusUnsupportedMediaType, err))
+			return
+		}
+
+		resMedia, err := cont.NewStreamFromAccept(req)
+		if err == nil && resMedia.NewEncoder == nil {
+			err = ErrUnsupportedStreamMedia
+		}
+
+		if err != nil {
+			_ = status.WriteError(ctx, res, status.SafeError(http.StatusUnsupportedMediaType, err))
+			return
+		}
+
+		ctx = meta.WithContent(ctx, req, res, nil)
+		res.Header().Set(TypeKey, resMedia.WithUTF8())
+		res.Header().Set(gzhttp.HeaderNoCompression, "1")
+
+		buffer := cont.pool.Get()
+		defer cont.pool.Put(buffer)
+
+		writer := &commitWriter{res: res, buffer: buffer}
+		capped := &capReader{r: req.Body, max: maxReceiveSize.Bytes()}
+		st := &RequestStream[Req, Res]{
+			Stream: Stream[Res]{
+				ctx:        ctx,
+				writer:     writer,
+				encoder:    resMedia.NewEncoder(writer),
+				controller: http.NewResponseController(res),
+				timeout:    timeout,
+				limiter:    limiter,
+			},
+			decoder: reqMedia.NewDecoder(capped),
+			capped:  capped,
+		}
+		finalizeStream(ctx, res, st, handler(ctx, st))
+	}
+}
+
+// Stream is a send-only streaming response handle.
+//
+// Stream is not safe for concurrent use: Send is expected to be called from one goroutine at a time,
+// matching the gRPC server-streaming convention.
+type Stream[Res any] struct {
+	ctx        context.Context
+	encoder    stream.Encoder
+	err        error
+	writer     *commitWriter
+	controller *http.ResponseController
+	limiter    meta.RateLimiter
+	timeout    time.Duration
+}
+
+// Send encodes res and flushes it to the client.
+//
+// The first successful Send commits the response: before that, the encoded value is held in a scratch
+// buffer so a failed first encode never writes a partial success body. Send is sticky: once it returns
+// a non-nil error, every later call returns that same error immediately, so a handler that ignores the
+// error degrades to a no-op rather than an infinite producer.
+//
+// Load control:
+// If a limiter was captured at construction (see [NewStreamHandler]), Send charges one limiter token
+// before doing any work, mirroring gRPC's per-SendMsg charge (see
+// [github.com/alexfalkowski/go-service/v2/transport/grpc/limiter.serverStream.SendMsg]). Before the first
+// successful Send this surfaces as an ordinary 429 [status.Error] through the pre-commit error path;
+// after commit it aborts the response the same way any other post-commit Send error does,
+// since a mid-stream 429 cannot be written once headers are sent. A denial or a limiter error is sticky
+// like any other Send error.
+func (s *Stream[Res]) Send(res *Res) error {
+	if s.err != nil {
+		return s.err
+	}
+
+	if err := s.takeLimiterToken(); err != nil {
+		s.err = err
+		return err
+	}
+
+	if err := s.extendDeadline(); err != nil {
+		s.err = err
+		return err
+	}
+
+	if err := s.encoder.Encode(res); err != nil {
+		s.err = err
+		return err
+	}
+
+	if err := s.writer.commit(); err != nil {
+		s.err = err
+		return err
+	}
+
+	if err := s.controller.Flush(); err != nil {
+		s.err = err
+		return err
+	}
+
+	return nil
+}
+
+// takeLimiterToken charges one limiter token for one Send or Recv message, on top of the token already
+// charged when the stream opened (see [github.com/alexfalkowski/go-service/v2/transport/http/limiter.Handler.ServeHTTP]).
+//
+// It is a no-op, with no overhead beyond the nil check, when no limiter was captured at construction — the
+// common case, since most routes have no limiter configured, or reach a stream handler outside that
+// middleware. A denial maps to the same 429 [status.Error] the limiter middleware itself returns for a
+// rejected request; a Take failure maps to the same [status.InternalServerError] the middleware returns
+// for a limiter error.
+//
+// The RateLimit and RateLimit-Policy response headers are not re-emitted here: they describe only the
+// stream-open decision, since HTTP response headers cannot change once a streaming response is committed.
+func (s *Stream[Res]) takeLimiterToken() error {
+	if s.limiter == nil {
+		return nil
+	}
+
+	allowed, _, err := s.limiter.Take(s.ctx)
+	if err != nil {
+		return status.InternalServerError(err)
+	}
+
+	if !allowed {
+		return status.Error(http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests))
+	}
+
+	return nil
+}
+
+func (s *Stream[Res]) extendDeadline() error {
+	if s.timeout <= 0 {
+		return nil
+	}
+
+	return s.controller.SetWriteDeadline(time.Now().Add(s.timeout.Duration()))
+}
+
+func (s *Stream[Res]) committed() bool {
+	return s.writer.committed
+}
+
+func (s *Stream[Res]) close() error {
+	return s.encoder.Close()
+}
+
+// RequestStream is a bidirectional streaming handle: both the request and the response stream.
+//
+// RequestStream is not safe for arbitrary concurrent use. The supported pattern, matching gRPC's bidi
+// streaming convention, is one goroutine calling Recv and one goroutine calling Send.
+type RequestStream[Req any, Res any] struct {
+	decoder stream.Decoder
+	capped  *capReader
+	Stream[Res]
+}
+
+// Recv decodes the next request value.
+//
+// Recv returns io.EOF once the client half-closes the request stream, matching the gRPC idiom and the
+// terminal behavior of the underlying stream decoders.
+//
+// Recv is bounded independently by the per-value cap configured on [NewRequestStreamHandler]: the cap
+// resets before every Recv rather than accumulating across the whole request stream (see [capReader]).
+// A value over the cap surfaces as a [http.MaxBytesError], the same error type
+// [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler]'s buffered path already produces,
+// so it maps to the same 413 through [github.com/alexfalkowski/go-service/v2/net/http/status.Code].
+//
+// Load control:
+// If a limiter was captured at construction, Recv charges one limiter token after a value decodes
+// successfully and within the per-value cap, mirroring gRPC's per-RecvMsg charge (see
+// [github.com/alexfalkowski/go-service/v2/transport/grpc/limiter.serverStream.RecvMsg]) — a stream-end
+// io.EOF or an oversized value is not a received message and is never charged. See [Stream.Send] for how
+// a denial or limiter error is mapped and surfaced.
+//
+// A decoder is not guaranteed to return capped's Read-time error unwrapped: it may fold it into its own
+// error value instead (observed with the standard library JSON decoder under GOEXPERIMENT=jsonv2, which
+// wraps a mid-scan Read error into a *json.SyntaxError with no Unwrap method). Recv therefore checks
+// capped's own latched error directly once Decode fails, rather than trusting Decode's returned error
+// to still be classifiable as the size-limit error.
+func (s *RequestStream[Req, Res]) Recv() (*Req, error) {
+	s.capped.resetValue(bufferedLen(s.decoder))
+
+	req := ptr.Zero[Req]()
+	if err := s.decoder.Decode(req); err != nil {
+		if s.capped.err != nil {
+			return nil, s.capped.err
+		}
+
+		return nil, err
+	}
+
+	if s.capped.exceededBy(bufferedLen(s.decoder)) {
+		return nil, s.capped.exceededError()
+	}
+
+	if err := s.takeLimiterToken(); err != nil {
+		return nil, err
+	}
+
+	if err := s.extendReadDeadline(); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// IsFinished reports whether err is the terminal [io.EOF] Recv returns once the client half-closes the
+// request stream, letting a handler's Recv loop end cleanly without importing errors/io itself.
+func (s *RequestStream[Req, Res]) IsFinished(err error) bool {
+	return errors.Is(err, io.EOF)
+}
+
+func (s *RequestStream[Req, Res]) extendReadDeadline() error {
+	if s.timeout <= 0 {
+		return nil
+	}
+
+	return s.controller.SetReadDeadline(time.Now().Add(s.timeout.Duration()))
+}
+
+func (s *RequestStream[Req, Res]) close() error {
+	err := s.Stream.close()
+
+	if decErr := s.decoder.Close(); err == nil {
+		err = decErr
+	}
+
+	return err
+}
+
+// capReader wraps an [io.Reader] with a byte counter that [RequestStream.Recv] resets before every
+// decoded value, so a stream decoder bound to it for the whole request body (see [stream.Decoder]) gets
+// a per-value cap rather than a cumulative one. This is the inbound mirror of
+// [github.com/alexfalkowski/go-service/v2/net/http/client.capReader] — same reset-before/check-after
+// sequencing around Decode — placed in this package rather than shared with the client because the
+// reset call has to happen at the exact point a decoded value boundary is known, and RequestStream is
+// that point on the server side just as [github.com/alexfalkowski/go-service/v2/net/http/client.ResponseStream]
+// is on the client side.
+//
+// capReader never truncates or discards a Read call's data, for the same reason documented on the
+// client-side type: every byte pulled from the underlying request body is always returned to the
+// decoder, so the decoder's own internal buffering can never be desynchronized by this guard. Read still
+// refuses to pull more data once the budget from a previous Read within the same value is already
+// spent, bounding a single pathological value across repeated Read calls; Recv's post-Decode exceeded
+// check additionally catches a value whose entire content arrived in one Read call that already
+// exceeded the budget.
+//
+// Read-ahead correction: a decoder such as [encoding/json.Decoder] fills its own internal buffer in
+// chunks, so one Decode call can pull bytes belonging to a later value out of the underlying reader
+// (confirmed by a direct repro: decoding the first of two small NDJSON lines read the whole remaining
+// buffer, attributing both lines' bytes to the first value and rejecting it as oversized even though
+// neither line alone was near the cap). [Recv] corrects for this via [bufferedLen], which subtracts
+// whatever the decoder still holds unconsumed in its own buffer (see [stream.Decoder]'s wrapped
+// [encoding/json.Decoder.Buffered]) from the raw bytes capReader counted for this call, so only bytes
+// actually consumed to produce the value just decoded count against its cap. This works for every kind
+// reachable from content negotiation today (only "json"/NDJSON is registered in [streamKinds]); a kind
+// whose decoder does not expose a compatible Buffered method gets no correction, and falls back to the
+// same "bound on reads attributed to one value" precision this type always documented.
+//
+// One deliberate difference from the client-side type: max <= 0 disables the cap outright (Read never
+// refuses to read and exceeded always reports false), rather than assuming a caller-enforced positive
+// default. The client's capReader may assume [github.com/alexfalkowski/go-service/v2/net/http/client.Client]
+// always resolves a positive maxResponseSize before construction; the inbound side is wired through DI
+// from [config/server.Config.GetMaxReceiveSize], which can be projected to zero when the HTTP transport
+// itself is disabled (see [github.com/alexfalkowski/go-service/v2/transport/http.maxReceiveSize]), and a
+// disabled transport has no request to cap.
+type capReader struct {
+	r    io.Reader
+	err  error
+	max  int64
+	read int64
+}
+
+// resetValue rearms the byte counter for the next decoded value, clearing any size-limit error latched
+// by the previous value's Read calls. bufferedAhead has already been read from the underlying stream by
+// the decoder while handling the previous value, so it starts this value's accounting rather than being
+// discarded when the counter resets.
+func (r *capReader) resetValue(bufferedAhead int64) {
+	r.read = bufferedAhead
+	r.err = nil
+}
+
+// exceededBy reports whether the bytes read since the last resetValue, minus bufferedAhead, exceed the
+// configured cap. bufferedAhead is the decoder's own read-ahead for a later value (see [bufferedLen]);
+// subtracting it corrects for a decoder that pulled more than one value's worth of bytes out of the
+// reader in a single underlying Read. The corrected count is clamped to zero, and this always reports
+// false when the cap is disabled (max <= 0). This is the post-Decode check; Read below applies its own
+// uncorrected, live check to bound a single pathological value across repeated Read calls.
+func (r *capReader) exceededBy(bufferedAhead int64) bool {
+	if r.max <= 0 {
+		return false
+	}
+
+	attributed := max(r.read-bufferedAhead, 0)
+
+	return attributed > r.max
+}
+
+// Read implements [io.Reader]. Once the bytes read since the last resetValue already reach the
+// configured cap, Read refuses to read more and returns exceededError, and every subsequent call
+// returns that same error until resetValue is called. Read never refuses to read when the cap is
+// disabled (max <= 0).
+func (r *capReader) Read(p []byte) (int, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	if r.max > 0 && r.read >= r.max {
+		r.err = r.exceededError()
+		return 0, r.err
+	}
+
+	n, err := r.r.Read(p)
+	r.read += int64(n)
+
+	return n, err
+}
+
+// exceededError returns the error surfaced for a value that exceeds the configured cap: a raw
+// [http.MaxBytesError], matching what [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler]'s
+// buffered path already produces for an oversized request body, so both paths resolve to the same 413
+// through [github.com/alexfalkowski/go-service/v2/net/http/status.Code].
+func (r *capReader) exceededError() error {
+	return &http.MaxBytesError{Limit: r.max}
+}
+
+// bufferedLen returns the number of bytes decoder has already pulled from its underlying reader for a
+// value it has not decoded yet, so a caller can subtract them from the raw bytes [capReader] counted
+// for the value it just decoded (see [capReader.exceededBy]).
+//
+// This only recognizes decoders whose Buffered method matches [encoding/json.Decoder.Buffered]'s shape
+// and returns a concrete [bytes.Reader] — true today for every [stream.Decoder] reachable from content
+// negotiation, since only the "json" kind (NDJSON) is registered in [streamKinds]. It returns 0 for any
+// decoder that does not match, which is always safe: the correction is skipped, not a wrong non-zero
+// answer, so the check falls back to the same "bound on reads attributed to one value" behavior
+// documented on [capReader] rather than any incorrect result.
+func bufferedLen(decoder stream.Decoder) int64 {
+	buffered, ok := decoder.(interface{ Buffered() io.Reader })
+	if !ok {
+		return 0
+	}
+
+	reader, ok := buffered.Buffered().(*bytes.Reader)
+	if !ok {
+		return 0
+	}
+
+	return int64(reader.Len())
+}
+
+// commitWriter buffers writes until commit is called, after which writes go straight to the live
+// response writer.
+//
+// Buffering only the first value, rather than swapping the encoder to a new writer after commit, keeps
+// one encoder instance bound to one writer for the life of the stream — required for codecs (yaml) that
+// carry document-separator state tied to their writer.
+type commitWriter struct {
+	res       http.ResponseWriter
+	buffer    *bytes.Buffer
+	committed bool
+}
+
+// Write implements [io.Writer]. Before commit, writes accumulate in buffer; after commit, they go
+// straight to res.
+func (w *commitWriter) Write(p []byte) (int, error) {
+	if w.committed {
+		return w.res.Write(p)
+	}
+
+	return w.buffer.Write(p)
+}
+
+// commit flushes any buffered bytes to the live response writer. It is a no-op once already committed.
+func (w *commitWriter) commit() error {
+	if w.committed {
+		return nil
+	}
+
+	w.committed = true
+	_, err := w.buffer.WriteTo(w.res)
+
+	return err
+}
+
+// closer is satisfied by both [*Stream] and [*RequestStream] (which overrides close to also close its
+// decoder), letting [finalizeStream] handle both handler shapes with one implementation.
+type closer interface {
+	committed() bool
+	close() error
+}
+
+// finalizeStream applies the streaming error contract after a stream handler returns.
+//
+// If the response was never committed, a handler error is rendered as an ordinary HTTP error via
+// [status.WriteError] (a nil error leaves an empty, implicitly-200 response). If the response was
+// committed, any handler error — or a failure finalizing the encoder on the success path — is
+// recorded for operator diagnostics and the response is aborted via panic([http.ErrAbortHandler]),
+// which [transport/http.recoveryHandler] and the access logger already special-case for a committed
+// response.
+func finalizeStream(ctx context.Context, res http.ResponseWriter, s closer, err error) {
+	if !s.committed() {
+		if err != nil {
+			_ = status.WriteError(ctx, res, err)
+		}
+
+		return
+	}
+
+	if err == nil {
+		err = s.close()
+	}
+
+	if err != nil {
+		status.RecordError(ctx, err)
+		panic(http.ErrAbortHandler)
+	}
+}

--- a/net/http/content/stream_media.go
+++ b/net/http/content/stream_media.go
@@ -1,0 +1,81 @@
+package content
+
+import (
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+// streamKinds maps a media subtype to the [stream.Map] kind that encodes/decodes it.
+//
+// This mapping is explicit rather than reusing the subtype as the kind directly: "application/x-ndjson"
+// has subtype "x-ndjson", but it is framed newline-delimited JSON, so it reuses the "json" streaming
+// kind rather than needing its own codec.
+var streamKinds = map[string]string{
+	"x-ndjson": jsonKind,
+}
+
+// NewStreamMedia builds a StreamMedia from a media type string and streaming registry.
+//
+// Unlike [NewMedia], NewStreamMedia never falls back to JSON: an unparsable media type, a subtype with
+// no entry in the streaming media mapping, or a kind unregistered in sm all return
+// [ErrUnsupportedStreamMedia]. Streaming callers must fail explicitly rather than silently degrading to
+// a different wire format.
+func NewStreamMedia(mediaType string, sm *stream.Map) (StreamMedia, error) {
+	value, err := media.Parse(mediaType)
+	if err != nil {
+		return StreamMedia{}, ErrUnsupportedStreamMedia
+	}
+
+	kind, ok := streamKinds[value.Subtype()]
+	if !ok {
+		return StreamMedia{}, ErrUnsupportedStreamMedia
+	}
+
+	newEncoder := sm.GetEncoder(kind)
+	newDecoder := sm.GetDecoder(kind)
+	if newEncoder == nil && newDecoder == nil {
+		return StreamMedia{}, ErrUnsupportedStreamMedia
+	}
+
+	return StreamMedia{NewEncoder: newEncoder, NewDecoder: newDecoder, Type: value}, nil
+}
+
+// StreamMedia describes a resolved streaming media type and its encoder/decoder constructors.
+//
+// NewEncoder or NewDecoder may be nil when the registered kind supports only one direction; callers
+// must check the one they intend to use.
+type StreamMedia struct {
+	// NewEncoder constructs a [stream.Encoder] bound to a response writer, or nil if the kind has no
+	// registered encoder constructor.
+	NewEncoder stream.EncoderFunc
+
+	// NewDecoder constructs a [stream.Decoder] bound to a request body, or nil if the kind has no
+	// registered decoder constructor.
+	NewDecoder stream.DecoderFunc
+
+	// Type is the parsed media type.
+	media.Type
+}
+
+// NewStreamFromAccept parses the first request Accept media type and resolves a streaming encoder.
+//
+// If Accept is not set, it falls back to Content-Type. Unlike [Content.NewFromAccept], an unregistered
+// or unparsable media type returns [ErrUnsupportedStreamMedia] instead of falling back to JSON.
+func (c *Content) NewStreamFromAccept(req *http.Request) (StreamMedia, error) {
+	mediaType := firstListItem(req.Header.Get(AcceptKey))
+	if strings.IsEmpty(mediaType) {
+		mediaType = req.Header.Get(TypeKey)
+	}
+
+	return NewStreamMedia(mediaType, c.sm)
+}
+
+// NewStreamFromContentType parses the request Content-Type header and resolves a streaming decoder.
+//
+// Unlike [Content.NewFromContentType], an unregistered or unparsable media type returns
+// [ErrUnsupportedStreamMedia] instead of falling back to JSON.
+func (c *Content) NewStreamFromContentType(req *http.Request) (StreamMedia, error) {
+	return NewStreamMedia(req.Header.Get(TypeKey), c.sm)
+}

--- a/net/http/content/stream_media_test.go
+++ b/net/http/content/stream_media_test.go
@@ -1,0 +1,31 @@
+package content_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStreamMediaResolvesNDJSON(t *testing.T) {
+	m, err := content.NewStreamMedia(media.NDJSON, stream.NewMap())
+
+	require.NoError(t, err)
+	require.NotNil(t, m.NewEncoder)
+	require.NotNil(t, m.NewDecoder)
+	require.Equal(t, media.NDJSON, m.String())
+}
+
+func TestNewStreamMediaRejectsUnmappedSubtype(t *testing.T) {
+	_, err := content.NewStreamMedia(media.JSON, stream.NewMap())
+
+	require.ErrorIs(t, err, content.ErrUnsupportedStreamMedia)
+}
+
+func TestNewStreamMediaRejectsUnparsableType(t *testing.T) {
+	_, err := content.NewStreamMedia("not-a-media-type", stream.NewMap())
+
+	require.ErrorIs(t, err, content.ErrUnsupportedStreamMedia)
+}

--- a/net/http/content/stream_test.go
+++ b/net/http/content/stream_test.go
@@ -1,0 +1,737 @@
+package content_test
+
+import (
+	"bufio"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/klauspost/compress/gzhttp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStreamHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+	require.NotEmpty(t, res.Header().Get(gzhttp.HeaderNoCompression))
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.Equal(t, "Hello Alice", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewStreamHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
+	inner := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "Hello Bob"})
+	})
+	handler := gzhttp.GzipHandler(inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Empty(t, res.Header().Get("Content-Encoding"))
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, bufio.NewScanner(res.Body)))
+}
+
+func TestNewStreamHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, _ *content.Stream[test.Response]) error {
+		return status.Error(http.StatusBadRequest, test.ErrFailed.Error())
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+}
+
+func TestNewStreamHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Unencodable]) error {
+		return stream.Send(&test.Unencodable{})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+}
+
+func TestNewStreamHandlerAbortsAfterCommit(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return test.ErrFailed
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+}
+
+func TestNewStreamHandlerRejectsUnsupportedMedia(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, _ *content.Stream[test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.JSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
+}
+
+func TestNewStreamHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 2}
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, 0, limiter.Remaining)
+}
+
+func TestNewStreamHandlerSendAbortsAfterCommitWhenLimiterExhausted(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 1}
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewStreamHandlerSendPreCommitDenialMapsTo429(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 0}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "Hello Bob"})
+	})
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusTooManyRequests, res.Code)
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+}
+
+func TestNewRequestStreamHandlerRejectsHTTP1(t *testing.T) {
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 1
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusHTTPVersionNotSupported, res.Code)
+}
+
+func TestNewRequestStreamHandlerRecvAndSend(t *testing.T) {
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+				return err
+			}
+		}
+	})
+
+	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.Equal(t, "Hello Alice", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewRequestStreamHandlerRejectsUnsupportedRequestMedia(t *testing.T) {
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.JSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
+}
+
+func TestNewRequestStreamHandlerRecvUnderCapSucceeds(t *testing.T) {
+	tests := []struct {
+		name string
+		cap  bytes.Size
+	}{
+		{name: "cap above the combined size of both values", cap: 64},
+		{name: "cap between one value's size and the combined size of both", cap: 24},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var names []string
+
+			handler := content.NewRequestStreamHandler(test.Content, 0, tt.cap, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+				for {
+					req, err := stream.Recv()
+					if err != nil {
+						if stream.IsFinished(err) {
+							return nil
+						}
+
+						return err
+					}
+
+					names = append(names, req.Name)
+				}
+			})
+
+			body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+			req.ProtoMajor = 2
+			req.Header.Set(content.TypeKey, media.NDJSON)
+			req.Header.Set(content.AcceptKey, media.NDJSON)
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusOK, res.Code)
+			require.Equal(t, []string{"Bob", "Alice"}, names)
+		})
+	}
+}
+
+func TestNewRequestStreamHandlerRecvRejectsValueOverCap(t *testing.T) {
+	var recvErr error
+
+	handler := content.NewRequestStreamHandler(test.Content, 0, 16, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, recvErr = stream.Recv()
+		return recvErr
+	})
+
+	body := "{\"Name\":\"a value with a name far longer than the configured cap\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+
+	var maxBytesErr *http.MaxBytesError
+	require.ErrorAs(t, recvErr, &maxBytesErr)
+	require.Equal(t, int64(16), maxBytesErr.Limit)
+	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(recvErr))
+}
+
+func TestNewRequestStreamHandlerRecvRejectsBufferedValueOverCap(t *testing.T) {
+	var secondErr error
+
+	handler := content.NewRequestStreamHandler(test.Content, 0, 16, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, err := stream.Recv()
+		require.NoError(t, err)
+
+		_, secondErr = stream.Recv()
+		return secondErr
+	})
+
+	body := "{\"Name\":\"A\"}\n{\"Name\":\"a value with a name far longer than the configured cap\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+
+	var maxBytesErr *http.MaxBytesError
+	require.ErrorAs(t, secondErr, &maxBytesErr)
+	require.Equal(t, int64(16), maxBytesErr.Limit)
+}
+
+func TestNewRequestStreamHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavior(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		maxSize bytes.Size
+		decoder func(io.Reader) stream.Decoder
+	}{
+		{
+			name:    "decode succeeds in one read",
+			body:    "a value with far more than eight bytes",
+			maxSize: 8,
+			decoder: func(r io.Reader) stream.Decoder { return &test.SingleReadDecoder{R: r} },
+		},
+		{
+			name:    "decoder discards the error's type",
+			body:    "{\"Name\":\"a value with a name far longer than the configured cap\"}\n",
+			maxSize: 16,
+			decoder: func(r io.Reader) stream.Decoder { return &test.OpaqueErrorDecoder{R: r} },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := stream.NewMap()
+			sm.RegisterDecoder("json", tt.decoder)
+			cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+			var recvErr error
+
+			handler := content.NewRequestStreamHandler(cont, 0, tt.maxSize, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+				_, recvErr = stream.Recv()
+				return recvErr
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(tt.body))
+			req.ProtoMajor = 2
+			req.Header.Set(content.TypeKey, media.NDJSON)
+			req.Header.Set(content.AcceptKey, media.NDJSON)
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+
+			var maxBytesErr *http.MaxBytesError
+			require.ErrorAs(t, recvErr, &maxBytesErr)
+			require.Equal(t, int64(tt.maxSize), maxBytesErr.Limit)
+			require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(recvErr))
+		})
+	}
+}
+
+func TestNewRequestStreamHandlerRecvCapIsPerValueNotCumulative(t *testing.T) {
+	const values = 10
+
+	var names []string
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	handler := content.NewRequestStreamHandler(test.Content, 0, 24, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			names = append(names, req.Name)
+		}
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
+	req.ProtoMajor = 2
+	req.ContentLength = -1
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(res, req)
+		close(done)
+	}()
+
+	for range values {
+		_, err := pipeWriter.Write([]byte("{\"Name\":\"Bob\"}\n"))
+		require.NoError(t, err)
+	}
+	require.NoError(t, pipeWriter.Close())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for handler to finish")
+	}
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Len(t, names, values)
+}
+
+func TestNewRequestStreamHandlerRecvChargesOneLimiterTokenPerMessage(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 2}
+
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			_, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+		}
+	})
+
+	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, 0, limiter.Remaining)
+}
+
+func TestNewRequestStreamHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 1}
+
+	var recvErr error
+	handler := content.NewRequestStreamHandler(test.Content, 0, 16, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, recvErr = stream.Recv()
+		return recvErr
+	})
+
+	body := "{\"Name\":\"a value with a name far longer than the configured cap\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+	require.Equal(t, 1, limiter.Remaining)
+}
+
+func TestNewStreamHandlerSendIsSticky(t *testing.T) {
+	var firstErr, secondErr error
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Unencodable]) error {
+		firstErr = stream.Send(&test.Unencodable{})
+		secondErr = stream.Send(&test.Unencodable{})
+		return firstErr
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Error(t, firstErr)
+	require.Equal(t, firstErr, secondErr)
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewStreamHandlerSendExtendDeadlineFailure(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, time.MustParseDuration("1s"), func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewStreamHandlerSendCommitFailure(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.ErrResponseWriter{}
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+}
+
+func TestNewStreamHandlerSendFlushFailure(t *testing.T) {
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.NoFlushResponseWriter{}
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+}
+
+func TestNewStreamHandlerSendLimiterErrorMapsTo500(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
+	res := httptest.NewRecorder()
+
+	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewRequestStreamHandlerRecvLimiterErrorMapsTo500(t *testing.T) {
+	var recvErr error
+
+	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, recvErr = stream.Recv()
+		return recvErr
+	})
+
+	body := "{\"Name\":\"Bob\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, http.StatusInternalServerError, status.Code(recvErr))
+}
+
+func TestNewRequestStreamHandlerRecvBufferedLenFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		decoder stream.Decoder
+	}{
+		{name: "no buffered method", decoder: test.NoBufferedDecoder{}},
+		{name: "wrong buffered type", decoder: test.WrongBufferedDecoder{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := stream.NewMap()
+			sm.RegisterDecoder("json", func(io.Reader) stream.Decoder { return tt.decoder })
+			cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+			handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+				_, err := stream.Recv()
+				return err
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{}"))
+			req.ProtoMajor = 2
+			req.Header.Set(content.TypeKey, media.NDJSON)
+			req.Header.Set(content.AcceptKey, media.NDJSON)
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusOK, res.Code)
+		})
+	}
+}
+
+func TestNewRequestStreamHandlerRecvRecoversStickyCapReaderError(t *testing.T) {
+	sm := stream.NewMap()
+	sm.RegisterDecoder("json", func(r io.Reader) stream.Decoder { return &test.TripleReadDecoder{R: r} })
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	handler := content.NewRequestStreamHandler(cont, 0, bytes.Size(1), func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, err := stream.Recv()
+		return err
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("ab"))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+}
+
+func TestNewStreamHandlerRejectsNilEncoderForRegisteredKind(t *testing.T) {
+	sm := stream.NewMap()
+	sm.RegisterEncoder("json", nil)
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	handler := content.NewStreamHandler(cont, 0, func(_ context.Context, _ *content.Stream[test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
+}
+
+func TestNewRequestStreamHandlerRejectsNilDecoderForRegisteredKind(t *testing.T) {
+	sm := stream.NewMap()
+	sm.RegisterDecoder("json", nil)
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
+}
+
+func TestNewRequestStreamHandlerRejectsNilEncoderForRegisteredKind(t *testing.T) {
+	sm := stream.NewMap()
+	sm.RegisterEncoder("json", nil)
+	cont := content.NewContent(test.Encoder, sm, test.Pool)
+
+	handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
+}
+
+func decodeNDJSONGreeting(t *testing.T, scanner *bufio.Scanner) string {
+	t.Helper()
+
+	require.True(t, scanner.Scan())
+
+	var res map[string]any
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &res))
+
+	greeting, _ := res["Greeting"].(string)
+	return greeting
+}

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -93,6 +93,18 @@ type Server = http.Server
 // standard library semantics.
 type ResponseWriter = http.ResponseWriter
 
+// Flusher is an alias for [net/http.Flusher].
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type Flusher = http.Flusher
+
+// ResponseController is an alias for [net/http.ResponseController].
+//
+// It is provided so go-service code can depend on a consistent import path while preserving
+// standard library semantics.
+type ResponseController = http.ResponseController
+
 // RoundTripper is an alias for [net/http.RoundTripper].
 //
 // It is provided so go-service code can depend on a consistent import path while preserving
@@ -124,6 +136,9 @@ var ErrUseLastResponse = http.ErrUseLastResponse
 
 // ErrServerClosed is an alias for [http.ErrServerClosed].
 var ErrServerClosed = http.ErrServerClosed
+
+// ErrAbortHandler is an alias for [http.ErrAbortHandler].
+var ErrAbortHandler = http.ErrAbortHandler
 
 // NoBody is an alias for [http.NoBody].
 var NoBody = http.NoBody
@@ -246,6 +261,13 @@ func NewChainedHandlers(handlers ...ChainedHandler) *ChainedHandlers {
 // This is a thin wrapper around [net/http.MaxBytesHandler].
 func MaxBytesHandler(h Handler, n int64) Handler {
 	return http.MaxBytesHandler(h, n)
+}
+
+// NewResponseController constructs a ResponseController for rw.
+//
+// This is a thin wrapper around [net/http.NewResponseController].
+func NewResponseController(rw ResponseWriter) *ResponseController {
+	return http.NewResponseController(rw)
 }
 
 // NewTelemetryHandler wraps handler with OpenTelemetry instrumentation when tracing or metrics are enabled.

--- a/net/http/media/media.go
+++ b/net/http/media/media.go
@@ -36,6 +36,11 @@ const HumanJSON = "application/hjson"
 // MessagePack is the vendor media type for MessagePack payloads.
 const MessagePack = "application/vnd.msgpack"
 
+// NDJSON is the media type for newline-delimited JSON streams.
+//
+// This is used for streaming HTTP request/response bodies backed by encoding/stream/json.
+const NDJSON = "application/x-ndjson"
+
 // Protobuf is the media type for protobuf binary payloads.
 //
 // This is commonly used when transporting protobuf wire-format bodies over HTTP.

--- a/net/http/meta/meta.go
+++ b/net/http/meta/meta.go
@@ -9,6 +9,8 @@ import (
 
 const contentKey = context.Key("content")
 
+const limiterKey = context.Key("limiter")
+
 // NoPrefix is an alias for [meta.NoPrefix].
 const NoPrefix = meta.NoPrefix
 
@@ -17,12 +19,6 @@ type Map = meta.Map
 
 // Pair is an alias for [meta.Pair].
 type Pair = meta.Pair
-
-type content struct {
-	request  *http.Request
-	response http.ResponseWriter
-	encoder  encoding.Encoder
-}
 
 // CamelStrings exports all stored meta attributes as a string map with lowerCamelCased keys.
 //
@@ -45,6 +41,12 @@ func NewPair(key string, value meta.Value) Pair {
 // WithAttributes stores all provided metadata pairs on ctx.
 func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
 	return meta.WithAttributes(ctx, pairs...)
+}
+
+type content struct {
+	request  *http.Request
+	response http.ResponseWriter
+	encoder  encoding.Encoder
 }
 
 // Request returns the stored *[http.Request] from ctx.
@@ -76,4 +78,42 @@ func Encoder(ctx context.Context) encoding.Encoder {
 // The encoder may be nil when a handler only needs request and response access.
 func WithContent(ctx context.Context, req *http.Request, res http.ResponseWriter, enc encoding.Encoder) context.Context {
 	return context.WithValue(ctx, contentKey, content{request: req, response: res, encoder: enc})
+}
+
+// RateLimiter is the minimal per-message load-control interface a streaming handler charges against.
+//
+// It is deliberately narrower than [github.com/alexfalkowski/go-service/v2/transport/limiter.Limiter]'s
+// concrete type and defined locally: net/... packages must not import transport/... (see AGENTS.md).
+// *[github.com/alexfalkowski/go-service/v2/transport/limiter.Limiter] already satisfies this interface
+// structurally via its Take method, so [transport/http/limiter.Handler.ServeHTTP] can pass it to
+// WithLimiter without an adapter.
+type RateLimiter interface {
+	// Take attempts to take a token for the key derived from ctx. It reports whether the request is
+	// allowed and any error from the underlying store; the header value returned alongside the same
+	// decision by the concrete limiter is intentionally not part of this interface, since RateLimit
+	// headers cannot be re-sent once a streaming response is committed.
+	Take(ctx context.Context) (bool, string, error)
+}
+
+// WithLimiter stores limiter in ctx and returns the derived context.
+//
+// This is a separate context key from WithContent (rather than an added content field) because a limiter is
+// route-specific and usually absent — most WithContent calls have no limiter to carry, and every existing
+// WithContent call site would otherwise have to pass an always-present argument for a value that is usually
+// nil. limiter is typically the same limiter that already charged one token for the request at stream open
+// (see [transport/http/limiter.Handler.ServeHTTP]); storing it here lets a streaming handler, constructed
+// deeper in the call chain, charge additional per-message tokens against the same limiter. limiter may be
+// nil, meaning no limiter is configured for the request.
+func WithLimiter(ctx context.Context, limiter RateLimiter) context.Context {
+	return context.WithValue(ctx, limiterKey, limiter)
+}
+
+// Limiter returns the stored [RateLimiter] from ctx, or nil if WithLimiter was never called or was called
+// with a nil limiter.
+//
+// Unlike Request, Response, and Encoder, Limiter never panics on a missing value: a limiter is optional
+// per-route configuration, so nil ("no limiter configured") is the common case rather than a caller error.
+func Limiter(ctx context.Context) RateLimiter {
+	limiter, _ := ctx.Value(limiterKey).(RateLimiter)
+	return limiter
 }

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -34,6 +34,24 @@ func TestWithContentAllowsPartialContent(t *testing.T) {
 	require.Same(t, res, httpmeta.Response(ctx))
 }
 
+func TestLimiterReturnsNilWithoutWithLimiter(t *testing.T) {
+	require.Nil(t, httpmeta.Limiter(t.Context()))
+}
+
+func TestWithLimiterAllowsNil(t *testing.T) {
+	ctx := httpmeta.WithLimiter(t.Context(), nil)
+
+	require.Nil(t, httpmeta.Limiter(ctx))
+}
+
+func TestWithLimiterStoresLimiter(t *testing.T) {
+	lim := &test.AllowAllLimiter{}
+
+	ctx := httpmeta.WithLimiter(t.Context(), lim)
+
+	require.Same(t, lim, httpmeta.Limiter(ctx))
+}
+
 func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 	roundTripper := httpmeta.NewRoundTripper(
 		env.UserAgent("agent"),

--- a/net/http/protocols.go
+++ b/net/http/protocols.go
@@ -11,6 +11,13 @@ import "net/http"
 //
 // This helper is used by go-service HTTP server and transport construction to consistently enable
 // the same protocol set across servers and clients.
+//
+// Client-side h2c caveat: enabling both HTTP/1.1 and h2c on a client transport, as this helper does,
+// does not make [net/http.Transport] negotiate h2c against a plain "http://" URL — with HTTP/1.1 also
+// enabled, the standard library client uses HTTP/1.1 for cleartext requests. h2c prior-knowledge
+// negotiation only happens when a transport has HTTP/1.1 disabled (`SetHTTP1(false)`) so h2c is the only
+// enabled cleartext option. This helper's default (both enabled) intentionally favors broad
+// interoperability with HTTP/1.1-only servers over automatic h2c negotiation to arbitrary endpoints.
 func Protocols() *http.Protocols {
 	protocols := &http.Protocols{}
 	protocols.SetHTTP1(true)

--- a/net/http/rest/client.go
+++ b/net/http/rest/client.go
@@ -38,10 +38,11 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 	})
 }
 
-// WithClientTimeout sets the client timeout using a duration string (for example "1s" or "500ms").
+// WithClientTimeout sets the unary client timeout using a duration string (for example "1s" or
+// "500ms").
 //
-// The duration string is parsed using [time.MustParseDuration] and will panic if it cannot be parsed.
-// The resulting duration is applied to the underlying [http.Client.Timeout].
+// The duration string is parsed using [time.MustParseDuration] and panics if it cannot be parsed.
+// Streaming calls remain bounded by their caller-provided contexts.
 func WithClientTimeout(timeout string) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.timeout = time.MustParseDuration(timeout)
@@ -55,7 +56,8 @@ func WithClientTimeout(timeout string) ClientOption {
 // nil dependencies.
 //
 // Behavior:
-//   - It constructs a content-aware [client.Client] configured with the selected RoundTripper and timeout.
+//   - It constructs a content-aware [client.Client] configured with the selected RoundTripper and unary
+//     timeout. Stream calls use their request contexts instead.
 //   - It disables automatic redirect following (returns redirect responses instead of following them).
 func NewClient(opts ...ClientOption) *Client {
 	os := options(opts...)

--- a/net/http/rest/client_test.go
+++ b/net/http/rest/client_test.go
@@ -1,0 +1,32 @@
+package rest_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/rest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientUsesTimeout(t *testing.T) {
+	rest.Register(nil, test.Content, test.Pool, 0, 0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set(content.TypeKey, media.Text)
+		res.WriteHeader(http.StatusOK)
+		res.(http.Flusher).Flush()
+		<-req.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	client := rest.NewClient(rest.WithClientTimeout("10ms"))
+
+	err := client.Get(t.Context(), server.URL, rest.Options{})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-sync"
 )
@@ -16,14 +18,11 @@ func ExampleGet() {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
-	rest.Register(rest.RegisterParams{
-		Router: router,
-		Content: content.NewContent(
-			encoding.NewMap(),
-			pool,
-		),
-		Pool: pool,
-	})
+	rest.Register(router, content.NewContent(
+		encoding.NewMap(),
+		stream.NewMap(),
+		pool,
+	), pool, 0, 0)
 
 	rest.Get("/hello", func(context.Context) (*exampleResponse, error) {
 		return &exampleResponse{Message: "hello"}, nil
@@ -41,6 +40,38 @@ func ExampleGet() {
 	// {
 	//   "message": "hello"
 	// }
+}
+
+func ExampleStreamGet() {
+	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
+	pool := sync.NewBufferPool()
+	rest.Register(router, content.NewContent(
+		encoding.NewMap(),
+		stream.NewMap(),
+		pool,
+	), pool, 0, 0)
+
+	rest.StreamGet("/hello", func(_ context.Context, stream *content.Stream[exampleResponse]) error {
+		if err := stream.Send(&exampleResponse{Message: "hello"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&exampleResponse{Message: "world"})
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	fmt.Println(res.Code)
+	fmt.Print(res.Body.String())
+	// Output:
+	// 200
+	// {"message":"hello"}
+	// {"message":"world"}
 }
 
 type exampleResponse struct {

--- a/net/http/rest/rest.go
+++ b/net/http/rest/rest.go
@@ -1,34 +1,20 @@
 package rest
 
 import (
-	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-sync"
 )
 
 var (
-	router *http.Router
-	cont   *content.Content
-	pool   *sync.BufferPool
+	router         *http.Router
+	cont           *content.Content
+	pool           *sync.BufferPool
+	timeout        time.Duration
+	maxReceiveSize bytes.Size
 )
-
-// RegisterParams defines dependencies used to register REST package globals.
-//
-// This package uses package-level registration to avoid threading commonly-shared dependencies
-// through every helper call. These dependencies are typically provided by DI wiring.
-type RegisterParams struct {
-	di.In
-
-	// Router registers server-side routes for this package's helpers.
-	Router *http.Router
-
-	// Content resolves encoders/decoders based on HTTP media types (Content-Type).
-	Content *content.Content
-
-	// Pool is a buffer pool used by client helpers to reduce allocations while encoding/decoding bodies.
-	Pool *sync.BufferPool
-}
 
 // Register stores the dependencies used by server and client helpers in package-level variables.
 //
@@ -40,8 +26,25 @@ type RegisterParams struct {
 // After registration:
 //   - server-side helpers (Get/Post/etc.) register handlers on the registered router, and
 //   - client helpers (NewClient) build clients using the registered content codecs and buffer pool.
-func Register(params RegisterParams) {
-	router = params.Router
-	cont = params.Content
-	pool = params.Pool
+//
+// t is the streaming inactivity timeout applied by this package's streaming route helpers (StreamRoute,
+// StreamGet, StreamRouteRequest, StreamPost, StreamPut, StreamPatch). A successful Send extends the
+// response write deadline by this duration. For bidirectional routes, a successful Recv also extends the
+// request read deadline (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewStreamHandler] and
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]), turning the
+// whole-stream read and write timeouts into per-message inactivity budgets. Zero disables the extensions.
+//
+// m is the per-value request body size cap applied by this package's bidirectional streaming route
+// helpers (StreamRouteRequest, StreamPost, StreamPut, StreamPatch). Unlike the buffered request-body
+// path's cumulative limit, this bounds each value decoded by
+// [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv] independently — a
+// long-lived stream with many small values is never rejected for its cumulative size (see decision B18
+// in the streaming design). Zero disables the per-value cap entirely.
+func Register(r *http.Router, c *content.Content, p *sync.BufferPool, t time.Duration, m bytes.Size) {
+	router = r
+	cont = c
+	pool = p
+	timeout = t
+	maxReceiveSize = m
 }

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -80,3 +80,99 @@ func RouteRequest[Req any, Res any](pattern string, handler content.RequestHandl
 func Route[Res any](pattern string, handler content.Handler[Res]) {
 	router.Handle(pattern, content.NewHandler(cont, handler))
 }
+
+// StreamGet registers an HTTP GET handler under pattern for a send-only streaming response: the
+// response streams incrementally rather than being buffered whole.
+//
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
+// This helper delegates to StreamRoute.
+func StreamGet[Res any](pattern string, handler content.StreamHandler[Res]) {
+	StreamRoute(strings.Join(strings.Space, http.MethodGet, pattern), handler)
+}
+
+// StreamPost registers an HTTP POST handler under pattern for a bidirectional stream: both the
+// request and response bodies stream incrementally rather than being buffered whole.
+//
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
+// This helper delegates to StreamRouteRequest.
+//
+// HTTP/2 requirement: see StreamRouteRequest. StreamGet and StreamRoute have no such requirement and
+// stay fully supported on HTTP/1.1.
+func StreamPost[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
+	StreamRouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler)
+}
+
+// StreamPut registers an HTTP PUT handler under pattern for a bidirectional stream: both the request
+// and response bodies stream incrementally rather than being buffered whole.
+//
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
+// This helper delegates to StreamRouteRequest.
+//
+// HTTP/2 requirement: see StreamRouteRequest.
+func StreamPut[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
+	StreamRouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler)
+}
+
+// StreamPatch registers an HTTP PATCH handler under pattern for a bidirectional stream: both the
+// request and response bodies stream incrementally rather than being buffered whole.
+//
+// The effective route pattern passed to the router is method-qualified (see Delete for details).
+// This helper delegates to StreamRouteRequest.
+//
+// HTTP/2 requirement: see StreamRouteRequest.
+func StreamPatch[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
+	StreamRouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler)
+}
+
+// StreamRouteRequest registers a handler under pattern for a bidirectional stream: both the request
+// and response bodies stream incrementally rather than being buffered whole.
+//
+// The handler is built using
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler], which:
+//   - resolves the request decoder from Content-Type and the response encoder from the first Accept
+//     media type (falling back to Content-Type), both via the streaming media registry, and
+//   - rejects an unregistered or unparseable streaming media type with 415.
+//
+// HTTP/2 requirement:
+// Bidirectional streaming requires HTTP/2 (including h2c): an HTTP/1.x request body is buffered ahead
+// of the handler by intermediaries and the Go transport, so interleaving Recv/Send hangs rather than
+// failing. [content.NewRequestStreamHandler] rejects requests with req.ProtoMajor < 2 with
+// 505 HTTP Version Not Supported before the handler runs. Deploying a route registered through this
+// helper therefore requires the server, and any intermediary in front of it, to support HTTP/2 or h2c.
+//
+// Registration:
+// The resulting handler is registered on the package-level router configured via [Register], and the
+// route is marked streaming on the router's route policy (see
+// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
+// limiting is applied lazily instead of buffering the whole body.
+// [Register] must be called before StreamRouteRequest; otherwise router/cont will be nil and this
+// function will panic.
+//
+// Inbound size limiting:
+// maxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
+// Recv, not the request body as a whole — see [content.NewRequestStreamHandler].
+func StreamRouteRequest[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
+	router.HandleStreaming(pattern, content.NewRequestStreamHandler(cont, timeout, maxReceiveSize, handler))
+}
+
+// StreamRoute registers a handler under pattern for a send-only streaming response: the response
+// streams incrementally rather than being buffered whole; the request body is not streamed.
+//
+// The handler is built using [github.com/alexfalkowski/go-service/v2/net/http/content.NewStreamHandler], which:
+//   - selects a streaming encoder based on the first Accept media type, falling back to Content-Type
+//     when Accept is absent, via the streaming media registry, and
+//   - rejects an unregistered or unparseable streaming media type with 415.
+//
+// Unlike StreamRouteRequest and its method-qualified helpers, StreamRoute has no HTTP/2 requirement
+// and stays fully supported on HTTP/1.1 chunked responses.
+//
+// Registration:
+// The resulting handler is registered on the package-level router configured via Register, and the
+// route is marked streaming on the router's route policy (see
+// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
+// limiting is applied lazily instead of buffering the whole body.
+// Register must be called before StreamRoute; otherwise router/cont will be nil and this function will
+// panic.
+func StreamRoute[Res any](pattern string, handler content.StreamHandler[Res]) {
+	router.HandleStreaming(pattern, content.NewStreamHandler(cont, timeout, handler))
+}

--- a/net/http/rest/server_test.go
+++ b/net/http/rest/server_test.go
@@ -1,0 +1,134 @@
+package rest_test
+
+import (
+	"bufio"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/rest"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	router := http.NewRouter(mux, policy)
+	rest.Register(router, test.Content, test.Pool, 0, 0)
+
+	rest.StreamGet("/hello", func(_ context.Context, stream *content.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+	require.True(t, policy.IsStreaming(req))
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))
+	require.Equal(t, "Hello Alice", decodeGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestStreamPostRejectsHTTP1(t *testing.T) {
+	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
+	rest.Register(router, test.Content, test.Pool, 0, 0)
+
+	rest.StreamPost("/hello", func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 1
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusHTTPVersionNotSupported, res.Code)
+}
+
+func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		call   func(string, content.RequestStreamHandler[test.Request, test.Response])
+	}{
+		{name: "post", method: http.MethodPost, call: rest.StreamPost[test.Request, test.Response]},
+		{name: "put", method: http.MethodPut, call: rest.StreamPut[test.Request, test.Response]},
+		{name: "patch", method: http.MethodPatch, call: rest.StreamPatch[test.Request, test.Response]},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			policy := http.NewRoutePolicy()
+			router := http.NewRouter(mux, policy)
+			rest.Register(router, test.Content, test.Pool, 0, 0)
+
+			tt.call("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+				for {
+					req, err := stream.Recv()
+					if err != nil {
+						if stream.IsFinished(err) {
+							return nil
+						}
+
+						return err
+					}
+
+					if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+						return err
+					}
+				}
+			})
+
+			body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
+			req := httptest.NewRequestWithContext(t.Context(), tt.method, "/hello", strings.NewReader(body))
+			req.ProtoMajor = 2
+			req.Header.Set(content.TypeKey, media.NDJSON)
+			req.Header.Set(content.AcceptKey, media.NDJSON)
+			res := httptest.NewRecorder()
+
+			mux.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusOK, res.Code)
+			require.True(t, policy.IsStreaming(req))
+
+			scanner := bufio.NewScanner(res.Body)
+			require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))
+			require.Equal(t, "Hello Alice", decodeGreeting(t, scanner))
+			require.False(t, scanner.Scan())
+		})
+	}
+}
+
+func decodeGreeting(t *testing.T, scanner *bufio.Scanner) string {
+	t.Helper()
+
+	require.True(t, scanner.Scan())
+
+	var res map[string]any
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &res))
+
+	greeting, _ := res["Greeting"].(string)
+	return greeting
+}

--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -7,6 +7,7 @@ func NewRoutePolicy() *RoutePolicy {
 	return &RoutePolicy{
 		operations:      map[string]struct{}{},
 		unauthenticated: map[string]struct{}{},
+		streaming:       map[string]struct{}{},
 	}
 }
 
@@ -18,6 +19,7 @@ func NewRoutePolicy() *RoutePolicy {
 type RoutePolicy struct {
 	operations      map[string]struct{}
 	unauthenticated map[string]struct{}
+	streaming       map[string]struct{}
 }
 
 // Operation marks pattern as a service-owned operation path.
@@ -30,6 +32,12 @@ func (r *RoutePolicy) Operation(pattern string) {
 // AllowUnauthenticated marks pattern as not requiring transport token authentication.
 func (r *RoutePolicy) AllowUnauthenticated(pattern string) {
 	r.unauthenticated[pattern] = struct{}{}
+}
+
+// Streaming marks pattern as a route whose request body, response body, or both are streamed
+// incrementally rather than buffered whole.
+func (r *RoutePolicy) Streaming(pattern string) {
+	r.streaming[pattern] = struct{}{}
 }
 
 // IsOperation reports whether req targets a registered operation path.
@@ -50,6 +58,22 @@ func (r *RoutePolicy) IsUnauthenticated(req *Request) bool {
 	}
 
 	_, ok := r.unauthenticated[req.URL.Path]
+	return ok
+}
+
+// IsStreaming reports whether req targets a route whose request body, response body, or both are
+// streamed incrementally rather than buffered whole.
+func (r *RoutePolicy) IsStreaming(req *Request) bool {
+	if !strings.IsEmpty(req.Pattern) {
+		_, ok := r.streaming[req.Pattern]
+		return ok
+	}
+
+	if _, ok := r.streaming[routeRequestPattern(req)]; ok {
+		return true
+	}
+
+	_, ok := r.streaming[req.URL.Path]
 	return ok
 }
 
@@ -83,6 +107,13 @@ func (r *Router) HandleOperationFunc(pattern string, handler HandlerFunc) {
 // HandleUnauthenticated registers handler and marks pattern as not requiring transport token authentication.
 func (r *Router) HandleUnauthenticated(pattern string, handler Handler) {
 	r.routePolicy.AllowUnauthenticated(pattern)
+	r.Handle(pattern, handler)
+}
+
+// HandleStreaming registers handler and marks pattern as a route whose request body, response body,
+// or both are streamed incrementally rather than buffered whole.
+func (r *Router) HandleStreaming(pattern string, handler Handler) {
+	r.routePolicy.Streaming(pattern)
 	r.Handle(pattern, handler)
 }
 

--- a/net/http/routes_test.go
+++ b/net/http/routes_test.go
@@ -36,25 +36,24 @@ func TestRoutePolicyClassifiesUnauthenticatedRequests(t *testing.T) {
 	policy := http.NewRoutePolicy()
 	policy.AllowUnauthenticated("POST /events")
 
-	tests := []struct {
-		name   string
-		method string
-		path   string
-		match  bool
-	}{
+	runRouteMatchCases(t, []routeMatchCase{
 		{name: "registered event receiver", method: http.MethodPost, path: "/events", match: true},
 		{name: "wrong method", method: http.MethodGet, path: "/events", match: false},
 		{name: "application event path", method: http.MethodPost, path: "/admin/events", match: false},
 		{name: "nested event path", method: http.MethodPost, path: "/events/foo", match: false},
-	}
+	}, policy.IsUnauthenticated)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, http.NoBody)
+func TestRoutePolicyClassifiesStreamingRequests(t *testing.T) {
+	policy := http.NewRoutePolicy()
+	policy.Streaming("POST /stream")
 
-			require.Equal(t, tt.match, policy.IsUnauthenticated(req))
-		})
-	}
+	runRouteMatchCases(t, []routeMatchCase{
+		{name: "registered streaming route", method: http.MethodPost, path: "/stream", match: true},
+		{name: "wrong method", method: http.MethodGet, path: "/stream", match: false},
+		{name: "application streaming path", method: http.MethodPost, path: "/admin/stream", match: false},
+		{name: "nested streaming path", method: http.MethodPost, path: "/stream/foo", match: false},
+	}, policy.IsStreaming)
 }
 
 func TestRouterRegistersHandlerAndPolicy(t *testing.T) {
@@ -74,4 +73,42 @@ func TestRouterRegistersHandlerAndPolicy(t *testing.T) {
 	require.Equal(t, "POST /events/{tenant}", req.Pattern)
 	require.True(t, policy.IsUnauthenticated(req))
 	require.Equal(t, http.StatusAccepted, res.Code)
+}
+
+func TestRouterRegistersHandlerAndStreamingPolicy(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	router := http.NewRouter(mux, policy)
+
+	router.HandleStreaming("POST /stream/{id}", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/stream/acme", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, "POST /stream/{id}", req.Pattern)
+	require.True(t, policy.IsStreaming(req))
+	require.Equal(t, http.StatusOK, res.Code)
+}
+
+type routeMatchCase struct {
+	name   string
+	method string
+	path   string
+	match  bool
+}
+
+func runRouteMatchCases(t *testing.T, cases []routeMatchCase, check func(*http.Request) bool) {
+	t.Helper()
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, http.NoBody)
+
+			require.Equal(t, tt.match, check(req))
+		})
+	}
 }

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -69,10 +69,10 @@ func WithClientAccept(accept string) ClientOption {
 	})
 }
 
-// WithClientTimeout sets the client timeout using a duration string (for example "1s" or "500ms").
+// WithClientTimeout sets the unary client timeout using a duration string (for example "1s" or
+// "500ms").
 //
-// The duration string is parsed using [time.MustParseDuration] and will panic if it cannot be parsed.
-// The resulting duration is applied to the underlying [http.Client.Timeout].
+// The duration string is parsed using [time.MustParseDuration] and panics if it cannot be parsed.
 func WithClientTimeout(timeout string) ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.timeout = time.MustParseDuration(timeout)
@@ -86,8 +86,8 @@ func WithClientTimeout(timeout string) ClientOption {
 // nil dependencies.
 //
 // The returned client issues RPC-style POST requests to the provided base url using the configured
-// Content-Type and transport options. Redirect following is disabled by default (redirect responses
-// are returned instead of being followed).
+// Content-Type, transport, and unary timeout options. Redirect following is disabled by default
+// (redirect responses are returned instead of being followed).
 func NewClient(url string, opts ...ClientOption) *Client {
 	os := options(opts...)
 	client := client.NewClient(cont, pool,

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -12,10 +13,32 @@ import (
 )
 
 func TestPostRequiresRequest(t *testing.T) {
-	client := rpc.NewClient("http://example.com")
+	client := rpc.NewClient("http://example.com", rpc.WithClientTimeout("1s"))
 
 	var res test.Response
 	require.ErrorIs(t, client.Post(t.Context(), "/hello", nil, &res), rpc.ErrInvalidRequest)
+}
+
+func TestPostUsesConfiguredTimeout(t *testing.T) {
+	rpc.Register(nil, test.Content, test.Pool, 0, 0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set("Content-Type", media.JSON)
+		res.WriteHeader(http.StatusOK)
+		res.(http.Flusher).Flush()
+		<-req.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	client := rpc.NewClient(server.URL,
+		rpc.WithClientContentType(media.JSON),
+		rpc.WithClientTimeout("10ms"),
+	)
+	var res test.Response
+
+	err := client.Post(t.Context(), "/hello", &test.Request{Name: "Bob"}, &res)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestPostRequiresNonNilTypedRequest(t *testing.T) {
@@ -44,11 +67,7 @@ func TestPostRequiresNonNilTypedResponse(t *testing.T) {
 func TestPostUsesAccept(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rpc.Register(rpc.RegisterParams{
-		Router:  router,
-		Content: test.Content,
-		Pool:    test.Pool,
-	})
+	rpc.Register(router, test.Content, test.Pool, 0, 0)
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	server := httptest.NewServer(mux)

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
@@ -16,14 +17,11 @@ func ExampleClient_Post() {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
-	rpc.Register(rpc.RegisterParams{
-		Router: router,
-		Content: content.NewContent(
-			encoding.NewMap(),
-			pool,
-		),
-		Pool: pool,
-	})
+	rpc.Register(router, content.NewContent(
+		encoding.NewMap(),
+		stream.NewMap(),
+		pool,
+	), pool, 0, 0)
 
 	rpc.Route("/hello", func(_ context.Context, req *exampleRequest) (*exampleResponse, error) {
 		return &exampleResponse{Message: "hello " + req.Name}, nil

--- a/net/http/rpc/rpc.go
+++ b/net/http/rpc/rpc.go
@@ -1,34 +1,20 @@
 package rpc
 
 import (
-	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-sync"
 )
 
 var (
-	router *http.Router
-	cont   *content.Content
-	pool   *sync.BufferPool
+	router         *http.Router
+	cont           *content.Content
+	pool           *sync.BufferPool
+	timeout        time.Duration
+	maxReceiveSize bytes.Size
 )
-
-// RegisterParams defines dependencies used to register RPC package globals.
-//
-// This package relies on package-level registration to avoid threading commonly shared dependencies
-// through every helper call. These dependencies are typically provided by DI wiring.
-type RegisterParams struct {
-	di.In
-
-	// Router registers server-side routes for this package's helpers.
-	Router *http.Router
-
-	// Content resolves encoders/decoders based on HTTP media types (Content-Type).
-	Content *content.Content
-
-	// Pool is a buffer pool used by client helpers to reduce allocations while encoding/decoding bodies.
-	Pool *sync.BufferPool
-}
 
 // Register stores the dependencies used by server and client helpers in package-level variables.
 //
@@ -36,8 +22,23 @@ type RegisterParams struct {
 //
 // Important: Register must be called before using any server-side route helpers or client helpers in this
 // package. If it is not called, globals will be nil and helper calls will panic.
-func Register(params RegisterParams) {
-	router = params.Router
-	cont = params.Content
-	pool = params.Pool
+//
+// t is the streaming inactivity timeout applied by this package's streaming route helper (StreamRoute). A
+// successful Send extends the response write deadline by this duration, and a successful Recv extends the
+// request read deadline (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewStreamHandler] and
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]), turning the
+// whole-stream read and write timeouts into per-message inactivity budgets. Zero disables the extensions.
+//
+// m is the per-value request body size cap applied by this package's streaming route helper
+// (StreamRoute). Unlike the buffered request-body path's cumulative limit, this bounds each value
+// decoded by [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv]
+// independently — a long-lived stream with many small values is never rejected for its cumulative size
+// (see decision B18 in the streaming design). Zero disables the per-value cap entirely.
+func Register(r *http.Router, c *content.Content, p *sync.BufferPool, t time.Duration, m bytes.Size) {
+	router = r
+	cont = c
+	pool = p
+	timeout = t
+	maxReceiveSize = m
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -30,3 +30,45 @@ func Route[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 		content.NewRequestHandler(cont, handler),
 	)
 }
+
+// StreamRoute registers an RPC-style HTTP POST handler under pattern for a bidirectional stream: both
+// the request and response bodies stream incrementally rather than being buffered whole.
+//
+// The effective route pattern passed to the router is method-qualified and has the form:
+//
+//	"POST <pattern>"
+//
+// Unlike REST, where a streamed response with no streamed request (StreamGet/StreamRoute) is a
+// distinct shape, RPC's single POST-only style makes StreamRoute bidi-capable by nature, mirroring
+// how [Route] is already POST-only.
+//
+// The handler is built using
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler], which:
+//   - resolves the request decoder from Content-Type and the response encoder from the first Accept
+//     media type (falling back to Content-Type), both via the streaming media registry, and
+//   - rejects an unregistered or unparseable streaming media type with 415.
+//
+// HTTP/2 requirement:
+// Bidirectional streaming requires HTTP/2 (including h2c): an HTTP/1.x request body is buffered ahead
+// of the handler by intermediaries and the Go transport, so interleaving Recv/Send hangs rather than
+// failing. [content.NewRequestStreamHandler] rejects requests with req.ProtoMajor < 2 with
+// 505 HTTP Version Not Supported before the handler runs. Deploying a route registered through this
+// helper therefore requires the server, and any intermediary in front of it, to support HTTP/2 or h2c.
+//
+// Registration:
+// The resulting handler is registered on the package-level router configured via [Register], and the
+// route is marked streaming on the router's route policy (see
+// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
+// limiting is applied lazily instead of buffering the whole body.
+// [Register] must be called before StreamRoute; otherwise router/cont will be nil and this function
+// will panic.
+//
+// Inbound size limiting:
+// maxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
+// Recv, not the request body as a whole — see [content.NewRequestStreamHandler].
+func StreamRoute[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
+	router.HandleStreaming(
+		strings.Join(strings.Space, http.MethodPost, pattern),
+		content.NewRequestStreamHandler(cont, timeout, maxReceiveSize, handler),
+	)
+}

--- a/net/http/rpc/server_test.go
+++ b/net/http/rpc/server_test.go
@@ -1,0 +1,90 @@
+package rpc_test
+
+import (
+	"bufio"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamRouteRejectsHTTP1(t *testing.T) {
+	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
+	rpc.Register(router, test.Content, test.Pool, 0, 0)
+
+	rpc.StreamRoute("/hello", func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 1
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusHTTPVersionNotSupported, res.Code)
+}
+
+func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	router := http.NewRouter(mux, policy)
+	rpc.Register(router, test.Content, test.Pool, 0, 0)
+
+	rpc.StreamRoute("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+				return err
+			}
+		}
+	})
+
+	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.True(t, policy.IsStreaming(req))
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))
+	require.Equal(t, "Hello Alice", decodeGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func decodeGreeting(t *testing.T, scanner *bufio.Scanner) string {
+	t.Helper()
+
+	require.True(t, scanner.Scan())
+
+	var res map[string]any
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &res))
+
+	greeting, _ := res["Greeting"].(string)
+	return greeting
+}

--- a/transport/grpc/benchmark_test.go
+++ b/transport/grpc/benchmark_test.go
@@ -1,19 +1,21 @@
 package grpc_test
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/alexfalkowski/go-service/v2/config/client"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/server"
-	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	telemetryerrors "github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	transportgrpc "github.com/alexfalkowski/go-service/v2/transport/grpc"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 func init() {
@@ -21,178 +23,199 @@ func init() {
 }
 
 // BenchmarkGRPC compares the standard gRPC stack with the supported go-service server stack and telemetry layers.
-//
-//nolint:funlen
 func BenchmarkGRPC(b *testing.B) {
-	b.Run("std", func(b *testing.B) {
-		b.ReportAllocs()
+	b.Run("std", benchmarkStdGRPC)
+	benchmarkGRPCLayers(b, benchmarkGRPC)
+}
 
-		l, err := net.Listen(b.Context(), "tcp", "localhost:0")
-		require.NoError(b, err)
+// BenchmarkGRPCStream measures gRPC bidirectional streaming (SayStreamHello) with fixed 1 KiB request payloads.
+func BenchmarkGRPCStream(b *testing.B) {
+	for _, messageCount := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("%d-messages", messageCount), func(b *testing.B) {
+			b.Helper()
 
-		server := grpc.NewServer(test.ConfigOptions, test.DefaultTimeout)
-		defer server.GracefulStop()
+			benchmarkGRPCLayers(b, func(b *testing.B, log *logger.Logger, trace, tlsEnabled bool) {
+				b.Helper()
 
-		v1.RegisterGreeterServiceServer(server, test.NewService())
+				benchmarkGRPCStream(b, log, trace, tlsEnabled, messageCount)
+			})
+		})
+	}
+}
 
-		//nolint:errcheck
-		go server.Serve(l)
-
-		conn, err := transportgrpc.NewClientConn(l.Addr().String(), transportgrpc.WithTransportCredentials(transportgrpc.NewInsecureCredentials()))
-		require.NoError(b, err)
-
-		client := v1.NewGreeterServiceClient(conn)
-		req := &v1.SayHelloRequest{Name: "test"}
-
-		b.ResetTimer()
-
-		for b.Loop() {
-			_, err := client.SayHello(b.Context(), req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-		}
-
-		b.StopTimer()
-		require.NoError(b, conn.Close())
-	})
+func benchmarkGRPCLayers(b *testing.B, benchmark func(*testing.B, *logger.Logger, bool, bool)) {
+	b.Helper()
 
 	b.Run("none", func(b *testing.B) {
-		b.ReportAllocs()
 		test.ResetTelemetry(b)
 		defer test.ResetTelemetry(b)
 
-		lc := fxtest.NewLifecycle(b)
-		cfg := test.NewInsecureTransportConfig()
-
-		g, err := transportgrpc.NewServer(transportgrpc.ServerParams{
-			Shutdowner:   test.NewShutdowner(),
-			Config:       cfg.GRPC,
-			MethodPolicy: transportgrpc.NewMethodPolicy(),
-			UserAgent:    test.UserAgent, Version: test.Version,
-		})
-		require.NoError(b, err)
-		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
-
-		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
-		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-
-		lc.RequireStart()
-
-		_, addr, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
-		cl := &client.Config{Address: addr}
-
-		conn, err := transportgrpc.NewClient(cl.Address)
-		require.NoError(b, err)
-
-		client := v1.NewGreeterServiceClient(conn)
-		req := &v1.SayHelloRequest{Name: "test"}
-
-		b.ResetTimer()
-
-		for b.Loop() {
-			_, err := client.SayHello(b.Context(), req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-		}
-
-		b.StopTimer()
-		require.NoError(b, conn.Close())
-		lc.RequireStop()
+		benchmark(b, nil, false, false)
 	})
 
 	b.Run("log", func(b *testing.B) {
-		b.ReportAllocs()
-
-		logger, err := logger.NewLogger(logger.LoggerParams{})
-		require.NoError(b, err)
-		lc := fxtest.NewLifecycle(b)
-		cfg := test.NewInsecureTransportConfig()
-
-		g, err := transportgrpc.NewServer(transportgrpc.ServerParams{
-			Shutdowner: test.NewShutdowner(),
-			Config:     cfg.GRPC, Logger: logger,
-			MethodPolicy: transportgrpc.NewMethodPolicy(),
-			UserAgent:    test.UserAgent, Version: test.Version,
-		})
-		require.NoError(b, err)
-		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
-
-		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
-		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-		errors.Register(errors.NewHandler(nil))
-
-		lc.RequireStart()
-
-		_, addr, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
-		cl := &client.Config{Address: addr}
-
-		conn, err := transportgrpc.NewClient(cl.Address)
+		log, err := logger.NewLogger(logger.LoggerParams{})
 		require.NoError(b, err)
 
-		client := v1.NewGreeterServiceClient(conn)
-		req := &v1.SayHelloRequest{Name: "test"}
-
-		b.ResetTimer()
-
-		for b.Loop() {
-			_, err := client.SayHello(b.Context(), req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-		}
-
-		b.StopTimer()
-		require.NoError(b, conn.Close())
-		lc.RequireStop()
+		benchmark(b, log, false, false)
 	})
 
 	b.Run("trace", func(b *testing.B) {
-		b.ReportAllocs()
-
-		logger, err := logger.NewLogger(logger.LoggerParams{})
-		require.NoError(b, err)
-		lc := fxtest.NewLifecycle(b)
-		cfg := test.NewInsecureTransportConfig()
-
-		test.RegisterTracer(lc, nil)
-
-		g, err := transportgrpc.NewServer(transportgrpc.ServerParams{
-			Shutdowner: test.NewShutdowner(),
-			Config:     cfg.GRPC, Logger: logger,
-			MethodPolicy: transportgrpc.NewMethodPolicy(),
-			UserAgent:    test.UserAgent, Version: test.Version,
-		})
-		require.NoError(b, err)
-		cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, g.GetService().String())
-
-		v1.RegisterGreeterServiceServer(g.ServiceRegistrar(), test.NewService())
-		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{g.GetService()}})
-		errors.Register(errors.NewHandler(nil))
-
-		lc.RequireStart()
-
-		_, addr, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
-		cl := &client.Config{Address: addr}
-
-		conn, err := transportgrpc.NewClient(cl.Address)
+		log, err := logger.NewLogger(logger.LoggerParams{})
 		require.NoError(b, err)
 
-		client := v1.NewGreeterServiceClient(conn)
-		req := &v1.SayHelloRequest{Name: "test"}
+		benchmark(b, log, true, false)
+	})
 
-		b.ResetTimer()
+	b.Run("tls", func(b *testing.B) {
+		benchmark(b, nil, false, true)
+	})
+}
 
-		for b.Loop() {
-			_, err := client.SayHello(b.Context(), req)
-			if err != nil {
+func benchmarkStdGRPC(b *testing.B) {
+	b.ReportAllocs()
+
+	listener, err := net.Listen(b.Context(), "tcp", "localhost:0")
+	require.NoError(b, err)
+
+	grpcServer := grpc.NewServer(test.ConfigOptions, test.DefaultTimeout)
+	defer grpcServer.GracefulStop()
+
+	v1.RegisterGreeterServiceServer(grpcServer, test.NewService())
+
+	//nolint:errcheck
+	go grpcServer.Serve(listener)
+
+	conn, err := transportgrpc.NewClientConn(listener.Addr().String(), transportgrpc.WithTransportCredentials(transportgrpc.NewInsecureCredentials()))
+	require.NoError(b, err)
+
+	greeterClient := v1.NewGreeterServiceClient(conn)
+	req := &v1.SayHelloRequest{Name: "test"}
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, err := greeterClient.SayHello(b.Context(), req)
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+
+	b.StopTimer()
+	require.NoError(b, conn.Close())
+}
+
+func benchmarkGRPC(b *testing.B, log *logger.Logger, trace, tlsEnabled bool) {
+	b.Helper()
+	b.ReportAllocs()
+
+	greeterClient, cleanup := startBenchmarkGRPC(b, log, trace, tlsEnabled)
+	req := &v1.SayHelloRequest{Name: "test"}
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, err := greeterClient.SayHello(b.Context(), req)
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+
+	b.StopTimer()
+	cleanup()
+}
+
+func benchmarkGRPCStream(b *testing.B, log *logger.Logger, trace, tlsEnabled bool, messageCount int) {
+	b.Helper()
+	b.ReportAllocs()
+
+	greeterClient, cleanup := startBenchmarkGRPC(b, log, trace, tlsEnabled)
+	name := strings.Repeat("b", 1024)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		stream, err := greeterClient.SayStreamHello(b.Context())
+		if err != nil {
+			require.NoError(b, err)
+		}
+
+		for range messageCount {
+			if _, err := test.SendStreamHello(b, stream, name); err != nil {
 				require.NoError(b, err)
 			}
 		}
 
-		b.StopTimer()
+		require.NoError(b, stream.CloseSend())
+	}
+
+	b.StopTimer()
+	cleanup()
+}
+
+func startBenchmarkGRPC(b *testing.B, log *logger.Logger, trace, tlsEnabled bool) (v1.GreeterServiceClient, func()) {
+	b.Helper()
+
+	lc := test.QuietLifecycle(b)
+	cfg := test.NewInsecureTransportConfig()
+	if tlsEnabled {
+		cfg = test.NewSecureTransportConfig()
+	}
+
+	if trace {
+		test.RegisterTracer(lc, nil)
+	}
+
+	grpcServer, err := transportgrpc.NewServer(transportgrpc.ServerParams{
+		Shutdowner:   test.NewShutdowner(),
+		Config:       cfg.GRPC,
+		Logger:       log,
+		MethodPolicy: transportgrpc.NewMethodPolicy(),
+		UserAgent:    test.UserAgent,
+		Version:      test.Version,
+	})
+	require.NoError(b, err)
+	cfg.GRPC.Address = test.BoundAddress(cfg.GRPC.Address, grpcServer.GetService().String())
+
+	v1.RegisterGreeterServiceServer(grpcServer.ServiceRegistrar(), &benchmarkGreeterService{Service: test.NewService()})
+	if log != nil {
+		telemetryerrors.Register(telemetryerrors.NewHandler(nil))
+	}
+
+	server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{grpcServer.GetService()}})
+	lc.RequireStart()
+
+	_, address, _ := net.SplitNetworkAddress(cfg.GRPC.Address)
+	clientOpts := []transportgrpc.ClientOption{}
+	if tlsEnabled {
+		clientOpts = append(clientOpts, transportgrpc.WithClientTLS(test.NewTLSClientConfig()))
+	}
+
+	conn, err := transportgrpc.NewClient(address, clientOpts...)
+	require.NoError(b, err)
+
+	return v1.NewGreeterServiceClient(conn), func() {
 		require.NoError(b, conn.Close())
 		lc.RequireStop()
-	})
+	}
+}
+
+type benchmarkGreeterService struct {
+	*test.Service
+}
+
+func (s *benchmarkGreeterService) SayStreamHello(stream v1.GreeterService_SayStreamHelloServer) error {
+	for {
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := stream.Send(&v1.SayStreamHelloResponse{Message: "Hello " + req.GetName()}); err != nil {
+			return err
+		}
+	}
 }

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	configclient "github.com/alexfalkowski/go-service/v2/config/client"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -11,219 +12,25 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/client"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/errors"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/time"
 	transporthttp "github.com/alexfalkowski/go-service/v2/transport/http"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 // BenchmarkHTTP compares the standard HTTP stack with the supported go-service server stack and telemetry layers.
-//
-//nolint:funlen
 func BenchmarkHTTP(b *testing.B) {
-	b.Run("std", func(b *testing.B) {
-		b.ReportAllocs()
-
-		mux := http.NewServeMux()
-		mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
-
-		listener, err := net.Listen(b.Context(), "tcp", "localhost:0")
-		require.NoError(b, err)
-		defer listener.Close()
-
-		server := &http.Server{
-			Handler:           mux,
-			ReadHeaderTimeout: time.Second.Duration(),
-		}
-		defer server.Close()
-
-		//nolint:errcheck
-		go server.Serve(listener)
-
-		client := &http.Client{Transport: http.DefaultTransport}
-		url := fmt.Sprintf("http://%s/hello", listener.Addr().String())
-
-		b.ResetTimer()
-
-		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
-		require.NoError(b, err)
-
-		for b.Loop() {
-			resp, err := client.Do(req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-			closeResponse(b, resp)
-		}
-
-		b.StopTimer()
-		client.CloseIdleConnections()
-	})
-
-	b.Run("none", func(b *testing.B) {
-		b.ReportAllocs()
-
-		mux := transporthttp.NewServeMux()
-		policy := transporthttp.NewRoutePolicy()
-		router := transporthttp.NewRouter(mux, policy)
-		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-		lc := fxtest.NewLifecycle(b)
-		cfg := test.NewInsecureTransportConfig()
-
-		h, err := transporthttp.NewServer(transporthttp.ServerParams{
-			Shutdowner:  test.NewShutdowner(),
-			Mux:         mux,
-			Pool:        test.Pool,
-			Config:      cfg.HTTP,
-			UserAgent:   test.UserAgent,
-			Version:     test.Version,
-			ID:          uuid.NewGenerator(),
-			RoutePolicy: policy,
-		})
-		require.NoError(b, err)
-		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
-
-		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-
-		lc.RequireStart()
-
-		_, addr, _ := net.SplitNetworkAddress(cfg.HTTP.Address)
-		client := &transporthttp.Client{Transport: transporthttp.DefaultTransport}
-		url := fmt.Sprintf("http://%s/hello", addr)
-
-		b.ResetTimer()
-
-		req, err := transporthttp.NewRequestWithContext(b.Context(), transporthttp.MethodGet, url, transporthttp.NoBody)
-		require.NoError(b, err)
-
-		for b.Loop() {
-			resp, err := client.Do(req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-			closeResponse(b, resp)
-		}
-
-		b.StopTimer()
-		client.CloseIdleConnections()
-		lc.RequireStop()
-	})
-
-	b.Run("log", func(b *testing.B) {
-		b.ReportAllocs()
-
-		mux := transporthttp.NewServeMux()
-		policy := transporthttp.NewRoutePolicy()
-		router := transporthttp.NewRouter(mux, policy)
-		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-		lc := fxtest.NewLifecycle(b)
-		logger, err := logger.NewLogger(logger.LoggerParams{})
-		require.NoError(b, err)
-		cfg := test.NewInsecureTransportConfig()
-
-		h, err := transporthttp.NewServer(transporthttp.ServerParams{
-			Shutdowner:  test.NewShutdowner(),
-			Mux:         mux,
-			Pool:        test.Pool,
-			Config:      cfg.HTTP,
-			Logger:      logger,
-			UserAgent:   test.UserAgent,
-			Version:     test.Version,
-			ID:          uuid.NewGenerator(),
-			RoutePolicy: policy,
-		})
-		require.NoError(b, err)
-		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
-
-		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-		errors.Register(errors.NewHandler(nil))
-
-		lc.RequireStart()
-
-		_, addr, _ := net.SplitNetworkAddress(cfg.HTTP.Address)
-		client := &transporthttp.Client{Transport: transporthttp.DefaultTransport}
-		url := fmt.Sprintf("http://%s/hello", addr)
-
-		b.ResetTimer()
-
-		req, err := transporthttp.NewRequestWithContext(b.Context(), transporthttp.MethodGet, url, transporthttp.NoBody)
-		require.NoError(b, err)
-
-		for b.Loop() {
-			resp, err := client.Do(req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-			closeResponse(b, resp)
-		}
-
-		b.StopTimer()
-		client.CloseIdleConnections()
-		lc.RequireStop()
-	})
-
-	b.Run("trace", func(b *testing.B) {
-		b.ReportAllocs()
-
-		mux := transporthttp.NewServeMux()
-		policy := transporthttp.NewRoutePolicy()
-		router := transporthttp.NewRouter(mux, policy)
-		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-		lc := fxtest.NewLifecycle(b)
-		logger, err := logger.NewLogger(logger.LoggerParams{})
-		require.NoError(b, err)
-		cfg := test.NewInsecureTransportConfig()
-
-		test.RegisterTracer(lc, nil)
-
-		h, err := transporthttp.NewServer(transporthttp.ServerParams{
-			Shutdowner:  test.NewShutdowner(),
-			Mux:         mux,
-			Pool:        test.Pool,
-			Config:      cfg.HTTP,
-			Logger:      logger,
-			UserAgent:   test.UserAgent,
-			Version:     test.Version,
-			ID:          uuid.NewGenerator(),
-			RoutePolicy: policy,
-		})
-		require.NoError(b, err)
-		cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, h.GetService().String())
-
-		server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{h.GetService()}})
-		errors.Register(errors.NewHandler(nil))
-
-		lc.RequireStart()
-
-		_, addr, _ := net.SplitNetworkAddress(cfg.HTTP.Address)
-		client := &transporthttp.Client{Transport: transporthttp.DefaultTransport}
-		url := fmt.Sprintf("http://%s/hello", addr)
-
-		b.ResetTimer()
-
-		req, err := transporthttp.NewRequestWithContext(b.Context(), transporthttp.MethodGet, url, transporthttp.NoBody)
-		require.NoError(b, err)
-
-		for b.Loop() {
-			resp, err := client.Do(req)
-			if err != nil {
-				require.NoError(b, err)
-			}
-			closeResponse(b, resp)
-		}
-
-		b.StopTimer()
-		client.CloseIdleConnections()
-		lc.RequireStop()
-	})
+	b.Run("std", benchmarkStdHTTP)
+	benchmarkHTTPLayers(b, benchmarkHTTP)
 }
 
 // BenchmarkMVC measures the supported MVC HTML rendering path through the HTTP transport stack.
@@ -263,32 +70,6 @@ func BenchmarkMVC(b *testing.B) {
 		client.CloseIdleConnections()
 		world.RequireStop()
 	})
-}
-
-func closeResponse(b *testing.B, resp *http.Response) {
-	b.Helper()
-
-	_, err := io.Copy(io.Discard, resp.Body)
-	require.NoError(b, err)
-	require.NoError(b, resp.Body.Close())
-}
-
-func newHTTPBenchmarkWorld(b *testing.B) *test.World {
-	b.Helper()
-
-	logger, err := logger.NewLogger(logger.LoggerParams{})
-	require.NoError(b, err)
-
-	return test.NewWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(logger))
-}
-
-func startHTTPBenchmarkWorld(b *testing.B, world *test.World) {
-	b.Helper()
-
-	world.RequireStart()
-	conn, err := test.Connect(b.Context(), world.TransportConfig.HTTP.Address)
-	require.NoError(b, err)
-	require.NoError(b, conn.Close())
 }
 
 // BenchmarkRPC measures RPC client/server body encoding overhead across supported HTTP media types.
@@ -469,4 +250,331 @@ func BenchmarkRest(b *testing.B) {
 		b.StopTimer()
 		world.RequireStop()
 	})
+}
+
+// BenchmarkRestStream measures REST bidirectional streaming (StreamPost) round-trip overhead.
+func BenchmarkRestStream(b *testing.B) {
+	b.ReportAllocs()
+
+	world := test.NewWorld(b, test.WithWorldSecure(), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
+	rest.StreamPost("/hello", streamHello)
+	startHTTPBenchmarkWorld(b, world)
+
+	url := world.PathServerURL("https", "hello")
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		err := world.Rest.RequestStream(b.Context(), http.MethodPost, url, rest.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, streamHelloClient("Bob", 1))
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+
+	b.StopTimer()
+	world.RequireStop()
+}
+
+// BenchmarkHTTPStream measures bidirectional streaming with fixed 1 KiB request payloads through progressively enabled HTTP transport layers and TLS.
+func BenchmarkHTTPStream(b *testing.B) {
+	for _, messageCount := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("%d-messages", messageCount), func(b *testing.B) {
+			b.Helper()
+
+			benchmarkHTTPLayers(b, func(b *testing.B, log *logger.Logger, trace, tlsEnabled bool) {
+				b.Helper()
+
+				benchmarkHTTPStream(b, log, trace, tlsEnabled, messageCount)
+			})
+		})
+	}
+}
+
+// BenchmarkRPCStream measures RPC bidirectional streaming (StreamRoute) round-trip overhead.
+//
+// rpc.Client has no streaming method (only Post), so this benchmarks a raw
+// [github.com/alexfalkowski/go-service/v2/net/http/client.Client] directly against the world's server
+// URL, matching the correctness test this benchmark mirrors.
+func BenchmarkRPCStream(b *testing.B) {
+	b.ReportAllocs()
+
+	world := test.NewWorld(b, test.WithWorldSecure(), test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+	rpc.StreamRoute("/hello", streamHello)
+	startHTTPBenchmarkWorld(b, world)
+
+	httpClient, err := world.NewHTTP()
+	require.NoError(b, err)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(httpClient.Transport))
+	url := world.PathServerURL("https", "hello")
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		err := c.RequestStream(b.Context(), http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, streamHelloClient("Bob", 1))
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+
+	b.StopTimer()
+	httpClient.CloseIdleConnections()
+	world.RequireStop()
+}
+
+func streamHello(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			if stream.IsFinished(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+			return err
+		}
+	}
+}
+
+func streamHelloClient(name string, messageCount int) func(context.Context, *client.RequestResponseStream) error {
+	return func(_ context.Context, stream *client.RequestResponseStream) error {
+		for range messageCount {
+			if err := stream.Send(&test.Request{Name: name}); err != nil {
+				return err
+			}
+
+			var res test.Response
+			if err := stream.Recv(&res); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func benchmarkHTTPLayers(b *testing.B, benchmark func(*testing.B, *logger.Logger, bool, bool)) {
+	b.Helper()
+
+	b.Run("none", func(b *testing.B) {
+		benchmark(b, nil, false, false)
+	})
+
+	b.Run("log", func(b *testing.B) {
+		log, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
+
+		benchmark(b, log, false, false)
+	})
+
+	b.Run("trace", func(b *testing.B) {
+		log, err := logger.NewLogger(logger.LoggerParams{})
+		require.NoError(b, err)
+
+		benchmark(b, log, true, false)
+	})
+
+	b.Run("tls", func(b *testing.B) {
+		benchmark(b, nil, false, true)
+	})
+}
+
+func benchmarkStdHTTP(b *testing.B) {
+	b.ReportAllocs()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /hello", func(_ http.ResponseWriter, _ *http.Request) {})
+
+	listener, err := net.Listen(b.Context(), "tcp", "localhost:0")
+	require.NoError(b, err)
+	defer listener.Close()
+
+	httpServer := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second.Duration(),
+	}
+	defer httpServer.Close()
+
+	//nolint:errcheck
+	go httpServer.Serve(listener)
+
+	httpClient := &http.Client{Transport: http.DefaultTransport}
+	url := fmt.Sprintf("http://%s/hello", listener.Addr().String())
+	req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			require.NoError(b, err)
+		}
+		closeResponse(b, resp)
+	}
+
+	b.StopTimer()
+	httpClient.CloseIdleConnections()
+}
+
+func benchmarkHTTP(b *testing.B, log *logger.Logger, trace, tlsEnabled bool) {
+	b.Helper()
+	b.ReportAllocs()
+
+	address, cleanup := startBenchmarkHTTPServer(b, log, trace, tlsEnabled, func(router *transporthttp.Router, _ *transporthttp.Config) {
+		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	})
+	httpClient, scheme, closeIdleConnections := newBenchmarkHTTPClient(b, tlsEnabled)
+	url := fmt.Sprintf("%s://%s/hello", scheme, address)
+	req, err := transporthttp.NewRequestWithContext(b.Context(), transporthttp.MethodGet, url, transporthttp.NoBody)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			require.NoError(b, err)
+		}
+		closeResponse(b, resp)
+	}
+
+	b.StopTimer()
+	closeIdleConnections()
+	cleanup()
+}
+
+func benchmarkHTTPStream(b *testing.B, log *logger.Logger, trace, tlsEnabled bool, messageCount int) {
+	b.Helper()
+	b.ReportAllocs()
+
+	address, cleanup := startBenchmarkHTTPServer(b, log, trace, tlsEnabled, func(router *transporthttp.Router, cfg *transporthttp.Config) {
+		rest.Register(router, test.Content, test.Pool, cfg.GetTimeout(), cfg.GetMaxReceiveSize())
+		rest.StreamPost("/hello", streamHello)
+	})
+	httpClient, scheme, closeIdleConnections := newHTTPStreamClient(b, tlsEnabled)
+	url := fmt.Sprintf("%s://%s/hello", scheme, address)
+	requestStream := streamHelloClient(strings.Repeat("b", 1024), messageCount)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		err := httpClient.RequestStream(b.Context(), http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, requestStream)
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+
+	b.StopTimer()
+	closeIdleConnections()
+	cleanup()
+}
+
+func startBenchmarkHTTPServer(b *testing.B, log *logger.Logger, trace, tlsEnabled bool, register func(*transporthttp.Router, *transporthttp.Config)) (string, func()) {
+	b.Helper()
+
+	mux := transporthttp.NewServeMux()
+	policy := transporthttp.NewRoutePolicy()
+	router := transporthttp.NewRouter(mux, policy)
+	lc := test.QuietLifecycle(b)
+	cfg := test.NewInsecureTransportConfig()
+	if tlsEnabled {
+		cfg = test.NewSecureTransportConfig()
+	}
+
+	if trace {
+		test.RegisterTracer(lc, nil)
+	}
+
+	register(router, cfg.HTTP)
+
+	httpServer, err := transporthttp.NewServer(transporthttp.ServerParams{
+		Shutdowner:  test.NewShutdowner(),
+		Mux:         mux,
+		Pool:        test.Pool,
+		Config:      cfg.HTTP,
+		Logger:      log,
+		UserAgent:   test.UserAgent,
+		Version:     test.Version,
+		ID:          uuid.NewGenerator(),
+		RoutePolicy: policy,
+	})
+	require.NoError(b, err)
+	cfg.HTTP.Address = test.BoundAddress(cfg.HTTP.Address, httpServer.GetService().String())
+
+	if log != nil {
+		errors.Register(errors.NewHandler(nil))
+	}
+
+	server.Register(server.RegisterParams{Lifecycle: lc, Drain: server.NewDrain(), Services: []*server.Service{httpServer.GetService()}})
+	lc.RequireStart()
+
+	_, address, _ := net.SplitNetworkAddress(cfg.HTTP.Address)
+
+	return address, lc.RequireStop
+}
+
+func newBenchmarkHTTPClient(b *testing.B, tlsEnabled bool) (*transporthttp.Client, string, func()) {
+	b.Helper()
+
+	if !tlsEnabled {
+		httpClient := &transporthttp.Client{Transport: transporthttp.DefaultTransport}
+
+		return httpClient, "http", httpClient.CloseIdleConnections
+	}
+
+	tlsConfig, err := configclient.NewConfig(test.FS, test.NewTLSClientConfig())
+	require.NoError(b, err)
+
+	transport := http.Transport(tlsConfig)
+	httpClient := &transporthttp.Client{Transport: transport}
+
+	return httpClient, "https", httpClient.CloseIdleConnections
+}
+
+func newHTTPStreamClient(b *testing.B, tlsEnabled bool) (*client.Client, string, func()) {
+	b.Helper()
+
+	transport := http.Transport(nil)
+	scheme := "http"
+	if tlsEnabled {
+		tlsConfig, err := configclient.NewConfig(test.FS, test.NewTLSClientConfig())
+		require.NoError(b, err)
+
+		transport = http.Transport(tlsConfig)
+		scheme = "https"
+	} else {
+		transport.Protocols.SetHTTP1(false)
+	}
+
+	return client.NewClient(test.Content, test.Pool, client.WithRoundTripper(transport)), scheme, transport.CloseIdleConnections
+}
+
+func closeResponse(b *testing.B, resp *http.Response) {
+	b.Helper()
+
+	_, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(b, err)
+	require.NoError(b, resp.Body.Close())
+}
+
+func newHTTPBenchmarkWorld(b *testing.B) *test.World {
+	b.Helper()
+
+	log, err := logger.NewLogger(logger.LoggerParams{})
+	require.NoError(b, err)
+
+	return test.NewWorld(b, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP(), test.WithWorldLogger(log))
+}
+
+func startHTTPBenchmarkWorld(b *testing.B, world *test.World) {
+	b.Helper()
+
+	world.RequireStart()
+	conn, err := test.Connect(b.Context(), world.TransportConfig.HTTP.Address)
+	require.NoError(b, err)
+	require.NoError(b, conn.Close())
 }

--- a/transport/http/body/body.go
+++ b/transport/http/body/body.go
@@ -5,20 +5,28 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/body"
 )
 
-// NewHandler constructs request body size limiting middleware.
+// NewHandler constructs request body size limiting middleware that never buffers routes marked streaming in routePolicy,
+// and buffers every other route.
 //
 // The limit is expressed in bytes and is passed to the underlying
-// [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler] wrapper.
-func NewHandler(limit int64) *Handler {
-	return &Handler{limit: limit}
+// [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler] and
+// [github.com/alexfalkowski/go-service/v2/net/http/body.NewLazyHandler] wrappers. Unlike the buffered path,
+// the streaming branch does not enforce limit as a cumulative body-size ceiling; see
+// [github.com/alexfalkowski/go-service/v2/net/http/body.NewLazyHandler].
+func NewHandler(routePolicy *http.RoutePolicy, limit int64) *Handler {
+	return &Handler{routePolicy: routePolicy, limit: limit}
 }
 
 // Handler limits request bodies before downstream handlers decode them.
 //
-// Accepted non-empty bodies are buffered and replaced with a fresh readable
-// body for downstream handlers. Empty bodies are passed through unchanged.
+// Accepted non-empty bodies are buffered and replaced with a fresh readable body for downstream
+// handlers, unless routePolicy marks the request's route as streaming, in which case the body is
+// never buffered and no cumulative limit is enforced as it is read (see
+// [github.com/alexfalkowski/go-service/v2/net/http/body.NewLazyHandler]). Empty bodies are passed
+// through unchanged.
 type Handler struct {
-	limit int64
+	routePolicy *http.RoutePolicy
+	limit       int64
 }
 
 // ServeHTTP enforces the configured request body limit.
@@ -27,6 +35,18 @@ type Handler struct {
 // underlying HTTP max-bytes error response and does not call next. If the body
 // cannot be read, ServeHTTP writes a bad-request response and does not call
 // next. Otherwise, it delegates to next with a readable request body.
+//
+// When routePolicy marks req's route as streaming, ServeHTTP never buffers the body (see
+// [github.com/alexfalkowski/go-service/v2/net/http/body.NewLazyHandler]): it still rejects a request
+// whose declared Content-Length exceeds the limit before next runs, but otherwise delegates to next
+// without enforcing any cumulative limit as next reads the body. A streaming route's per-value cap, if
+// any, is applied by next itself (see
+// [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv]), not by ServeHTTP.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	if h.routePolicy != nil && h.routePolicy.IsStreaming(req) {
+		body.NewLazyHandler(next, h.limit).ServeHTTP(res, req)
+		return
+	}
+
 	body.NewHandler(next, h.limit).ServeHTTP(res, req)
 }

--- a/transport/http/body/body_test.go
+++ b/transport/http/body/body_test.go
@@ -5,28 +5,71 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/transport/http/body"
 	"github.com/stretchr/testify/require"
 )
 
-func TestHandlerSkipsEmptyBodyBuffering(t *testing.T) {
-	handler := body.NewHandler(1024)
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+func TestHandlerBuffersNonStreamingRoutes(t *testing.T) {
+	routePolicy := http.NewRoutePolicy()
+	routePolicy.Streaming("POST /stream")
+	handler := body.NewHandler(routePolicy, 1024)
+
+	t.Run("skips empty body buffering", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+		require.NoError(t, err)
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req, func(res http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.NoBody, req.Body)
+			res.WriteHeader(http.StatusOK)
+		})
+
+		require.Equal(t, http.StatusOK, res.Code)
+	})
+
+	t.Run("writes bad request when body read fails", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", &test.ErrReaderCloser{})
+		require.NoError(t, err)
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {
+			require.Fail(t, "next handler should not be called")
+		})
+
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		test.RequireTrimmedResponseBody(t, res, "http: bad request")
+	})
+}
+
+func TestHandlerDoesNotLimitStreamingRoutesMidStream(t *testing.T) {
+	routePolicy := http.NewRoutePolicy()
+	routePolicy.Streaming("POST /stream")
+	handler := body.NewHandler(routePolicy, 64)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/stream", &test.UnknownLengthReader{Reader: strings.NewReader(strings.Repeat("a", 100))})
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
 
-	handler.ServeHTTP(res, req, func(res http.ResponseWriter, req *http.Request) {
-		require.Equal(t, http.NoBody, req.Body)
-		res.WriteHeader(http.StatusOK)
+	var data []byte
+	var readErr error
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		data, _, readErr = io.ReadAll(req.Body)
 	})
 
+	require.NoError(t, readErr)
+	require.Len(t, data, 100)
 	require.Equal(t, http.StatusOK, res.Code)
 }
 
-func TestHandlerWritesBadRequestWhenBodyReadFails(t *testing.T) {
-	handler := body.NewHandler(1024)
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", &test.ErrReaderCloser{})
+func TestHandlerRejectsStreamingRouteContentLengthOverLimit(t *testing.T) {
+	routePolicy := http.NewRoutePolicy()
+	routePolicy.Streaming("POST /stream")
+	handler := body.NewHandler(routePolicy, 64)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/stream", strings.NewReader(strings.Repeat("a", 100)))
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
 
@@ -34,6 +77,6 @@ func TestHandlerWritesBadRequestWhenBodyReadFails(t *testing.T) {
 		require.Fail(t, "next handler should not be called")
 	})
 
-	require.Equal(t, http.StatusBadRequest, res.Code)
-	test.RequireTrimmedResponseBody(t, res, "http: bad request")
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+	test.RequireTrimmedResponseBody(t, res, "http: request entity too large")
 }

--- a/transport/http/body/doc.go
+++ b/transport/http/body/doc.go
@@ -2,7 +2,11 @@
 //
 // The middleware caps inbound request bodies before downstream handlers decode
 // them. Accepted requests receive a buffered replacement body, while oversized
-// or unreadable bodies are rejected through the response writer.
+// or unreadable bodies are rejected through the response writer. [NewHandler] never
+// buffers routes marked streaming in its route policy: it keeps the
+// declared-Content-Length short-circuit but does not enforce a cumulative limit as the body is read,
+// since a streaming route caps individual decoded values at the content layer instead of a whole-body
+// total.
 //
 // Start with [NewHandler].
 package body

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -92,7 +92,10 @@ func TestRoundTripperWithTokenDoesNotSendAuthorizationToCrossOriginRedirect(t *t
 	require.NoError(t, err)
 
 	client := &http.Client{Transport: rt}
-	res, err := client.Get(trusted.URL + "/start")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, trusted.URL+"/start", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
 	require.ErrorIs(t, err, http.ErrUseLastResponse)
 	require.Nil(t, res)
 	require.Equal(t, "Bearer secret", trustedAuthorization)

--- a/transport/http/limiter/limiter.go
+++ b/transport/http/limiter/limiter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
@@ -60,7 +61,15 @@ type Handler struct {
 //   - If the limiter returns an error, it writes an internal server error response.
 //   - It writes RateLimit and RateLimit-Policy headers describing the current decision.
 //   - If the request is not allowed, it writes an HTTP 429 response with Retry-After when reset timing is available.
-//   - Otherwise it calls next.
+//   - Otherwise it stores the underlying limiter on the request context (see [meta.WithLimiter]) and calls next.
+//
+// Context population:
+//
+// The stream-open decision above charges one token per request, matching every other route. Streaming
+// routes charge additional tokens per message by retrieving the same limiter from the context via
+// [meta.Limiter] and calling Take again from [net/http/content.Stream.Send] and
+// [net/http/content.RequestStream.Recv]; the RateLimit/RateLimit-Policy headers above still describe only
+// this stream-open decision, since HTTP headers cannot be re-sent once a streaming response is committed.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	if h.routePolicy.IsOperation(req) {
 		next(res, req)
@@ -87,7 +96,8 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		return
 	}
 
-	next(res, req)
+	ctx = meta.WithLimiter(ctx, h.limiter.Limiter)
+	next(res, req.WithContext(ctx))
 }
 
 // NewClientLimiter constructs an HTTP client-side rate limiter.

--- a/transport/http/limiter/limiter_test.go
+++ b/transport/http/limiter/limiter_test.go
@@ -1,10 +1,12 @@
 package limiter_test
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	httplimiter "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
@@ -28,6 +30,70 @@ func TestRoundTripperClosesBodyOnLimiterError(t *testing.T) {
 	require.Nil(t, res)
 	require.Error(t, err)
 	require.True(t, body.Closed)
+}
+
+func TestHandlerStoresLimiterOnContextWhenAllowed(t *testing.T) {
+	server, err := httplimiter.NewServerLimiter(test.NoopLifecycle{}, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 1))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close(t.Context())) })
+
+	handler := httplimiter.NewHandler(http.NewRoutePolicy(), server)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	var called bool
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		called = true
+		require.Same(t, server.Limiter, meta.Limiter(req.Context()))
+	})
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, res.Code)
+}
+
+func TestHandlerDoesNotStoreLimiterOnContextWhenDenied(t *testing.T) {
+	server, err := httplimiter.NewServerLimiter(test.NoopLifecycle{}, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close(t.Context())) })
+
+	routePolicy := http.NewRoutePolicy()
+	first, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	httplimiter.NewHandler(routePolicy, server).ServeHTTP(httptest.NewRecorder(), first, func(http.ResponseWriter, *http.Request) {})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/hello", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	httplimiter.NewHandler(routePolicy, server).ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unexpected next call")
+	})
+
+	require.Equal(t, http.StatusTooManyRequests, res.Code)
+	require.Nil(t, meta.Limiter(req.Context()))
+}
+
+func TestHandlerBypassesOperationPathWithNoLimiterOnContext(t *testing.T) {
+	server, err := httplimiter.NewServerLimiter(test.NoopLifecycle{}, limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close(t.Context())) })
+
+	routePolicy := http.NewRoutePolicy()
+	routePolicy.Operation("GET /healthz")
+
+	handler := httplimiter.NewHandler(routePolicy, server)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/healthz", http.NoBody)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+
+	var called bool
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		called = true
+		require.Nil(t, meta.Limiter(req.Context()))
+	})
+
+	require.True(t, called)
 }
 
 func TestRoundTripperClosesBodyOnLimiterDenial(t *testing.T) {

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -1,15 +1,18 @@
 package http
 
 import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/health"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
+	sync "github.com/alexfalkowski/go-sync"
 )
 
 // Module wires the HTTP transport stack into [go.uber.org/fx].
@@ -19,7 +22,15 @@ import (
 //   - mux, route policy, and router construction ([http.NewServeMux], [http.NewRoutePolicy], [http.NewRouter])
 //   - content negotiation and encoding ([content.NewContent])
 //   - MVC view rendering helpers ([mvc.NewFunctionMap], [mvc.Register])
-//   - RPC and REST routing ([rpc.Register], [rest.Register])
+//   - RPC and REST routing ([rpc.Register], [rest.Register] — called from [registerRoutes] rather than
+//     as their own separate Fx invoke targets, so their timeout/maxReceiveSize arguments are plain
+//     values this package computes from its own *[Config], not separate Fx-resolved dependencies),
+//     including the streaming route helpers (rest.StreamRoute/StreamGet/StreamRouteRequest/StreamPost/
+//     StreamPut/StreamPatch and rpc.StreamRoute): a successful Send extends the response write deadline,
+//     while a successful Recv on a bidirectional stream extends the request read deadline (see
+//     [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]); bidirectional
+//     streaming routes also bound each decoded request value instead of the request body's cumulative size
+//     (see [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler])
 //   - transport-level middleware wiring (limiter and token helpers)
 //   - server construction ([NewServer])
 //   - operational endpoints (Prometheus metrics and health)
@@ -34,8 +45,7 @@ var Module = di.Module(
 	di.Constructor(content.NewContent),
 	di.Constructor(mvc.NewFunctionMap),
 	di.Register(mvc.Register),
-	di.Register(rpc.Register),
-	di.Register(rest.Register),
+	di.Register(registerRoutes),
 	di.Constructor(NewServerLimiter),
 	di.Constructor(NewToken),
 	di.Constructor(token.NewGenerator),
@@ -44,3 +54,27 @@ var Module = di.Module(
 	di.Register(metrics.Register),
 	health.Module,
 )
+
+// registerRoutes wires [rest.Register] and [rpc.Register] with the router, content, and buffer pool
+// dependencies Fx resolves normally, plus a timeout/maxReceiveSize pair computed here from cfg and
+// passed as plain arguments.
+//
+// Calling rest.Register/rpc.Register directly (rather than as their own separate Fx invoke targets)
+// means timeout ([time.Duration]) and maxReceiveSize ([bytes.Size]) never need to exist as their own DI
+// graph nodes: those are common, easily-collided types (nothing else in the DI graph keys on them, but
+// nothing stops something else from needing to someday), so resolving them by bare type would be
+// fragile in a way resolving *[Config] is not. net/http/rest and net/http/rpc must not import this
+// package (see AGENTS.md), so cfg's values are computed here and passed in, mirroring how NewServer
+// already derives its own ReadTimeout/WriteTimeout/max receive size from the same *Config.
+func registerRoutes(cfg *Config, router *http.Router, cont *content.Content, pool *sync.BufferPool) {
+	var timeout time.Duration
+	var maxReceiveSize bytes.Size
+
+	if cfg.IsEnabled() {
+		timeout = cfg.GetTimeout()
+		maxReceiveSize = cfg.GetMaxReceiveSize()
+	}
+
+	rest.Register(router, cont, pool, timeout, maxReceiveSize)
+	rpc.Register(router, cont, pool, timeout, maxReceiveSize)
+}

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -3,12 +3,15 @@ package http_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/client"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -185,4 +188,112 @@ func TestRestInvalidStatusCode(t *testing.T) {
 
 	err = world.Rest.Patch(t.Context(), url, opts)
 	require.Error(t, err)
+}
+
+func TestRestStreamPostRecvAndSendOverRealServer(t *testing.T) {
+	world := test.NewStartedWorld(t, test.WithWorldSecure(), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
+
+	rest.StreamPost("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+				return err
+			}
+		}
+	})
+
+	url := world.PathServerURL("https", "hello")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var greetings []string
+	err := world.Rest.RequestStream(ctx, http.MethodPost, url, rest.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			for _, name := range []string{"Bob", "Alice"} {
+				if err := stream.Send(&test.Request{Name: name}); err != nil {
+					return err
+				}
+
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					return err
+				}
+
+				greetings = append(greetings, res.Greeting)
+			}
+
+			return nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice"}, greetings)
+}
+
+func TestRestStreamPostRefreshesReadDeadlineOverH2C(t *testing.T) {
+	config := test.NewInsecureTransportConfig()
+	config.HTTP.Timeout = 100 * time.Millisecond
+	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
+	rest.Register(world.Router, test.Content, test.Pool, config.HTTP.GetTimeout(), config.HTTP.GetMaxReceiveSize())
+
+	rest.StreamPost("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+				return err
+			}
+		}
+	})
+	world.Start()
+
+	transport := http.Transport(nil)
+	transport.Protocols.SetHTTP1(false)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(transport))
+
+	url := world.PathServerURL("http", "hello")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var greetings []string
+	err := c.RequestStream(ctx, http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			for index, name := range []string{"Bob", "Alice", "Carol", "Dan"} {
+				if index > 0 {
+					time.Sleep(40 * time.Millisecond)
+				}
+
+				if err := stream.Send(&test.Request{Name: name}); err != nil {
+					return err
+				}
+
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					return err
+				}
+
+				greetings = append(greetings, res.Greeting)
+			}
+
+			time.Sleep(120 * time.Millisecond)
+			return stream.Send(&test.Request{Name: "Eve"})
+		})
+	require.Error(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice", "Hello Carol", "Hello Dan"}, greetings)
 }

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -4,13 +4,16 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/client"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +29,6 @@ func TestRPCNoContent(t *testing.T) {
 			client := rpc.NewClient(world.ServerURL("http"),
 				rpc.WithClientContentType(mt.ContentType),
 				rpc.WithClientRoundTripper(httpClient.Transport),
-				rpc.WithClientTimeout("10s"),
 			)
 			req := &test.Request{Name: "Bob"}
 			res := &test.Response{}
@@ -41,25 +43,30 @@ func TestRPCNoContent(t *testing.T) {
 func TestRPCWithContent(t *testing.T) {
 	for _, mt := range test.MessageMediaTypes() {
 		t.Run(mt.Name, func(t *testing.T) {
-			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
-
-			rpc.Route("/hello", test.SuccessSayHello)
-			httpClient, err := world.NewHTTP()
-			require.NoError(t, err)
-
-			client := rpc.NewClient(world.ServerURL("http"),
-				rpc.WithClientContentType(mt.ContentType),
-				rpc.WithClientRoundTripper(httpClient.Transport),
-				rpc.WithClientTimeout("10s"),
-			)
-			req := &test.Request{Name: "Bob"}
-			res := &test.Response{}
-
-			err = client.Post(t.Context(), "/hello", req, res)
-			require.NoError(t, err)
-			require.Equal(t, "Hello Bob", res.Greeting)
+			requireSuccessfulRPCPost(t, mt.ContentType)
 		})
 	}
+}
+
+func requireSuccessfulRPCPost(t *testing.T, contentType string) {
+	t.Helper()
+
+	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
+
+	rpc.Route("/hello", test.SuccessSayHello)
+	httpClient, err := world.NewHTTP()
+	require.NoError(t, err)
+
+	client := rpc.NewClient(world.ServerURL("http"),
+		rpc.WithClientContentType(contentType),
+		rpc.WithClientRoundTripper(httpClient.Transport),
+	)
+	req := &test.Request{Name: "Bob"}
+	res := &test.Response{}
+
+	err = client.Post(t.Context(), "/hello", req, res)
+	require.NoError(t, err)
+	require.Equal(t, "Hello Bob", res.Greeting)
 }
 
 func TestSuccessProtobufRPC(t *testing.T) {
@@ -192,21 +199,7 @@ func TestRPCNotFound(t *testing.T) {
 func TestAllowedRPC(t *testing.T) {
 	for _, mt := range test.MessageMediaTypes() {
 		t.Run(mt.Name, func(t *testing.T) {
-			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
-
-			rpc.Route("/hello", test.SuccessSayHello)
-			httpClient, err := world.NewHTTP()
-			require.NoError(t, err)
-
-			client := rpc.NewClient(world.ServerURL("http"),
-				rpc.WithClientContentType(mt.ContentType),
-				rpc.WithClientRoundTripper(httpClient.Transport))
-			req := &test.Request{Name: "Bob"}
-			res := &test.Response{}
-
-			err = client.Post(t.Context(), "/hello", req, res)
-			require.NoError(t, err)
-			require.Equal(t, "Hello Bob", res.Greeting)
+			requireSuccessfulRPCPost(t, mt.ContentType)
 		})
 	}
 }
@@ -272,4 +265,65 @@ func TestInvalidRPCResponse(t *testing.T) {
 			require.Error(t, client.Post(t.Context(), "/hello", &test.Request{Name: "Bob"}, nil))
 		})
 	}
+}
+
+func TestRPCStreamRouteRefreshesReadDeadlineOverHTTP2(t *testing.T) {
+	config := test.NewSecureTransportConfig()
+	config.HTTP.Timeout = 100 * time.Millisecond
+	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldSecure(), test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
+	rpc.Register(world.Router, test.Content, test.Pool, config.HTTP.GetTimeout(), config.HTTP.GetMaxReceiveSize())
+
+	rpc.StreamRoute("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if stream.IsFinished(err) {
+					return nil
+				}
+
+				return err
+			}
+
+			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+				return err
+			}
+		}
+	})
+	world.Start()
+
+	httpClient, err := world.NewHTTP()
+	require.NoError(t, err)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(httpClient.Transport))
+
+	url := world.PathServerURL("https", "hello")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var greetings []string
+	err = c.RequestStream(ctx, http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			for index, name := range []string{"Bob", "Alice", "Carol", "Dan"} {
+				if index > 0 {
+					time.Sleep(40 * time.Millisecond)
+				}
+
+				if err := stream.Send(&test.Request{Name: name}); err != nil {
+					return err
+				}
+
+				var res test.Response
+				if err := stream.Recv(&res); err != nil {
+					return err
+				}
+
+				greetings = append(greetings, res.Greeting)
+			}
+
+			time.Sleep(120 * time.Millisecond)
+			return stream.Send(&test.Request{Name: "Eve"})
+		})
+	require.Error(t, err)
+	require.Equal(t, []string{"Hello Bob", "Hello Alice", "Hello Carol", "Hello Dan"}, greetings)
 }

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -102,13 +102,19 @@ type ServerParams struct {
 //   - optional token verification ([github.com/alexfalkowski/go-service/v2/transport/http/token]) when `params.Verifier` is non-nil
 //   - optional rate limiting ([github.com/alexfalkowski/go-service/v2/transport/http/limiter]) when `params.Limiter` is non-nil
 //   - optional access control ([github.com/alexfalkowski/go-service/v2/transport/http/token]) when `params.Access` is non-nil
-//   - inbound request body size limiting ([github.com/alexfalkowski/go-service/v2/transport/http/body])
+//   - inbound request body size limiting ([github.com/alexfalkowski/go-service/v2/transport/http/body]); routes
+//     registered as streaming (see `params.RoutePolicy`) are never buffered by this middleware, and
+//     bidirectional streaming routes cap each decoded request value independently at the content layer
+//     instead (see [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv])
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - gzip compression wrapping the final mux handler, including not-found fallbacks ([github.com/klauspost/compress/gzhttp.GzipHandler] with [http.NewNotFoundHandler])
 //
 // Route policy from `params.RoutePolicy` controls middleware bypasses. Registered operation routes
 // (health/metrics/etc.) bypass logging, token verification, rate limiting, and access control.
-// Registered unauthenticated routes bypass token verification and access control only.
+// Registered unauthenticated routes bypass token verification and access control only. Registered
+// streaming routes are never buffered by the inbound body middleware (see
+// [github.com/alexfalkowski/go-service/v2/transport/http/body.NewHandler]); they keep the
+// declared-Content-Length short-circuit but no cumulative mid-stream limit.
 //
 // TLS:
 //
@@ -149,7 +155,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(token.NewAccessHandler(params.RoutePolicy, params.Access))
 	}
 
-	neg.Use(body.NewHandler(params.Config.GetMaxReceiveSize().Bytes()))
+	neg.Use(body.NewHandler(params.RoutePolicy, params.Config.GetMaxReceiveSize().Bytes()))
 
 	for _, hd := range params.Handlers {
 		neg.Use(hd)

--- a/transport/http/telemetry/logger/logger.go
+++ b/transport/http/telemetry/logger/logger.go
@@ -63,7 +63,13 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	attrs = append(attrs, logger.String(meta.MethodKey, method))
 	defer func() {
 		if value := recover(); value != nil {
-			h.logPanic(ctx, attrs, runtime.ConvertRecover(value), time.Since(start).String())
+			// A streaming handler that already committed its response aborts via
+			// http.ErrAbortHandler (see net/http/content's streaming error contract) so net/http can
+			// sever the in-flight connection. That is an intentional, expected outcome of a truncated
+			// stream, not a bug, so it must not be logged as a recovered panic.
+			if err, ok := value.(error); !ok || !errors.Is(err, http.ErrAbortHandler) {
+				h.logPanic(ctx, attrs, runtime.ConvertRecover(value), time.Since(start).String())
+			}
 			panic(value)
 		}
 	}()

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -85,6 +85,39 @@ func TestHandlerSkipsOperationPath(t *testing.T) {
 	require.Empty(t, logs.String())
 }
 
+func TestHandlerLogsRecoveredPanic(t *testing.T) {
+	var logs bytes.Buffer
+	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+	handler := httplogger.NewHandler(http.NewRoutePolicy(), &logger.Logger{Logger: slogLogger})
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/greeter/say-hello", http.NoBody)
+
+	require.PanicsWithValue(t, "boom", func() {
+		handler.ServeHTTP(res, req, func(_ http.ResponseWriter, _ *http.Request) {
+			panic("boom")
+		})
+	})
+
+	require.Contains(t, logs.String(), `"msg":"http: panic"`)
+	require.Contains(t, logs.String(), `"level":"ERROR"`)
+}
+
+func TestHandlerSuppressesAbortHandlerPanicLog(t *testing.T) {
+	var logs bytes.Buffer
+	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+	handler := httplogger.NewHandler(http.NewRoutePolicy(), &logger.Logger{Logger: slogLogger})
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/greeter/say-hello", http.NoBody)
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req, func(_ http.ResponseWriter, _ *http.Request) {
+			panic(http.ErrAbortHandler)
+		})
+	})
+
+	require.Empty(t, logs.String())
+}
+
 func TestRoundTripperLogsTransportError(t *testing.T) {
 	var logs bytes.Buffer
 	transportErr := errors.New("dial failed")

--- a/transport/limiter/benchmark_test.go
+++ b/transport/limiter/benchmark_test.go
@@ -4,16 +4,16 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/fxtest"
 )
 
 // BenchmarkLimiterManyDistinctKeys measures limiter behavior after its independent-key cap is reached.
 func BenchmarkLimiterManyDistinctKeys(b *testing.B) {
-	lc := fxtest.NewLifecycle(b)
+	lc := test.QuietLifecycle(b)
 	lim, err := limiter.NewLimiter(lc, limiter.KeyMap{"user-agent": meta.UserAgent}, &limiter.Config{
 		Kind:     "user-agent",
 		Tokens:   1,


### PR DESCRIPTION
## What

- Adds NDJSON streaming for REST and RPC routes, including send-only and bidirectional helpers, while restoring the default 30-second timeout and timeout options for unary REST/RPC clients.
- Applies unary timeouts through the request context only, so long-lived `Stream` and `RequestStream` calls remain governed by their caller-provided contexts.
- Corrects per-value streaming size accounting when a decoder reads ahead, and refreshes the server read deadline after each successful bidirectional receive over HTTP/2 and h2c.
- Retains the intentional `rest.Register`/`rpc.Register` positional-argument migration; callers affected by the earlier timeout removal can use the restored `WithTimeout` or `WithClientTimeout` options again.

## Why

- Unary clients need a safe default deadline, but a whole-client timeout incorrectly terminates healthy long-lived streams.
- Decoder buffering and a fixed request read deadline could otherwise let an oversized buffered value evade its cap or close an active bidirectional stream despite regular messages.

## Testing

- `make lint` - passed
- `make specs` - initially ran 2,587 tests; the changed HTTP suites passed, but an unrelated `transport/grpc/health` test timed out while the local Loki endpoint returned `400 snappy: corrupt input`; `make package=transport/grpc/health specs` then passed (25 tests).
- `make sec` - passed; no reachable vulnerabilities or secrets were reported.
- Added coverage for unary REST/RPC timeout options, buffered oversized stream values, long-lived streams with a configured unary timeout, and read-deadline refresh over HTTP/2 and h2c.

AI-assisted-by: [Codex](https://openai.com/codex/)
