### PR TITLE
feat(stream): remove redundant request metadata encoder

### DIFF
--- a/net/http/content/handler.go
+++ b/net/http/content/handler.go
@@ -16,8 +16,7 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 // Context population:
 // The handler attaches request-scoped values to the context via net/http/meta:
 //   - the original *[http.Request],
-//   - the [http.ResponseWriter], and
-//   - the selected encoder.
+//   - the [http.ResponseWriter].
 //
 // Content negotiation:
 // Request-body decoding uses the request Content-Type, falling back to JSON when Content-Type is absent.
@@ -25,7 +24,7 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 // the package documentation) is rejected with [ErrUnsupportedRequestMedia] rather than falling back to
 // JSON; see [Content.NewFromRequestBody]. Response encoding uses the request Accept header, falling back
 // to Content-Type when Accept is absent. The response Content-Type header is set to the negotiated
-// response media type.
+// response media type. The selected response encoder remains internal to the handler.
 //
 // Errors:
 // If request decoding fails, NewRequestHandler converts the decode error into a 400 Bad Request using
@@ -86,7 +85,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 		ctx := req.Context()
 
 		mediaType := cont.NewFromAccept(req)
-		ctx = meta.WithContent(ctx, req, res, mediaType.Encoder)
+		ctx = meta.WithRequestResponse(ctx, req, res)
 		res.Header().Set(TypeKey, mediaType.WithUTF8())
 
 		data, err := handler(ctx)

--- a/net/http/content/stream/drain.go
+++ b/net/http/content/stream/drain.go
@@ -4,7 +4,7 @@ import "github.com/alexfalkowski/go-service/v2/context"
 
 func withDrain(ctx context.Context, drain <-chan struct{}, onDrain func()) (context.Context, context.CancelCauseFunc) {
 	if drain == nil {
-		return ctx, nil
+		return ctx, func(error) {}
 	}
 
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -12,9 +12,7 @@ func withDrain(ctx context.Context, drain <-chan struct{}, onDrain func()) (cont
 		select {
 		case <-drain:
 			cancel(ErrDraining)
-			if onDrain != nil {
-				onDrain()
-			}
+			onDrain()
 		case <-ctx.Done():
 		}
 	}()

--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -24,7 +24,7 @@ import (
 // A handler error returned before the first successful Send is an ordinary HTTP error rendered
 // through [status.WriteError]. A handler error returned after the first successful Send aborts the
 // response via panic([http.ErrAbortHandler]) instead, since the response is already committed — see
-// [Stream.Send] and [finishResponse].
+// [Stream.Send] and [handleResponse].
 //
 // Drain:
 // When opts.Drain starts before the handler is invoked, this handler returns 503. Otherwise it cancels
@@ -50,15 +50,13 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 			return
 		}
 
-		limiter := meta.Limiter(ctx)
-
 		resMedia, err := NewMediaFromAccept(req, sm)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
 		}
 
-		ctx = meta.WithContent(ctx, req, res, nil)
+		ctx = meta.WithRequestResponse(ctx, req, res)
 		res.Header().Set(content.TypeKey, resMedia.WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
@@ -66,21 +64,19 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 		defer cont.ReturnBuffer(buffer)
 
 		writer := &commitWriter{res: res, buffer: buffer}
-		controller := http.NewResponseController(res)
-		ctx, cancel := withDrain(ctx, opts.Drain, nil)
-		if cancel != nil {
-			defer cancel(nil)
-		}
 
-		st := &Stream[Res]{
+		ctx, cancel := withDrain(ctx, opts.Drain, func() {})
+		defer cancel(nil)
+
+		stream := &Stream[Res]{
 			ctx:          ctx,
 			writer:       writer,
 			encoder:      resMedia.NewEncoder(writer),
-			controller:   controller,
+			controller:   http.NewResponseController(res),
 			writeTimeout: opts.WriteTimeout,
-			limiter:      limiter,
+			limiter:      meta.Limiter(ctx),
 		}
-		finishResponse(ctx, res, st, handler(ctx, st))
+		handleResponse(ctx, res, stream, handler(ctx, stream))
 	}
 }
 
@@ -88,7 +84,7 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 //
 // The handler must propagate a [Stream.Send] error by returning it (directly, or wrapped) rather than
 // ignoring it and continuing. Send is sticky — once it fails, every later call returns the same error
-// immediately — but only the handler returning that error triggers [finishResponse]'s abort/HTTP-error
+// immediately — but only the handler returning that error triggers [handleResponse]'s abort/HTTP-error
 // handling; a handler that swallows a Send error and returns nil degrades to a no-op loop over a dead
 // connection instead of ending the request. When configured [Options.Drain] starts, ctx is
 // canceled with [ErrDraining]; handlers that wait on an upstream source must select on ctx.Done and
@@ -133,11 +129,8 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 		ctx := req.Context()
 		if isDraining(opts.Drain) {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
-
 			return
 		}
-
-		limiter := meta.Limiter(ctx)
 
 		if req.ProtoMajor < 2 {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusHTTPVersionNotSupported, ErrBidiRequiresHTTP2))
@@ -156,7 +149,7 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 			return
 		}
 
-		ctx = meta.WithContent(ctx, req, res, nil)
+		ctx = meta.WithRequestResponse(ctx, req, res)
 		res.Header().Set(content.TypeKey, resMedia.WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
@@ -164,31 +157,26 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 		defer cont.ReturnBuffer(buffer)
 
 		writer := &commitWriter{res: res, buffer: buffer}
-		controller := http.NewResponseController(res)
-		ctx, cancel := withDrain(ctx, opts.Drain, func() {
-			_ = req.Body.Close()
-		})
-		if cancel != nil {
-			defer cancel(nil)
-		}
+		ctx, cancel := withDrain(ctx, opts.Drain, func() { _ = req.Body.Close() })
+		defer cancel(nil)
 
 		capped := budget.NewReader(req.Body, opts.MaxReceiveSize.Bytes())
 		decoder := reqMedia.NewDecoder(capped)
-		st := &RequestStream[Req, Res]{
+		stream := &RequestStream[Req, Res]{
 			Stream: Stream[Res]{
 				ctx:          ctx,
 				writer:       writer,
 				encoder:      &requestEncoder{Encoder: resMedia.NewEncoder(writer), decoder: decoder},
-				controller:   controller,
+				controller:   http.NewResponseController(res),
 				readTimeout:  opts.ReadTimeout,
 				writeTimeout: opts.WriteTimeout,
-				limiter:      limiter,
+				limiter:      meta.Limiter(ctx),
 			},
 			decoder:        decoder,
 			capped:         capped,
 			maxReceiveSize: opts.MaxReceiveSize.Bytes(),
 		}
-		finishResponse(ctx, res, &st.Stream, handler(ctx, st))
+		handleResponse(ctx, res, &stream.Stream, handler(ctx, stream))
 	}
 }
 
@@ -201,7 +189,7 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 // an active Recv returns [ErrDraining].
 type RequestHandler[Req any, Res any] func(ctx context.Context, stream *RequestStream[Req, Res]) error
 
-// finishResponse applies the streaming error contract after a stream handler returns.
+// handleResponse applies the streaming error contract after a stream handler returns.
 //
 // If the response was never committed, a handler error is rendered as an ordinary HTTP error via
 // [status.WriteError] (a nil error leaves an empty, implicitly-200 response). If the response was
@@ -209,9 +197,9 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, stream *RequestS
 // recorded for operator diagnostics and the response is aborted via panic([http.ErrAbortHandler]),
 // which [transport/http.recoveryHandler] and the access logger already special-case for a committed
 // response.
-func finishResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
+func handleResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if s.draining() {
-		finishResponseDuringDrain(ctx, res, s, err)
+		drainResponse(ctx, res, s, err)
 		return
 	}
 
@@ -231,7 +219,7 @@ func finishResponse[Res any](ctx context.Context, res http.ResponseWriter, s *St
 	}
 }
 
-func finishResponseDuringDrain[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
+func drainResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if !s.committed() {
 		_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
 		return

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -13,13 +13,10 @@
 //
 //   - the active `http.ResponseWriter`
 //
-//   - the negotiated `encoding.Encoder` (typically selected from the request Content-Type)
-//
 // # Safety and expectations
 //
-// Request, Response, and Encoder are intentionally strict helpers: they expect the corresponding values
-// to have been stored in the context via WithContent. Calling them without content metadata present will
-// panic due to type assertions.
+// Request and Response return nil when request-response metadata is absent. Handler pipelines that need
+// those values should install them with WithRequestResponse before invoking downstream logic.
 //
 // These helpers are typically used in tightly controlled handler pipelines (for example those created by
 // [github.com/alexfalkowski/go-service/v2/net/http/content.NewHandler] /

--- a/net/http/meta/meta.go
+++ b/net/http/meta/meta.go
@@ -2,12 +2,11 @@ package meta
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 )
 
-const contentKey = context.Key("content")
+const requestResponseKey = context.Key("request-response")
 
 const limiterKey = context.Key("limiter")
 
@@ -43,41 +42,32 @@ func WithAttributes(ctx context.Context, pairs ...Pair) context.Context {
 	return meta.WithAttributes(ctx, pairs...)
 }
 
-type content struct {
+type requestResponse struct {
 	request  *http.Request
 	response http.ResponseWriter
-	encoder  encoding.Encoder
 }
 
 // Request returns the stored *[http.Request] from ctx.
 //
-// Panics: Request expects WithContent to have been called. It will panic if no content metadata is stored
-// in ctx or if the stored value is invalid.
+// It returns nil when WithRequestResponse has not been called.
 func Request(ctx context.Context) *http.Request {
-	return ctx.Value(contentKey).(content).request
+	requestResponse, _ := ctx.Value(requestResponseKey).(requestResponse)
+
+	return requestResponse.request
 }
 
 // Response returns the stored [http.ResponseWriter] from ctx.
 //
-// Panics: Response expects WithContent to have been called. It will panic if no content metadata is stored
-// in ctx or if the stored value is invalid.
+// It returns nil when WithRequestResponse has not been called.
 func Response(ctx context.Context) http.ResponseWriter {
-	return ctx.Value(contentKey).(content).response
+	requestResponse, _ := ctx.Value(requestResponseKey).(requestResponse)
+
+	return requestResponse.response
 }
 
-// Encoder returns the stored [encoding.Encoder] from ctx.
-//
-// Panics: Encoder expects WithContent to have been called. It will panic if no content metadata is stored
-// in ctx or if the stored value is invalid.
-func Encoder(ctx context.Context) encoding.Encoder {
-	return ctx.Value(contentKey).(content).encoder
-}
-
-// WithContent stores HTTP content metadata in ctx and returns the derived context.
-//
-// The encoder may be nil when a handler only needs request and response access.
-func WithContent(ctx context.Context, req *http.Request, res http.ResponseWriter, enc encoding.Encoder) context.Context {
-	return context.WithValue(ctx, contentKey, content{request: req, response: res, encoder: enc})
+// WithRequestResponse stores the HTTP request and response writer in ctx and returns the derived context.
+func WithRequestResponse(ctx context.Context, req *http.Request, res http.ResponseWriter) context.Context {
+	return context.WithValue(ctx, requestResponseKey, requestResponse{request: req, response: res})
 }
 
 // RateLimiter is the minimal per-message load-control interface a streaming handler charges against.
@@ -97,10 +87,8 @@ type RateLimiter interface {
 
 // WithLimiter stores limiter in ctx and returns the derived context.
 //
-// This is a separate context key from WithContent (rather than an added content field) because a limiter is
-// route-specific and usually absent — most WithContent calls have no limiter to carry, and every existing
-// WithContent call site would otherwise have to pass an always-present argument for a value that is usually
-// nil. limiter is typically the same limiter that already charged one token for the request at stream open
+// This is a separate context key from WithRequestResponse because a limiter is route-specific and usually
+// absent. limiter is typically the same limiter that already charged one token for the request at stream open
 // (see [transport/http/limiter.Handler.ServeHTTP]); storing it here lets a streaming handler, constructed
 // deeper in the call chain, charge additional per-message tokens against the same limiter. limiter may be
 // nil, meaning no limiter is configured for the request.
@@ -111,8 +99,8 @@ func WithLimiter(ctx context.Context, limiter RateLimiter) context.Context {
 // Limiter returns the stored [RateLimiter] from ctx, or nil if WithLimiter was never called or was called
 // with a nil limiter.
 //
-// Unlike Request, Response, and Encoder, Limiter never panics on a missing value: a limiter is optional
-// per-route configuration, so nil ("no limiter configured") is the common case rather than a caller error.
+// Like Request and Response, Limiter returns nil on a missing value. A limiter is optional per-route
+// configuration, so nil ("no limiter configured") is the common case rather than a caller error.
 func Limiter(ctx context.Context) RateLimiter {
 	limiter, _ := ctx.Value(limiterKey).(RateLimiter)
 	return limiter

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -13,25 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithContent(t *testing.T) {
+func TestWithRequestResponse(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
-	enc := test.NewEncoder(nil)
 
-	ctx := httpmeta.WithContent(t.Context(), req, res, enc)
+	ctx := httpmeta.WithRequestResponse(t.Context(), req, res)
 
 	require.Same(t, req, httpmeta.Request(ctx))
 	require.Same(t, res, httpmeta.Response(ctx))
-	require.Same(t, enc, httpmeta.Encoder(ctx))
 }
 
-func TestWithContentAllowsPartialContent(t *testing.T) {
-	res := httptest.NewRecorder()
-
-	ctx := httpmeta.WithContent(t.Context(), nil, res, nil)
-
-	require.Same(t, res, httpmeta.Response(ctx))
+func TestRequestResponseReturnsNilWithoutMetadata(t *testing.T) {
+	require.Nil(t, httpmeta.Request(t.Context()))
+	require.Nil(t, httpmeta.Response(t.Context()))
 }
 
 func TestLimiterReturnsNilWithoutWithLimiter(t *testing.T) {

--- a/net/http/mvc/controller.go
+++ b/net/http/mvc/controller.go
@@ -5,7 +5,7 @@ import "github.com/alexfalkowski/go-service/v2/context"
 // Controller executes an MVC action and returns a View, a model, and an error.
 //
 // Controllers are invoked by the routing helpers in this package (see Route/Get/Post/etc.). Those helpers
-// populate the request context with HTTP content metadata before calling the Controller.
+// populate the request context with the HTTP request and response writer before calling the Controller.
 //
 // Return values:
 //   - view: the view that should be rendered. It is typically prebuilt during startup or route registration

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -77,7 +77,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 		res.Header().Set(content.TypeKey, htmlContentType)
 
 		ctx := req.Context()
-		ctx = meta.WithContent(ctx, req, res, nil)
+		ctx = meta.WithRequestResponse(ctx, req, res)
 
 		view, model, err := controller(ctx)
 		if err != nil {
@@ -103,7 +103,7 @@ func writeNotFound(req *http.Request, res http.ResponseWriter) {
 	err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
 	res.Header().Set(content.TypeKey, htmlContentType)
 	ctx := req.Context()
-	ctx = meta.WithContent(ctx, req, res, nil)
+	ctx = meta.WithRequestResponse(ctx, req, res)
 	ctx = meta.WithAttributes(ctx, meta.NewPair("mvcModelError", meta.Error(err)))
 
 	view, model := notFoundController(ctx)

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -299,7 +299,7 @@ func TestViewRenderReturnsWriteError(t *testing.T) {
 	})
 
 	view := mvc.NewFullView("views/hello.tmpl")
-	ctx := meta.WithContent(t.Context(), nil, &test.ErrResponseWriter{}, nil)
+	ctx := meta.WithRequestResponse(t.Context(), nil, &test.ErrResponseWriter{})
 
 	err := view.Render(ctx, &test.Model)
 
@@ -339,7 +339,7 @@ func TestNewViewUsesLayoutPathWhenBasenameCollides(t *testing.T) {
 			})
 
 			res := httptest.NewRecorder()
-			ctx := meta.WithContent(t.Context(), nil, res, nil)
+			ctx := meta.WithRequestResponse(t.Context(), nil, res)
 
 			err := tt.view().Render(ctx, &test.Model)
 


### PR DESCRIPTION
## What

- Simplify HTTP request context metadata to request and response values, keeping negotiated response encoders private to content handlers.
- Preserve streaming drain finalization and per-message limiter behavior while removing redundant local state.
- Intentionally remove `meta.WithContent` and `meta.Encoder`; consumers that only need HTTP request/response metadata now use `meta.WithRequestResponse`.

## Why

- Content encoding is owned by the content and streaming handler APIs, so exposing the selected encoder through request metadata creates an unnecessary and misleading public dependency.
- Consolidating request metadata makes absent metadata safe to inspect and keeps streaming handler setup focused on its active dependencies.

## Testing

- `make package=net/http/meta specs` - passed
- `make package=net/http/content specs` - passed
- `make package=net/http/content/stream specs` - passed
- `make package=net/http/mvc specs` - passed
- `make lint` - passed
- `make sec` - passed; no reachable vulnerabilities or secrets found.
- Full repository suite remains CI coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
