### PR TITLE
feat(http): capture mvc handler failures in access logs

### DIFF
--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -64,6 +64,10 @@ func Patch[Model any](pattern string, controller Controller[Model]) bool {
 // corresponding status code (see [github.com/alexfalkowski/go-service/v2/net/http/status.Code]) only after rendering succeeds. The raw error remains
 // available as `mvcModelError` metadata for compatibility; templates that render it can expose diagnostic details.
 // If rendering itself fails, the handler writes the render error status instead.
+//
+// Controller errors and rendering failures are recorded as request-scoped operator diagnostics via
+// [github.com/alexfalkowski/go-service/v2/net/http/status.RecordError], surfaced through the HTTP access log.
+// When more than one error occurs, the first error is retained.
 func Route[Model any](pattern string, controller Controller[Model]) bool {
 	if !IsDefined() {
 		return false
@@ -77,6 +81,8 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 
 		view, model, err := controller(ctx)
 		if err != nil {
+			status.RecordError(ctx, err)
+
 			code := status.Code(err)
 			message := errors.SafeMessage(err, status.DefaultMessage(code))
 			model := &Error{Code: code, Message: message}

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -32,10 +33,13 @@ func TestStaticPathValueRejectsTraversal(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/robots.txt", http.NoBody)
 	handler, _ := mux.Handler(req)
 	req.SetPathValue("file", "../views/hello.tmpl")
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.ErrorIs(t, status.RequestError(ctx), fs.ErrInvalid)
 }
 
 func TestStaticPathValueSetsContentType(t *testing.T) {
@@ -136,11 +140,36 @@ func TestStaticFileRejectsPermissionDenied(t *testing.T) {
 	require.True(t, mvc.StaticFile("/asset", "asset.txt"))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset", http.NoBody)
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusForbidden, res.Code)
+	require.ErrorIs(t, status.RequestError(ctx), fs.ErrPermission)
+}
+
+func TestStaticFileRecordsRequestErrorWhenStatFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mvc.Register(mvc.RegisterParams{
+		Router:      newTestRouter(mux),
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  statErrorFileSystem{},
+		Pool:        test.Pool,
+		Layout:      test.Layout,
+	})
+	require.True(t, mvc.StaticFile("/asset", "asset.txt"))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/asset", http.NoBody)
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.ErrorIs(t, status.RequestError(ctx), test.ErrFailed)
 }
 
 func TestStaticFileSetsCacheControl(t *testing.T) {
@@ -347,12 +376,15 @@ func TestRouteErrorIncludesSafeModelAndRawMetaInTemplate(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(content.TypeKey, media.HTML)
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
 	test.RequireResponseBodyContains(t, res, "400 http: bad request invalid argument")
+	require.ErrorIs(t, status.RequestError(ctx), fs.ErrInvalid)
 }
 
 func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
@@ -375,12 +407,15 @@ func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(content.TypeKey, media.HTML)
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	test.RequireEmptyResponseBody(t, res)
+	require.Error(t, status.RequestError(ctx))
 }
 
 func TestRouteRenderErrorDoesNotUseNotFoundController(t *testing.T) {
@@ -436,12 +471,15 @@ func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(content.TypeKey, media.HTML)
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	test.RequireEmptyResponseBody(t, res)
+	require.ErrorIs(t, status.RequestError(ctx), fs.ErrInvalid)
 }
 
 func TestNotFoundHandlesNotFound(t *testing.T) {
@@ -591,12 +629,15 @@ func TestNotFoundWritesRenderStatusWhenViewMissing(t *testing.T) {
 	}))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+	ctx := status.WithRequestError(req.Context())
+	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
 
 	mvc.NewHandler(mux).ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	test.RequireEmptyResponseBody(t, res)
+	require.ErrorIs(t, status.RequestError(ctx), mvc.ErrMissingView)
 }
 
 func TestNotFoundDoesNotReplaceMethodNotAllowed(t *testing.T) {
@@ -665,4 +706,24 @@ type permissionFileSystem struct{}
 
 func (permissionFileSystem) Open(string) (fs.File, error) {
 	return nil, fs.ErrPermission
+}
+
+type statErrorFileSystem struct{}
+
+func (statErrorFileSystem) Open(string) (fs.File, error) {
+	return &statErrorFile{}, nil
+}
+
+type statErrorFile struct{}
+
+func (statErrorFile) Stat() (fs.FileInfo, error) {
+	return nil, test.ErrFailed
+}
+
+func (statErrorFile) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (statErrorFile) Close() error {
+	return nil
 }

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -23,8 +24,8 @@ func StaticFile(pattern, name string, opts ...StaticOption) bool {
 	}
 
 	options := options(opts...)
-	handler := func(res http.ResponseWriter, _ *http.Request) {
-		serveFile(res, name, options)
+	handler := func(res http.ResponseWriter, req *http.Request) {
+		serveFile(req.Context(), res, name, options)
 	}
 
 	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
@@ -46,21 +47,24 @@ func StaticPathValue(pattern, value, prefix string, opts ...StaticOption) bool {
 	handler := func(res http.ResponseWriter, req *http.Request) {
 		cleaned := path.Clean(req.PathValue(value))
 		if cleaned == "." || cleaned != req.PathValue(value) || !fs.ValidPath(cleaned) || strings.Contains(cleaned, `\`) {
-			res.WriteHeader(staticStatusCode(status.BadRequestError(fs.ErrInvalid)))
+			err := status.BadRequestError(fs.ErrInvalid)
+			status.RecordError(req.Context(), err)
+			res.WriteHeader(staticStatusCode(err))
 			return
 		}
 
 		name := path.Join(prefix, cleaned)
-		serveFile(res, name, options)
+		serveFile(req.Context(), res, name, options)
 	}
 
 	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
 	return true
 }
 
-func serveFile(res http.ResponseWriter, name string, options *staticOptions) {
+func serveFile(ctx context.Context, res http.ResponseWriter, name string, options *staticOptions) {
 	f, err := fileSystem.Open(name)
 	if err != nil {
+		status.RecordError(ctx, err)
 		res.WriteHeader(staticStatusCode(err))
 		return
 	}
@@ -68,6 +72,7 @@ func serveFile(res http.ResponseWriter, name string, options *staticOptions) {
 
 	info, err := f.Stat()
 	if err != nil {
+		status.RecordError(ctx, err)
 		res.WriteHeader(staticStatusCode(err))
 		return
 	}

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -175,6 +175,7 @@ func writeView(ctx context.Context, res http.ResponseWriter, view *View, model a
 
 func renderView(ctx context.Context, res http.ResponseWriter, view *View, model any, code int) error {
 	if view == nil {
+		status.RecordError(ctx, ErrMissingView)
 		return ErrMissingView
 	}
 
@@ -182,6 +183,7 @@ func renderView(ctx context.Context, res http.ResponseWriter, view *View, model 
 	defer pool.Put(buffer)
 
 	if err := view.render(ctx, buffer, model); err != nil {
+		status.RecordError(ctx, err)
 		return err
 	}
 


### PR DESCRIPTION
## What

- Capture MVC controller, static-file, and rendering failures as request diagnostics, so access logs retain the cause without changing client responses.
- Preserve the first diagnostic when a controller error is followed by a rendering failure.

## Why

- Operators can now diagnose MVC 4xx and 5xx responses from access logs without exposing internal error details to clients.

## Testing

- `make specs package=net/http/mvc` - passed
- `make lint package=net/http/mvc` - passed
- `make lint` - passed
- `make specs` - passed
- Added MVC coverage for static-file open/stat failures, invalid static paths, controller failures, template failures, and missing not-found views.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
