### PR TITLE
refactor(stream): separate private media and codec helpers

### DIFF
--- a/net/http/content/stream/encoder.go
+++ b/net/http/content/stream/encoder.go
@@ -1,0 +1,19 @@
+package stream
+
+import "github.com/alexfalkowski/go-service/v2/encoding/stream"
+
+// requestEncoder keeps bidirectional stream finalization on the response stream while closing both codecs.
+type requestEncoder struct {
+	stream.Encoder
+	decoder stream.Decoder
+}
+
+func (e *requestEncoder) Close() error {
+	if err := e.Encoder.Close(); err != nil {
+		_ = e.decoder.Close()
+
+		return err
+	}
+
+	return e.decoder.Close()
+}

--- a/net/http/content/stream/media.go
+++ b/net/http/content/stream/media.go
@@ -126,7 +126,7 @@ func NewMediaFromAccept(req *http.Request, sm *stream.Map) (Media, error) {
 // rejecting the whole list, the same way an unparsable single Accept value already falls through to
 // [NewMedia]'s own rejection when nothing else in the list matches.
 func matchStreamAccept(header string) (string, bool) {
-	var exact, major, bare streamAcceptMatch
+	var exact, major, bare mediaRangeMatch
 
 	for _, item := range accept.Items(header) {
 		value, err := media.Parse(item)
@@ -164,24 +164,6 @@ func matchStreamAccept(header string) (string, bool) {
 	}
 }
 
-// streamAcceptMatch is the controlling Accept item found so far for one specificity tier (exact
-// subtype, "type/*" wildcard, or bare "*/*" wildcard) in [matchStreamAccept]'s scan.
-type streamAcceptMatch struct {
-	value string
-	found bool
-	zero  bool
-}
-
-// consider records item as this tier's controlling reference if none has been recorded yet. Only the
-// first occurrence within a tier is kept: RFC 9110 §12.5.1 lets the most specific tier present control
-// regardless of order, and within one tier this package has no further precedence rule to break a tie
-// between duplicate references, so the first one found is as good as any.
-func (m *streamAcceptMatch) consider(zero bool, value string) {
-	if !m.found {
-		m.found, m.zero, m.value = true, zero, value
-	}
-}
-
 // NewMediaFromContentType parses the request Content-Type header and resolves a streaming decoder.
 //
 // Unlike [Content.NewMediaFromContentType], an unregistered or unparsable media type returns
@@ -213,4 +195,22 @@ func NewMediaFromContentType(req *http.Request, sm *stream.Map) (Media, error) {
 	}
 
 	return m, nil
+}
+
+// mediaRangeMatch is the controlling media range found so far for one specificity tier (exact subtype,
+// "type/*" wildcard, or bare "*/*" wildcard) in [matchStreamAccept]'s scan.
+type mediaRangeMatch struct {
+	value string
+	found bool
+	zero  bool
+}
+
+// consider records item as this tier's controlling reference if none has been recorded yet. Only the
+// first occurrence within a tier is kept: RFC 9110 §12.5.1 lets the most specific tier present control
+// regardless of order, and within one tier this package has no further precedence rule to break a tie
+// between duplicate references, so the first one found is as good as any.
+func (m *mediaRangeMatch) consider(zero bool, value string) {
+	if !m.found {
+		m.found, m.zero, m.value = true, zero, value
+	}
 }

--- a/net/http/content/stream/stream.go
+++ b/net/http/content/stream/stream.go
@@ -158,22 +158,6 @@ func (s *Stream[Res]) close() error {
 	return s.encoder.Close()
 }
 
-// requestEncoder keeps bidirectional stream finalization on the response stream while closing both codecs.
-type requestEncoder struct {
-	stream.Encoder
-	decoder stream.Decoder
-}
-
-func (e *requestEncoder) Close() error {
-	if err := e.Encoder.Close(); err != nil {
-		_ = e.decoder.Close()
-
-		return err
-	}
-
-	return e.decoder.Close()
-}
-
 // RequestStream is a bidirectional streaming handle: both the request and the response stream.
 //
 // RequestStream is not safe for arbitrary concurrent use. The supported pattern, matching gRPC's bidi


### PR DESCRIPTION
## What

- Organize private media matching and request codec-finalization helpers into focused source files without changing their behavior.

## Why

- Keep related implementation concerns localized so future maintenance remains clear while preserving existing HTTP streaming behavior.

## Testing

- `make package=net/http/content/stream specs` - passed
- Existing package coverage exercises media selection and request codec-close behavior; no behavior change required new tests.
- `make package=net/http/content/stream lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
