### PR TITLE
feat(http): improve bidirectional stream deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1158,9 +1158,13 @@ back to JSON, unlike single-value negotiation.
 > - `max_receive_size` applies per decoded value on a streaming request body, not as a cumulative total
 >   across the whole stream; overall stream volume is controlled by the configured rate limiter instead,
 >   which charges one token per streamed message in addition to the token charged when the stream opens.
-> - A successful `Send` extends the HTTP server's configured write timeout, so a slow-but-active stream
->   is not severed by a whole-stream deadline; bound a client-side streaming call with the request
->   context instead of the client's overall request timeout.
+> - A successful `Send` extends the HTTP server's configured write timeout, and on a bidirectional
+>   stream a successful `Recv` extends both the read and write timeouts (and `Send` extends both too),
+>   so a slow-but-active stream is not severed by a whole-stream deadline in either direction; bound a
+>   client-side streaming call with the request context instead of the client's overall request timeout.
+> - The per-message read/write timeouts follow the same `options.read_timeout`/`options.write_timeout`
+>   precedence as the server's own timeouts (see [Transport configuration (servers)](#transport-configuration-servers)),
+>   falling back to `timeout` when the corresponding option is unset.
 > - Streaming requests are never retried by the client's retry middleware.
 
 ### HTTP route misses

--- a/config/server/config.go
+++ b/config/server/config.go
@@ -74,6 +74,32 @@ func (c *Config) GetTimeout() time.Duration {
 	return c.Timeout
 }
 
+// GetReadTimeout returns the configured read timeout, resolved from the "read_timeout" [Config.Options]
+// key and falling back to [Config.GetTimeout] — the same options-aware precedence
+// [github.com/alexfalkowski/go-service/v2/net/http.NewServer] uses for the server's own ReadTimeout.
+//
+// A nil receiver falls back to [time.DefaultTimeout] (through GetTimeout).
+func (c *Config) GetReadTimeout() time.Duration {
+	if c == nil {
+		return time.DefaultTimeout
+	}
+
+	return c.Options.NonNegativeDuration("read_timeout", c.GetTimeout())
+}
+
+// GetWriteTimeout returns the configured write timeout, resolved from the "write_timeout"
+// [Config.Options] key and falling back to [Config.GetTimeout] — the same options-aware precedence
+// [github.com/alexfalkowski/go-service/v2/net/http.NewServer] uses for the server's own WriteTimeout.
+//
+// A nil receiver falls back to [time.DefaultTimeout] (through GetTimeout).
+func (c *Config) GetWriteTimeout() time.Duration {
+	if c == nil {
+		return time.DefaultTimeout
+	}
+
+	return c.Options.NonNegativeDuration("write_timeout", c.GetTimeout())
+}
+
 // NewConfig constructs a server-side runtime TLS config from cfg.
 //
 // If cfg is nil or empty, NewConfig returns a TLS 1.3-or-newer config that does

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -48,6 +49,45 @@ func TestGetTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, tt.cfg.GetTimeout())
 		})
+	}
+}
+
+func TestGetReadAndWriteTimeout(t *testing.T) {
+	getters := []struct {
+		get   func(*server.Config) time.Duration
+		key   string
+		other string
+	}{
+		{key: "read_timeout", other: "write_timeout", get: (*server.Config).GetReadTimeout},
+		{key: "write_timeout", other: "read_timeout", get: (*server.Config).GetWriteTimeout},
+	}
+
+	for _, g := range getters {
+		tests := []struct {
+			cfg  *server.Config
+			name string
+			want time.Duration
+		}{
+			{name: "nil", want: time.DefaultTimeout},
+			{name: "zero", cfg: &server.Config{}, want: time.DefaultTimeout},
+			{name: "falls back to timeout", cfg: &server.Config{Timeout: 5 * time.Second}, want: 5 * time.Second},
+			{
+				name: "diverges from timeout via option",
+				cfg:  &server.Config{Timeout: 5 * time.Second, Options: options.Map{g.key: "10s"}},
+				want: 10 * time.Second,
+			},
+			{
+				name: "unaffected by the other direction's option",
+				cfg:  &server.Config{Timeout: 5 * time.Second, Options: options.Map{g.other: "10s"}},
+				want: 5 * time.Second,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(g.key+" "+tt.name, func(t *testing.T) {
+				require.Equal(t, tt.want, g.get(tt.cfg))
+			})
+		}
 	}
 }
 

--- a/internal/test/http.go
+++ b/internal/test/http.go
@@ -62,6 +62,54 @@ type NoFlushResponseWriter struct {
 	Code int
 }
 
+// DeadlineResponseWriter is an [http.ResponseWriter] test double that implements
+// [http.ResponseController.SetReadDeadline] and [http.ResponseController.SetWriteDeadline] through
+// caller-supplied functions, letting a test control exactly when each deadline extension succeeds or
+// fails (including across repeated calls within one request, via a closure with its own counter). A
+// nil func always succeeds.
+type DeadlineResponseWriter struct {
+	SetReadDeadlineFunc  func() error
+	SetWriteDeadlineFunc func() error
+	Body                 bytes.Buffer
+	Code                 int
+}
+
+// Header is always empty.
+func (w *DeadlineResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+// Write appends p to Body.
+func (w *DeadlineResponseWriter) Write(p []byte) (int, error) {
+	return w.Body.Write(p)
+}
+
+// WriteHeader stores code in the Code field.
+func (w *DeadlineResponseWriter) WriteHeader(code int) {
+	w.Code = code
+}
+
+// Flush is a no-op, satisfying [http.Flusher].
+func (w *DeadlineResponseWriter) Flush() {}
+
+// SetReadDeadline calls SetReadDeadlineFunc, or succeeds if it is nil.
+func (w *DeadlineResponseWriter) SetReadDeadline(time.Time) error {
+	if w.SetReadDeadlineFunc == nil {
+		return nil
+	}
+
+	return w.SetReadDeadlineFunc()
+}
+
+// SetWriteDeadline calls SetWriteDeadlineFunc, or succeeds if it is nil.
+func (w *DeadlineResponseWriter) SetWriteDeadline(time.Time) error {
+	if w.SetWriteDeadlineFunc == nil {
+		return nil
+	}
+
+	return w.SetWriteDeadlineFunc()
+}
+
 // Header is always empty.
 func (w *NoFlushResponseWriter) Header() http.Header {
 	return http.Header{}

--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -87,7 +87,7 @@ func RestRequestError(_ context.Context, _ *Request) (*Response, error) {
 }
 
 func registerRest(router *http.Router) {
-	rest.Register(router, Content, Pool, 0, 0)
+	rest.Register(router, Content, Pool, content.StreamOptions{})
 }
 
 func restClient(client *http.Client, os *worldOpts) *rest.Client {

--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	g "github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	h "github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -70,5 +71,5 @@ func ErrorsInternalProtobufSayHello(_ context.Context, _ *v1.SayHelloRequest) (*
 }
 
 func (w *World) registerRPC() {
-	rpc.Register(w.Router, Content, Pool, 0, 0)
+	rpc.Register(w.Router, Content, Pool, content.StreamOptions{})
 }

--- a/net/http/client/example_test.go
+++ b/net/http/client/example_test.go
@@ -17,7 +17,7 @@ import (
 func ExampleClient_RequestStream() {
 	pool := sync.NewBufferPool()
 	cont := content.NewContent(encoding.NewMap(), stream.NewMap(), pool)
-	handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, stream *content.RequestStream[exampleRequest, exampleResponse]) error {
+	handler := content.NewRequestStreamHandler(cont, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[exampleRequest, exampleResponse]) error {
 		req, err := stream.Recv()
 		if err != nil {
 			return err

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestStreamRecvsValues(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func TestStreamRecvsValues(t *testing.T) {
 func TestStreamGetIssuesGetRequest(t *testing.T) {
 	var method string
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
 
@@ -103,7 +103,7 @@ func TestStreamPostPutPatchIssueBidiRequests(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var method string
 
-			handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+			handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 				req, err := stream.Recv()
 				if err != nil {
 					return err
@@ -202,7 +202,7 @@ func TestStreamSurfacesErrorResponseBeforeCallingHandler(t *testing.T) {
 }
 
 func TestRequestStreamInterleavesOverHTTP2(t *testing.T) {
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		for {
 			req, err := stream.Recv()
 			if err != nil {
@@ -306,7 +306,7 @@ func TestRequestStreamSurfacesErrorResponseViaRecv(t *testing.T) {
 }
 
 func TestRequestStreamSendIsSticky(t *testing.T) {
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		for {
 			if _, err := stream.Recv(); err != nil {
 				if stream.IsFinished(err) {
@@ -341,7 +341,7 @@ func TestRequestStreamSendIsSticky(t *testing.T) {
 }
 
 func TestStreamRejectsValueOverCap(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "a greeting far longer than the configured cap"})
 	})
 
@@ -361,7 +361,7 @@ func TestStreamRejectsValueOverCap(t *testing.T) {
 }
 
 func TestStreamRejectsValueOverCapWhenDecodeSucceedsInOneRead(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "a greeting far longer than the configured cap"})
 	})
 
@@ -409,7 +409,7 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+			handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 				return stream.Send(&test.Response{Greeting: tt.greeting})
 			})
 
@@ -439,7 +439,7 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 func TestStreamCapIsPerValueNotCumulative(t *testing.T) {
 	const values = 10
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		for range values {
 			if err := stream.Send(&test.Response{Greeting: "hi"}); err != nil {
 				return err
@@ -583,7 +583,7 @@ func TestRequestStreamClosesPipeOnHandlerPanic(t *testing.T) {
 }
 
 func TestStreamSurvivesSlowValuesWithConfiguredUnaryTimeout(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}

--- a/net/http/content/stream.go
+++ b/net/http/content/stream.go
@@ -15,6 +15,26 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
+// StreamOptions configures the streaming route helpers built by [NewStreamHandler] and
+// [NewRequestStreamHandler].
+//
+// The zero value disables every knob: no deadline extension and no per-value receive cap, matching
+// today's behavior when no options are supplied.
+type StreamOptions struct {
+	// ReadTimeout is the per-message inactivity budget applied to [RequestStream.Recv]'s request read
+	// deadline. Zero disables read deadline extension. Unused by [NewStreamHandler]'s send-only stream.
+	ReadTimeout time.Duration
+
+	// WriteTimeout is the per-message inactivity budget applied to [Stream.Send]'s response write
+	// deadline. Zero disables write deadline extension.
+	WriteTimeout time.Duration
+
+	// MaxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a
+	// whole (see [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]). Zero disables the
+	// per-value cap. Unused by [NewStreamHandler]'s send-only stream.
+	MaxReceiveSize bytes.Size
+}
+
 // StreamHandler handles a send-only stream: the response streams, the request does not.
 //
 // The handler must propagate a [Stream.Send] error by returning it (directly, or wrapped) rather than
@@ -45,9 +65,9 @@ type RequestStreamHandler[Req any, Res any] func(ctx context.Context, stream *Re
 // response via panic([http.ErrAbortHandler]) instead, since the response is already committed — see
 // [Stream.Send] and [finalizeStream].
 //
-// timeout, when positive, is pushed forward as the response write deadline after every successful
-// Send (see [http.ResponseController.SetWriteDeadline]), turning a whole-stream write timeout into a
-// per-message inactivity budget. Pass zero to disable this.
+// opts.WriteTimeout, when positive, is pushed forward as the response write deadline after every
+// successful Send (see [http.ResponseController.SetWriteDeadline]), turning a whole-stream write
+// timeout into a per-message inactivity budget. Zero disables this.
 //
 // Load control:
 // If the request context carries a limiter (see [meta.WithLimiter], populated by
@@ -55,7 +75,7 @@ type RequestStreamHandler[Req any, Res any] func(ctx context.Context, stream *Re
 // allowed to open the stream), every Send charges one additional token against that same limiter — see
 // [Stream.Send]. A route reached without that middleware, or with no limiter configured, sees no
 // per-message charging.
-func NewStreamHandler[Res any](cont *Content, timeout time.Duration, handler StreamHandler[Res]) http.HandlerFunc {
+func NewStreamHandler[Res any](cont *Content, opts StreamOptions, handler StreamHandler[Res]) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		limiter := meta.Limiter(ctx)
@@ -79,12 +99,12 @@ func NewStreamHandler[Res any](cont *Content, timeout time.Duration, handler Str
 
 		writer := &commitWriter{res: res, buffer: buffer}
 		st := &Stream[Res]{
-			ctx:        ctx,
-			writer:     writer,
-			encoder:    resMedia.NewEncoder(writer),
-			controller: http.NewResponseController(res),
-			timeout:    timeout,
-			limiter:    limiter,
+			ctx:          ctx,
+			writer:       writer,
+			encoder:      resMedia.NewEncoder(writer),
+			controller:   http.NewResponseController(res),
+			writeTimeout: opts.WriteTimeout,
+			limiter:      limiter,
 		}
 		finalizeStream(ctx, res, st, handler(ctx, st))
 	}
@@ -105,22 +125,23 @@ func NewStreamHandler[Res any](cont *Content, timeout time.Duration, handler Str
 // so a failure there is answered as RFC 9110 §15.5.7 rather than §15.5.16.
 //
 // Inbound size limiting:
-// maxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a whole
-// (see [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]): a request with many small
+// opts.MaxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a
+// whole (see [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]): a request with many small
 // values is never rejected for its cumulative size, only
-// for a single value that exceeds maxReceiveSize. A value at or under the limit is a normal terminal
+// for a single value that exceeds opts.MaxReceiveSize. A value at or under the limit is a normal terminal
 // [http.MaxBytesError] surfaced from Recv; the deviation is that no total byte ceiling exists for a
 // streaming route the way [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler]'s buffered
-// path enforces one. maxReceiveSize <= 0 disables the per-value cap entirely.
+// path enforces one. opts.MaxReceiveSize <= 0 disables the per-value cap entirely.
 //
 // Timeout:
-// When timeout is positive, every successful [RequestStream.Recv] extends the request read deadline
-// and every successful [Stream.Send] extends the response write deadline. This turns the server's
-// whole-request read and write timeouts into per-message inactivity budgets. Pass zero to disable this.
+// When opts.ReadTimeout is positive, every successful [RequestStream.Recv] extends the request read
+// deadline; when opts.WriteTimeout is positive, every successful [Stream.Send] extends the response
+// write deadline. This turns the server's whole-request read and write timeouts into per-message
+// inactivity budgets. Zero disables the corresponding extension.
 //
 // See [NewStreamHandler] for the error contract and load control: Recv charges one token per successfully
 // decoded, in-cap value, the same way Send does, against the same request-scoped limiter.
-func NewRequestStreamHandler[Req any, Res any](cont *Content, timeout time.Duration, maxReceiveSize bytes.Size, handler RequestStreamHandler[Req, Res]) http.HandlerFunc {
+func NewRequestStreamHandler[Req any, Res any](cont *Content, opts StreamOptions, handler RequestStreamHandler[Req, Res]) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		limiter := meta.Limiter(ctx)
@@ -154,19 +175,20 @@ func NewRequestStreamHandler[Req any, Res any](cont *Content, timeout time.Durat
 		defer cont.pool.Put(buffer)
 
 		writer := &commitWriter{res: res, buffer: buffer}
-		capped := budget.NewReader(req.Body, maxReceiveSize.Bytes())
+		capped := budget.NewReader(req.Body, opts.MaxReceiveSize.Bytes())
 		st := &RequestStream[Req, Res]{
 			Stream: Stream[Res]{
-				ctx:        ctx,
-				writer:     writer,
-				encoder:    resMedia.NewEncoder(writer),
-				controller: http.NewResponseController(res),
-				timeout:    timeout,
-				limiter:    limiter,
+				ctx:          ctx,
+				writer:       writer,
+				encoder:      resMedia.NewEncoder(writer),
+				controller:   http.NewResponseController(res),
+				readTimeout:  opts.ReadTimeout,
+				writeTimeout: opts.WriteTimeout,
+				limiter:      limiter,
 			},
 			decoder:        reqMedia.NewDecoder(capped),
 			capped:         capped,
-			maxReceiveSize: maxReceiveSize.Bytes(),
+			maxReceiveSize: opts.MaxReceiveSize.Bytes(),
 		}
 		finalizeStream(ctx, res, st, handler(ctx, st))
 	}
@@ -183,7 +205,10 @@ type Stream[Res any] struct {
 	writer     *commitWriter
 	controller *http.ResponseController
 	limiter    meta.RateLimiter
-	timeout    time.Duration
+	// readTimeout is zero for a send-only [Stream] built by [NewStreamHandler]; [NewRequestStreamHandler]
+	// sets it, letting Send extend both deadlines for a bidirectional stream (see [Stream.Send]).
+	readTimeout  time.Duration
+	writeTimeout time.Duration
 }
 
 // Send encodes res and flushes it to the client.
@@ -192,6 +217,13 @@ type Stream[Res any] struct {
 // buffer so a failed first encode never writes a partial success body. Send is sticky: once it returns
 // a non-nil error, every later call returns that same error immediately, so a handler that ignores the
 // error degrades to a no-op rather than an infinite producer.
+//
+// Deadlines:
+// Send always extends the write deadline (see [NewStreamHandler]/[NewRequestStreamHandler]'s timeout
+// semantics). On a bidirectional stream built by [NewRequestStreamHandler], Send also extends the
+// request read deadline, the same way [RequestStream.Recv] extends the write deadline: activity in
+// either direction proves the peer is alive, so both deadlines move forward together and only genuine
+// inactivity in both directions severs the stream. This is a no-op for a send-only [Stream].
 //
 // Load control:
 // If a limiter was captured at construction (see [NewStreamHandler]), Send charges one limiter token
@@ -211,7 +243,12 @@ func (s *Stream[Res]) Send(res *Res) error {
 		return err
 	}
 
-	if err := s.extendDeadline(); err != nil {
+	if err := s.extendWriteDeadline(); err != nil {
+		s.err = err
+		return err
+	}
+
+	if err := s.extendReadDeadline(); err != nil {
 		s.err = err
 		return err
 	}
@@ -262,12 +299,24 @@ func (s *Stream[Res]) takeLimiterToken() error {
 	return nil
 }
 
-func (s *Stream[Res]) extendDeadline() error {
-	if s.timeout <= 0 {
+func (s *Stream[Res]) extendWriteDeadline() error {
+	if s.writeTimeout <= 0 {
 		return nil
 	}
 
-	return s.controller.SetWriteDeadline(time.Now().Add(s.timeout.Duration()))
+	return s.controller.SetWriteDeadline(time.Now().Add(s.writeTimeout.Duration()))
+}
+
+// extendReadDeadline extends the request read deadline. It is a no-op for a send-only [Stream] built
+// by [NewStreamHandler] (readTimeout stays zero there); [RequestStream.Recv] uses it directly, and
+// [Stream.Send] uses it too so a bidirectional stream's write-side activity also keeps the read side
+// alive (see [RequestStream]).
+func (s *Stream[Res]) extendReadDeadline() error {
+	if s.readTimeout <= 0 {
+		return nil
+	}
+
+	return s.controller.SetReadDeadline(time.Now().Add(s.readTimeout.Duration()))
 }
 
 func (s *Stream[Res]) committed() bool {
@@ -301,6 +350,14 @@ type RequestStream[Req any, Res any] struct {
 // [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler]'s buffered path already produces,
 // so it maps to the same 413 through [github.com/alexfalkowski/go-service/v2/net/http/status.Code].
 //
+// Deadlines:
+// Recv extends the read deadline before attempting Decode, so the wait for the next value — including
+// the first — is bounded by the configured timeout rather than only the calls after it. A successful
+// Recv extends the read deadline again (refreshing the wait for the value after this one) and also
+// extends the write deadline, the same way [Stream.Send] extends the read deadline: activity in either
+// direction proves the peer is alive, so both deadlines move forward together and only genuine
+// inactivity in both directions severs the stream.
+//
 // Load control:
 // If a limiter was captured at construction, Recv charges one limiter token after a value decodes
 // successfully and within the per-value cap, mirroring gRPC's per-RecvMsg charge (see
@@ -314,6 +371,10 @@ type RequestStream[Req any, Res any] struct {
 // capped's own latched error directly once Decode fails, rather than trusting Decode's returned error
 // to still be classifiable as the size-limit error.
 func (s *RequestStream[Req, Res]) Recv() (*Req, error) {
+	if err := s.extendReadDeadline(); err != nil {
+		return nil, err
+	}
+
 	s.capped.Reset(budget.BufferedLen(s.decoder))
 
 	req := ptr.Zero[Req]()
@@ -337,6 +398,10 @@ func (s *RequestStream[Req, Res]) Recv() (*Req, error) {
 		return nil, err
 	}
 
+	if err := s.extendWriteDeadline(); err != nil {
+		return nil, err
+	}
+
 	return req, nil
 }
 
@@ -344,14 +409,6 @@ func (s *RequestStream[Req, Res]) Recv() (*Req, error) {
 // request stream, letting a handler's Recv loop end cleanly without importing errors/io itself.
 func (s *RequestStream[Req, Res]) IsFinished(err error) bool {
 	return errors.Is(err, io.EOF)
-}
-
-func (s *RequestStream[Req, Res]) extendReadDeadline() error {
-	if s.timeout <= 0 {
-		return nil
-	}
-
-	return s.controller.SetReadDeadline(time.Now().Add(s.timeout.Duration()))
 }
 
 func (s *RequestStream[Req, Res]) close() error {

--- a/net/http/content/stream_test.go
+++ b/net/http/content/stream_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestNewStreamHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -48,7 +48,7 @@ func TestNewStreamHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
 }
 
 func TestNewStreamHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
-	inner := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	inner := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
 	handler := compress.GzipHandler(inner)
@@ -65,7 +65,7 @@ func TestNewStreamHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
 }
 
 func TestNewStreamHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, _ *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, _ *content.Stream[test.Response]) error {
 		return status.Error(http.StatusBadRequest, test.ErrFailed.Error())
 	})
 
@@ -80,7 +80,7 @@ func TestNewStreamHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
 }
 
 func TestNewStreamHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Unencodable]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Unencodable]) error {
 		return stream.Send(&test.Unencodable{})
 	})
 
@@ -95,7 +95,7 @@ func TestNewStreamHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
 }
 
 func TestNewStreamHandlerAbortsAfterCommit(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ func TestNewStreamHandlerAbortsAfterCommit(t *testing.T) {
 }
 
 func TestNewStreamHandlerRejectsUnsupportedMedia(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, _ *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, _ *content.Stream[test.Response]) error {
 		return nil
 	})
 
@@ -143,7 +143,7 @@ func TestNewStreamHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+			handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 				return stream.Send(&test.Response{Greeting: "Hello Bob"})
 			})
 
@@ -169,7 +169,7 @@ func TestNewStreamHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
 func TestNewStreamHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 2}
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -191,7 +191,7 @@ func TestNewStreamHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
 func TestNewStreamHandlerSendAbortsAfterCommitWhenLimiterExhausted(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 1}
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -221,7 +221,7 @@ func TestNewStreamHandlerSendPreCommitDenialMapsTo429(t *testing.T) {
 	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
 	res := httptest.NewRecorder()
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
 
@@ -232,7 +232,7 @@ func TestNewStreamHandlerSendPreCommitDenialMapsTo429(t *testing.T) {
 }
 
 func TestNewRequestStreamHandlerRejectsHTTP1(t *testing.T) {
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
 		return nil
 	})
 
@@ -248,7 +248,7 @@ func TestNewRequestStreamHandlerRejectsHTTP1(t *testing.T) {
 }
 
 func TestNewRequestStreamHandlerRecvAndSend(t *testing.T) {
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		for {
 			req, err := stream.Recv()
 			if err != nil {
@@ -284,7 +284,7 @@ func TestNewRequestStreamHandlerRecvAndSend(t *testing.T) {
 }
 
 func TestNewRequestStreamHandlerRejectsUnsupportedRequestMedia(t *testing.T) {
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
 		return nil
 	})
 
@@ -312,7 +312,8 @@ func TestNewRequestStreamHandlerRecvUnderCapSucceeds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var names []string
 
-			handler := content.NewRequestStreamHandler(test.Content, 0, tt.cap, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+			opts := content.StreamOptions{MaxReceiveSize: tt.cap}
+			handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 				for {
 					req, err := stream.Recv()
 					if err != nil {
@@ -345,7 +346,8 @@ func TestNewRequestStreamHandlerRecvUnderCapSucceeds(t *testing.T) {
 func TestNewRequestStreamHandlerRecvDeliversScalarValueAtExactCap(t *testing.T) {
 	pipeReader, pipeWriter := io.Pipe()
 
-	handler := content.NewRequestStreamHandler(test.Content, 0, bytes.Size(2), func(_ context.Context, stream *content.RequestStream[int, int]) error {
+	opts := content.StreamOptions{MaxReceiveSize: bytes.Size(2)}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[int, int]) error {
 		req, err := stream.Recv()
 		if err != nil {
 			return err
@@ -384,7 +386,8 @@ func TestNewRequestStreamHandlerRecvDeliversScalarValueAtExactCap(t *testing.T) 
 func TestNewRequestStreamHandlerRecvRejectsValueOverCap(t *testing.T) {
 	var recvErr error
 
-	handler := content.NewRequestStreamHandler(test.Content, 0, 16, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	opts := content.StreamOptions{MaxReceiveSize: 16}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		_, recvErr = stream.Recv()
 		return recvErr
 	})
@@ -409,7 +412,8 @@ func TestNewRequestStreamHandlerRecvRejectsValueOverCap(t *testing.T) {
 func TestNewRequestStreamHandlerRecvRejectsBufferedValueOverCap(t *testing.T) {
 	var secondErr error
 
-	handler := content.NewRequestStreamHandler(test.Content, 0, 16, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	opts := content.StreamOptions{MaxReceiveSize: 16}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		_, err := stream.Recv()
 		require.NoError(t, err)
 
@@ -464,7 +468,8 @@ func TestNewRequestStreamHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavi
 
 			var recvErr error
 
-			handler := content.NewRequestStreamHandler(cont, 0, tt.maxSize, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+			opts := content.StreamOptions{MaxReceiveSize: tt.maxSize}
+			handler := content.NewRequestStreamHandler(cont, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 				_, recvErr = stream.Recv()
 				return recvErr
 			})
@@ -494,7 +499,8 @@ func TestNewRequestStreamHandlerRecvCapIsPerValueNotCumulative(t *testing.T) {
 
 	pipeReader, pipeWriter := io.Pipe()
 
-	handler := content.NewRequestStreamHandler(test.Content, 0, 24, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	opts := content.StreamOptions{MaxReceiveSize: 24}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		for {
 			req, err := stream.Recv()
 			if err != nil {
@@ -541,7 +547,7 @@ func TestNewRequestStreamHandlerRecvCapIsPerValueNotCumulative(t *testing.T) {
 func TestNewRequestStreamHandlerRecvChargesOneLimiterTokenPerMessage(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 2}
 
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		for {
 			_, err := stream.Recv()
 			if err != nil {
@@ -572,7 +578,8 @@ func TestNewRequestStreamHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testi
 	limiter := &test.CountingLimiter{Remaining: 1}
 
 	var recvErr error
-	handler := content.NewRequestStreamHandler(test.Content, 0, 16, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	opts := content.StreamOptions{MaxReceiveSize: 16}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		_, recvErr = stream.Recv()
 		return recvErr
 	})
@@ -594,7 +601,7 @@ func TestNewRequestStreamHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testi
 func TestNewStreamHandlerSendIsSticky(t *testing.T) {
 	var firstErr, secondErr error
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Unencodable]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Unencodable]) error {
 		firstErr = stream.Send(&test.Unencodable{})
 		secondErr = stream.Send(&test.Unencodable{})
 		return firstErr
@@ -612,7 +619,8 @@ func TestNewStreamHandlerSendIsSticky(t *testing.T) {
 }
 
 func TestNewStreamHandlerSendExtendDeadlineFailure(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, time.MustParseDuration("1s"), func(_ context.Context, stream *content.Stream[test.Response]) error {
+	opts := content.StreamOptions{WriteTimeout: time.MustParseDuration("1s")}
+	handler := content.NewStreamHandler(test.Content, opts, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
@@ -625,8 +633,141 @@ func TestNewStreamHandlerSendExtendDeadlineFailure(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 }
 
+func TestNewRequestStreamHandlerSendExtendReadDeadlineFailure(t *testing.T) {
+	opts := content.StreamOptions{ReadTimeout: time.MustParseDuration("1s"), WriteTimeout: time.MustParseDuration("1s")}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.DeadlineResponseWriter{SetReadDeadlineFunc: func() error { return test.ErrFailed }}
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewRequestStreamHandlerRecvFirstCallIsBoundedByReadTimeout(t *testing.T) {
+	done := make(chan struct{})
+	t.Cleanup(func() { <-done })
+
+	pipeReader, pipeWriter := io.Pipe()
+	t.Cleanup(func() { _ = pipeWriter.Close() })
+
+	recvErr := make(chan error, 1)
+
+	opts := content.StreamOptions{ReadTimeout: time.MustParseDuration("200ms")}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, err := stream.Recv()
+		recvErr <- err
+
+		return err
+	})
+
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL, pipeReader)
+	require.NoError(t, err)
+	req.ContentLength = -1
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+
+	go func() {
+		defer close(done)
+
+		resp, doErr := server.Client().Do(req)
+		if doErr == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case err := <-recvErr:
+		require.Error(t, err)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Recv did not return within the configured read timeout")
+	}
+}
+
+func TestNewRequestStreamHandlerRecvExtendReadDeadlineFailureBeforeDecode(t *testing.T) {
+	var recvErr error
+
+	opts := content.StreamOptions{ReadTimeout: time.MustParseDuration("1s")}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, recvErr = stream.Recv()
+		return recvErr
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"Bob\"}\n"))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.DeadlineResponseWriter{SetReadDeadlineFunc: func() error { return test.ErrFailed }}
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.ErrorIs(t, recvErr, test.ErrFailed)
+}
+
+func TestNewRequestStreamHandlerRecvExtendReadDeadlineFailureAfterDecode(t *testing.T) {
+	var recvErr error
+	calls := 0
+
+	opts := content.StreamOptions{ReadTimeout: time.MustParseDuration("1s")}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, recvErr = stream.Recv()
+		return recvErr
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"Bob\"}\n"))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.DeadlineResponseWriter{SetReadDeadlineFunc: func() error {
+		calls++
+		if calls == 1 {
+			return nil
+		}
+
+		return test.ErrFailed
+	}}
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.ErrorIs(t, recvErr, test.ErrFailed)
+}
+
+func TestNewRequestStreamHandlerRecvExtendWriteDeadlineFailure(t *testing.T) {
+	var recvErr error
+
+	opts := content.StreamOptions{ReadTimeout: time.MustParseDuration("1s"), WriteTimeout: time.MustParseDuration("1s")}
+	handler := content.NewRequestStreamHandler(test.Content, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+		_, recvErr = stream.Recv()
+		return recvErr
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"Bob\"}\n"))
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.DeadlineResponseWriter{SetWriteDeadlineFunc: func() error { return test.ErrFailed }}
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.ErrorIs(t, recvErr, test.ErrFailed)
+}
+
 func TestNewStreamHandlerSendCommitFailure(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
@@ -640,7 +781,7 @@ func TestNewStreamHandlerSendCommitFailure(t *testing.T) {
 }
 
 func TestNewStreamHandlerSendFlushFailure(t *testing.T) {
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
@@ -659,7 +800,7 @@ func TestNewStreamHandlerSendLimiterErrorMapsTo500(t *testing.T) {
 	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
 	res := httptest.NewRecorder()
 
-	handler := content.NewStreamHandler(test.Content, 0, func(_ context.Context, stream *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
@@ -671,7 +812,7 @@ func TestNewStreamHandlerSendLimiterErrorMapsTo500(t *testing.T) {
 func TestNewRequestStreamHandlerRecvLimiterErrorMapsTo500(t *testing.T) {
 	var recvErr error
 
-	handler := content.NewRequestStreamHandler(test.Content, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	handler := content.NewRequestStreamHandler(test.Content, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		_, recvErr = stream.Recv()
 		return recvErr
 	})
@@ -707,7 +848,7 @@ func TestNewRequestStreamHandlerRecvBufferedLenFallback(t *testing.T) {
 			sm.Register("json", codec)
 			cont := content.NewContent(test.Encoder, sm, test.Pool)
 
-			handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+			handler := content.NewRequestStreamHandler(cont, content.StreamOptions{}, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 				_, err := stream.Recv()
 				return err
 			})
@@ -732,7 +873,8 @@ func TestNewRequestStreamHandlerRecvRecoversStickyCapReaderError(t *testing.T) {
 	sm.Register("json", codec)
 	cont := content.NewContent(test.Encoder, sm, test.Pool)
 
-	handler := content.NewRequestStreamHandler(cont, 0, bytes.Size(1), func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	opts := content.StreamOptions{MaxReceiveSize: bytes.Size(1)}
+	handler := content.NewRequestStreamHandler(cont, opts, func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		_, err := stream.Recv()
 		return err
 	})
@@ -755,7 +897,7 @@ func TestNewStreamHandlerRejectsNilEncoderForRegisteredKind(t *testing.T) {
 	sm.Register("json", codec)
 	cont := content.NewContent(test.Encoder, sm, test.Pool)
 
-	handler := content.NewStreamHandler(cont, 0, func(_ context.Context, _ *content.Stream[test.Response]) error {
+	handler := content.NewStreamHandler(cont, content.StreamOptions{}, func(_ context.Context, _ *content.Stream[test.Response]) error {
 		return nil
 	})
 
@@ -786,7 +928,7 @@ func TestNewRequestStreamHandlerRejectsNilCodecFieldForRegisteredKind(t *testing
 			sm.Register("json", codec)
 			cont := content.NewContent(test.Encoder, sm, test.Pool)
 
-			handler := content.NewRequestStreamHandler(cont, 0, 0, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
+			handler := content.NewRequestStreamHandler(cont, content.StreamOptions{}, func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
 				return nil
 			})
 

--- a/net/http/rest/client_test.go
+++ b/net/http/rest/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewClientUsesTimeout(t *testing.T) {
-	rest.Register(nil, test.Content, test.Pool, 0, 0)
+	rest.Register(nil, test.Content, test.Pool, content.StreamOptions{})
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set(content.TypeKey, media.Text)

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -22,7 +22,7 @@ func ExampleGet() {
 		encoding.NewMap(),
 		stream.NewMap(),
 		pool,
-	), pool, 0, 0)
+	), pool, content.StreamOptions{})
 
 	rest.Get("/hello", func(context.Context) (*exampleResponse, error) {
 		return &exampleResponse{Message: "hello"}, nil
@@ -50,7 +50,7 @@ func ExampleStreamGet() {
 		encoding.NewMap(),
 		stream.NewMap(),
 		pool,
-	), pool, 0, 0)
+	), pool, content.StreamOptions{})
 
 	rest.StreamGet("/hello", func(_ context.Context, stream *content.Stream[exampleResponse]) error {
 		if err := stream.Send(&exampleResponse{Message: "hello"}); err != nil {

--- a/net/http/rest/rest.go
+++ b/net/http/rest/rest.go
@@ -1,19 +1,16 @@
 package rest
 
 import (
-	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-sync"
 )
 
 var (
-	router         *http.Router
-	cont           *content.Content
-	pool           *sync.BufferPool
-	timeout        time.Duration
-	maxReceiveSize bytes.Size
+	router *http.Router
+	cont   *content.Content
+	pool   *sync.BufferPool
+	opts   content.StreamOptions
 )
 
 // Register stores the dependencies used by server and client helpers in package-level variables.
@@ -27,24 +24,14 @@ var (
 //   - server-side helpers (Get/Post/etc.) register handlers on the registered router, and
 //   - client helpers (NewClient) build clients using the registered content codecs and buffer pool.
 //
-// t is the streaming inactivity timeout applied by this package's streaming route helpers (StreamRoute,
-// StreamGet, StreamRouteRequest, StreamPost, StreamPut, StreamPatch). A successful Send extends the
-// response write deadline by this duration. For bidirectional routes, a successful Recv also extends the
-// request read deadline (see
+// so is passed through unchanged to this package's streaming route helpers (StreamRoute, StreamGet,
+// StreamRouteRequest, StreamPost, StreamPut, StreamPatch) via
 // [github.com/alexfalkowski/go-service/v2/net/http/content.NewStreamHandler] and
-// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]), turning the
-// whole-stream read and write timeouts into per-message inactivity budgets. Zero disables the extensions.
-//
-// m is the per-value request body size cap applied by this package's bidirectional streaming route
-// helpers (StreamRouteRequest, StreamPost, StreamPut, StreamPatch). Unlike the buffered request-body
-// path's cumulative limit, this bounds each value decoded by
-// [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv] independently — a
-// long-lived stream with many small values is never rejected for its cumulative size (see decision B18
-// in the streaming design). Zero disables the per-value cap entirely.
-func Register(r *http.Router, c *content.Content, p *sync.BufferPool, t time.Duration, m bytes.Size) {
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]; see those
+// constructors for the timeout and per-value receive-size semantics.
+func Register(r *http.Router, c *content.Content, p *sync.BufferPool, so content.StreamOptions) {
 	router = r
 	cont = c
 	pool = p
-	timeout = t
-	maxReceiveSize = m
+	opts = so
 }

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -151,10 +151,10 @@ func StreamPatch[Req any, Res any](pattern string, handler content.RequestStream
 // function will panic.
 //
 // Inbound size limiting:
-// maxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
+// opts.MaxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
 // Recv, not the request body as a whole — see [content.NewRequestStreamHandler].
 func StreamRouteRequest[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
-	router.HandleStreaming(pattern, content.NewRequestStreamHandler(cont, timeout, maxReceiveSize, handler))
+	router.HandleStreaming(pattern, content.NewRequestStreamHandler(cont, opts, handler))
 }
 
 // StreamRoute registers a handler under pattern for a send-only streaming response: the response
@@ -176,5 +176,5 @@ func StreamRouteRequest[Req any, Res any](pattern string, handler content.Reques
 // Register must be called before StreamRoute; otherwise router/cont will be nil and this function will
 // panic.
 func StreamRoute[Res any](pattern string, handler content.StreamHandler[Res]) {
-	router.HandleStreaming(pattern, content.NewStreamHandler(cont, timeout, handler))
+	router.HandleStreaming(pattern, content.NewStreamHandler(cont, opts, handler))
 }

--- a/net/http/rest/server_test.go
+++ b/net/http/rest/server_test.go
@@ -20,7 +20,7 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
-	rest.Register(router, test.Content, test.Pool, 0, 0)
+	rest.Register(router, test.Content, test.Pool, content.StreamOptions{})
 
 	rest.StreamGet("/hello", func(_ context.Context, stream *content.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
@@ -49,7 +49,7 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 func TestStreamPostRejectsHTTP1(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rest.Register(router, test.Content, test.Pool, 0, 0)
+	rest.Register(router, test.Content, test.Pool, content.StreamOptions{})
 
 	rest.StreamPost("/hello", func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
 		return nil
@@ -82,7 +82,7 @@ func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
 			mux := http.NewServeMux()
 			policy := http.NewRoutePolicy()
 			router := http.NewRouter(mux, policy)
-			rest.Register(router, test.Content, test.Pool, 0, 0)
+			rest.Register(router, test.Content, test.Pool, content.StreamOptions{})
 
 			tt.call("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 				for {

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func TestPostRequiresRequest(t *testing.T) {
 }
 
 func TestPostUsesConfiguredTimeout(t *testing.T) {
-	rpc.Register(nil, test.Content, test.Pool, 0, 0)
+	rpc.Register(nil, test.Content, test.Pool, content.StreamOptions{})
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Type", media.JSON)
@@ -67,7 +68,7 @@ func TestPostRequiresNonNilTypedResponse(t *testing.T) {
 func TestPostUsesAccept(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rpc.Register(router, test.Content, test.Pool, 0, 0)
+	rpc.Register(router, test.Content, test.Pool, content.StreamOptions{})
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	server := httptest.NewServer(mux)

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -21,7 +21,7 @@ func ExampleClient_Post() {
 		encoding.NewMap(),
 		stream.NewMap(),
 		pool,
-	), pool, 0, 0)
+	), pool, content.StreamOptions{})
 
 	rpc.Route("/hello", func(_ context.Context, req *exampleRequest) (*exampleResponse, error) {
 		return &exampleResponse{Message: "hello " + req.Name}, nil

--- a/net/http/rpc/rpc.go
+++ b/net/http/rpc/rpc.go
@@ -1,19 +1,16 @@
 package rpc
 
 import (
-	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-sync"
 )
 
 var (
-	router         *http.Router
-	cont           *content.Content
-	pool           *sync.BufferPool
-	timeout        time.Duration
-	maxReceiveSize bytes.Size
+	router *http.Router
+	cont   *content.Content
+	pool   *sync.BufferPool
+	opts   content.StreamOptions
 )
 
 // Register stores the dependencies used by server and client helpers in package-level variables.
@@ -23,22 +20,12 @@ var (
 // Important: Register must be called before using any server-side route helpers or client helpers in this
 // package. If it is not called, globals will be nil and helper calls will panic.
 //
-// t is the streaming inactivity timeout applied by this package's streaming route helper (StreamRoute). A
-// successful Send extends the response write deadline by this duration, and a successful Recv extends the
-// request read deadline (see
-// [github.com/alexfalkowski/go-service/v2/net/http/content.NewStreamHandler] and
-// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]), turning the
-// whole-stream read and write timeouts into per-message inactivity budgets. Zero disables the extensions.
-//
-// m is the per-value request body size cap applied by this package's streaming route helper
-// (StreamRoute). Unlike the buffered request-body path's cumulative limit, this bounds each value
-// decoded by [github.com/alexfalkowski/go-service/v2/net/http/content.RequestStream.Recv]
-// independently — a long-lived stream with many small values is never rejected for its cumulative size
-// (see decision B18 in the streaming design). Zero disables the per-value cap entirely.
-func Register(r *http.Router, c *content.Content, p *sync.BufferPool, t time.Duration, m bytes.Size) {
+// so is passed through unchanged to this package's streaming route helper (StreamRoute) via
+// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]; see that
+// constructor for the timeout and per-value receive-size semantics.
+func Register(r *http.Router, c *content.Content, p *sync.BufferPool, so content.StreamOptions) {
 	router = r
 	cont = c
 	pool = p
-	timeout = t
-	maxReceiveSize = m
+	opts = so
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -66,11 +66,11 @@ func Route[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 // will panic.
 //
 // Inbound size limiting:
-// maxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
+// opts.MaxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
 // Recv, not the request body as a whole — see [content.NewRequestStreamHandler].
 func StreamRoute[Req any, Res any](pattern string, handler content.RequestStreamHandler[Req, Res]) {
 	router.HandleStreaming(
 		strings.Join(strings.Space, http.MethodPost, pattern),
-		content.NewRequestStreamHandler(cont, timeout, maxReceiveSize, handler),
+		content.NewRequestStreamHandler(cont, opts, handler),
 	)
 }

--- a/net/http/rpc/server_test.go
+++ b/net/http/rpc/server_test.go
@@ -19,7 +19,7 @@ import (
 func TestStreamRouteRejectsHTTP1(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rpc.Register(router, test.Content, test.Pool, 0, 0)
+	rpc.Register(router, test.Content, test.Pool, content.StreamOptions{})
 
 	rpc.StreamRoute("/hello", func(_ context.Context, _ *content.RequestStream[test.Request, test.Response]) error {
 		return nil
@@ -40,7 +40,7 @@ func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
-	rpc.Register(router, test.Content, test.Pool, 0, 0)
+	rpc.Register(router, test.Content, test.Pool, content.StreamOptions{})
 
 	rpc.StreamRoute("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
 		for {

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -265,7 +265,7 @@ func BenchmarkRestStream(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		err := world.Rest.RequestStream(b.Context(), http.MethodPost, url, rest.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, streamHelloClient("Bob", 1))
+		err := world.Rest.StreamPost(b.Context(), url, rest.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, streamHelloClient("Bob", 1))
 		if err != nil {
 			require.NoError(b, err)
 		}
@@ -311,7 +311,7 @@ func BenchmarkRPCStream(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		err := c.RequestStream(b.Context(), http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, streamHelloClient("Bob", 1))
+		err := c.StreamPost(b.Context(), url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, streamHelloClient("Bob", 1))
 		if err != nil {
 			require.NoError(b, err)
 		}
@@ -452,7 +452,8 @@ func benchmarkHTTPStream(b *testing.B, log *logger.Logger, trace, tlsEnabled boo
 	b.ReportAllocs()
 
 	address, cleanup := startBenchmarkHTTPServer(b, log, trace, tlsEnabled, func(router *transporthttp.Router, cfg *transporthttp.Config) {
-		rest.Register(router, test.Content, test.Pool, cfg.GetTimeout(), cfg.GetMaxReceiveSize())
+		opts := content.StreamOptions{ReadTimeout: cfg.GetReadTimeout(), WriteTimeout: cfg.GetWriteTimeout(), MaxReceiveSize: cfg.GetMaxReceiveSize()}
+		rest.Register(router, test.Content, test.Pool, opts)
 		rest.StreamPost("/hello", streamHello)
 	})
 	httpClient, scheme, closeIdleConnections := newHTTPStreamClient(b, tlsEnabled)
@@ -462,7 +463,7 @@ func benchmarkHTTPStream(b *testing.B, log *logger.Logger, trace, tlsEnabled boo
 	b.ResetTimer()
 
 	for b.Loop() {
-		err := httpClient.RequestStream(b.Context(), http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, requestStream)
+		err := httpClient.StreamPost(b.Context(), url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, requestStream)
 		if err != nil {
 			require.NoError(b, err)
 		}

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -1,14 +1,12 @@
 package http
 
 import (
-	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
-	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/alexfalkowski/go-service/v2/transport/http/health"
 	"github.com/alexfalkowski/go-service/v2/transport/http/telemetry/metrics"
 	"github.com/alexfalkowski/go-service/v2/transport/http/token"
@@ -23,14 +21,15 @@ import (
 //   - content negotiation and encoding ([content.NewContent])
 //   - MVC view rendering helpers ([mvc.NewFunctionMap], [mvc.Register])
 //   - RPC and REST routing ([rpc.Register], [rest.Register] — called from [registerRoutes] rather than
-//     as their own separate Fx invoke targets, so their timeout/maxReceiveSize arguments are plain
-//     values this package computes from its own *[Config], not separate Fx-resolved dependencies),
+//     as their own separate Fx invoke targets, so their [content.StreamOptions] argument is a plain
+//     value this package computes from its own *[Config], not a separate Fx-resolved dependency),
 //     including the streaming route helpers (rest.StreamRoute/StreamGet/StreamRouteRequest/StreamPost/
-//     StreamPut/StreamPatch and rpc.StreamRoute): a successful Send extends the response write deadline,
-//     while a successful Recv on a bidirectional stream extends the request read deadline (see
-//     [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]); bidirectional
-//     streaming routes also bound each decoded request value instead of the request body's cumulative size
-//     (see [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler])
+//     StreamPut/StreamPatch and rpc.StreamRoute): on a bidirectional stream, a successful Send or Recv
+//     extends both the response write deadline and the request read deadline (see
+//     [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler]); a send-only
+//     stream extends only the write deadline. Bidirectional streaming routes also bound each decoded
+//     request value instead of the request body's cumulative size (see
+//     [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestStreamHandler])
 //   - transport-level middleware wiring (limiter and token helpers)
 //   - server construction ([NewServer])
 //   - operational endpoints (Prometheus metrics and health)
@@ -56,25 +55,30 @@ var Module = di.Module(
 )
 
 // registerRoutes wires [rest.Register] and [rpc.Register] with the router, content, and buffer pool
-// dependencies Fx resolves normally, plus a timeout/maxReceiveSize pair computed here from cfg and
-// passed as plain arguments.
+// dependencies Fx resolves normally, plus a [content.StreamOptions] value computed here from cfg and
+// passed as a plain argument.
 //
 // Calling rest.Register/rpc.Register directly (rather than as their own separate Fx invoke targets)
-// means timeout ([time.Duration]) and maxReceiveSize ([bytes.Size]) never need to exist as their own DI
-// graph nodes: those are common, easily-collided types (nothing else in the DI graph keys on them, but
-// nothing stops something else from needing to someday), so resolving them by bare type would be
-// fragile in a way resolving *[Config] is not. net/http/rest and net/http/rpc must not import this
-// package (see AGENTS.md), so cfg's values are computed here and passed in, mirroring how NewServer
-// already derives its own ReadTimeout/WriteTimeout/max receive size from the same *Config.
+// means [content.StreamOptions] never needs to exist as its own DI graph node: it is a common,
+// easily-collided type (nothing else in the DI graph keys on it, but nothing stops something else from
+// needing to someday), so resolving it by bare type would be fragile in a way resolving *[Config] is
+// not. net/http/rest and net/http/rpc must not import this package (see AGENTS.md), so cfg's values are
+// computed here and passed in, mirroring how NewServer already derives its own
+// ReadTimeout/WriteTimeout/max receive size from the same *Config: the read/write timeouts resolve
+// through the same options-aware precedence (options key, falling back to cfg.GetTimeout()) NewServer
+// uses for its own ReadTimeout/WriteTimeout, so a service that diverges options.read_timeout/
+// write_timeout from timeout gets a matching streaming budget instead of a silently different one.
 func registerRoutes(cfg *Config, router *http.Router, cont *content.Content, pool *sync.BufferPool) {
-	var timeout time.Duration
-	var maxReceiveSize bytes.Size
+	var so content.StreamOptions
 
 	if cfg.IsEnabled() {
-		timeout = cfg.GetTimeout()
-		maxReceiveSize = cfg.GetMaxReceiveSize()
+		so = content.StreamOptions{
+			ReadTimeout:    cfg.GetReadTimeout(),
+			WriteTimeout:   cfg.GetWriteTimeout(),
+			MaxReceiveSize: cfg.GetMaxReceiveSize(),
+		}
 	}
 
-	rest.Register(router, cont, pool, timeout, maxReceiveSize)
-	rpc.Register(router, cont, pool, timeout, maxReceiveSize)
+	rest.Register(router, cont, pool, so)
+	rpc.Register(router, cont, pool, so)
 }

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -216,7 +216,7 @@ func TestRestStreamPostRecvAndSendOverRealServer(t *testing.T) {
 	defer cancel()
 
 	var greetings []string
-	err := world.Rest.RequestStream(ctx, http.MethodPost, url, rest.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
+	err := world.Rest.StreamPost(ctx, url, rest.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
 		func(_ context.Context, stream *client.RequestResponseStream) error {
 			for _, name := range []string{"Bob", "Alice"} {
 				if err := stream.Send(&test.Request{Name: name}); err != nil {
@@ -241,24 +241,10 @@ func TestRestStreamPostRefreshesReadDeadlineOverH2C(t *testing.T) {
 	config := test.NewInsecureTransportConfig()
 	config.HTTP.Timeout = 100 * time.Millisecond
 	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
-	rest.Register(world.Router, test.Content, test.Pool, config.HTTP.GetTimeout(), config.HTTP.GetMaxReceiveSize())
-
-	rest.StreamPost("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
-		for {
-			req, err := stream.Recv()
-			if err != nil {
-				if stream.IsFinished(err) {
-					return nil
-				}
-
-				return err
-			}
-
-			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
-				return err
-			}
-		}
+	rest.Register(world.Router, test.Content, test.Pool, content.StreamOptions{
+		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
 	})
+	rest.StreamPost("/hello", echoStreamServer)
 	world.Start()
 
 	transport := http.Transport(nil)
@@ -272,28 +258,181 @@ func TestRestStreamPostRefreshesReadDeadlineOverH2C(t *testing.T) {
 	defer cancel()
 
 	var greetings []string
-	err := c.RequestStream(ctx, http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
-		func(_ context.Context, stream *client.RequestResponseStream) error {
-			for index, name := range []string{"Bob", "Alice", "Carol", "Dan"} {
-				if index > 0 {
-					time.Sleep(40 * time.Millisecond)
-				}
-
-				if err := stream.Send(&test.Request{Name: name}); err != nil {
-					return err
-				}
-
-				var res test.Response
-				if err := stream.Recv(&res); err != nil {
-					return err
-				}
-
-				greetings = append(greetings, res.Greeting)
-			}
-
-			time.Sleep(120 * time.Millisecond)
-			return stream.Send(&test.Request{Name: "Eve"})
-		})
+	err := c.StreamPost(ctx, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, staleClientAfterFourEchoes(&greetings))
 	require.Error(t, err)
 	require.Equal(t, []string{"Hello Bob", "Hello Alice", "Hello Carol", "Hello Dan"}, greetings)
+}
+
+func echoStreamServer(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			if stream.IsFinished(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
+			return err
+		}
+	}
+}
+
+func staleClientAfterFourEchoes(greetings *[]string) client.RequestStreamHandler {
+	return func(_ context.Context, stream *client.RequestResponseStream) error {
+		for index, name := range []string{"Bob", "Alice", "Carol", "Dan"} {
+			if index > 0 {
+				time.Sleep(40 * time.Millisecond)
+			}
+
+			if err := stream.Send(&test.Request{Name: name}); err != nil {
+				return err
+			}
+
+			var res test.Response
+			if err := stream.Recv(&res); err != nil {
+				return err
+			}
+
+			*greetings = append(*greetings, res.Greeting)
+		}
+
+		time.Sleep(120 * time.Millisecond)
+		return stream.Send(&test.Request{Name: "Eve"})
+	}
+}
+
+func TestRestStreamPostSurvivesReceiveOnlyActivePhase(t *testing.T) {
+	config := test.NewInsecureTransportConfig()
+	config.HTTP.Timeout = 100 * time.Millisecond
+	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
+	rest.Register(world.Router, test.Content, test.Pool, content.StreamOptions{
+		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
+	})
+	rest.StreamPost("/hello", receiveOnlyActivePhaseServer)
+	world.Start()
+
+	transport := http.Transport(nil)
+	transport.Protocols.SetHTTP1(false)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(transport))
+
+	url := world.PathServerURL("http", "hello")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var greeting string
+	err := c.StreamPost(ctx, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, receiveOnlyActivePhaseClient(&greeting))
+	require.NoError(t, err)
+	require.Equal(t, "Hello Bob, Alice, Carol, Dan, Erin, Frank", greeting)
+}
+
+func receiveOnlyActivePhaseServer(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	var names []string
+
+	for range 6 {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		names = append(names, req.Name)
+	}
+
+	return stream.Send(&test.Response{Greeting: "Hello " + strings.Join(", ", names...)})
+}
+
+func receiveOnlyActivePhaseClient(greeting *string) client.RequestStreamHandler {
+	return func(_ context.Context, stream *client.RequestResponseStream) error {
+		for i, name := range []string{"Bob", "Alice", "Carol", "Dan", "Erin", "Frank"} {
+			if i > 0 {
+				time.Sleep(30 * time.Millisecond)
+			}
+
+			if err := stream.Send(&test.Request{Name: name}); err != nil {
+				return err
+			}
+		}
+
+		var res test.Response
+		if err := stream.Recv(&res); err != nil {
+			return err
+		}
+
+		*greeting = res.Greeting
+		return nil
+	}
+}
+
+func TestRestStreamPostSurvivesSendOnlyActivePhase(t *testing.T) {
+	config := test.NewInsecureTransportConfig()
+	config.HTTP.Timeout = 100 * time.Millisecond
+	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
+	rest.Register(world.Router, test.Content, test.Pool, content.StreamOptions{
+		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
+	})
+	rest.StreamPost("/hello", sendOnlyActivePhaseServer)
+	world.Start()
+
+	transport := http.Transport(nil)
+	transport.Protocols.SetHTTP1(false)
+
+	c := client.NewClient(test.Content, test.Pool, client.WithRoundTripper(transport))
+
+	url := world.PathServerURL("http", "hello")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var greetings []string
+	err := c.StreamPost(ctx, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, sendOnlyActivePhaseClient(&greetings))
+	require.NoError(t, err)
+	require.Equal(t, []string{"one", "two", "three", "four", "five", "six", "Hello Eve"}, greetings)
+}
+
+func sendOnlyActivePhaseServer(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
+	for i, name := range []string{"one", "two", "three", "four", "five", "six"} {
+		if i > 0 {
+			time.Sleep(30 * time.Millisecond)
+		}
+
+		if err := stream.Send(&test.Response{Greeting: name}); err != nil {
+			return err
+		}
+	}
+
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	return stream.Send(&test.Response{Greeting: "Hello " + req.Name})
+}
+
+func sendOnlyActivePhaseClient(greetings *[]string) client.RequestStreamHandler {
+	return func(_ context.Context, stream *client.RequestResponseStream) error {
+		for range 6 {
+			var res test.Response
+			if err := stream.Recv(&res); err != nil {
+				return err
+			}
+
+			*greetings = append(*greetings, res.Greeting)
+		}
+
+		if err := stream.Send(&test.Request{Name: "Eve"}); err != nil {
+			return err
+		}
+
+		var res test.Response
+		if err := stream.Recv(&res); err != nil {
+			return err
+		}
+
+		*greetings = append(*greetings, res.Greeting)
+		return nil
+	}
 }

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -271,24 +271,10 @@ func TestRPCStreamRouteRefreshesReadDeadlineOverHTTP2(t *testing.T) {
 	config := test.NewSecureTransportConfig()
 	config.HTTP.Timeout = 100 * time.Millisecond
 	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldSecure(), test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
-	rpc.Register(world.Router, test.Content, test.Pool, config.HTTP.GetTimeout(), config.HTTP.GetMaxReceiveSize())
-
-	rpc.StreamRoute("/hello", func(_ context.Context, stream *content.RequestStream[test.Request, test.Response]) error {
-		for {
-			req, err := stream.Recv()
-			if err != nil {
-				if stream.IsFinished(err) {
-					return nil
-				}
-
-				return err
-			}
-
-			if err := stream.Send(&test.Response{Greeting: "Hello " + req.Name}); err != nil {
-				return err
-			}
-		}
+	rpc.Register(world.Router, test.Content, test.Pool, content.StreamOptions{
+		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
 	})
+	rpc.StreamRoute("/hello", echoStreamServer)
 	world.Start()
 
 	httpClient, err := world.NewHTTP()
@@ -302,28 +288,7 @@ func TestRPCStreamRouteRefreshesReadDeadlineOverHTTP2(t *testing.T) {
 	defer cancel()
 
 	var greetings []string
-	err = c.RequestStream(ctx, http.MethodPost, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
-		func(_ context.Context, stream *client.RequestResponseStream) error {
-			for index, name := range []string{"Bob", "Alice", "Carol", "Dan"} {
-				if index > 0 {
-					time.Sleep(40 * time.Millisecond)
-				}
-
-				if err := stream.Send(&test.Request{Name: name}); err != nil {
-					return err
-				}
-
-				var res test.Response
-				if err := stream.Recv(&res); err != nil {
-					return err
-				}
-
-				greetings = append(greetings, res.Greeting)
-			}
-
-			time.Sleep(120 * time.Millisecond)
-			return stream.Send(&test.Request{Name: "Eve"})
-		})
+	err = c.StreamPost(ctx, url, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON}, staleClientAfterFourEchoes(&greetings))
 	require.Error(t, err)
 	require.Equal(t, []string{"Hello Bob", "Hello Alice", "Hello Carol", "Hello Dan"}, greetings)
 }


### PR DESCRIPTION
## What

- Make bidirectional HTTP streaming treat successful sends and receives as activity in both directions, with read and write deadlines resolved from the transport's corresponding server options.
- Replace scalar streaming setup arguments with `content.StreamOptions`, so REST, RPC, and direct content handlers receive the same complete streaming configuration.
- Intentionally change the exported `content.NewStreamHandler`, `content.NewRequestStreamHandler`, `rest.Register`, and `rpc.Register` signatures; direct callers must now construct and pass `content.StreamOptions` instead of timeout and receive-size scalar arguments.
- Document the streaming timeout behavior and migration boundary in the README, and add focused unit and HTTP/2 integration coverage for active receive-only and send-only stream phases.

## Why

- A bidirectional stream can remain healthy while messages flow in only one direction; refreshing both deadlines prevents the inactive opposite direction from terminating that valid stream.
- Aligning streaming deadlines with `options.read_timeout` and `options.write_timeout` prevents a transport configuration from applying different budgets to the server and its streaming routes.
- The intentional API migration groups related streaming controls into a single extensible value, avoiding additional breaking scalar parameters as streaming behavior grows.

## Testing

- `make specs` - passed (2,684 race-and-coverage tests)
- `make lint` - passed (0 issues)
- `make sec` - passed (no reachable vulnerabilities; Trivy reported no vulnerabilities or secrets)
- New and updated tests cover independent read/write timeout resolution, bidirectional deadline refresh during send-only and receive-only active phases, and the updated streaming helper call sites.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
