### PR TITLE
feat(http): preserve stream shutdown finalization

### DIFF
--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
@@ -23,7 +24,7 @@ import (
 // A handler error returned before the first successful Send is an ordinary HTTP error rendered
 // through [status.WriteError]. A handler error returned after the first successful Send aborts the
 // response via panic([http.ErrAbortHandler]) instead, since the response is already committed — see
-// [Stream.Send] and [finalizeStream].
+// [Stream.Send] and [finishResponse].
 //
 // Drain:
 // When opts.Drain starts before the handler is invoked, this handler returns 503. Otherwise it cancels
@@ -52,10 +53,6 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 		limiter := meta.Limiter(ctx)
 
 		resMedia, err := NewMediaFromAccept(req, sm)
-		if err == nil && resMedia.NewEncoder == nil {
-			err = ErrUnsupportedMedia
-		}
-
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
@@ -83,7 +80,7 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 			writeTimeout: opts.WriteTimeout,
 			limiter:      limiter,
 		}
-		finalizeStream(ctx, res, st, handler(ctx, st))
+		finishResponse(ctx, res, st, handler(ctx, st))
 	}
 }
 
@@ -91,7 +88,7 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 //
 // The handler must propagate a [Stream.Send] error by returning it (directly, or wrapped) rather than
 // ignoring it and continuing. Send is sticky — once it fails, every later call returns the same error
-// immediately — but only the handler returning that error triggers [finalizeStream]'s abort/HTTP-error
+// immediately — but only the handler returning that error triggers [finishResponse]'s abort/HTTP-error
 // handling; a handler that swallows a Send error and returns nil degrades to a no-op loop over a dead
 // connection instead of ending the request. When configured [Options.Drain] starts, ctx is
 // canceled with [ErrDraining]; handlers that wait on an upstream source must select on ctx.Done and
@@ -154,10 +151,6 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 		}
 
 		resMedia, err := NewMediaFromAccept(req, sm)
-		if err == nil && resMedia.NewEncoder == nil {
-			err = ErrUnsupportedMedia
-		}
-
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
@@ -180,21 +173,22 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 		}
 
 		capped := budget.NewReader(req.Body, opts.MaxReceiveSize.Bytes())
+		decoder := reqMedia.NewDecoder(capped)
 		st := &RequestStream[Req, Res]{
 			Stream: Stream[Res]{
 				ctx:          ctx,
 				writer:       writer,
-				encoder:      resMedia.NewEncoder(writer),
+				encoder:      &requestEncoder{Encoder: resMedia.NewEncoder(writer), decoder: decoder},
 				controller:   controller,
 				readTimeout:  opts.ReadTimeout,
 				writeTimeout: opts.WriteTimeout,
 				limiter:      limiter,
 			},
-			decoder:        reqMedia.NewDecoder(capped),
+			decoder:        decoder,
 			capped:         capped,
 			maxReceiveSize: opts.MaxReceiveSize.Bytes(),
 		}
-		finalizeStream(ctx, res, st, handler(ctx, st))
+		finishResponse(ctx, res, &st.Stream, handler(ctx, st))
 	}
 }
 
@@ -207,15 +201,7 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 // an active Recv returns [ErrDraining].
 type RequestHandler[Req any, Res any] func(ctx context.Context, stream *RequestStream[Req, Res]) error
 
-// closer is satisfied by both [*Stream] and [*RequestStream] (which overrides close to also close its
-// decoder), letting [finalizeStream] handle both handler shapes with one implementation.
-type closer interface {
-	committed() bool
-	draining() bool
-	close() error
-}
-
-// finalizeStream applies the streaming error contract after a stream handler returns.
+// finishResponse applies the streaming error contract after a stream handler returns.
 //
 // If the response was never committed, a handler error is rendered as an ordinary HTTP error via
 // [status.WriteError] (a nil error leaves an empty, implicitly-200 response). If the response was
@@ -223,37 +209,48 @@ type closer interface {
 // recorded for operator diagnostics and the response is aborted via panic([http.ErrAbortHandler]),
 // which [transport/http.recoveryHandler] and the access logger already special-case for a committed
 // response.
-func finalizeStream(ctx context.Context, res http.ResponseWriter, s closer, err error) {
+func finishResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if s.draining() {
-		if !s.committed() {
-			_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
-
-			return
-		}
-
-		err = s.close()
-		if err == nil {
-			return
-		}
+		finishResponseDuringDrain(ctx, res, s, err)
+		return
 	}
 
 	if !s.committed() {
 		if err != nil {
 			_ = status.WriteError(ctx, res, err)
 		}
-
 		return
 	}
 
-	if err == nil {
-		err = s.close()
+	if err != nil {
+		abortResponse(ctx, err)
 	}
 
-	if err != nil {
-		status.RecordError(ctx, err)
-		span := tracer.SpanFromContext(ctx)
-		span.RecordError(err)
-		span.SetStatus(tracer.StatusCodeError, err.Error())
-		panic(http.ErrAbortHandler)
+	if closeErr := s.close(); closeErr != nil {
+		abortResponse(ctx, closeErr)
 	}
+}
+
+func finishResponseDuringDrain[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
+	if !s.committed() {
+		_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
+		return
+	}
+
+	closeErr := s.close()
+	if err != nil && !errors.Is(err, ErrDraining) && !errors.Is(err, ctx.Err()) {
+		abortResponse(ctx, err)
+	}
+
+	if closeErr != nil {
+		abortResponse(ctx, closeErr)
+	}
+}
+
+func abortResponse(ctx context.Context, err error) {
+	status.RecordError(ctx, err)
+	span := tracer.SpanFromContext(ctx)
+	span.RecordError(err)
+	span.SetStatus(tracer.StatusCodeError, err.Error())
+	panic(http.ErrAbortHandler)
 }

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -1,0 +1,514 @@
+package stream_test
+
+import (
+	"bufio"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/json"
+	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/compress"
+	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+	require.NotEmpty(t, res.Header().Get(compress.HeaderNoCompression))
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.Equal(t, "Hello Alice", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
+	inner := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "Hello Bob"})
+	})
+	handler := compress.GzipHandler(inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Empty(t, res.Header().Get("Content-Encoding"))
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, bufio.NewScanner(res.Body)))
+}
+
+func TestNewHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+		return status.Error(http.StatusBadRequest, test.ErrFailed.Error())
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+}
+
+func TestNewHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
+		return stream.Send(&test.Unencodable{})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+}
+
+func TestNewHandlerAbortsAfterCommit(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return test.ErrFailed
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+}
+
+func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
+	drain := make(chan struct{})
+	handler := contentstream.NewHandler(
+		test.Content,
+		test.StreamEncoder,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			close(drain)
+			<-ctx.Done()
+
+			return ctx.Err()
+		})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewHandlerAbortsAfterCommitOnDrainForUnrelatedError(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+	drain := make(chan struct{})
+	handler := http.NewTelemetryHandler(contentstream.NewHandler(
+		test.Content,
+		test.StreamEncoder,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			close(drain)
+			<-ctx.Done()
+
+			return test.ErrFailed
+		}), "http.server")
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+	require.Equal(t, tracer.StatusCodeError, spans[0].Status().Code)
+	require.Equal(t, test.ErrFailed.Error(), spans[0].Status().Description)
+	require.NotEmpty(t, spans[0].Events())
+}
+
+func TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError(t *testing.T) {
+	drain := make(chan struct{})
+	handler := contentstream.NewHandler(
+		test.Content,
+		test.StreamEncoder,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			close(drain)
+			<-ctx.Done()
+
+			return errors.Join(test.ErrFailed, ctx.Err())
+		})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewHandlerDoesNotSendAfterDrain(t *testing.T) {
+	drain := make(chan struct{})
+	handler := contentstream.NewHandler(
+		test.Content,
+		test.StreamEncoder,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			close(drain)
+			<-ctx.Done()
+
+			return stream.Send(&test.Response{Greeting: "Hello Alice"})
+		})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewHandlerReturnsServiceUnavailableOnDrainBeforeCommit(t *testing.T) {
+	drain := make(chan struct{})
+	close(drain)
+	called := false
+	handler := contentstream.NewHandler(
+		test.Content,
+		test.StreamEncoder,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, _ *contentstream.Stream[test.Response]) error {
+			called = true
+			<-ctx.Done()
+
+			return ctx.Err()
+		})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, res.Code)
+	require.False(t, called)
+}
+
+func TestNewHandlerAbortsAfterCommitRecordsTraceError(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+	handler := http.NewTelemetryHandler(contentstream.NewHandler(
+		test.Content,
+		test.StreamEncoder,
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			return test.ErrFailed
+		}), "http.server")
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+	require.Equal(t, tracer.StatusCodeError, spans[0].Status().Code)
+	require.Equal(t, test.ErrFailed.Error(), spans[0].Status().Description)
+	require.NotEmpty(t, spans[0].Events())
+}
+
+func TestNewHandlerRejectsUnsupportedMedia(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.JSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotAcceptable, res.Code)
+}
+
+func TestNewHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
+	tests := []struct {
+		name        string
+		accept      string
+		contentType string
+	}{
+		{name: "curl default", accept: "*/*"},
+		{name: "subtype wildcard", accept: "application/*"},
+		{name: "browser-style list", accept: "text/html,application/xhtml+xml,*/*;q=0.8"},
+		{name: "absent accept and content-type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+				return stream.Send(&test.Response{Greeting: "Hello Bob"})
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+			if tt.accept != "" {
+				req.Header.Set(content.AcceptKey, tt.accept)
+			}
+
+			if tt.contentType != "" {
+				req.Header.Set(content.TypeKey, tt.contentType)
+			}
+
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusOK, res.Code)
+			require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+		})
+	}
+}
+
+func TestNewHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 2}
+
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, 0, limiter.Remaining)
+}
+
+func TestNewHandlerSendAbortsAfterCommitWhenLimiterExhausted(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 1}
+
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+			return err
+		}
+
+		return stream.Send(&test.Response{Greeting: "Hello Alice"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	scanner := bufio.NewScanner(res.Body)
+	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.False(t, scanner.Scan())
+}
+
+func TestNewHandlerSendPreCommitDenialMapsTo429(t *testing.T) {
+	limiter := &test.CountingLimiter{Remaining: 0}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
+	res := httptest.NewRecorder()
+
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "Hello Bob"})
+	})
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusTooManyRequests, res.Code)
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+}
+
+func TestNewHandlerSendIsSticky(t *testing.T) {
+	var firstErr, secondErr error
+
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
+		firstErr = stream.Send(&test.Unencodable{})
+		secondErr = stream.Send(&test.Unencodable{})
+		return firstErr
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Error(t, firstErr)
+	require.Equal(t, firstErr, secondErr)
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewHandlerSendExtendDeadlineFailure(t *testing.T) {
+	opts := contentstream.Options{WriteTimeout: time.MustParseDuration("1s")}
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, opts, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewHandlerSendCommitFailure(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.ErrResponseWriter{}
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+}
+
+func TestNewHandlerSendFlushFailure(t *testing.T) {
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := &test.NoFlushResponseWriter{}
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+}
+
+func TestNewHandlerSendLimiterErrorMapsTo500(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
+	res := httptest.NewRecorder()
+
+	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestNewHandlerRejectsNilEncoderForRegisteredKind(t *testing.T) {
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = nil
+	sm.Register("json", codec)
+	cont := content.NewContent(test.Encoder, test.Pool)
+
+	handler := contentstream.NewHandler(cont, sm, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+		return nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotAcceptable, res.Code)
+}
+
+func decodeNDJSONGreeting(t *testing.T, scanner *bufio.Scanner) string {
+	t.Helper()
+
+	require.True(t, scanner.Scan())
+
+	var res map[string]any
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &res))
+
+	greeting, _ := res["Greeting"].(string)
+	return greeting
+}

--- a/net/http/content/stream/media.go
+++ b/net/http/content/stream/media.go
@@ -14,18 +14,18 @@ import (
 // produces. matchStreamAccept uses its major type to decide whether an Accept wildcard is satisfiable.
 var ndjsonType = media.MustParse(media.NDJSON)
 
-// streamKinds maps a media subtype to the [stream.Map] kind that encodes/decodes it.
+// streamKinds maps a normalized media type to the [stream.Map] kind that encodes/decodes it.
 //
-// This mapping is explicit rather than reusing the subtype as the kind directly: "application/x-ndjson"
-// has subtype "x-ndjson", but it is framed newline-delimited JSON, so it reuses the "json" streaming
-// kind rather than needing its own codec.
+// This mapping is explicit rather than reusing the media type as the kind directly:
+// "application/x-ndjson" is framed newline-delimited JSON, so it reuses the "json" streaming kind rather
+// than needing its own codec.
 var streamKinds = map[string]string{
-	"x-ndjson": "json",
+	media.NDJSON: "json",
 }
 
 // NewMedia builds a Media from a media type string and streaming registry.
 //
-// NewMedia never falls back to JSON: an unparsable media type, a subtype with
+// NewMedia never falls back to JSON: an unparsable media type, a media type with
 // no entry in the streaming media mapping, or a kind unregistered in sm all return
 // [ErrUnsupportedMedia]. Streaming callers must fail explicitly rather than silently degrading to
 // a different wire format.
@@ -35,7 +35,7 @@ func NewMedia(mediaType string, sm *stream.Map) (Media, error) {
 		return Media{}, ErrUnsupportedMedia
 	}
 
-	kind, ok := streamKinds[value.Subtype()]
+	kind, ok := streamKinds[value.String()]
 	if !ok {
 		return Media{}, ErrUnsupportedMedia
 	}
@@ -66,7 +66,8 @@ type Media struct {
 }
 
 // NewMediaFromAccept resolves the request Accept header to a streaming encoder, falling back to
-// Content-Type when Accept is absent, and to [media.NDJSON] when neither is set.
+// Content-Type when Accept is absent, and to [media.NDJSON] when neither is set. A registered
+// codec without an encoder is unsupported.
 //
 // An Accept list is satisfiable for the server's producible streaming media type if it contains an
 // exact match, or a matching wildcard ("*/*", or "type/*" where type matches the producible type's own
@@ -84,22 +85,31 @@ type Media struct {
 // only concrete, unproducible media types must get an explicit rejection, not a silently different wire
 // format.
 func NewMediaFromAccept(req *http.Request, sm *stream.Map) (Media, error) {
+	var mediaType string
+
 	header := req.Header.Get(content.AcceptKey)
 	if strings.IsEmpty(header) {
-		mediaType := req.Header.Get(content.TypeKey)
-		if strings.IsEmpty(mediaType) {
-			mediaType = media.NDJSON
+		m := req.Header.Get(content.TypeKey)
+		if strings.IsEmpty(m) {
+			m = media.NDJSON
 		}
 
-		return NewMedia(mediaType, sm)
+		mediaType = m
+	} else {
+		m, ok := matchStreamAccept(header)
+		if !ok {
+			return Media{}, ErrUnsupportedMedia
+		}
+
+		mediaType = m
 	}
 
-	mediaType, ok := matchStreamAccept(header)
-	if !ok {
+	resolved, err := NewMedia(mediaType, sm)
+	if err != nil || resolved.NewEncoder == nil {
 		return Media{}, ErrUnsupportedMedia
 	}
 
-	return NewMedia(mediaType, sm)
+	return resolved, nil
 }
 
 // matchStreamAccept reports whether header, an Accept header value, is satisfiable for a registered
@@ -126,7 +136,7 @@ func matchStreamAccept(header string) (string, bool) {
 
 		zero := accept.IsZeroQuality(item)
 
-		if _, ok := streamKinds[value.Subtype()]; ok {
+		if _, ok := streamKinds[value.String()]; ok {
 			exact.consider(zero, value.String())
 			continue
 		}
@@ -193,11 +203,11 @@ func NewMediaFromContentType(req *http.Request, sm *stream.Map) (Media, error) {
 	// Re-resolve the kind rather than carrying it on Media, keeping the struct free of a field
 	// that exists only for this one caller. A missing entry, a nil decoder constructor, or a banned kind
 	// are all treated as unsupported so this fails closed: neither the missing-entry nor the banned-kind
-	// arm can currently fire, because streamKinds' only mapping ("x-ndjson" to "json") already passed the
+	// arm can currently fire, because streamKinds' only mapping ("application/x-ndjson" to "json") already passed the
 	// lookup inside NewMedia and "json" is not a banned kind. Both stay as guards for a future
-	// streamKinds entry that maps to a banned kind, or a NewMedia change that admits an unknown
-	// subtype.
-	kind, ok := streamKinds[m.Subtype()]
+	// streamKinds entry that maps to a banned kind, or a NewMedia change that admits an unknown media
+	// type.
+	kind, ok := streamKinds[m.String()]
 	if !ok || m.NewDecoder == nil || !policy.CanDecode(kind) {
 		return Media{}, ErrUnsupportedMedia
 	}

--- a/net/http/content/stream/media_test.go
+++ b/net/http/content/stream/media_test.go
@@ -25,6 +25,19 @@ func TestNewFromContentTypeRejectsEncoderOnlyKind(t *testing.T) {
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
+func TestNewFromAcceptRejectsDecoderOnlyKind(t *testing.T) {
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = nil
+	sm.Register("json", codec)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
+	req.Header.Set(content.AcceptKey, media.NDJSON)
+
+	_, err := contentstream.NewMediaFromAccept(req, sm)
+
+	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
+}
+
 func TestNewFromContentTypeResolvesNDJSON(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 	req.Header.Set(content.TypeKey, media.NDJSON)
@@ -34,6 +47,15 @@ func TestNewFromContentTypeResolvesNDJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m.NewDecoder)
 	require.Equal(t, media.NDJSON, m.String())
+}
+
+func TestNewFromContentTypeRejectsWrongMajorNDJSON(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
+	req.Header.Set(content.TypeKey, "text/x-ndjson")
+
+	_, err := contentstream.NewMediaFromContentType(req, test.StreamEncoder)
+
+	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
 func TestNewMediaResolvesUsableDecoderForEveryStreamKind(t *testing.T) {
@@ -62,6 +84,12 @@ func TestNewMediaRejectsUnmappedSubtype(t *testing.T) {
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
+func TestNewMediaRejectsWrongMajorNDJSON(t *testing.T) {
+	_, err := contentstream.NewMedia("text/x-ndjson", encodingstream.NewMap())
+
+	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
+}
+
 func TestNewMediaRejectsUnparsableType(t *testing.T) {
 	_, err := contentstream.NewMedia("not-a-media-type", encodingstream.NewMap())
 
@@ -85,6 +113,7 @@ func TestNewFromAcceptResolvesWildcardOrExactMatchAnywhereInList(t *testing.T) {
 		{name: "absent accept, absent content-type"},
 		{name: "exact match overrides a co-present zero quality bare wildcard", accept: "*/*;q=0, " + media.NDJSON},
 		{name: "subtype wildcard overrides a co-present zero quality bare wildcard", accept: "*/*;q=0, application/*"},
+		{name: "subtype wildcard overrides wrong-major zero quality type", accept: "text/x-ndjson;q=0, application/*"},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +142,7 @@ func TestNewFromAcceptRejectsConcreteOnlyUnsatisfiableAccept(t *testing.T) {
 		accept string
 	}{
 		{name: "concrete unproducible type", accept: media.JSON},
+		{name: "concrete type with wrong major", accept: "text/x-ndjson"},
 		{name: "concrete list with no match and no wildcard", accept: media.JSON + ", " + media.YAML},
 		{name: "unparsable", accept: "not-a-media-type"},
 		{name: "subtype wildcard with mismatched major type", accept: "text/*"},

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -7,105 +7,47 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
-	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-			return err
-		}
+func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T) {
+	encoder := &closeTracker{}
+	decoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	sm.Register("json", codec)
+	drain := make(chan struct{})
+	handler := contentstream.NewRequestHandler(
+		test.Content, sm,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
 
-		return stream.Send(&test.Response{Greeting: "Hello Alice"})
-	})
+			close(drain)
+			<-ctx.Done()
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
+			return test.ErrFailed
+		},
+	)
 
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
-	require.NotEmpty(t, res.Header().Get(compress.HeaderNoCompression))
-
-	scanner := bufio.NewScanner(res.Body)
-	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
-	require.Equal(t, "Hello Alice", decodeNDJSONGreeting(t, scanner))
-	require.False(t, scanner.Scan())
-}
-
-func TestNewHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
-	inner := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		return stream.Send(&test.Response{Greeting: "Hello Bob"})
-	})
-	handler := compress.GzipHandler(inner)
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	req.Header.Set("Accept-Encoding", "gzip")
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Empty(t, res.Header().Get("Content-Encoding"))
-	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, bufio.NewScanner(res.Body)))
-}
-
-func TestNewHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
-		return status.Error(http.StatusBadRequest, test.ErrFailed.Error())
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
-}
-
-func TestNewHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
-		return stream.Send(&test.Unencodable{})
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusInternalServerError, res.Code)
-	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
-}
-
-func TestNewHandlerAbortsAfterCommit(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-			return err
-		}
-
-		return test.ErrFailed
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
 	req.Header.Set(content.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
@@ -113,88 +55,39 @@ func TestNewHandlerAbortsAfterCommit(t *testing.T) {
 		handler.ServeHTTP(res, req)
 	})
 
-	scanner := bufio.NewScanner(res.Body)
-	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+	require.Equal(t, 1, encoder.closes)
+	require.Equal(t, 1, decoder.closes)
 }
 
-func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
-	drain := make(chan struct{})
-	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
-		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
-			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-				return err
-			}
+func TestNewRequestHandlerClosesDecoderWhenEncoderCloseFails(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+	decoder := &closeTracker{err: errors.New("decoder close")}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return test.CloseErrEncoder{} }
+	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	sm.Register("json", codec)
+	handler := http.NewTelemetryHandler(contentstream.NewRequestHandler(
+		test.Content, sm,
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			return stream.Send(&test.Response{Greeting: "Hello Bob"})
+		},
+	), "http.server")
 
-			close(drain)
-			<-ctx.Done()
-
-			return ctx.Err()
-		})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(content.TypeKey, media.NDJSON)
 	req.Header.Set(content.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
-	handler.ServeHTTP(res, req)
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
 
-	require.Equal(t, http.StatusOK, res.Code)
-	scanner := bufio.NewScanner(res.Body)
-	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
-	require.False(t, scanner.Scan())
-}
-
-func TestNewHandlerDoesNotSendAfterDrain(t *testing.T) {
-	drain := make(chan struct{})
-	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
-		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
-			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-				return err
-			}
-
-			close(drain)
-			<-ctx.Done()
-
-			return stream.Send(&test.Response{Greeting: "Hello Alice"})
-		})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusOK, res.Code)
-	scanner := bufio.NewScanner(res.Body)
-	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
-	require.False(t, scanner.Scan())
-}
-
-func TestNewHandlerReturnsServiceUnavailableOnDrainBeforeCommit(t *testing.T) {
-	drain := make(chan struct{})
-	close(drain)
-	called := false
-	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
-		contentstream.Options{Drain: drain}, func(ctx context.Context, _ *contentstream.Stream[test.Response]) error {
-			called = true
-			<-ctx.Done()
-
-			return ctx.Err()
-		})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusServiceUnavailable, res.Code)
-	require.False(t, called)
+	require.Equal(t, 1, decoder.closes)
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+	require.Equal(t, test.ErrFailed.Error(), spans[0].Status().Description)
 }
 
 func TestNewRequestHandlerReturnsServiceUnavailableOnDrainBeforeHandler(t *testing.T) {
@@ -339,150 +232,6 @@ func TestNewRequestHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
 	require.False(t, scanner.Scan())
-}
-
-func TestNewHandlerAbortsAfterCommitRecordsTraceError(t *testing.T) {
-	exporter := test.EnableIsolatedSpanExporter(t)
-	handler := http.NewTelemetryHandler(contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
-		contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-				return err
-			}
-
-			return test.ErrFailed
-		}), "http.server")
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
-		handler.ServeHTTP(res, req)
-	})
-
-	spans := exporter.Spans()
-	require.Len(t, spans, 1)
-	require.Equal(t, tracer.StatusCodeError, spans[0].Status().Code)
-	require.Equal(t, test.ErrFailed.Error(), spans[0].Status().Description)
-	require.NotEmpty(t, spans[0].Events())
-}
-
-func TestNewHandlerRejectsUnsupportedMedia(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
-		return nil
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.JSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusNotAcceptable, res.Code)
-}
-
-func TestNewHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
-	tests := []struct {
-		name        string
-		accept      string
-		contentType string
-	}{
-		{name: "curl default", accept: "*/*"},
-		{name: "subtype wildcard", accept: "application/*"},
-		{name: "browser-style list", accept: "text/html,application/xhtml+xml,*/*;q=0.8"},
-		{name: "absent accept and content-type"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-				return stream.Send(&test.Response{Greeting: "Hello Bob"})
-			})
-
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-			if tt.accept != "" {
-				req.Header.Set(content.AcceptKey, tt.accept)
-			}
-
-			if tt.contentType != "" {
-				req.Header.Set(content.TypeKey, tt.contentType)
-			}
-
-			res := httptest.NewRecorder()
-
-			handler.ServeHTTP(res, req)
-
-			require.Equal(t, http.StatusOK, res.Code)
-			require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
-		})
-	}
-}
-
-func TestNewHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
-	limiter := &test.CountingLimiter{Remaining: 2}
-
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-			return err
-		}
-
-		return stream.Send(&test.Response{Greeting: "Hello Alice"})
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, 0, limiter.Remaining)
-}
-
-func TestNewHandlerSendAbortsAfterCommitWhenLimiterExhausted(t *testing.T) {
-	limiter := &test.CountingLimiter{Remaining: 1}
-
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
-			return err
-		}
-
-		return stream.Send(&test.Response{Greeting: "Hello Alice"})
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
-	res := httptest.NewRecorder()
-
-	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
-		handler.ServeHTTP(res, req)
-	})
-
-	scanner := bufio.NewScanner(res.Body)
-	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
-	require.False(t, scanner.Scan())
-}
-
-func TestNewHandlerSendPreCommitDenialMapsTo429(t *testing.T) {
-	limiter := &test.CountingLimiter{Remaining: 0}
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
-	res := httptest.NewRecorder()
-
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		return stream.Send(&test.Response{Greeting: "Hello Bob"})
-	})
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusTooManyRequests, res.Code)
-	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
 }
 
 func TestNewRequestHandlerRejectsHTTP1(t *testing.T) {
@@ -879,41 +628,6 @@ func TestNewRequestHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testing.T) 
 	require.Equal(t, 1, limiter.Remaining)
 }
 
-func TestNewHandlerSendIsSticky(t *testing.T) {
-	var firstErr, secondErr error
-
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
-		firstErr = stream.Send(&test.Unencodable{})
-		secondErr = stream.Send(&test.Unencodable{})
-		return firstErr
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Error(t, firstErr)
-	require.Equal(t, firstErr, secondErr)
-	require.Equal(t, http.StatusInternalServerError, res.Code)
-}
-
-func TestNewHandlerSendExtendDeadlineFailure(t *testing.T) {
-	opts := contentstream.Options{WriteTimeout: time.MustParseDuration("1s")}
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, opts, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		return stream.Send(&test.Response{Greeting: "hi"})
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusInternalServerError, res.Code)
-}
-
 func TestNewRequestHandlerSendExtendReadDeadlineFailure(t *testing.T) {
 	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("1s"), WriteTimeout: time.MustParseDuration("1s")}
 	handler := contentstream.NewRequestHandler(
@@ -1062,49 +776,6 @@ func TestNewRequestHandlerRecvExtendWriteDeadlineFailure(t *testing.T) {
 	require.ErrorIs(t, recvErr, test.ErrFailed)
 }
 
-func TestNewHandlerSendCommitFailure(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		return stream.Send(&test.Response{Greeting: "hi"})
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := &test.ErrResponseWriter{}
-
-	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
-		handler.ServeHTTP(res, req)
-	})
-}
-
-func TestNewHandlerSendFlushFailure(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		return stream.Send(&test.Response{Greeting: "hi"})
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := &test.NoFlushResponseWriter{}
-
-	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
-		handler.ServeHTTP(res, req)
-	})
-}
-
-func TestNewHandlerSendLimiterErrorMapsTo500(t *testing.T) {
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
-	res := httptest.NewRecorder()
-
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
-		return stream.Send(&test.Response{Greeting: "hi"})
-	})
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusInternalServerError, res.Code)
-}
-
 func TestNewRequestHandlerRecvLimiterErrorMapsTo500(t *testing.T) {
 	var recvErr error
 
@@ -1189,26 +860,6 @@ func TestNewRequestHandlerRecvRecoversStickyCapReaderError(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
 }
 
-func TestNewHandlerRejectsNilEncoderForRegisteredKind(t *testing.T) {
-	sm := encodingstream.NewMap()
-	codec := sm.Get("json")
-	codec.Encoder = nil
-	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
-
-	handler := contentstream.NewHandler(cont, sm, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
-		return nil
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusNotAcceptable, res.Code)
-}
-
 func TestNewRequestHandlerRejectsNilCodecFieldForRegisteredKind(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1244,18 +895,6 @@ func TestNewRequestHandlerRejectsNilCodecFieldForRegisteredKind(t *testing.T) {
 	}
 }
 
-func decodeNDJSONGreeting(t *testing.T, scanner *bufio.Scanner) string {
-	t.Helper()
-
-	require.True(t, scanner.Scan())
-
-	var res map[string]any
-	require.NoError(t, json.Unmarshal(scanner.Bytes(), &res))
-
-	greeting, _ := res["Greeting"].(string)
-	return greeting
-}
-
 type drainAfterDecode struct {
 	drain  chan struct{}
 	closed <-chan struct{}
@@ -1284,4 +923,37 @@ func (b *drainBody) Close() error {
 	close(b.closed)
 
 	return nil
+}
+
+type closeTracker struct {
+	closes int
+	err    error
+}
+
+type trackedEncoder struct {
+	tracker *closeTracker
+}
+
+func (*trackedEncoder) Encode(any) error {
+	return nil
+}
+
+func (e *trackedEncoder) Close() error {
+	e.tracker.closes++
+
+	return nil
+}
+
+type trackedDecoder struct {
+	tracker *closeTracker
+}
+
+func (*trackedDecoder) Decode(any) error {
+	return nil
+}
+
+func (d *trackedDecoder) Close() error {
+	d.tracker.closes++
+
+	return d.tracker.err
 }

--- a/net/http/content/stream/stream.go
+++ b/net/http/content/stream/stream.go
@@ -158,6 +158,22 @@ func (s *Stream[Res]) close() error {
 	return s.encoder.Close()
 }
 
+// requestEncoder keeps bidirectional stream finalization on the response stream while closing both codecs.
+type requestEncoder struct {
+	stream.Encoder
+	decoder stream.Decoder
+}
+
+func (e *requestEncoder) Close() error {
+	if err := e.Encoder.Close(); err != nil {
+		_ = e.decoder.Close()
+
+		return err
+	}
+
+	return e.decoder.Close()
+}
+
 // RequestStream is a bidirectional streaming handle: both the request and the response stream.
 //
 // RequestStream is not safe for arbitrary concurrent use. The supported pattern, matching gRPC's bidi
@@ -265,14 +281,4 @@ func (s *RequestStream[Req, Res]) decode() (*Req, error) {
 // request stream, letting a handler's Recv loop end cleanly without importing errors/io itself.
 func (s *RequestStream[Req, Res]) IsFinished(err error) bool {
 	return errors.Is(err, io.EOF)
-}
-
-func (s *RequestStream[Req, Res]) close() error {
-	err := s.Stream.close()
-
-	if decErr := s.decoder.Close(); err == nil {
-		err = decErr
-	}
-
-	return err
 }


### PR DESCRIPTION
## What

- Resolve streaming codecs by full media type and reject unsupported media representations.
- Guarantee that Accept negotiation yields a response encoder, while bidirectional streams finalize both codecs before aborting during drain.

## Why

- Keep streaming protocol negotiation explicit and preserve codec cleanup when shutdown races with a committed handler failure.

## Testing

- `make package=net/http/content/stream specs` - passed
- `make package=net/http/client specs` - passed
- `make package=net/http/content/stream lint` - passed
- `make sec` - passed; govulncheck found no affected code and Trivy reported no vulnerabilities or secrets.
- `git diff --check` - passed
- Validation is scoped to the changed streaming package and its direct HTTP client consumer; CI covers the full suite.

AI-assisted-by: [Codex](https://openai.com/codex/)
