### PR TITLE
feat(http): wrap gzhttp behind a dedicated compress package

### DIFF
--- a/net/http/compress/compress.go
+++ b/net/http/compress/compress.go
@@ -1,0 +1,25 @@
+package compress
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/klauspost/compress/gzhttp"
+)
+
+// HeaderNoCompression is an alias for [gzhttp.HeaderNoCompression].
+//
+// Setting this response header before the response is written disables gzip compression for that response.
+const HeaderNoCompression = gzhttp.HeaderNoCompression
+
+// GzipHandler wraps h so its response is transparently gzip-compressed for clients that advertise support.
+//
+// This is a thin wrapper around [gzhttp.GzipHandler].
+func GzipHandler(h http.Handler) http.HandlerFunc {
+	return gzhttp.GzipHandler(h)
+}
+
+// Transport wraps rt so outbound requests advertise gzip support and gzipped responses are transparently decompressed.
+//
+// This is a thin wrapper around [gzhttp.Transport] with gzip compression enabled.
+func Transport(rt http.RoundTripper) http.RoundTripper {
+	return gzhttp.Transport(rt, gzhttp.TransportEnableGzip(true))
+}

--- a/net/http/content/stream.go
+++ b/net/http/content/stream.go
@@ -7,11 +7,11 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/klauspost/compress/gzhttp"
 )
 
 // StreamHandler handles a send-only stream: the response streams, the request does not.
@@ -71,7 +71,7 @@ func NewStreamHandler[Res any](cont *Content, timeout time.Duration, handler Str
 
 		ctx = meta.WithContent(ctx, req, res, nil)
 		res.Header().Set(TypeKey, resMedia.WithUTF8())
-		res.Header().Set(gzhttp.HeaderNoCompression, "1")
+		res.Header().Set(compress.HeaderNoCompression, "1")
 
 		buffer := cont.pool.Get()
 		defer cont.pool.Put(buffer)
@@ -148,7 +148,7 @@ func NewRequestStreamHandler[Req any, Res any](cont *Content, timeout time.Durat
 
 		ctx = meta.WithContent(ctx, req, res, nil)
 		res.Header().Set(TypeKey, resMedia.WithUTF8())
-		res.Header().Set(gzhttp.HeaderNoCompression, "1")
+		res.Header().Set(compress.HeaderNoCompression, "1")
 
 		buffer := cont.pool.Get()
 		defer cont.pool.Put(buffer)

--- a/net/http/content/stream_test.go
+++ b/net/http/content/stream_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/klauspost/compress/gzhttp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +39,7 @@ func TestNewStreamHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
-	require.NotEmpty(t, res.Header().Get(gzhttp.HeaderNoCompression))
+	require.NotEmpty(t, res.Header().Get(compress.HeaderNoCompression))
 
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
@@ -51,7 +51,7 @@ func TestNewStreamHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
 	inner := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
-	handler := gzhttp.GzipHandler(inner)
+	handler := compress.GzipHandler(inner)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(content.AcceptKey, media.NDJSON)

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/breaker"
@@ -14,7 +15,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/retry"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
-	"github.com/klauspost/compress/gzhttp"
 )
 
 // ClientOption configures HTTP client construction.
@@ -55,7 +55,7 @@ func (f clientOptionFunc) apply(o *clientOpts) {
 // When enabled, the composed RoundTripper will advertise support for gzip and transparently decompress
 // gzipped responses when the server sends them.
 //
-// This option uses [github.com/klauspost/compress/gzhttp] and wraps the underlying transport.
+// This option uses [github.com/alexfalkowski/go-service/v2/net/http/compress] and wraps the underlying transport.
 func WithClientCompression() ClientOption {
 	return clientOptionFunc(func(o *clientOpts) {
 		o.compression = true
@@ -222,7 +222,7 @@ func NewRoundTripper(opts ...ClientOption) (http.RoundTripper, error) {
 	}
 
 	if resolved.compression {
-		hrt = gzhttp.Transport(hrt, gzhttp.TransportEnableGzip(true))
+		hrt = compress.Transport(hrt)
 	}
 
 	if resolved.gen != nil {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
@@ -22,7 +23,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	sync "github.com/alexfalkowski/go-sync"
-	"github.com/klauspost/compress/gzhttp"
 )
 
 // ServerParams defines dependencies for constructing an HTTP transport [Server].
@@ -107,7 +107,8 @@ type ServerParams struct {
 //     bidirectional streaming routes cap each decoded request value independently at the content layer
 //     instead (see [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv])
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
-//   - gzip compression wrapping the final mux handler, including not-found fallbacks ([github.com/klauspost/compress/gzhttp.GzipHandler] with [http.NewNotFoundHandler])
+//   - gzip compression wrapping the final mux handler, including not-found fallbacks
+//     ([github.com/alexfalkowski/go-service/v2/net/http/compress.GzipHandler] with [http.NewNotFoundHandler])
 //
 // Route policy from `params.RoutePolicy` controls middleware bypasses. Registered operation routes
 // (health/metrics/etc.) bypass logging, token verification, rate limiting, and access control.
@@ -162,7 +163,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	}
 
 	handler := http.NewNotFoundHandler(params.Mux, params.Pool, mvc.NotFoundHandler(), content.NotFoundHandler())
-	neg.UseHandler(gzhttp.GzipHandler(handler))
+	neg.UseHandler(compress.GzipHandler(handler))
 
 	handler = http.NewTelemetryHandler(neg, "http.server")
 	httpServer := http.NewServer(params.Config.Options, params.Config.GetTimeout(), handler)


### PR DESCRIPTION
## What

- Extracted the three call sites that used `github.com/klauspost/compress/gzhttp` directly (`net/http/content.Stream`, `transport/http.Server`, `transport/http.NewRoundTripper`) into a new `net/http/compress` package exposing `HeaderNoCompression`, `GzipHandler`, and `Transport`.
- Behavior is unchanged: `GzipHandler` and `Transport` still delegate to the same upstream `gzhttp.GzipHandler`/`gzhttp.Transport` (with gzip enabled) they replaced.
- Updated `transport/http.Server`'s GoDoc handler-chain comment to reference the new package instead of `gzhttp` directly, and rewrapped the line to stay under the repository's line-length limit.

## Why

- Centralizes go-service's dependency on `klauspost/compress/gzhttp` behind one local package instead of three call sites, so a future change to compression behavior, or swapping the underlying library, only touches one file.

## Testing

- `package=net/http/compress make specs` - passed (no tests; this package is a zero-branch delegation wrapper, matching the existing repo convention for similar thin wrappers such as `ptr` and `id/uuid` that rely on indirect coverage from callers)
- `package=net/http/content make specs` - passed
- `package=transport/http make specs` - passed
- `package=net/http/compress make golangci-lint` - passed
- `package=net/http/content make golangci-lint` - passed
- `package=transport/http make golangci-lint` - passed (caught and fixed a doc-comment line-length issue introduced by the package rename)
- `go build ./...` - passed
- `go vet ./net/http/... ./transport/http/...` - passed
- `gofmt -l` on the changed packages - clean

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
