### PR TITLE
feat(content): separate unary and stream payload handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,8 +645,8 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   `proto.UnmarshalOptions.RecursionLimit`.
 - `msgpack` and `gob` fail the decoder-bounds rule above, so they are
   intentionally rejected for request-body decoding by
-  `net/http/content.Media.CanDecodeRequest` with HTTP 415 and intentionally
-  absent from `net/http/content`'s `streamKinds`. Both remain fully supported
+  `net/http/content/unary.Media.CanDecodeRequest` with HTTP 415 and intentionally
+  absent from `net/http/content/stream`'s `streamKinds`. Both remain fully supported
   for response encoding, which is why they still resolve as media types.
   `encoding/gob`'s own `Decoder` documents that it does only basic sanity
   checking on decoded input sizes and that its limits are not configurable, so

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ net-http-benchmarks:
 	@$(MAKE) package=net/http benchtime=100x benchmark
 
 http-content-benchmarks:
-	@$(MAKE) package=net/http/content benchtime=100x benchmark
+	@$(MAKE) package=net/http/content/unary benchtime=100x benchmark
+	@$(MAKE) package=net/http/content/stream benchtime=100x benchmark
 
 # Run bounded fuzz tests. Set fuzztime=<duration-or-count> to override the default 1000 executions per target.
 fuzzes: bytes-fuzz time-fuzz encoding-fuzz compress-fuzz net-fuzz

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ exactly one canonical kind (no aliases):
 > - `bytes` is the passthrough encoder for `io.ReaderFrom`/`io.WriterTo` payloads.
 > - HTTP media-type aliases such as `pb`, `proto`, `protobin`, `pbbin`, `pbtxt`, `prototxt`,
 >   `pbjson`, `octet-stream`, `plain`, and `yml` are resolved to the canonical kinds above by
->   `net/http/content` before they ever reach this registry. See [HTTP content types](#http-content-types).
+>   `net/http/content/unary` before they ever reach this registry. See [HTTP content types](#http-content-types).
 > - `encoding/stream.Map` is a separate registry for streaming (multi-value) encoding — `json`, `msgpack`,
 >   `gob`, `yaml` — used by [HTTP streaming (NDJSON)](#http-streaming-ndjson), not by this single-value
 >   registry.
@@ -1126,7 +1126,7 @@ Built-in protobuf-oriented media type aliases include:
 > `application/vnd.msgpack` and `application/gob` can be resolved as media types and remain valid
 > response codecs, but REST/RPC request-body decoding — for both single-value and streaming
 > (NDJSON) requests — rejects them with HTTP 415. This follows the decoder-bounds rule documented in
-> `net/http/content`'s package documentation: a codec is admissible for decoding untrusted input only
+> `net/http/content/unary`'s package documentation: a codec is admissible for decoding untrusted input only
 > when it is both ratio-bounded and depth-bounded, which msgpack and gob are not.
 
 ### HTTP streaming (NDJSON)
@@ -1146,18 +1146,14 @@ matching `client.Stream`/`client.RequestStream` functions, which take the same k
 See `net/http/client`'s `ExampleClient_RequestStream` for a complete HTTP/2 bidirectional client call.
 
 > [!IMPORTANT]
-> Streaming helpers now live in `github.com/alexfalkowski/go-service/v2/net/http/content/stream` rather than
-> `net/http/content`. Update imports and replace `content.StreamOptions`, `content.StreamHandler`,
-> `content.RequestStreamHandler`, `content.Stream`, `content.RequestStream`, `content.StreamMedia`,
-> `content.NewStreamHandler`, `content.NewRequestStreamHandler`, and `content.NewStreamMedia` with their
-> `stream` equivalents. Replace `cont.NewStreamFromMedia`, `cont.NewStreamFromAccept`, and
-> `cont.NewStreamFromContentType` with `stream.NewMedia`, `stream.NewMediaFromAccept`, and
-> `stream.NewMediaFromContentType`, respectively, passing an explicit `*encoding/stream.Map` as the registry
-> argument. `content.Content` now owns only single-value codecs; pass that streaming registry separately
-> to `stream.NewHandler`, `stream.NewRequestHandler`, and `client.NewClient`.
-> Replace `content.ErrUnsupportedStreamMedia` and `content.ErrBidiRequiresHTTP2` with
-> `stream.ErrUnsupportedMedia` and `stream.ErrBidiRequiresHTTP2`.
-> `rest.Register` and `rpc.Register` take both that streaming registry and `stream.Options`.
+> Single-value helpers live in `github.com/alexfalkowski/go-service/v2/net/http/content/unary`; streaming helpers
+> live in `github.com/alexfalkowski/go-service/v2/net/http/content/stream`. Import `unary` for `Content`, `Media`,
+> `NewContent`, `NewHandler`, and `NewRequestHandler`; import `stream` for incremental request/response helpers.
+> `stream.NewHandler` and `stream.NewRequestHandler` take `*stream.Content`, while unary handlers take
+> `*unary.Content`. `rest.Register`, `rpc.Register`, and `client.NewClient` take the unary and streaming content
+> owners separately.
+> Migrate root `content` imports and identifiers to `content/unary` and `unary`, respectively; use
+> `net/http.ContentTypeKey` and `net/http.AcceptKey` for the shared header names.
 
 The initial wire format is NDJSON (`application/x-ndjson`), newline-delimited JSON values, resolved
 through a separate streaming encoder/decoder registry (`encoding/stream.Map`) from the single-value one
@@ -1194,7 +1190,7 @@ back to JSON, unlike single-value negotiation.
 
 The HTTP transport wraps the mux with `net/http.NewNotFoundHandler` so generated 404 responses can be rendered consistently while preserving other mux responses such as 405 Method Not Allowed.
 
-- REST/RPC-style missing routes use `net/http/content.NotFoundHandler`, which writes the standard `status.WriteError` response.
+- REST/RPC-style missing routes use `net/http/status.NotFoundHandler`, which writes the standard `status.WriteError` response.
 - MVC missing routes can use `net/http/mvc.NotFoundHandler` to render the registered MVC not-found view when the request accepts HTML (`Accept: text/html`) or is an HTMX request (`Hx-Request: true`).
 - Routes that match and write their own status are not replaced by this mux-level not-found handler.
 

--- a/encoding/map.go
+++ b/encoding/map.go
@@ -22,7 +22,7 @@ import (
 //
 // Callers that need to accept alternate spellings of these kinds (for example HTTP media subtypes such
 // as "pb" or "octet-stream") are expected to translate them to the canonical kind above before calling
-// [Map.Get]; see [github.com/alexfalkowski/go-service/v2/net/http/content]'s unaryKind.
+// [Map.Get]; see [github.com/alexfalkowski/go-service/v2/net/http/content/unary]'s unaryKind.
 //
 // Callers can add additional kinds or override existing kinds via [Map.Register].
 func NewMap() *Map {

--- a/internal/test/encoding.go
+++ b/internal/test/encoding.go
@@ -2,10 +2,11 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
-	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -13,10 +14,13 @@ import (
 var Encoder = encoding.NewMap()
 
 // StreamEncoder contains the real streaming encoders/decoders exercised by content and transport tests.
-var StreamEncoder = stream.NewMap()
+var StreamEncoder = encodingstream.NewMap()
 
-// Content is the shared unary HTTP content registry backed by Encoder.
-var Content = content.NewContent(Encoder, Pool)
+// UnaryContent is the shared unary HTTP content registry backed by Encoder.
+var UnaryContent = unary.NewContent(Encoder, Pool)
+
+// StreamContent is the shared streaming HTTP content registry backed by StreamEncoder.
+var StreamContent = contentstream.NewContent(StreamEncoder, Pool)
 
 // NewEncoder returns an encoder test double whose Encode and Decode methods fail with the supplied error.
 func NewEncoder(err error) encoding.Encoder {

--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -6,20 +6,20 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 )
 
 // RegisterHandlers registers DELETE and GET REST handlers for the service-prefixed path.
-func RegisterHandlers[Res any](path string, h content.Handler[Res]) {
+func RegisterHandlers[Res any](path string, h unary.Handler[Res]) {
 	rest.Delete(http.Pattern(Name, path), h)
 	rest.Get(http.Pattern(Name, path), h)
 }
 
 // RegisterRequestHandlers registers POST, PUT, and PATCH REST handlers for the service-prefixed path.
-func RegisterRequestHandlers[Req any, Res any](path string, h content.RequestHandler[Req, Res]) {
+func RegisterRequestHandlers[Req any, Res any](path string, h unary.RequestHandler[Req, Res]) {
 	rest.Post(http.Pattern(Name, path), h)
 	rest.Put(http.Pattern(Name, path), h)
 	rest.Patch(http.Pattern(Name, path), h)
@@ -88,7 +88,7 @@ func RestRequestError(_ context.Context, _ *Request) (*Response, error) {
 }
 
 func registerRest(router *http.Router) {
-	rest.Register(router, Content, StreamEncoder, Pool, stream.Options{})
+	rest.Register(router, UnaryContent, StreamContent, Pool, stream.Options{})
 }
 
 func restClient(client *http.Client, os *worldOpts) *rest.Client {

--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -71,5 +71,5 @@ func ErrorsInternalProtobufSayHello(_ context.Context, _ *v1.SayHelloRequest) (*
 }
 
 func (w *World) registerRPC() {
-	rpc.Register(w.Router, Content, StreamEncoder, Pool, stream.Options{})
+	rpc.Register(w.Router, UnaryContent, StreamContent, Pool, stream.Options{})
 }

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -3,11 +3,11 @@ package client
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -102,18 +102,17 @@ func WithRedirect(redirect Redirect) ClientOption {
 	})
 }
 
-// NewClient constructs a Client that encodes requests and decodes responses using content.
+// NewClient constructs a Client that encodes requests and decodes responses using unary and stream content.
 //
 // It reuses buffers from pool and applies the configured transport, unary timeout, and redirect policy.
 //
 // The underlying *[http.Client] is constructed via [http.NewClient] with no timeout. [WithTimeout]
 // applies the configured deadline only to [Client.Do], preserving long-lived streaming calls.
 //
-// [Stream] and [RequestStream] resolve streaming media types through streamMap (see
-// [github.com/alexfalkowski/go-service/v2/net/http/content/stream.NewMedia]).
+// [Stream] and [RequestStream] resolve streaming media types through streamContent.
 //
 // Callers should treat the returned Client as safe for concurrent use.
-func NewClient(content *content.Content, streamMap *stream.Map, pool *sync.BufferPool, opts ...ClientOption) *Client {
+func NewClient(uc *unary.Content, sc *stream.Content, pool *sync.BufferPool, opts ...ClientOption) *Client {
 	clientOptions := options(opts...)
 
 	client := http.NewClient(clientOptions.roundTripper, 0)
@@ -127,8 +126,8 @@ func NewClient(content *content.Content, streamMap *stream.Map, pool *sync.Buffe
 
 	return &Client{
 		client:          client,
-		content:         content,
-		streamMap:       streamMap,
+		unaryContent:    uc,
+		streamContent:   sc,
 		pool:            pool,
 		timeout:         clientOptions.timeout,
 		maxResponseSize: clientOptions.maxResponseSize.Bytes(),
@@ -137,7 +136,7 @@ func NewClient(content *content.Content, streamMap *stream.Map, pool *sync.Buffe
 
 // Options describes the request/response payloads and media types for a single call.
 //
-// ContentType is used to select the request encoder via net/http/content. Accept is used to request
+// ContentType is used to select the request encoder via net/http/content/unary. Accept is used to request
 // a distinct response media type.
 // Typical values are media types like "application/json" or go-service specific protobuf media types.
 //
@@ -177,8 +176,8 @@ func (o Options) HasResponse() bool {
 // The Client uses a shared buffer pool to reduce allocations when encoding/decoding bodies.
 type Client struct {
 	client          *http.Client
-	content         *content.Content
-	streamMap       *stream.Map
+	unaryContent    *unary.Content
+	streamContent   *stream.Content
 	pool            *sync.BufferPool
 	timeout         time.Duration
 	maxResponseSize int64
@@ -219,7 +218,7 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 	return c.Do(ctx, http.MethodPatch, url, opts)
 }
 
-// Do issues a request with method and url, encoding and decoding bodies via content.
+// Do issues a request with method and url, encoding and decoding bodies via unary.
 //
 // Encoding:
 //   - If opts.Request is non-nil, it is encoded into the request body using the encoder selected by
@@ -265,7 +264,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 	}
 
 	// The server handlers return text/error to indicate an error.
-	responseMedia := c.content.NewFromMedia(responseContentType(response.Header, opts))
+	responseMedia := c.unaryContent.NewFromMedia(responseContentType(response.Header, opts))
 	if err := mediaStatusError(response, responseMedia, responseBody.String()); err != nil {
 		return err
 	}
@@ -278,7 +277,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 		// caller supplying a customized registry can still reach a nil dereference here. Response
 		// decoding is intentionally not subject to the request-decode policy that guards
 		// Content.NewFromRequestBody (a configured response endpoint is a different trust context from
-		// an inbound request body); see the decoder-bounds rule in net/http/content's documentation.
+		// an inbound request body); see the decoder-bounds rule in net/http/content/unary's documentation.
 		if err := responseMedia.Encoder.Decode(responseBody, opts.Response); err != nil {
 			return errors.Prefix("http: decode", err)
 		}
@@ -294,7 +293,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 // This is shared by Do and Stream; RequestStream builds its own pipe-backed request instead, since a
 // bidirectional streaming request has no single-value body to encode upfront.
 func (c *Client) newRequest(ctx context.Context, method, url string, opts Options) (*http.Request, error) {
-	requestMedia := c.content.NewFromMedia(opts.ContentType)
+	requestMedia := c.unaryContent.NewFromMedia(opts.ContentType)
 
 	body := io.Reader(http.NoBody)
 	if opts.HasRequest() {
@@ -313,9 +312,9 @@ func (c *Client) newRequest(ctx context.Context, method, url string, opts Option
 		return nil, errors.Prefix("http: new request", err)
 	}
 
-	request.Header.Set(content.TypeKey, requestMedia.String())
+	request.Header.Set(http.ContentTypeKey, requestMedia.String())
 	if !strings.IsEmpty(opts.Accept) {
-		request.Header.Set(content.AcceptKey, opts.Accept)
+		request.Header.Set(http.AcceptKey, opts.Accept)
 	}
 
 	return request, nil
@@ -341,7 +340,7 @@ func (c *Client) readResponse(buffer *bytes.Buffer, body io.Reader) error {
 // error signal actually requires a message, so a non-error streaming response is left untouched for
 // the caller's decoder.
 func (c *Client) checkResponseStatus(response *http.Response, opts Options) error {
-	responseMedia := c.content.NewFromMedia(responseContentType(response.Header, opts))
+	responseMedia := c.unaryContent.NewFromMedia(responseContentType(response.Header, opts))
 
 	message := strings.Empty
 	if responseMedia.IsError() {
@@ -367,7 +366,7 @@ func (c *Client) checkResponseStatus(response *http.Response, opts Options) erro
 // initial response of a [Stream] or [RequestStream] call, before either streams values from/to the
 // caller-supplied handler. Factoring it out keeps both paths honoring the same text/error and status
 // code contract instead of the streaming path silently dropping it (see [Client.checkResponseStatus]).
-func mediaStatusError(response *http.Response, responseMedia content.Media, message string) error {
+func mediaStatusError(response *http.Response, responseMedia unary.Media, message string) error {
 	if responseMedia.IsError() {
 		code := response.StatusCode
 		if !isErrorStatus(code) {
@@ -397,7 +396,7 @@ func defaultErrorMessage(code int) string {
 }
 
 func responseContentType(header http.Header, opts Options) string {
-	if contentType := header.Get(content.TypeKey); !strings.IsEmpty(contentType) {
+	if contentType := header.Get(http.ContentTypeKey); !strings.IsEmpty(contentType) {
 		return contentType
 	}
 

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -21,12 +21,12 @@ import (
 
 func TestDoAllowsResponseAtMaxResponseSize(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Text)
+		res.Header().Set(http.ContentTypeKey, media.Text)
 		_, _ = io.WriteString(res, "hello")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(5))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(5))
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.NoError(t, err)
@@ -34,14 +34,14 @@ func TestDoAllowsResponseAtMaxResponseSize(t *testing.T) {
 
 func TestDoUsesConfiguredTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.Header().Set(content.TypeKey, media.Text)
+		res.Header().Set(http.ContentTypeKey, media.Text)
 		res.WriteHeader(http.StatusOK)
 		res.(http.Flusher).Flush()
 		<-req.Context().Done()
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithTimeout(10*time.Millisecond))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithTimeout(10*time.Millisecond))
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 
@@ -50,12 +50,12 @@ func TestDoUsesConfiguredTimeout(t *testing.T) {
 
 func TestDoRejectsResponseOverMaxResponseSize(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Text)
+		res.Header().Set(http.ContentTypeKey, media.Text)
 		_, _ = io.WriteString(res, "hello!")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(5))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(5))
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.Error(t, err)
@@ -65,13 +65,13 @@ func TestDoRejectsResponseOverMaxResponseSize(t *testing.T) {
 
 func TestDoRejectsErrorResponseOverMaxResponseSize(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Error)
+		res.Header().Set(http.ContentTypeKey, media.Error)
 		res.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(res, "too large")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(5))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(5))
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.Error(t, err)
@@ -81,13 +81,13 @@ func TestDoRejectsErrorResponseOverMaxResponseSize(t *testing.T) {
 
 func TestDoPreservesErrorMediaStatusCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Error)
+		res.Header().Set(http.ContentTypeKey, media.Error)
 		res.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(res, "bad request")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.Error(t, err)
@@ -97,12 +97,12 @@ func TestDoPreservesErrorMediaStatusCode(t *testing.T) {
 
 func TestDoUsesDefaultMessageForNonstandardErrorStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Text)
+		res.Header().Set(http.ContentTypeKey, media.Text)
 		res.WriteHeader(http.StatusClientClosedRequest)
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.Error(t, err)
@@ -122,13 +122,13 @@ func TestDoNormalizesErrorMediaSuccessStatusCode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-				res.Header().Set(content.TypeKey, media.Error)
+				res.Header().Set(http.ContentTypeKey, media.Error)
 				res.WriteHeader(tt.code)
 				_, _ = io.WriteString(res, "upstream error")
 			}))
 			t.Cleanup(server.Close)
 
-			c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+			c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 			err := c.Get(t.Context(), server.URL, client.Options{Response: &struct{}{}})
 			require.Error(t, err)
@@ -140,12 +140,12 @@ func TestDoNormalizesErrorMediaSuccessStatusCode(t *testing.T) {
 
 func TestDoUsesDefaultMaxResponseSize(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Text)
+		res.Header().Set(http.ContentTypeKey, media.Text)
 		_, _ = io.WriteString(res, "hello")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(0))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(0))
 
 	err := c.Get(t.Context(), server.URL, client.Options{})
 	require.NoError(t, err)
@@ -155,15 +155,15 @@ func TestDoUsesDefaultMaxResponseSize(t *testing.T) {
 func TestDoUsesMsgPack(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		var request test.Request
-		require.Equal(t, media.MessagePack, req.Header.Get(content.TypeKey))
+		require.Equal(t, media.MessagePack, req.Header.Get(http.ContentTypeKey))
 		require.NoError(t, test.Encoder.Get("msgpack").Decode(req.Body, &request))
-		res.Header().Set(content.TypeKey, media.MessagePack+"; profile=test")
+		res.Header().Set(http.ContentTypeKey, media.MessagePack+"; profile=test")
 		require.NoError(t, test.Encoder.Get("msgpack").Encode(res, &test.Response{Greeting: "Hello " + request.Name}))
 	}))
 	t.Cleanup(server.Close)
 
 	var response test.Response
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.Post(t.Context(), server.URL, client.Options{
 		ContentType: media.MessagePack,
@@ -175,17 +175,17 @@ func TestDoUsesMsgPack(t *testing.T) {
 }
 
 func TestDoSendsAccept(t *testing.T) {
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		var request test.Request
-		require.Equal(t, media.JSON, req.Header.Get(content.TypeKey))
-		require.Equal(t, media.YAML, req.Header.Get(content.AcceptKey))
+		require.Equal(t, media.JSON, req.Header.Get(http.ContentTypeKey))
+		require.Equal(t, media.YAML, req.Header.Get(http.AcceptKey))
 		require.NoError(t, test.Encoder.Get("json").Decode(req.Body, &request))
 		body := bytes.NewBuffer(nil)
 		require.NoError(t, test.Encoder.Get("yaml").Encode(body, &test.Response{Greeting: "Hello " + request.Name}))
 
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Header:     http.Header{content.TypeKey: []string{media.YAML}},
+			Header:     http.Header{http.ContentTypeKey: []string{media.YAML}},
 			Body:       io.NopCloser(body),
 		}, nil
 	})))
@@ -203,11 +203,11 @@ func TestDoSendsAccept(t *testing.T) {
 
 func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	var body io.ReadCloser
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		body = req.Body
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Header:     http.Header{content.TypeKey: []string{media.Text}},
+			Header:     http.Header{http.ContentTypeKey: []string{media.Text}},
 			Body:       io.NopCloser(strings.NewReader("response")),
 		}, nil
 	})))
@@ -235,7 +235,7 @@ func TestDoDefaultRedirectRejectsCrossOriginCredentialRoundTrip(t *testing.T) {
 			Request:    req,
 		}, nil
 	})
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(authRoundTripper{RoundTripper: rt}))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(authRoundTripper{RoundTripper: rt}))
 
 	err := c.Get(t.Context(), "https://example.com/start", client.Options{})
 
@@ -247,7 +247,7 @@ func TestDoRedirectFollowAllowsExplicitCrossOriginCredentialRoundTrip(t *testing
 	var urls []string
 	rt := redirectingAuthRoundTripper(t, &urls, "https://other.example.com/target")
 	c := client.NewClient(
-		test.Content, test.StreamEncoder, test.Pool,
+		test.UnaryContent, test.StreamContent, test.Pool,
 		client.WithRoundTripper(authRoundTripper{RoundTripper: rt}),
 		client.WithRedirect(client.RedirectFollow),
 	)
@@ -270,7 +270,7 @@ func TestDoRedirectSameOriginRejectsCrossOriginCredentialRoundTrip(t *testing.T)
 		}, nil
 	})
 	c := client.NewClient(
-		test.Content, test.StreamEncoder, test.Pool,
+		test.UnaryContent, test.StreamContent, test.Pool,
 		client.WithRoundTripper(authRoundTripper{RoundTripper: rt}),
 		client.WithRedirect(client.RedirectSameOrigin),
 	)
@@ -285,7 +285,7 @@ func TestDoRedirectSameOriginAllowsSameOriginCredentialRoundTrip(t *testing.T) {
 	var urls []string
 	rt := redirectingAuthRoundTripper(t, &urls, "https://example.com/target")
 	c := client.NewClient(
-		test.Content, test.StreamEncoder, test.Pool,
+		test.UnaryContent, test.StreamContent, test.Pool,
 		client.WithRoundTripper(authRoundTripper{RoundTripper: rt}),
 		client.WithRedirect(client.RedirectSameOrigin),
 	)
@@ -308,7 +308,7 @@ func TestDoRedirectIgnoreRejectsRedirectRoundTrip(t *testing.T) {
 		}, nil
 	})
 	c := client.NewClient(
-		test.Content, test.StreamEncoder, test.Pool,
+		test.UnaryContent, test.StreamContent, test.Pool,
 		client.WithRoundTripper(rt),
 		client.WithRedirect(client.RedirectIgnore),
 	)
@@ -322,9 +322,9 @@ func TestDoRedirectIgnoreRejectsRedirectRoundTrip(t *testing.T) {
 func TestDoReturnsEncodeErrorFromNewRequest(t *testing.T) {
 	enc := encoding.NewMap()
 	enc.Register("json", test.NewEncoder(test.ErrFailed))
-	cont := content.NewContent(enc, test.Pool)
+	unaryContent := unary.NewContent(enc, test.Pool)
 
-	c := client.NewClient(cont, test.StreamEncoder, test.Pool)
+	c := client.NewClient(unaryContent, test.StreamContent, test.Pool)
 
 	err := c.Post(t.Context(), "http://example.com", client.Options{ContentType: media.JSON, Request: &test.Request{Name: "Bob"}})
 
@@ -333,7 +333,7 @@ func TestDoReturnsEncodeErrorFromNewRequest(t *testing.T) {
 }
 
 func TestDoReturnsNewRequestError(t *testing.T) {
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.Do(t.Context(), "BAD METHOD", "http://example.com", client.Options{})
 
@@ -345,7 +345,7 @@ func TestDoReturnsTransportError(t *testing.T) {
 		return nil, test.ErrFailed
 	})
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
 
 	err := c.Get(t.Context(), "http://example.com", client.Options{})
 
@@ -358,7 +358,7 @@ func TestDoReturnsCopyErrorFromReadResponse(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: &test.ErrReaderCloser{}, Request: req}, nil
 	})
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
 
 	err := c.Get(t.Context(), "http://example.com", client.Options{})
 
@@ -369,15 +369,15 @@ func TestDoReturnsCopyErrorFromReadResponse(t *testing.T) {
 func TestDoReturnsDecodeError(t *testing.T) {
 	enc := encoding.NewMap()
 	enc.Register("json", test.NewEncoder(test.ErrFailed))
-	cont := content.NewContent(enc, test.Pool)
+	unaryContent := unary.NewContent(enc, test.Pool)
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.JSON)
+		res.Header().Set(http.ContentTypeKey, media.JSON)
 		_, _ = io.WriteString(res, "{}")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(cont, test.StreamEncoder, test.Pool)
+	c := client.NewClient(unaryContent, test.StreamContent, test.Pool)
 
 	var res test.Response
 	err := c.Get(t.Context(), server.URL, client.Options{Response: &res})
@@ -390,13 +390,13 @@ func TestStreamReturnsCopyErrorFromCheckResponseStatus(t *testing.T) {
 	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusBadRequest,
-			Header:     http.Header{content.TypeKey: []string{media.Error}},
+			Header:     http.Header{http.ContentTypeKey: []string{media.Error}},
 			Body:       &test.ErrReaderCloser{},
 			Request:    req,
 		}, nil
 	})
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
 
 	err := c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{},
 		func(_ context.Context, _ *client.ResponseStream) error {
@@ -434,7 +434,7 @@ func redirectingAuthRoundTripper(t *testing.T, urls *[]string, target string) ht
 		require.Equal(t, "Bearer secret", req.Header.Get("Authorization"))
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Header:     http.Header{content.TypeKey: []string{media.Text}},
+			Header:     http.Header{http.ContentTypeKey: []string{media.Text}},
 			Body:       io.NopCloser(strings.NewReader("ok")),
 			Request:    req,
 		}, nil

--- a/net/http/client/doc.go
+++ b/net/http/client/doc.go
@@ -1,7 +1,7 @@
 // Package client provides a content-aware HTTP client wrapper used by go-service.
 //
 // This package wraps [github.com/alexfalkowski/go-service/v2/net/http.Client] to provide a higher-level API for making HTTP requests with:
-//   - request/response body encoding/decoding via [github.com/alexfalkowski/go-service/v2/net/http/content.Content], and
+//   - request/response body encoding/decoding via [github.com/alexfalkowski/go-service/v2/net/http/content/unary.Content], and
 //   - consistent error handling via [github.com/alexfalkowski/go-service/v2/net/http/status].
 //
 // The wrapper is intended for service-to-service HTTP calls where request payload format is selected

--- a/net/http/client/example_test.go
+++ b/net/http/client/example_test.go
@@ -9,19 +9,18 @@ import (
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-sync"
 )
 
 func ExampleClient_RequestStream() {
 	pool := sync.NewBufferPool()
-	streamMap := encodingstream.NewMap()
-	cont := content.NewContent(encoding.NewMap(), pool)
+	unaryContent := unary.NewContent(encoding.NewMap(), pool)
+	streamContent := contentstream.NewContent(encodingstream.NewMap(), pool)
 	handler := contentstream.NewRequestHandler(
-		cont,
-		streamMap,
+		streamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[exampleRequest, exampleResponse]) error {
 			req, err := stream.Recv()
 			if err != nil {
@@ -36,7 +35,7 @@ func ExampleClient_RequestStream() {
 	server.StartTLS()
 	defer server.Close()
 
-	c := client.NewClient(cont, streamMap, pool, client.WithRoundTripper(server.Client().Transport))
+	c := client.NewClient(unaryContent, streamContent, pool, client.WithRoundTripper(server.Client().Transport))
 	var response exampleResponse
 	err := c.RequestStream(context.Background(), http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
 		func(_ context.Context, stream *client.RequestResponseStream) error {

--- a/net/http/client/stream.go
+++ b/net/http/client/stream.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/budget"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -71,7 +70,7 @@ func (c *Client) StreamPatch(ctx context.Context, url string, opts Options, hand
 // Content negotiation:
 // The response streaming decoder is resolved from the response Content-Type header, falling back to
 // opts.ContentType, via the streaming registry passed to [NewClient] (see
-// [contentstream.NewMedia]). An unregistered or unparseable streaming media type, or a
+// [contentstream.Content.NewFromMedia]). An unregistered or unparseable streaming media type, or a
 // Client whose streaming registry has no matching codec, is returned as an error and handler is never called —
 // but only once the response exists: unlike a media type Stream could reject before dialing at all,
 // there is no way to know the response's actual Content-Type without making the request first, so a
@@ -191,7 +190,7 @@ func (c *Client) Stream(ctx context.Context, method, url string, opts Options, h
 // Timeouts:
 // See [Client.Stream]: the underlying [http.Client] never has a [http.Client.Timeout].
 func (c *Client) RequestStream(ctx context.Context, method, url string, opts Options, handler RequestStreamHandler) error {
-	reqMedia, err := contentstream.NewMedia(opts.ContentType, c.streamMap)
+	reqMedia, err := c.streamContent.NewFromMedia(opts.ContentType)
 	if err == nil && reqMedia.NewEncoder == nil {
 		err = contentstream.ErrUnsupportedMedia
 	}
@@ -211,10 +210,10 @@ func (c *Client) RequestStream(ctx context.Context, method, url string, opts Opt
 	// ContentLength = -1 forces chunked transfer encoding: the pipe has no known total length, and a
 	// declared Content-Length would make the transport try to read exactly that many bytes upfront.
 	request.ContentLength = -1
-	request.Header.Set(content.TypeKey, reqMedia.String())
+	request.Header.Set(http.ContentTypeKey, reqMedia.String())
 
 	if !strings.IsEmpty(opts.Accept) {
-		request.Header.Set(content.AcceptKey, opts.Accept)
+		request.Header.Set(http.AcceptKey, opts.Accept)
 	}
 
 	ready := make(chan responseResult, 1)
@@ -437,7 +436,7 @@ type responseDecoder struct {
 }
 
 func newResponseDecoder(c *Client, response *http.Response, opts Options) (*responseDecoder, error) {
-	resMedia, err := contentstream.NewMedia(responseContentType(response.Header, opts), c.streamMap)
+	resMedia, err := c.streamContent.NewFromMedia(responseContentType(response.Header, opts))
 	if err == nil && resMedia.NewDecoder == nil {
 		err = contentstream.ErrUnsupportedMedia
 	}

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -23,7 +23,7 @@ import (
 )
 
 func TestStreamRecvsValues(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -34,7 +34,7 @@ func TestStreamRecvsValues(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	var greetings []string
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
@@ -60,7 +60,7 @@ func TestStreamRecvsValues(t *testing.T) {
 func TestStreamGetIssuesGetRequest(t *testing.T) {
 	var method string
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
 
@@ -70,7 +70,7 @@ func TestStreamGetIssuesGetRequest(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	var greeting string
 	err := c.StreamGet(t.Context(), server.URL, client.Options{Accept: media.NDJSON},
@@ -105,7 +105,7 @@ func TestStreamPostPutPatchIssueBidiRequests(t *testing.T) {
 			var method string
 
 			handler := contentstream.NewRequestHandler(
-				test.Content, test.StreamEncoder,
+				test.StreamContent,
 				contentstream.Options{},
 				func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 					req, err := stream.Recv()
@@ -125,7 +125,7 @@ func TestStreamPostPutPatchIssueBidiRequests(t *testing.T) {
 			server.StartTLS()
 			t.Cleanup(server.Close)
 
-			c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(server.Client().Transport))
+			c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(server.Client().Transport))
 
 			var greeting string
 			err := tt.call(c, t.Context(), server.URL, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
@@ -152,12 +152,12 @@ func TestStreamPostPutPatchIssueBidiRequests(t *testing.T) {
 
 func TestStreamRequiresStreamRegistry(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.NDJSON)
+		res.Header().Set(http.ContentTypeKey, media.NDJSON)
 		_, _ = io.WriteString(res, "{}\n")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, nil, test.Pool)
+	c := client.NewClient(test.UnaryContent, nil, test.Pool)
 
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON}, func(_ context.Context, stream *client.ResponseStream) error {
 		var res test.Response
@@ -169,12 +169,12 @@ func TestStreamRequiresStreamRegistry(t *testing.T) {
 
 func TestStreamRejectsUnsupportedResponseMedia(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.JSON)
+		res.Header().Set(http.ContentTypeKey, media.JSON)
 		_, _ = io.WriteString(res, "{}")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{}, func(_ context.Context, _ *client.ResponseStream) error {
 		return nil
@@ -185,13 +185,13 @@ func TestStreamRejectsUnsupportedResponseMedia(t *testing.T) {
 
 func TestStreamSurfacesErrorResponseBeforeCallingHandler(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Error)
+		res.Header().Set(http.ContentTypeKey, media.Error)
 		res.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(res, "bad request")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	called := false
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{}, func(_ context.Context, _ *client.ResponseStream) error {
@@ -207,8 +207,7 @@ func TestStreamSurfacesErrorResponseBeforeCallingHandler(t *testing.T) {
 
 func TestRequestStreamInterleavesOverHTTP2(t *testing.T) {
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			for {
 				req, err := stream.Recv()
@@ -234,7 +233,7 @@ func TestRequestStreamInterleavesOverHTTP2(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(server.Client().Transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(server.Client().Transport))
 
 	var greetings []string
 	err := c.RequestStream(ctx, http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON, Accept: media.NDJSON},
@@ -260,7 +259,7 @@ func TestRequestStreamInterleavesOverHTTP2(t *testing.T) {
 }
 
 func TestRequestStreamRejectsUnsupportedRequestMedia(t *testing.T) {
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.invalid", client.Options{ContentType: media.JSON},
 		func(_ context.Context, _ *client.RequestResponseStream) error {
@@ -271,7 +270,7 @@ func TestRequestStreamRejectsUnsupportedRequestMedia(t *testing.T) {
 }
 
 func TestRequestStreamRequiresStreamRegistry(t *testing.T) {
-	c := client.NewClient(test.Content, nil, test.Pool)
+	c := client.NewClient(test.UnaryContent, nil, test.Pool)
 
 	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.invalid", client.Options{},
 		func(_ context.Context, _ *client.RequestResponseStream) error {
@@ -283,7 +282,7 @@ func TestRequestStreamRequiresStreamRegistry(t *testing.T) {
 
 func TestRequestStreamSurfacesErrorResponseViaRecv(t *testing.T) {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.Error)
+		res.Header().Set(http.ContentTypeKey, media.Error)
 		res.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(res, "bad request")
 	}))
@@ -294,7 +293,7 @@ func TestRequestStreamSurfacesErrorResponseViaRecv(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(server.Client().Transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(server.Client().Transport))
 
 	sendErr := errors.New("unset")
 	err := c.RequestStream(ctx, http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON},
@@ -313,8 +312,7 @@ func TestRequestStreamSurfacesErrorResponseViaRecv(t *testing.T) {
 
 func TestRequestStreamSendIsSticky(t *testing.T) {
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			for {
 				if _, err := stream.Recv(); err != nil {
@@ -334,7 +332,7 @@ func TestRequestStreamSendIsSticky(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(server.Client().Transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(server.Client().Transport))
 
 	var firstErr, secondErr error
 	err := c.RequestStream(ctx, http.MethodPost, server.URL, client.Options{ContentType: media.NDJSON},
@@ -350,14 +348,14 @@ func TestRequestStreamSendIsSticky(t *testing.T) {
 }
 
 func TestStreamRejectsValueOverCap(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "a greeting far longer than the configured cap"})
 	})
 
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(8))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(8))
 
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
 		func(_ context.Context, stream *client.ResponseStream) error {
@@ -370,7 +368,7 @@ func TestStreamRejectsValueOverCap(t *testing.T) {
 }
 
 func TestStreamRejectsValueOverCapWhenDecodeSucceedsInOneRead(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "a greeting far longer than the configured cap"})
 	})
 
@@ -381,9 +379,9 @@ func TestStreamRejectsValueOverCapWhenDecodeSucceedsInOneRead(t *testing.T) {
 	codec := sm.Get("json")
 	codec.Decoder = func(r io.Reader) encodingstream.Decoder { return &test.SingleReadDecoder{R: r} }
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
+	unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
-	c := client.NewClient(cont, sm, test.Pool, client.WithMaxResponseSize(8))
+	c := client.NewClient(unaryContent, contentstream.NewContent(sm, test.Pool), test.Pool, client.WithMaxResponseSize(8))
 
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
 		func(_ context.Context, stream *client.ResponseStream) error {
@@ -418,7 +416,7 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+			handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 				return stream.Send(&test.Response{Greeting: tt.greeting})
 			})
 
@@ -429,9 +427,9 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 			codec := sm.Get("json")
 			codec.Decoder = tt.decoder
 			sm.Register("json", codec)
-			cont := content.NewContent(test.Encoder, test.Pool)
+			unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
-			c := client.NewClient(cont, sm, test.Pool, client.WithMaxResponseSize(tt.maxSize))
+			c := client.NewClient(unaryContent, contentstream.NewContent(sm, test.Pool), test.Pool, client.WithMaxResponseSize(tt.maxSize))
 
 			err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
 				func(_ context.Context, stream *client.ResponseStream) error {
@@ -448,7 +446,7 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 func TestStreamCapIsPerValueNotCumulative(t *testing.T) {
 	const values = 10
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		for range values {
 			if err := stream.Send(&test.Response{Greeting: "hi"}); err != nil {
 				return err
@@ -463,7 +461,7 @@ func TestStreamCapIsPerValueNotCumulative(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(200))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(200))
 
 	count := 0
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
@@ -488,14 +486,14 @@ func TestStreamCapIsPerValueNotCumulative(t *testing.T) {
 
 func TestStreamRecvDoesNotFalsePositiveOnCoalescedReads(t *testing.T) {
 	handler := http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.NDJSON)
+		res.Header().Set(http.ContentTypeKey, media.NDJSON)
 		_, _ = res.Write([]byte("{\"Greeting\":\"Hello Bob\"}\n{\"Greeting\":\"Hello Alice\"}\n"))
 	})
 
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(32))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(32))
 
 	var greetings []string
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
@@ -520,12 +518,12 @@ func TestStreamRecvDoesNotFalsePositiveOnCoalescedReads(t *testing.T) {
 
 func TestStreamRecvRejectsBufferedValueOverCap(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.NDJSON)
+		res.Header().Set(http.ContentTypeKey, media.NDJSON)
 		_, _ = res.Write([]byte("{\"Greeting\":\"A\"}\n{\"Greeting\":\"a greeting far longer than the configured cap\"}\n"))
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithMaxResponseSize(20))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(20))
 
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
 		func(_ context.Context, stream *client.ResponseStream) error {
@@ -545,13 +543,13 @@ func TestStreamClosesResponseBodyOnHandlerPanic(t *testing.T) {
 	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Header:     http.Header{content.TypeKey: []string{media.NDJSON}},
+			Header:     http.Header{http.ContentTypeKey: []string{media.NDJSON}},
 			Body:       body,
 			Request:    req,
 		}, nil
 	})
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
 
 	require.PanicsWithValue(t, "boom", func() {
 		_ = c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{Accept: media.NDJSON},
@@ -575,7 +573,7 @@ func TestRequestStreamClosesPipeOnHandlerPanic(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody, Request: req}, nil
 	})
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
 
 	require.PanicsWithValue(t, "boom", func() {
 		_ = c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
@@ -592,7 +590,7 @@ func TestRequestStreamClosesPipeOnHandlerPanic(t *testing.T) {
 }
 
 func TestStreamSurvivesSlowValuesWithConfiguredUnaryTimeout(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -605,7 +603,7 @@ func TestStreamSurvivesSlowValuesWithConfiguredUnaryTimeout(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithTimeout(10*time.Millisecond))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithTimeout(10*time.Millisecond))
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
@@ -633,9 +631,9 @@ func TestStreamSurvivesSlowValuesWithConfiguredUnaryTimeout(t *testing.T) {
 func TestStreamReturnsEncodeErrorFromNewRequest(t *testing.T) {
 	enc := encoding.NewMap()
 	enc.Register("json", test.NewEncoder(test.ErrFailed))
-	cont := content.NewContent(enc, test.Pool)
+	unaryContent := unary.NewContent(enc, test.Pool)
 
-	c := client.NewClient(cont, test.StreamEncoder, test.Pool)
+	c := client.NewClient(unaryContent, test.StreamContent, test.Pool)
 
 	err := c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{ContentType: media.JSON, Request: &test.Request{Name: "Bob"}},
 		func(_ context.Context, _ *client.ResponseStream) error {
@@ -651,7 +649,7 @@ func TestStreamReturnsTransportError(t *testing.T) {
 		return nil, test.ErrFailed
 	})
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
 
 	err := c.Stream(t.Context(), http.MethodGet, "http://example.com", client.Options{}, func(_ context.Context, _ *client.ResponseStream) error {
 		return nil
@@ -666,9 +664,9 @@ func TestRequestStreamRejectsNilEncoderForRegisteredKind(t *testing.T) {
 	codec := sm.Get("json")
 	codec.Encoder = nil
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
+	unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
-	c := client.NewClient(cont, sm, test.Pool)
+	c := client.NewClient(unaryContent, contentstream.NewContent(sm, test.Pool), test.Pool)
 
 	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.invalid", client.Options{ContentType: media.NDJSON},
 		func(_ context.Context, _ *client.RequestResponseStream) error {
@@ -679,7 +677,7 @@ func TestRequestStreamRejectsNilEncoderForRegisteredKind(t *testing.T) {
 }
 
 func TestRequestStreamReturnsNewRequestError(t *testing.T) {
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool)
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
 	err := c.RequestStream(t.Context(), "BAD METHOD", "http://example.com", client.Options{ContentType: media.NDJSON},
 		func(_ context.Context, _ *client.RequestResponseStream) error {
@@ -699,9 +697,9 @@ func TestRequestStreamFinishReturnsEncoderCloseError(t *testing.T) {
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return test.CloseErrEncoder{} }
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
+	unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
-	c := client.NewClient(cont, sm, test.Pool, client.WithRoundTripper(rt))
+	c := client.NewClient(unaryContent, contentstream.NewContent(sm, test.Pool), test.Pool, client.WithRoundTripper(rt))
 
 	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
 		func(_ context.Context, _ *client.RequestResponseStream) error {
@@ -716,15 +714,15 @@ func TestNewResponseDecoderRejectsNilDecoderForRegisteredKind(t *testing.T) {
 	codec := sm.Get("json")
 	codec.Decoder = nil
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
+	unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(content.TypeKey, media.NDJSON)
+		res.Header().Set(http.ContentTypeKey, media.NDJSON)
 		_, _ = io.WriteString(res, "{}\n")
 	}))
 	t.Cleanup(server.Close)
 
-	c := client.NewClient(cont, sm, test.Pool)
+	c := client.NewClient(unaryContent, contentstream.NewContent(sm, test.Pool), test.Pool)
 
 	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON}, func(_ context.Context, stream *client.ResponseStream) error {
 		var res test.Response
@@ -749,15 +747,15 @@ func TestStreamRecvBufferedLenFallback(t *testing.T) {
 			codec := sm.Get("json")
 			codec.Decoder = func(io.Reader) encodingstream.Decoder { return tt.decoder }
 			sm.Register("json", codec)
-			cont := content.NewContent(test.Encoder, test.Pool)
+			unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
 			server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-				res.Header().Set(content.TypeKey, media.NDJSON)
+				res.Header().Set(http.ContentTypeKey, media.NDJSON)
 				_, _ = io.WriteString(res, "{}\n")
 			}))
 			t.Cleanup(server.Close)
 
-			c := client.NewClient(cont, sm, test.Pool)
+			c := client.NewClient(unaryContent, contentstream.NewContent(sm, test.Pool), test.Pool)
 
 			err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
 				func(_ context.Context, stream *client.ResponseStream) error {

--- a/net/http/content.go
+++ b/net/http/content.go
@@ -1,0 +1,7 @@
+package http
+
+// ContentTypeKey is the HTTP header key used for Content-Type.
+const ContentTypeKey = "Content-Type"
+
+// AcceptKey is the HTTP header key used for Accept.
+const AcceptKey = "Accept"

--- a/net/http/content/stream/benchmark_test.go
+++ b/net/http/content/stream/benchmark_test.go
@@ -1,0 +1,43 @@
+package stream_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+)
+
+var benchmarkMedia stream.Media
+
+// BenchmarkNewFromMediaNDJSON tracks the exact NDJSON media-type fast path used on streaming request paths.
+func BenchmarkNewFromMediaNDJSON(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia, _ = test.StreamContent.NewFromMedia(media.NDJSON)
+	}
+}
+
+// BenchmarkNewFromAcceptNDJSON tracks response media negotiation for a common NDJSON stream.
+func BenchmarkNewFromAcceptNDJSON(b *testing.B) {
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/hello", nil)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia, _ = test.StreamContent.NewFromAccept(req)
+	}
+}
+
+// BenchmarkNewFromContentTypeNDJSON tracks strict request media negotiation for an NDJSON stream.
+func BenchmarkNewFromContentTypeNDJSON(b *testing.B) {
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodPost, "/hello", nil)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia, _ = test.StreamContent.NewFromContentType(req)
+	}
+}

--- a/net/http/content/stream/content.go
+++ b/net/http/content/stream/content.go
@@ -1,0 +1,142 @@
+package stream
+
+import (
+	"github.com/alexfalkowski/go-service/v2/encoding/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/policy"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-sync"
+)
+
+// NewContent constructs Content that resolves streaming codecs from enc and buffers initial responses using pool.
+func NewContent(enc *stream.Map, pool *sync.BufferPool) *Content {
+	return &Content{enc: enc, pool: pool}
+}
+
+// Content resolves streaming codecs from HTTP media types and buffers initial responses before they commit.
+//
+// It uses an [stream.Map] registry to resolve streaming encoders and decoders. Unlike unary content,
+// streaming request and response media negotiation is strict: unsupported declared media is rejected rather
+// than falling back to another representation.
+type Content struct {
+	enc  *stream.Map
+	pool *sync.BufferPool
+}
+
+// NewFromMedia builds a Media from mediaType and Content's streaming registry.
+//
+// NewFromMedia never falls back to JSON: an unparsable media type, a media type with
+// no entry in the streaming media mapping, or an unregistered kind all return
+// [ErrUnsupportedMedia]. A nil Content also returns [ErrUnsupportedMedia]. Streaming callers must fail
+// explicitly rather than silently degrading to a different wire format.
+func (c *Content) NewFromMedia(mediaType string) (Media, error) {
+	if c == nil {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	if resolved, ok := knownMedia(mediaType, c.enc); ok {
+		return usableMedia(resolved)
+	}
+
+	value, err := media.Parse(mediaType)
+	if err != nil {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	kind, ok := streamKinds[value.String()]
+	if !ok {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	codec := c.enc.Get(kind)
+
+	return usableMedia(Media{NewEncoder: codec.Encoder, NewDecoder: codec.Decoder, Type: value})
+}
+
+// NewFromAccept resolves the request Accept header to a streaming encoder, falling back to
+// Content-Type when Accept is absent, and to [media.NDJSON] when neither is set. A registered
+// codec without an encoder is unsupported. A nil Content returns [ErrUnsupportedMedia].
+//
+// An Accept list is satisfiable for the server's producible streaming media type if it contains an
+// exact match, or a matching wildcard ("*/*", or "type/*" where type matches the producible type's own
+// major type), anywhere in the list. Per RFC 9110 §12.5.1, the most specific reference present controls
+// regardless of list order: an exact subtype match takes precedence over any wildcard, and a "type/*"
+// wildcard takes precedence over the bare "*/*" wildcard. Only that controlling reference's explicit
+// q=0 exclusion (see [github.com/alexfalkowski/go-service/v2/net/http/accept.IsZeroQuality]) decides
+// satisfiability — a q=0 on a less specific reference elsewhere in the list has no effect once a more
+// specific reference is present, and conversely a q=0 on the controlling reference cannot be overridden
+// by a less specific, non-excluded reference. A satisfiable list resolves to its exact match if the
+// controlling reference was one, otherwise to media.NDJSON.
+//
+// Unlike unary response-media negotiation, a non-empty Accept list that is not satisfiable this way returns
+// [ErrUnsupportedMedia] instead of falling back to JSON or to Content-Type: a client that named
+// only concrete, unproducible media types must get an explicit rejection, not a silently different wire
+// format.
+func (c *Content) NewFromAccept(req *http.Request) (Media, error) {
+	if c == nil {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	header := req.Header.Get(http.AcceptKey)
+	if !strings.IsEmpty(header) {
+		return c.newFromAcceptHeader(header)
+	}
+
+	mediaType := req.Header.Get(http.ContentTypeKey)
+	if strings.IsEmpty(mediaType) {
+		mediaType = media.NDJSON
+	}
+
+	return c.newEncoderMedia(mediaType)
+}
+
+func (c *Content) newFromAcceptHeader(header string) (Media, error) {
+	if resolved, ok := knownMedia(header, c.enc); ok {
+		return encoderMedia(resolved, nil)
+	}
+
+	mediaType, ok := matchStreamAccept(header)
+	if !ok {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	return c.newEncoderMedia(mediaType)
+}
+
+func (c *Content) newEncoderMedia(mediaType string) (Media, error) {
+	return encoderMedia(c.NewFromMedia(mediaType))
+}
+
+// NewFromContentType parses the request Content-Type header and resolves a streaming decoder.
+//
+// Unlike unary request-media negotiation, an unregistered or unparsable media type returns
+// [ErrUnsupportedMedia] instead of falling back to JSON.
+//
+// This is the streaming counterpart of unary request-media negotiation: after NewFromMedia resolves the
+// media type, it re-checks the resolved kind against the same request-decode policy that guards
+// unary request bodies (see the decoder-bounds rule in the package documentation), so a streaming media
+// type that maps to a banned kind is rejected here even though NewFromMedia itself has no opinion on
+// that policy. NewFromAccept and NewFromMedia are not policed this way: only this method decodes an
+// untrusted request body (see [Media.NewDecoder]'s other caller, the client's response-stream path,
+// which must keep decoding every registered kind).
+func (c *Content) NewFromContentType(req *http.Request) (Media, error) {
+	m, err := c.NewFromMedia(req.Header.Get(http.ContentTypeKey))
+	if err != nil {
+		return Media{}, err
+	}
+
+	// Re-resolve the kind rather than carrying it on Media, keeping the struct free of a field
+	// that exists only for this one caller. A missing entry, a nil decoder constructor, or a banned kind
+	// are all treated as unsupported so this fails closed: neither the missing-entry nor the banned-kind
+	// arm can currently fire, because streamKinds' only mapping ("application/x-ndjson" to "json") already passed the
+	// lookup inside NewFromMedia and "json" is not a banned kind. Both stay as guards for a future
+	// streamKinds entry that maps to a banned kind, or a NewFromMedia change that admits an unknown media
+	// type.
+	kind, ok := streamKinds[m.String()]
+	if !ok || m.NewDecoder == nil || !policy.CanDecode(kind) {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	return m, nil
+}

--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -2,22 +2,21 @@ package stream
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 )
 
-// NewHandler builds a handler for a send-only streaming response using sm to resolve streaming codecs.
+// NewHandler builds a handler for a send-only streaming response using cont to resolve streaming codecs and buffer
+// the initial response.
 //
 // Content negotiation:
 // The response encoder is resolved from the request Accept header, falling back to Content-Type,
-// using [NewMediaFromAccept]. Unlike single-value handlers, an Accept that cannot be satisfied
+// using [Content.NewFromAccept]. Unlike single-value handlers, an Accept that cannot be satisfied
 // is rejected with 406 rather than falling back to JSON.
 //
 // Error contract:
@@ -41,7 +40,7 @@ import (
 // allowed to open the stream), every Send charges one additional token against that same limiter — see
 // [Stream.Send]. A route reached without that middleware, or with no limiter configured, sees no
 // per-message charging.
-func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, handler Handler[Res]) http.HandlerFunc {
+func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		if isDraining(opts.Drain) {
@@ -49,18 +48,18 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 			return
 		}
 
-		resMedia, err := NewMediaFromAccept(req, sm)
+		resMedia, err := cont.NewFromAccept(req)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
 		}
 
 		ctx = meta.WithRequestResponse(ctx, req, res)
-		res.Header().Set(content.TypeKey, resMedia.WithUTF8())
+		res.Header().Set(http.ContentTypeKey, resMedia.WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
-		buffer := cont.BorrowBuffer()
-		defer cont.ReturnBuffer(buffer)
+		buffer := cont.pool.Get()
+		defer cont.pool.Put(buffer)
 
 		ctx, cancel := context.WithCancelCause(ctx)
 		defer cancel(nil)
@@ -99,7 +98,8 @@ func NewHandler[Res any](cont *content.Content, sm *stream.Map, opts Options, ha
 // return its error so the framework can finish the response.
 type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 
-// NewRequestHandler builds a handler for a bidirectional stream using sm to resolve streaming codecs.
+// NewRequestHandler builds a handler for a bidirectional stream using cont to resolve streaming codecs and buffer
+// the initial response.
 //
 // HTTP/2 requirement:
 // Bidirectional streaming requires HTTP/2 (including h2c): an HTTP/1.x request body is buffered ahead
@@ -107,9 +107,9 @@ type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 // failing. Requests with req.ProtoMajor < 2 are rejected with 505 before the handler runs.
 //
 // Content negotiation:
-// The request decoder is resolved from Content-Type via [NewMediaFromContentType], rejecting
+// The request decoder is resolved from Content-Type via [Content.NewFromContentType], rejecting
 // an unregistered or unparseable media type with 415. The response encoder is resolved from Accept
-// (falling back to Content-Type) via [NewMediaFromAccept], rejecting an Accept that cannot be
+// (falling back to Content-Type) via [Content.NewFromAccept], rejecting an Accept that cannot be
 // satisfied with 406 instead: Accept negotiates the response representation, not the request payload,
 // so a failure there is answered as RFC 9110 §15.5.7 rather than §15.5.16.
 //
@@ -132,7 +132,7 @@ type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 // decoded, in-cap value, the same way Send does, against the same request-scoped limiter. Its drain
 // contract also applies: drain cancels the handler context and closes the request body to unblock an
 // active Recv. A client can need to reconnect if an HTTP/2 peer observes that body close as a stream reset.
-func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, opts Options, handler RequestHandler[Req, Res]) http.HandlerFunc {
+func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler RequestHandler[Req, Res]) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		if isDraining(opts.Drain) {
@@ -145,24 +145,24 @@ func NewRequestHandler[Req any, Res any](cont *content.Content, sm *stream.Map, 
 			return
 		}
 
-		reqMedia, err := NewMediaFromContentType(req, sm)
+		reqMedia, err := cont.NewFromContentType(req)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusUnsupportedMediaType, err))
 			return
 		}
 
-		resMedia, err := NewMediaFromAccept(req, sm)
+		resMedia, err := cont.NewFromAccept(req)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
 		}
 
 		ctx = meta.WithRequestResponse(ctx, req, res)
-		res.Header().Set(content.TypeKey, resMedia.WithUTF8())
+		res.Header().Set(http.ContentTypeKey, resMedia.WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
-		buffer := cont.BorrowBuffer()
-		defer cont.ReturnBuffer(buffer)
+		buffer := cont.pool.Get()
+		defer cont.pool.Put(buffer)
 
 		ctx, cancel := context.WithCancelCause(ctx)
 		defer cancel(nil)

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
@@ -23,7 +22,7 @@ import (
 )
 
 func TestNewHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -32,13 +31,13 @@ func TestNewHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
 	require.NotEmpty(t, res.Header().Get(compress.HeaderNoCompression))
 
 	scanner := bufio.NewScanner(res.Body)
@@ -48,13 +47,13 @@ func TestNewHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
 }
 
 func TestNewHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
-	inner := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	inner := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
 	handler := compress.GzipHandler(inner)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req.Header.Set("Accept-Encoding", "gzip")
 	res := httptest.NewRecorder()
 
@@ -65,37 +64,37 @@ func TestNewHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
 }
 
 func TestNewHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
 		return status.Error(http.StatusBadRequest, test.ErrFailed.Error())
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
-	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 }
 
 func TestNewHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
 		return stream.Send(&test.Unencodable{})
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
-	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 }
 
 func TestNewHandlerAbortsAfterCommit(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -104,7 +103,7 @@ func TestNewHandlerAbortsAfterCommit(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -118,8 +117,7 @@ func TestNewHandlerAbortsAfterCommit(t *testing.T) {
 func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 	drain := make(chan struct{})
 	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 				return err
@@ -132,7 +130,7 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -147,8 +145,7 @@ func TestNewHandlerAbortsAfterCommitOnDrainForUnrelatedError(t *testing.T) {
 	exporter := test.EnableIsolatedSpanExporter(t)
 	drain := make(chan struct{})
 	handler := http.NewTelemetryHandler(contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 				return err
@@ -161,7 +158,7 @@ func TestNewHandlerAbortsAfterCommitOnDrainForUnrelatedError(t *testing.T) {
 		}), "http.server")
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -182,8 +179,7 @@ func TestNewHandlerAbortsAfterCommitOnDrainForUnrelatedError(t *testing.T) {
 func TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError(t *testing.T) {
 	drain := make(chan struct{})
 	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 				return err
@@ -196,7 +192,7 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError(t *testing.T) {
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -210,8 +206,7 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError(t *testing.T) {
 func TestNewHandlerDoesNotSendAfterDrain(t *testing.T) {
 	drain := make(chan struct{})
 	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.Stream[test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 				return err
@@ -224,7 +219,7 @@ func TestNewHandlerDoesNotSendAfterDrain(t *testing.T) {
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -240,8 +235,7 @@ func TestNewHandlerReturnsServiceUnavailableOnDrainBeforeCommit(t *testing.T) {
 	close(drain)
 	called := false
 	handler := contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain}, func(ctx context.Context, _ *contentstream.Stream[test.Response]) error {
 			called = true
 			<-ctx.Done()
@@ -250,7 +244,7 @@ func TestNewHandlerReturnsServiceUnavailableOnDrainBeforeCommit(t *testing.T) {
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -262,8 +256,7 @@ func TestNewHandlerReturnsServiceUnavailableOnDrainBeforeCommit(t *testing.T) {
 func TestNewHandlerAbortsAfterCommitRecordsTraceError(t *testing.T) {
 	exporter := test.EnableIsolatedSpanExporter(t)
 	handler := http.NewTelemetryHandler(contentstream.NewHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 				return err
@@ -273,7 +266,7 @@ func TestNewHandlerAbortsAfterCommitRecordsTraceError(t *testing.T) {
 		}), "http.server")
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -288,12 +281,12 @@ func TestNewHandlerAbortsAfterCommitRecordsTraceError(t *testing.T) {
 }
 
 func TestNewHandlerRejectsUnsupportedMedia(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
 		return nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.JSON)
+	req.Header.Set(http.AcceptKey, media.JSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -315,17 +308,17 @@ func TestNewHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+			handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 				return stream.Send(&test.Response{Greeting: "Hello Bob"})
 			})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 			if tt.accept != "" {
-				req.Header.Set(content.AcceptKey, tt.accept)
+				req.Header.Set(http.AcceptKey, tt.accept)
 			}
 
 			if tt.contentType != "" {
-				req.Header.Set(content.TypeKey, tt.contentType)
+				req.Header.Set(http.ContentTypeKey, tt.contentType)
 			}
 
 			res := httptest.NewRecorder()
@@ -333,7 +326,7 @@ func TestNewHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
 			handler.ServeHTTP(res, req)
 
 			require.Equal(t, http.StatusOK, res.Code)
-			require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+			require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
 		})
 	}
 }
@@ -341,7 +334,7 @@ func TestNewHandlerResolvesWildcardOrBrowserStyleAccept(t *testing.T) {
 func TestNewHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 2}
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -350,7 +343,7 @@ func TestNewHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
 	res := httptest.NewRecorder()
 
@@ -363,7 +356,7 @@ func TestNewHandlerSendChargesOneLimiterTokenPerMessage(t *testing.T) {
 func TestNewHandlerSendAbortsAfterCommitWhenLimiterExhausted(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 1}
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 			return err
 		}
@@ -372,7 +365,7 @@ func TestNewHandlerSendAbortsAfterCommitWhenLimiterExhausted(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
 	res := httptest.NewRecorder()
 
@@ -389,31 +382,31 @@ func TestNewHandlerSendPreCommitDenialMapsTo429(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 0}
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
 	res := httptest.NewRecorder()
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})
 	})
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusTooManyRequests, res.Code)
-	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 }
 
 func TestNewHandlerSendIsSticky(t *testing.T) {
 	var firstErr, secondErr error
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
 		firstErr = stream.Send(&test.Unencodable{})
 		secondErr = stream.Send(&test.Unencodable{})
 		return firstErr
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -425,12 +418,12 @@ func TestNewHandlerSendIsSticky(t *testing.T) {
 
 func TestNewHandlerSendExtendDeadlineFailure(t *testing.T) {
 	opts := contentstream.Options{WriteTimeout: time.MustParseDuration("1s")}
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, opts, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, opts, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -439,12 +432,12 @@ func TestNewHandlerSendExtendDeadlineFailure(t *testing.T) {
 }
 
 func TestNewHandlerSendCommitFailure(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := &test.ErrResponseWriter{}
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -453,12 +446,12 @@ func TestNewHandlerSendCommitFailure(t *testing.T) {
 }
 
 func TestNewHandlerSendFlushFailure(t *testing.T) {
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := &test.NoFlushResponseWriter{}
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -468,11 +461,11 @@ func TestNewHandlerSendFlushFailure(t *testing.T) {
 
 func TestNewHandlerSendLimiterErrorMapsTo500(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
 	res := httptest.NewRecorder()
 
-	handler := contentstream.NewHandler(test.Content, test.StreamEncoder, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})
 	})
 
@@ -486,14 +479,12 @@ func TestNewHandlerRejectsNilEncoderForRegisteredKind(t *testing.T) {
 	codec := sm.Get("json")
 	codec.Encoder = nil
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
-
-	handler := contentstream.NewHandler(cont, sm, contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+	handler := contentstream.NewHandler(contentstream.NewContent(sm, test.Pool), contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
 		return nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)

--- a/net/http/content/stream/media.go
+++ b/net/http/content/stream/media.go
@@ -2,12 +2,8 @@ package stream
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding/stream"
-	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/accept"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
-	"github.com/alexfalkowski/go-service/v2/net/http/content/policy"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
-	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
 // ndjsonType is the parsed form of [media.NDJSON], the only streaming media type this package currently
@@ -21,31 +17,6 @@ var ndjsonType = media.MustParse(media.NDJSON)
 // than needing its own codec.
 var streamKinds = map[string]string{
 	media.NDJSON: "json",
-}
-
-// NewMedia builds a Media from a media type string and streaming registry.
-//
-// NewMedia never falls back to JSON: an unparsable media type, a media type with
-// no entry in the streaming media mapping, or a kind unregistered in sm all return
-// [ErrUnsupportedMedia]. Streaming callers must fail explicitly rather than silently degrading to
-// a different wire format.
-func NewMedia(mediaType string, sm *stream.Map) (Media, error) {
-	value, err := media.Parse(mediaType)
-	if err != nil {
-		return Media{}, ErrUnsupportedMedia
-	}
-
-	kind, ok := streamKinds[value.String()]
-	if !ok {
-		return Media{}, ErrUnsupportedMedia
-	}
-
-	codec := sm.Get(kind)
-	if codec.Encoder == nil && codec.Decoder == nil {
-		return Media{}, ErrUnsupportedMedia
-	}
-
-	return Media{NewEncoder: codec.Encoder, NewDecoder: codec.Decoder, Type: value}, nil
 }
 
 // Media describes a resolved streaming media type and its encoder/decoder constructors.
@@ -65,46 +36,29 @@ type Media struct {
 	media.Type
 }
 
-// NewMediaFromAccept resolves the request Accept header to a streaming encoder, falling back to
-// Content-Type when Accept is absent, and to [media.NDJSON] when neither is set. A registered
-// codec without an encoder is unsupported.
+// knownMedia resolves an exact built-in streaming media type without parsing its header value.
 //
-// An Accept list is satisfiable for the server's producible streaming media type if it contains an
-// exact match, or a matching wildcard ("*/*", or "type/*" where type matches the producible type's own
-// major type), anywhere in the list. Per RFC 9110 §12.5.1, the most specific reference present controls
-// regardless of list order: an exact subtype match takes precedence over any wildcard, and a "type/*"
-// wildcard takes precedence over the bare "*/*" wildcard. Only that controlling reference's explicit
-// q=0 exclusion (see [github.com/alexfalkowski/go-service/v2/net/http/accept.IsZeroQuality]) decides
-// satisfiability — a q=0 on a less specific reference elsewhere in the list has no effect once a more
-// specific reference is present, and conversely a q=0 on the controlling reference cannot be overridden
-// by a less specific, non-excluded reference. A satisfiable list resolves to its exact match if the
-// controlling reference was one, otherwise to media.NDJSON.
-//
-// Unlike [content.Content.NewMediaFromAccept], a non-empty Accept list that is not satisfiable this way returns
-// [ErrUnsupportedMedia] instead of falling back to JSON or to Content-Type: a client that named
-// only concrete, unproducible media types must get an explicit rejection, not a silently different wire
-// format.
-func NewMediaFromAccept(req *http.Request, sm *stream.Map) (Media, error) {
-	var mediaType string
-
-	header := req.Header.Get(content.AcceptKey)
-	if strings.IsEmpty(header) {
-		m := req.Header.Get(content.TypeKey)
-		if strings.IsEmpty(m) {
-			m = media.NDJSON
-		}
-
-		mediaType = m
-	} else {
-		m, ok := matchStreamAccept(header)
-		if !ok {
-			return Media{}, ErrUnsupportedMedia
-		}
-
-		mediaType = m
+// Streaming currently supports one such type, but keeping this separate from matchStreamAccept
+// makes the concrete-header fast path explicit and leaves the latter responsible only for full
+// Accept-list negotiation.
+func knownMedia(mediaType string, enc *stream.Map) (Media, bool) {
+	if mediaType != media.NDJSON {
+		return Media{}, false
 	}
 
-	resolved, err := NewMedia(mediaType, sm)
+	codec := enc.Get(streamKinds[media.NDJSON])
+	return Media{NewEncoder: codec.Encoder, NewDecoder: codec.Decoder, Type: ndjsonType}, true
+}
+
+func usableMedia(resolved Media) (Media, error) {
+	if resolved.NewEncoder == nil && resolved.NewDecoder == nil {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	return resolved, nil
+}
+
+func encoderMedia(resolved Media, err error) (Media, error) {
 	if err != nil || resolved.NewEncoder == nil {
 		return Media{}, ErrUnsupportedMedia
 	}
@@ -124,7 +78,7 @@ func NewMediaFromAccept(req *http.Request, sm *stream.Map) (Media, error) {
 // regardless of list order. When satisfiable, it returns the exact match's media type if the
 // controlling reference was one, otherwise [media.NDJSON]. An unparsable item is skipped rather than
 // rejecting the whole list, the same way an unparsable single Accept value already falls through to
-// [NewMedia]'s own rejection when nothing else in the list matches.
+// [Content.NewFromMedia]'s own rejection when nothing else in the list matches.
 func matchStreamAccept(header string) (string, bool) {
 	var exact, major, bare mediaRangeMatch
 
@@ -162,39 +116,6 @@ func matchStreamAccept(header string) (string, bool) {
 	default:
 		return "", false
 	}
-}
-
-// NewMediaFromContentType parses the request Content-Type header and resolves a streaming decoder.
-//
-// Unlike [Content.NewMediaFromContentType], an unregistered or unparsable media type returns
-// [ErrUnsupportedMedia] instead of falling back to JSON.
-//
-// This is the streaming counterpart of [content.Content.NewFromRequestBody]: after NewMedia resolves the
-// media type, it re-checks the resolved kind against the same request-decode policy that guards
-// unary request bodies (see the decoder-bounds rule in the package documentation), so a streaming media
-// type that maps to a banned kind is rejected here even though NewMedia itself has no opinion on
-// that policy. NewFromAccept and [NewMedia] are not policed this way: only this
-// constructor decodes an untrusted request body (see [Media.NewDecoder]'s other caller, the
-// client's response-stream path, which must keep decoding every registered kind).
-func NewMediaFromContentType(req *http.Request, sm *stream.Map) (Media, error) {
-	m, err := NewMedia(req.Header.Get(content.TypeKey), sm)
-	if err != nil {
-		return Media{}, err
-	}
-
-	// Re-resolve the kind rather than carrying it on Media, keeping the struct free of a field
-	// that exists only for this one caller. A missing entry, a nil decoder constructor, or a banned kind
-	// are all treated as unsupported so this fails closed: neither the missing-entry nor the banned-kind
-	// arm can currently fire, because streamKinds' only mapping ("application/x-ndjson" to "json") already passed the
-	// lookup inside NewMedia and "json" is not a banned kind. Both stay as guards for a future
-	// streamKinds entry that maps to a banned kind, or a NewMedia change that admits an unknown media
-	// type.
-	kind, ok := streamKinds[m.String()]
-	if !ok || m.NewDecoder == nil || !policy.CanDecode(kind) {
-		return Media{}, ErrUnsupportedMedia
-	}
-
-	return m, nil
 }
 
 // mediaRangeMatch is the controlling media range found so far for one specificity tier (exact subtype,

--- a/net/http/content/stream/media_test.go
+++ b/net/http/content/stream/media_test.go
@@ -6,7 +6,7 @@ import (
 
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/stretchr/testify/require"
@@ -18,9 +18,9 @@ func TestNewFromContentTypeRejectsEncoderOnlyKind(t *testing.T) {
 	codec.Decoder = nil
 	sm.Register("json", codec)
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
 
-	_, err := contentstream.NewMediaFromContentType(req, sm)
+	_, err := contentstream.NewContent(sm, test.Pool).NewFromContentType(req)
 
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
@@ -31,18 +31,35 @@ func TestNewFromAcceptRejectsDecoderOnlyKind(t *testing.T) {
 	codec.Encoder = nil
 	sm.Register("json", codec)
 	req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 
-	_, err := contentstream.NewMediaFromAccept(req, sm)
+	_, err := contentstream.NewContent(sm, test.Pool).NewFromAccept(req)
+
+	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
+}
+
+func TestNewFromMediaRejectsNilContent(t *testing.T) {
+	var content *contentstream.Content
+
+	_, err := content.NewFromMedia(media.NDJSON)
+
+	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
+}
+
+func TestNewFromAcceptRejectsNilContent(t *testing.T) {
+	var content *contentstream.Content
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
+
+	_, err := content.NewFromAccept(req)
 
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
 func TestNewFromContentTypeResolvesNDJSON(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
 
-	m, err := contentstream.NewMediaFromContentType(req, test.StreamEncoder)
+	m, err := test.StreamContent.NewFromContentType(req)
 
 	require.NoError(t, err)
 	require.NotNil(t, m.NewDecoder)
@@ -51,26 +68,26 @@ func TestNewFromContentTypeResolvesNDJSON(t *testing.T) {
 
 func TestNewFromContentTypeRejectsWrongMajorNDJSON(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, "text/x-ndjson")
+	req.Header.Set(http.ContentTypeKey, "text/x-ndjson")
 
-	_, err := contentstream.NewMediaFromContentType(req, test.StreamEncoder)
+	_, err := test.StreamContent.NewFromContentType(req)
 
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
-func TestNewMediaResolvesUsableDecoderForEveryStreamKind(t *testing.T) {
-	// The client's response-stream path (see net/http/client/stream.go) relies on NewMedia staying
+func TestNewFromMediaResolvesUsableDecoderForEveryStreamKind(t *testing.T) {
+	// The client's response-stream path (see net/http/client/stream.go) relies on NewFromMedia staying
 	// unpoliced: it must keep resolving a usable decoder for every registered streaming kind,
 	// including the ones NewFromContentType rejects for untrusted request bodies.
-	m, err := contentstream.NewMedia(media.NDJSON, test.StreamEncoder)
+	m, err := test.StreamContent.NewFromMedia(media.NDJSON)
 
 	require.NoError(t, err)
 	require.NotNil(t, m.NewDecoder)
 	require.Equal(t, media.NDJSON, m.String())
 }
 
-func TestNewMediaResolvesNDJSON(t *testing.T) {
-	m, err := contentstream.NewMedia(media.NDJSON, encodingstream.NewMap())
+func TestNewFromMediaResolvesNDJSON(t *testing.T) {
+	m, err := contentstream.NewContent(encodingstream.NewMap(), test.Pool).NewFromMedia(media.NDJSON)
 
 	require.NoError(t, err)
 	require.NotNil(t, m.NewEncoder)
@@ -78,20 +95,41 @@ func TestNewMediaResolvesNDJSON(t *testing.T) {
 	require.Equal(t, media.NDJSON, m.String())
 }
 
-func TestNewMediaRejectsUnmappedSubtype(t *testing.T) {
-	_, err := contentstream.NewMedia(media.JSON, encodingstream.NewMap())
+func TestNewFromMediaResolvesParameterizedNDJSON(t *testing.T) {
+	m, err := contentstream.NewContent(encodingstream.NewMap(), test.Pool).NewFromMedia(media.NDJSON + "; profile=test")
+
+	require.NoError(t, err)
+	require.NotNil(t, m.NewEncoder)
+	require.NotNil(t, m.NewDecoder)
+	require.Equal(t, media.NDJSON, m.String())
+}
+
+func TestNewFromMediaRejectsKindWithoutCodec(t *testing.T) {
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = nil
+	codec.Decoder = nil
+	sm.Register("json", codec)
+
+	_, err := contentstream.NewContent(sm, test.Pool).NewFromMedia(media.NDJSON)
 
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
-func TestNewMediaRejectsWrongMajorNDJSON(t *testing.T) {
-	_, err := contentstream.NewMedia("text/x-ndjson", encodingstream.NewMap())
+func TestNewFromMediaRejectsUnmappedSubtype(t *testing.T) {
+	_, err := contentstream.NewContent(encodingstream.NewMap(), test.Pool).NewFromMedia(media.JSON)
 
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
 
-func TestNewMediaRejectsUnparsableType(t *testing.T) {
-	_, err := contentstream.NewMedia("not-a-media-type", encodingstream.NewMap())
+func TestNewFromMediaRejectsWrongMajorNDJSON(t *testing.T) {
+	_, err := contentstream.NewContent(encodingstream.NewMap(), test.Pool).NewFromMedia("text/x-ndjson")
+
+	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
+}
+
+func TestNewFromMediaRejectsUnparsableType(t *testing.T) {
+	_, err := contentstream.NewContent(encodingstream.NewMap(), test.Pool).NewFromMedia("not-a-media-type")
 
 	require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 }
@@ -120,14 +158,14 @@ func TestNewFromAcceptResolvesWildcardOrExactMatchAnywhereInList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
 			if tt.accept != "" {
-				req.Header.Set(content.AcceptKey, tt.accept)
+				req.Header.Set(http.AcceptKey, tt.accept)
 			}
 
 			if tt.contentType != "" {
-				req.Header.Set(content.TypeKey, tt.contentType)
+				req.Header.Set(http.ContentTypeKey, tt.contentType)
 			}
 
-			m, err := contentstream.NewMediaFromAccept(req, test.StreamEncoder)
+			m, err := test.StreamContent.NewFromAccept(req)
 
 			require.NoError(t, err)
 			require.NotNil(t, m.NewEncoder)
@@ -158,9 +196,9 @@ func TestNewFromAcceptRejectsConcreteOnlyUnsatisfiableAccept(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
-			req.Header.Set(content.AcceptKey, tt.accept)
+			req.Header.Set(http.AcceptKey, tt.accept)
 
-			_, err := contentstream.NewMediaFromAccept(req, test.StreamEncoder)
+			_, err := test.StreamContent.NewFromAccept(req)
 
 			require.ErrorIs(t, err, contentstream.ErrUnsupportedMedia)
 		})

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
@@ -32,7 +31,7 @@ func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T
 	sm.Register("json", codec)
 	drain := make(chan struct{})
 	handler := contentstream.NewRequestHandler(
-		test.Content, sm,
+		contentstream.NewContent(sm, test.Pool),
 		contentstream.Options{Drain: drain}, func(ctx context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 				return err
@@ -47,8 +46,8 @@ func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -68,7 +67,7 @@ func TestNewRequestHandlerClosesDecoderWhenEncoderCloseFails(t *testing.T) {
 	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
 	sm.Register("json", codec)
 	handler := http.NewTelemetryHandler(contentstream.NewRequestHandler(
-		test.Content, sm,
+		contentstream.NewContent(sm, test.Pool),
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			return stream.Send(&test.Response{Greeting: "Hello Bob"})
 		},
@@ -76,8 +75,8 @@ func TestNewRequestHandlerClosesDecoderWhenEncoderCloseFails(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
@@ -95,7 +94,7 @@ func TestNewRequestHandlerReturnsServiceUnavailableOnDrainBeforeHandler(t *testi
 	close(drain)
 	called := false
 	handler := contentstream.NewRequestHandler(
-		test.Content, test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain},
 		func(_ context.Context, _ *contentstream.RequestStream[test.Request, test.Response]) error {
 			called = true
@@ -106,8 +105,8 @@ func TestNewRequestHandlerReturnsServiceUnavailableOnDrainBeforeHandler(t *testi
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -123,7 +122,7 @@ func TestNewRequestHandlerUnblocksRecvOnDrain(t *testing.T) {
 	started := make(chan struct{})
 	recvErr := make(chan error, 1)
 	handler := contentstream.NewRequestHandler(
-		test.Content, test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain},
 		func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			close(started)
@@ -138,8 +137,8 @@ func TestNewRequestHandlerUnblocksRecvOnDrain(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
 	req.ProtoMajor = 2
 	req.ContentLength = -1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 	done := make(chan struct{})
 
@@ -175,11 +174,9 @@ func TestNewRequestHandlerRecvRejectsValueWhenDrainStartsAfterDecode(t *testing.
 		return &drainAfterDecode{drain: drain, closed: body.closed}
 	}
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
-
 	var recvErr error
 	handler := contentstream.NewRequestHandler(
-		cont, sm,
+		contentstream.NewContent(sm, test.Pool),
 		contentstream.Options{Drain: drain},
 		func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
@@ -190,8 +187,8 @@ func TestNewRequestHandlerRecvRejectsValueWhenDrainStartsAfterDecode(t *testing.
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", body)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -204,7 +201,7 @@ func TestNewRequestHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 	var recvErr error
 	drain := make(chan struct{})
 	handler := contentstream.NewRequestHandler(
-		test.Content, test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{Drain: drain},
 		func(ctx context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
@@ -221,8 +218,8 @@ func TestNewRequestHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -236,16 +233,15 @@ func TestNewRequestHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 
 func TestNewRequestHandlerRejectsHTTP1(t *testing.T) {
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, _ *contentstream.RequestStream[test.Request, test.Response]) error {
 			return nil
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -255,8 +251,7 @@ func TestNewRequestHandlerRejectsHTTP1(t *testing.T) {
 
 func TestNewRequestHandlerRecvAndSend(t *testing.T) {
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			for {
 				req, err := stream.Recv()
@@ -277,14 +272,14 @@ func TestNewRequestHandlerRecvAndSend(t *testing.T) {
 	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
 
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
@@ -294,16 +289,15 @@ func TestNewRequestHandlerRecvAndSend(t *testing.T) {
 
 func TestNewRequestHandlerRejectsUnsupportedRequestMedia(t *testing.T) {
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, _ *contentstream.RequestStream[test.Request, test.Response]) error {
 			return nil
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.JSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.JSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -326,8 +320,7 @@ func TestNewRequestHandlerRecvUnderCapSucceeds(t *testing.T) {
 
 			opts := contentstream.Options{MaxReceiveSize: tt.cap}
 			handler := contentstream.NewRequestHandler(
-				test.Content,
-				test.StreamEncoder,
+				test.StreamContent,
 				opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 					for {
 						req, err := stream.Recv()
@@ -346,8 +339,8 @@ func TestNewRequestHandlerRecvUnderCapSucceeds(t *testing.T) {
 			body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 			req.ProtoMajor = 2
-			req.Header.Set(content.TypeKey, media.NDJSON)
-			req.Header.Set(content.AcceptKey, media.NDJSON)
+			req.Header.Set(http.ContentTypeKey, media.NDJSON)
+			req.Header.Set(http.AcceptKey, media.NDJSON)
 			res := httptest.NewRecorder()
 
 			handler.ServeHTTP(res, req)
@@ -362,7 +355,7 @@ func TestNewRequestHandlerRecvDeliversScalarValueAtExactCap(t *testing.T) {
 	pipeReader, pipeWriter := io.Pipe()
 
 	opts := contentstream.Options{MaxReceiveSize: bytes.Size(2)}
-	handler := contentstream.NewRequestHandler(test.Content, test.StreamEncoder, opts, func(_ context.Context, stream *contentstream.RequestStream[int, int]) error {
+	handler := contentstream.NewRequestHandler(test.StreamContent, opts, func(_ context.Context, stream *contentstream.RequestStream[int, int]) error {
 		req, err := stream.Recv()
 		if err != nil {
 			return err
@@ -374,8 +367,8 @@ func TestNewRequestHandlerRecvDeliversScalarValueAtExactCap(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
 	req.ProtoMajor = 2
 	req.ContentLength = -1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	done := make(chan struct{})
@@ -403,8 +396,7 @@ func TestNewRequestHandlerRecvRejectsValueOverCap(t *testing.T) {
 
 	opts := contentstream.Options{MaxReceiveSize: 16}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
 			return recvErr
@@ -413,8 +405,8 @@ func TestNewRequestHandlerRecvRejectsValueOverCap(t *testing.T) {
 	body := "{\"Name\":\"a value with a name far longer than the configured cap\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -432,8 +424,7 @@ func TestNewRequestHandlerRecvRejectsBufferedValueOverCap(t *testing.T) {
 
 	opts := contentstream.Options{MaxReceiveSize: 16}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, err := stream.Recv()
 			require.NoError(t, err)
@@ -445,8 +436,8 @@ func TestNewRequestHandlerRecvRejectsBufferedValueOverCap(t *testing.T) {
 	body := "{\"Name\":\"A\"}\n{\"Name\":\"a value with a name far longer than the configured cap\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -485,20 +476,19 @@ func TestNewRequestHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavior(t *
 			codec := sm.Get("json")
 			codec.Decoder = tt.decoder
 			sm.Register("json", codec)
-			cont := content.NewContent(test.Encoder, test.Pool)
-
 			var recvErr error
 
 			opts := contentstream.Options{MaxReceiveSize: tt.maxSize}
-			handler := contentstream.NewRequestHandler(cont, sm, opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			content := contentstream.NewContent(sm, test.Pool)
+			handler := contentstream.NewRequestHandler(content, opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 				_, recvErr = stream.Recv()
 				return recvErr
 			})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(tt.body))
 			req.ProtoMajor = 2
-			req.Header.Set(content.TypeKey, media.NDJSON)
-			req.Header.Set(content.AcceptKey, media.NDJSON)
+			req.Header.Set(http.ContentTypeKey, media.NDJSON)
+			req.Header.Set(http.AcceptKey, media.NDJSON)
 			res := httptest.NewRecorder()
 
 			handler.ServeHTTP(res, req)
@@ -522,8 +512,7 @@ func TestNewRequestHandlerRecvCapIsPerValueNotCumulative(t *testing.T) {
 
 	opts := contentstream.Options{MaxReceiveSize: 24}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			for {
 				req, err := stream.Recv()
@@ -542,8 +531,8 @@ func TestNewRequestHandlerRecvCapIsPerValueNotCumulative(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
 	req.ProtoMajor = 2
 	req.ContentLength = -1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	done := make(chan struct{})
@@ -572,8 +561,7 @@ func TestNewRequestHandlerRecvChargesOneLimiterTokenPerMessage(t *testing.T) {
 	limiter := &test.CountingLimiter{Remaining: 2}
 
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			for {
 				_, err := stream.Recv()
@@ -590,8 +578,8 @@ func TestNewRequestHandlerRecvChargesOneLimiterTokenPerMessage(t *testing.T) {
 	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
 	res := httptest.NewRecorder()
 
@@ -607,8 +595,7 @@ func TestNewRequestHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testing.T) 
 	var recvErr error
 	opts := contentstream.Options{MaxReceiveSize: 16}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
 			return recvErr
@@ -617,8 +604,8 @@ func TestNewRequestHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testing.T) 
 	body := "{\"Name\":\"a value with a name far longer than the configured cap\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), limiter))
 	res := httptest.NewRecorder()
 
@@ -631,16 +618,15 @@ func TestNewRequestHandlerRecvDoesNotChargeLimiterForOverCapValue(t *testing.T) 
 func TestNewRequestHandlerSendExtendReadDeadlineFailure(t *testing.T) {
 	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("1s"), WriteTimeout: time.MustParseDuration("1s")}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			return stream.Send(&test.Response{Greeting: "hi"})
 		})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := &test.DeadlineResponseWriter{SetReadDeadlineFunc: func() error { return test.ErrFailed }}
 
 	handler.ServeHTTP(res, req)
@@ -659,8 +645,7 @@ func TestNewRequestHandlerRecvFirstCallIsBoundedByReadTimeout(t *testing.T) {
 
 	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("200ms")}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, err := stream.Recv()
 			recvErr <- err
@@ -676,8 +661,8 @@ func TestNewRequestHandlerRecvFirstCallIsBoundedByReadTimeout(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL, pipeReader)
 	require.NoError(t, err)
 	req.ContentLength = -1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 
 	go func() {
 		defer close(done)
@@ -701,8 +686,7 @@ func TestNewRequestHandlerRecvExtendReadDeadlineFailureBeforeDecode(t *testing.T
 
 	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("1s")}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
 			return recvErr
@@ -710,8 +694,8 @@ func TestNewRequestHandlerRecvExtendReadDeadlineFailureBeforeDecode(t *testing.T
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"Bob\"}\n"))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := &test.DeadlineResponseWriter{SetReadDeadlineFunc: func() error { return test.ErrFailed }}
 
 	handler.ServeHTTP(res, req)
@@ -726,8 +710,7 @@ func TestNewRequestHandlerRecvExtendReadDeadlineFailureAfterDecode(t *testing.T)
 
 	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("1s")}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
 			return recvErr
@@ -735,8 +718,8 @@ func TestNewRequestHandlerRecvExtendReadDeadlineFailureAfterDecode(t *testing.T)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"Bob\"}\n"))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := &test.DeadlineResponseWriter{SetReadDeadlineFunc: func() error {
 		calls++
 		if calls == 1 {
@@ -757,8 +740,7 @@ func TestNewRequestHandlerRecvExtendWriteDeadlineFailure(t *testing.T) {
 
 	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("1s"), WriteTimeout: time.MustParseDuration("1s")}
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
 			return recvErr
@@ -766,8 +748,8 @@ func TestNewRequestHandlerRecvExtendWriteDeadlineFailure(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"Bob\"}\n"))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := &test.DeadlineResponseWriter{SetWriteDeadlineFunc: func() error { return test.ErrFailed }}
 
 	handler.ServeHTTP(res, req)
@@ -780,8 +762,7 @@ func TestNewRequestHandlerRecvLimiterErrorMapsTo500(t *testing.T) {
 	var recvErr error
 
 	handler := contentstream.NewRequestHandler(
-		test.Content,
-		test.StreamEncoder,
+		test.StreamContent,
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, recvErr = stream.Recv()
 			return recvErr
@@ -790,8 +771,8 @@ func TestNewRequestHandlerRecvLimiterErrorMapsTo500(t *testing.T) {
 	body := "{\"Name\":\"Bob\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	req = req.WithContext(meta.WithLimiter(req.Context(), test.ErrorLimiter{}))
 	res := httptest.NewRecorder()
 
@@ -816,17 +797,19 @@ func TestNewRequestHandlerRecvBufferedLenFallback(t *testing.T) {
 			codec := sm.Get("json")
 			codec.Decoder = func(io.Reader) encodingstream.Decoder { return tt.decoder }
 			sm.Register("json", codec)
-			cont := content.NewContent(test.Encoder, test.Pool)
-
-			handler := contentstream.NewRequestHandler(cont, sm, contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
-				_, err := stream.Recv()
-				return err
-			})
+			handler := contentstream.NewRequestHandler(
+				contentstream.NewContent(sm, test.Pool),
+				contentstream.Options{},
+				func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+					_, err := stream.Recv()
+					return err
+				},
+			)
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{}"))
 			req.ProtoMajor = 2
-			req.Header.Set(content.TypeKey, media.NDJSON)
-			req.Header.Set(content.AcceptKey, media.NDJSON)
+			req.Header.Set(http.ContentTypeKey, media.NDJSON)
+			req.Header.Set(http.AcceptKey, media.NDJSON)
 			res := httptest.NewRecorder()
 
 			handler.ServeHTTP(res, req)
@@ -841,18 +824,17 @@ func TestNewRequestHandlerRecvRecoversStickyCapReaderError(t *testing.T) {
 	codec := sm.Get("json")
 	codec.Decoder = func(r io.Reader) encodingstream.Decoder { return &test.TripleReadDecoder{R: r} }
 	sm.Register("json", codec)
-	cont := content.NewContent(test.Encoder, test.Pool)
-
 	opts := contentstream.Options{MaxReceiveSize: bytes.Size(1)}
-	handler := contentstream.NewRequestHandler(cont, sm, opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+	content := contentstream.NewContent(sm, test.Pool)
+	handler := contentstream.NewRequestHandler(content, opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 		_, err := stream.Recv()
 		return err
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("ab"))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
@@ -876,16 +858,15 @@ func TestNewRequestHandlerRejectsNilCodecFieldForRegisteredKind(t *testing.T) {
 			codec := sm.Get("json")
 			tt.mutate(&codec)
 			sm.Register("json", codec)
-			cont := content.NewContent(test.Encoder, test.Pool)
-
-			handler := contentstream.NewRequestHandler(cont, sm, contentstream.Options{}, func(_ context.Context, _ *contentstream.RequestStream[test.Request, test.Response]) error {
+			content := contentstream.NewContent(sm, test.Pool)
+			handler := contentstream.NewRequestHandler(content, contentstream.Options{}, func(_ context.Context, _ *contentstream.RequestStream[test.Request, test.Response]) error {
 				return nil
 			})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 			req.ProtoMajor = 2
-			req.Header.Set(content.TypeKey, media.NDJSON)
-			req.Header.Set(content.AcceptKey, media.NDJSON)
+			req.Header.Set(http.ContentTypeKey, media.NDJSON)
+			req.Header.Set(http.AcceptKey, media.NDJSON)
 			res := httptest.NewRecorder()
 
 			handler.ServeHTTP(res, req)

--- a/net/http/content/unary/benchmark_test.go
+++ b/net/http/content/unary/benchmark_test.go
@@ -1,33 +1,34 @@
-package content_test
+package unary_test
 
 import (
 	"net/http/httptest"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 )
 
 // benchmarkMedia prevents the compiler from eliminating media negotiation work.
-var benchmarkMedia content.Media
+var benchmarkMedia unary.Media
 
 // BenchmarkNewFromMediaJSON tracks the exact media-type fast path used on hot request paths.
 func BenchmarkNewFromMediaJSON(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkMedia = test.Content.NewFromMedia(media.JSON)
+		benchmarkMedia = test.UnaryContent.NewFromMedia(media.JSON)
 	}
 }
 
 // BenchmarkNewFromRequestJSON tracks request header media negotiation overhead for a common JSON body.
 func BenchmarkNewFromRequestJSON(b *testing.B) {
 	req := httptest.NewRequestWithContext(b.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.JSON)
+	req.Header.Set(http.ContentTypeKey, media.JSON)
 
 	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkMedia = test.Content.NewFromRequest(req)
+		benchmarkMedia = test.UnaryContent.NewFromRequest(req)
 	}
 }
 
@@ -35,7 +36,7 @@ func BenchmarkNewFromRequestJSON(b *testing.B) {
 func BenchmarkNewFromMediaWithParameters(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkMedia = test.Content.NewFromMedia("application/json; profile=test")
+		benchmarkMedia = test.UnaryContent.NewFromMedia("application/json; profile=test")
 	}
 }
 
@@ -43,11 +44,11 @@ func BenchmarkNewFromMediaWithParameters(b *testing.B) {
 // (exact "application/json", no parameters), avoiding [net/http/media.Parse] on the hot request path.
 func BenchmarkNewFromRequestBodyJSON(b *testing.B) {
 	req := httptest.NewRequestWithContext(b.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.JSON)
+	req.Header.Set(http.ContentTypeKey, media.JSON)
 
 	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkMedia, _ = test.Content.NewFromRequestBody(req)
+		benchmarkMedia, _ = test.UnaryContent.NewFromRequestBody(req)
 	}
 }
 
@@ -55,10 +56,10 @@ func BenchmarkNewFromRequestBodyJSON(b *testing.B) {
 // taken for any parameterized Content-Type such as "application/json; charset=utf-8".
 func BenchmarkNewFromRequestBodyWithParameters(b *testing.B) {
 	req := httptest.NewRequestWithContext(b.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.JSON+"; charset=utf-8")
+	req.Header.Set(http.ContentTypeKey, media.JSON+"; charset=utf-8")
 
 	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkMedia, _ = test.Content.NewFromRequestBody(req)
+		benchmarkMedia, _ = test.UnaryContent.NewFromRequestBody(req)
 	}
 }

--- a/net/http/content/unary/content.go
+++ b/net/http/content/unary/content.go
@@ -1,7 +1,6 @@
-package content
+package unary
 
 import (
-	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/accept"
@@ -9,12 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-sync"
 )
-
-// TypeKey is the HTTP header key used for Content-Type.
-const TypeKey = "Content-Type"
-
-// AcceptKey is the HTTP header key used for Accept.
-const AcceptKey = "Accept"
 
 // NewContent constructs a Content that resolves single-value encoders from enc and buffers responses using pool.
 func NewContent(enc *encoding.Map, pool *sync.BufferPool) *Content {
@@ -36,7 +29,7 @@ func NewContent(enc *encoding.Map, pool *sync.BufferPool) *Content {
 //     send.
 //
 // Error subtype behavior:
-//   - If the parsed subtype is "error", NewMedia returns a Media without an encoder.
+//   - If the parsed subtype is "error", NewFromMedia returns a Media without an encoder.
 //     Callers typically treat the body as a plain-text error message.
 //
 // Response buffering:
@@ -54,9 +47,9 @@ type Content struct {
 // If parsing fails, it falls back to JSON.
 // If the internal error media type is selected, it falls back to plain text.
 func (c *Content) NewFromRequest(req *http.Request) Media {
-	mediaType := req.Header.Get(TypeKey)
+	mediaType := req.Header.Get(http.ContentTypeKey)
 	if strings.IsEmpty(mediaType) {
-		mediaType = accept.First(req.Header.Get(AcceptKey))
+		mediaType = accept.First(req.Header.Get(http.AcceptKey))
 	}
 
 	return c.newRequestMedia(mediaType)
@@ -69,9 +62,9 @@ func (c *Content) NewFromRequest(req *http.Request) Media {
 // If parsing fails, it falls back to JSON.
 // If the internal error media type is selected, it falls back to plain text.
 func (c *Content) NewFromAccept(req *http.Request) Media {
-	mediaType := accept.First(req.Header.Get(AcceptKey))
+	mediaType := accept.First(req.Header.Get(http.AcceptKey))
 	if strings.IsEmpty(mediaType) {
-		mediaType = req.Header.Get(TypeKey)
+		mediaType = req.Header.Get(http.ContentTypeKey)
 	}
 
 	return c.newRequestMedia(mediaType)
@@ -82,7 +75,7 @@ func (c *Content) NewFromAccept(req *http.Request) Media {
 // If parsing fails, it falls back to JSON.
 // If the internal error media type is selected, it falls back to plain text.
 func (c *Content) NewFromContentType(req *http.Request) Media {
-	return c.newRequestMedia(req.Header.Get(TypeKey))
+	return c.newRequestMedia(req.Header.Get(http.ContentTypeKey))
 }
 
 // NewFromRequestBody parses the request Content-Type header and returns a matching Media for body decoding.
@@ -95,7 +88,7 @@ func (c *Content) NewFromContentType(req *http.Request) Media {
 // It also rejects media types that are available for internal use but intentionally unsupported for
 // public request-body decoding; see the decoder-bounds rule in the package documentation.
 func (c *Content) NewFromRequestBody(req *http.Request) (Media, error) {
-	m, err := c.requestMedia(req.Header.Get(TypeKey))
+	m, err := c.requestMedia(req.Header.Get(http.ContentTypeKey))
 	if err != nil {
 		return Media{}, err
 	}
@@ -115,7 +108,7 @@ func (c *Content) NewFromRequestBody(req *http.Request) (Media, error) {
 	return m, nil
 }
 
-// requestMedia resolves a request Content-Type strictly: unlike NewMedia there is no JSON fallback for
+// requestMedia resolves a request Content-Type strictly: unlike NewFromMedia there is no JSON fallback for
 // an unparseable or unregistered media type, because answering a declared Content-Type with a different
 // codec silently decodes the body as a format the caller did not send.
 //
@@ -159,21 +152,20 @@ func (c *Content) requestMedia(mediaType string) (Media, error) {
 //
 // If parsing fails, it falls back to JSON.
 func (c *Content) NewFromMedia(mediaType string) Media {
-	return NewMedia(mediaType, c.enc)
-}
+	if media, ok := knownMedia(mediaType, c.enc); ok {
+		return media
+	}
 
-// BorrowBuffer obtains a response buffer for a content extension and must be paired with [Content.ReturnBuffer].
-func (c *Content) BorrowBuffer() *bytes.Buffer {
-	return c.pool.Get()
-}
+	value, err := media.Parse(mediaType)
+	if err != nil {
+		return jsonMedia(c.enc)
+	}
 
-// ReturnBuffer returns a buffer obtained through [Content.BorrowBuffer].
-func (c *Content) ReturnBuffer(buffer *bytes.Buffer) {
-	c.pool.Put(buffer)
+	return newMedia(value, c.enc)
 }
 
 func (c *Content) newRequestMedia(mediaType string) Media {
-	m := NewMedia(mediaType, c.enc)
+	m := c.NewFromMedia(mediaType)
 	if m.IsError() {
 		return newMedia(textType, c.enc)
 	}

--- a/net/http/content/unary/content_test.go
+++ b/net/http/content/unary/content_test.go
@@ -1,4 +1,4 @@
-package content_test
+package unary_test
 
 import (
 	"net/http/httptest"
@@ -6,7 +6,8 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +15,7 @@ import (
 func TestNewFromMedia(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
-			media := test.Content.NewFromMedia(tc.mediaType)
+			media := test.UnaryContent.NewFromMedia(tc.mediaType)
 
 			require.Equal(t, tc.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tc.kind), media.Encoder)
@@ -26,9 +27,9 @@ func TestNewFromRequest(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-			req.Header.Set(content.TypeKey, tc.mediaType)
+			req.Header.Set(http.ContentTypeKey, tc.mediaType)
 
-			media := test.Content.NewFromRequest(req)
+			media := test.UnaryContent.NewFromRequest(req)
 
 			require.Equal(t, tc.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tc.kind), media.Encoder)
@@ -38,10 +39,10 @@ func TestNewFromRequest(t *testing.T) {
 
 func TestNewFromRequestPrefersContentType(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.TOML)
-	req.Header.Set(content.AcceptKey, media.YAML)
+	req.Header.Set(http.ContentTypeKey, media.TOML)
+	req.Header.Set(http.AcceptKey, media.YAML)
 
-	media := test.Content.NewFromRequest(req)
+	media := test.UnaryContent.NewFromRequest(req)
 
 	require.Equal(t, "toml", media.Subtype())
 	require.Same(t, test.Encoder.Get("toml"), media.Encoder)
@@ -49,10 +50,10 @@ func TestNewFromRequestPrefersContentType(t *testing.T) {
 
 func TestNewFromAcceptPrefersAccept(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.TOML)
-	req.Header.Set(content.AcceptKey, media.YAML)
+	req.Header.Set(http.ContentTypeKey, media.TOML)
+	req.Header.Set(http.AcceptKey, media.YAML)
 
-	media := test.Content.NewFromAccept(req)
+	media := test.UnaryContent.NewFromAccept(req)
 
 	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
@@ -74,9 +75,9 @@ func TestNewFromAcceptUsesFirstCompleteMediaRange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-			req.Header.Set(content.AcceptKey, tt.accept)
+			req.Header.Set(http.AcceptKey, tt.accept)
 
-			media := test.Content.NewFromAccept(req)
+			media := test.UnaryContent.NewFromAccept(req)
 
 			require.Equal(t, tt.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tt.kind), media.Encoder)
@@ -86,9 +87,9 @@ func TestNewFromAcceptUsesFirstCompleteMediaRange(t *testing.T) {
 
 func TestNewFromAcceptFallsBackToContentType(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.TOML)
+	req.Header.Set(http.ContentTypeKey, media.TOML)
 
-	media := test.Content.NewFromAccept(req)
+	media := test.UnaryContent.NewFromAccept(req)
 
 	require.Equal(t, "toml", media.Subtype())
 	require.Same(t, test.Encoder.Get("toml"), media.Encoder)
@@ -96,9 +97,9 @@ func TestNewFromAcceptFallsBackToContentType(t *testing.T) {
 
 func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.AcceptKey, `application/yaml; profile="a,b", application/toml`)
+	req.Header.Set(http.AcceptKey, `application/yaml; profile="a,b", application/toml`)
 
-	media := test.Content.NewFromRequest(req)
+	media := test.UnaryContent.NewFromRequest(req)
 
 	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
@@ -106,9 +107,9 @@ func TestNewFromRequestFallsBackToAccept(t *testing.T) {
 
 func TestNewFromRequestNormalizesMediaTypeCase(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, "Application/YAML")
+	req.Header.Set(http.ContentTypeKey, "Application/YAML")
 
-	media := test.Content.NewFromRequest(req)
+	media := test.UnaryContent.NewFromRequest(req)
 
 	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
@@ -116,9 +117,9 @@ func TestNewFromRequestNormalizesMediaTypeCase(t *testing.T) {
 
 func TestNewFromRequestNormalizesAcceptMediaTypeCase(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.AcceptKey, "Application/YAML, Application/TOML")
+	req.Header.Set(http.AcceptKey, "Application/YAML, Application/TOML")
 
-	media := test.Content.NewFromRequest(req)
+	media := test.UnaryContent.NewFromRequest(req)
 
 	require.Equal(t, "yaml", media.Subtype())
 	require.Same(t, test.Encoder.Get("yaml"), media.Encoder)
@@ -126,9 +127,9 @@ func TestNewFromRequestNormalizesAcceptMediaTypeCase(t *testing.T) {
 
 func TestNewFromRequestFallsBackFromInternalErrorMedia(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.AcceptKey, media.Error)
+	req.Header.Set(http.AcceptKey, media.Error)
 
-	media := test.Content.NewFromRequest(req)
+	media := test.UnaryContent.NewFromRequest(req)
 
 	require.Equal(t, "plain", media.Subtype())
 	require.Same(t, test.Encoder.Get("bytes"), media.Encoder)
@@ -138,9 +139,9 @@ func TestNewFromContentType(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-			req.Header.Set(content.TypeKey, tc.mediaType)
+			req.Header.Set(http.ContentTypeKey, tc.mediaType)
 
-			media := test.Content.NewFromContentType(req)
+			media := test.UnaryContent.NewFromContentType(req)
 
 			require.Equal(t, tc.subtype, media.Subtype())
 			require.Same(t, test.Encoder.Get(tc.kind), media.Encoder)
@@ -150,9 +151,9 @@ func TestNewFromContentType(t *testing.T) {
 
 func TestNewFromContentTypeFallsBackFromInternalErrorMedia(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.Error)
+	req.Header.Set(http.ContentTypeKey, media.Error)
 
-	media := test.Content.NewFromContentType(req)
+	media := test.UnaryContent.NewFromContentType(req)
 
 	require.Equal(t, "plain", media.Subtype())
 	require.Same(t, test.Encoder.Get("bytes"), media.Encoder)
@@ -162,11 +163,12 @@ func TestNewFromRequestBodyRejectsUnsafeBinaryMedia(t *testing.T) {
 	for _, mediaType := range []string{"application/gob", media.MessagePack, media.MessagePack + "; profile=test"} {
 		t.Run(mediaType, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-			req.Header.Set(content.TypeKey, mediaType)
+			req.Header.Set(http.ContentTypeKey, mediaType)
 
-			media, err := test.Content.NewFromRequestBody(req)
+			media, err := test.UnaryContent.NewFromRequestBody(req)
 
-			require.ErrorIs(t, err, content.ErrUnsupportedRequestMedia)
+			require.ErrorIs(t, err, unary.ErrUnsupportedRequestMedia)
+			require.EqualError(t, err, "unary: unsupported request media")
 			require.False(t, media.CanDecodeRequest())
 		})
 	}
@@ -176,11 +178,11 @@ func TestNewFromRequestBodyRejectsUnknownContentType(t *testing.T) {
 	for _, mediaType := range []string{"application/cbor", "/"} {
 		t.Run(mediaType, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-			req.Header.Set(content.TypeKey, mediaType)
+			req.Header.Set(http.ContentTypeKey, mediaType)
 
-			media, err := test.Content.NewFromRequestBody(req)
+			media, err := test.UnaryContent.NewFromRequestBody(req)
 
-			require.ErrorIs(t, err, content.ErrUnsupportedRequestMedia)
+			require.ErrorIs(t, err, unary.ErrUnsupportedRequestMedia)
 			require.False(t, media.CanDecodeRequest())
 		})
 	}
@@ -201,16 +203,16 @@ func TestNewFromRequestBodyRejectsNilRegisteredCodec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			enc := encoding.NewMap()
 			enc.Register(tt.register, nil)
-			cont := content.NewContent(enc, test.Pool)
+			cont := unary.NewContent(enc, test.Pool)
 
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 			if tt.contentType != "" {
-				req.Header.Set(content.TypeKey, tt.contentType)
+				req.Header.Set(http.ContentTypeKey, tt.contentType)
 			}
 
 			media, err := cont.NewFromRequestBody(req)
 
-			require.ErrorIs(t, err, content.ErrUnsupportedRequestMedia)
+			require.ErrorIs(t, err, unary.ErrUnsupportedRequestMedia)
 			require.False(t, media.CanDecodeRequest())
 		})
 	}
@@ -219,7 +221,7 @@ func TestNewFromRequestBodyRejectsNilRegisteredCodec(t *testing.T) {
 func TestNewFromRequestBodyDefaultsToJSONWhenContentTypeAbsent(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 
-	media, err := test.Content.NewFromRequestBody(req)
+	media, err := test.UnaryContent.NewFromRequestBody(req)
 
 	require.NoError(t, err)
 	require.Equal(t, "json", media.Subtype())
@@ -229,9 +231,9 @@ func TestNewFromRequestBodyDefaultsToJSONWhenContentTypeAbsent(t *testing.T) {
 
 func TestNewFromRequestBodyTreatsParameterizedInternalErrorContentTypeAsText(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-	req.Header.Set(content.TypeKey, media.Error+"; charset=utf-8")
+	req.Header.Set(http.ContentTypeKey, media.Error+"; charset=utf-8")
 
-	m, err := test.Content.NewFromRequestBody(req)
+	m, err := test.UnaryContent.NewFromRequestBody(req)
 
 	require.NoError(t, err)
 	require.Equal(t, "plain", m.Subtype())
@@ -255,9 +257,9 @@ func TestNewFromRequestBodyDecodesFallthroughReachableMediaTypes(t *testing.T) {
 	} {
 		t.Run(tc.mediaType, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
-			req.Header.Set(content.TypeKey, tc.mediaType)
+			req.Header.Set(http.ContentTypeKey, tc.mediaType)
 
-			media, err := test.Content.NewFromRequestBody(req)
+			media, err := test.UnaryContent.NewFromRequestBody(req)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.subtype, media.Subtype())
@@ -281,10 +283,10 @@ func TestNewFromAcceptResolvesJSONForWildcardOrUnknown(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 			if tc.accept != "" {
-				req.Header.Set(content.AcceptKey, tc.accept)
+				req.Header.Set(http.AcceptKey, tc.accept)
 			}
 
-			m := test.Content.NewFromAccept(req)
+			m := test.UnaryContent.NewFromAccept(req)
 
 			require.Equal(t, "json", m.Subtype())
 			require.Same(t, test.Encoder.Get("json"), m.Encoder)
@@ -304,7 +306,8 @@ func TestEveryEncoderKindIsClassified(t *testing.T) {
 	for _, kind := range encoding.NewMap().Keys() {
 		expected, ok := classified[kind]
 		require.True(t, ok, "kind %q needs an explicit request-decode classification", kind)
-		require.Equal(t, expected, content.NewMedia("application/"+kind, encoding.NewMap()).CanDecodeRequest(), "kind %q", kind)
+		content := unary.NewContent(encoding.NewMap(), test.Pool)
+		require.Equal(t, expected, content.NewFromMedia("application/"+kind).CanDecodeRequest(), "kind %q", kind)
 	}
 }
 
@@ -322,7 +325,7 @@ func TestNewFromMediaWithParameters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			media := test.Content.NewFromMedia(tt.mediaType)
+			media := test.UnaryContent.NewFromMedia(tt.mediaType)
 
 			require.Equal(t, tt.expected, media.String())
 			require.Equal(t, tt.subtype, media.Subtype())
@@ -332,15 +335,15 @@ func TestNewFromMediaWithParameters(t *testing.T) {
 }
 
 func TestNewFromMediaPreservesInternalErrorMedia(t *testing.T) {
-	media := test.Content.NewFromMedia(media.Error)
+	media := test.UnaryContent.NewFromMedia(media.Error)
 
 	require.Equal(t, "error", media.Subtype())
 	require.Nil(t, media.Encoder)
 }
 
-func TestNewMediaFallsBackToJSONWhenKnownEncoderIsMissing(t *testing.T) {
+func TestNewFromMediaFallsBackToJSONWhenKnownEncoderIsMissing(t *testing.T) {
 	enc := &encoding.Map{}
-	media := content.NewMedia(media.HumanJSON, enc)
+	media := unary.NewContent(enc, test.Pool).NewFromMedia(media.HumanJSON)
 
 	require.Equal(t, "json", media.Subtype())
 	require.Equal(t, "application/json", media.String())

--- a/net/http/content/unary/doc.go
+++ b/net/http/content/unary/doc.go
@@ -1,4 +1,4 @@
-// Package content provides HTTP content negotiation helpers used by go-service.
+// Package unary provides HTTP content negotiation and single-value handlers used by go-service.
 //
 // This package helps select an encoder/decoder based on HTTP media types (Content-Type and Accept) and
 // provides small building blocks for content-aware request/response handling.
@@ -19,7 +19,7 @@
 // # Error payloads
 //
 // go-service uses a dedicated error media subtype ("error") to signal error payloads (typically
-// rendered as plain text). When the subtype is "error", [NewMedia] returns a Media without an
+// rendered as plain text). When the subtype is "error", [Content.NewFromMedia] returns a Media without an
 // encoder and callers should treat the response body as an error message.
 //
 // # Defaults and fallbacks
@@ -49,4 +49,4 @@
 // which decodes responses through the same registries without this restriction).
 //
 // Start with [NewContent], [Content.NewFromRequest], and [Content.NewFromMedia].
-package content
+package unary

--- a/net/http/content/unary/errors.go
+++ b/net/http/content/unary/errors.go
@@ -1,4 +1,4 @@
-package content
+package unary
 
 import "github.com/alexfalkowski/go-service/v2/errors"
 
@@ -6,4 +6,4 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // HTTP request body. This covers three causes: the media type is intentionally denied (see the
 // decoder-bounds rule in the package documentation), the media type does not parse, or the media type
 // parses but resolves to no registered codec. See [Content.NewFromRequestBody].
-var ErrUnsupportedRequestMedia = errors.New("content: unsupported request media")
+var ErrUnsupportedRequestMedia = errors.New("unary: unsupported request media")

--- a/net/http/content/unary/handler.go
+++ b/net/http/content/unary/handler.go
@@ -1,4 +1,4 @@
-package content
+package unary
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -70,23 +70,13 @@ func NewHandler[Res any](cont *Content, handler Handler[Res]) http.HandlerFunc {
 	})
 }
 
-// NotFoundHandler returns a not-found handler that writes the standard content error response.
-func NotFoundHandler() http.NotFoundHandler {
-	return func(res http.ResponseWriter, req *http.Request) bool {
-		err := status.SafeError(http.StatusNotFound, nil)
-		_ = status.WriteError(req.Context(), res, err)
-
-		return true
-	}
-}
-
 func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res, error)) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
 		mediaType := cont.NewFromAccept(req)
 		ctx = meta.WithRequestResponse(ctx, req, res)
-		res.Header().Set(TypeKey, mediaType.WithUTF8())
+		res.Header().Set(http.ContentTypeKey, mediaType.WithUTF8())
 
 		data, err := handler(ctx)
 		if err != nil {

--- a/net/http/content/unary/handler_test.go
+++ b/net/http/content/unary/handler_test.go
@@ -1,4 +1,4 @@
-package content_test
+package unary_test
 
 import (
 	"net/http/httptest"
@@ -9,26 +9,26 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewRequestHandlerUsesAcceptForResponse(t *testing.T) {
-	handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *test.Request) (*test.Response, error) {
+	handler := unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, req *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "Hello " + req.Name}, nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(`{"name":"Bob"}`))
-	req.Header.Set(content.TypeKey, media.JSON)
-	req.Header.Set(content.AcceptKey, media.YAML)
+	req.Header.Set(http.ContentTypeKey, media.JSON)
+	req.Header.Set(http.AcceptKey, media.YAML)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.YAML, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.YAML, res.Header().Get(http.ContentTypeKey))
 	var response test.Response
 	require.NoError(t, test.Encoder.Get("yaml").Decode(res.Body, &response))
 	require.Equal(t, "Hello Bob", response.Greeting)
@@ -44,102 +44,92 @@ func TestNewRequestHandlerRejectsUnsafeBinaryRequestBody(t *testing.T) {
 	} {
 		t.Run(tc.kind, func(t *testing.T) {
 			called := false
-			handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *test.Request) (*test.Response, error) {
+			handler := unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, req *test.Request) (*test.Response, error) {
 				called = true
 				return &test.Response{Greeting: "Hello " + req.Name}, nil
 			})
 			body := bytes.NewBuffer(nil)
 			require.NoError(t, test.Encoder.Get(tc.kind).Encode(body, &test.Request{Name: "Bob"}))
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", body)
-			req.Header.Set(content.TypeKey, tc.mediaType)
+			req.Header.Set(http.ContentTypeKey, tc.mediaType)
 			res := httptest.NewRecorder()
 
 			handler.ServeHTTP(res, req)
 
 			require.False(t, called)
 			require.Equal(t, http.StatusUnsupportedMediaType, res.Code)
-			require.Equal(t, "text/error; charset=utf-8", res.Header().Get(content.TypeKey))
+			require.Equal(t, "text/error; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 			test.RequireTrimmedResponseBody(t, res, "http: unsupported media type")
 		})
 	}
 }
 
 func TestNewRequestHandlerTreatsInternalErrorContentTypeAsText(t *testing.T) {
-	handler := content.NewRequestHandler(test.Content, func(_ context.Context, req *bytes.Buffer) (*bytes.Buffer, error) {
+	handler := unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, req *bytes.Buffer) (*bytes.Buffer, error) {
 		return bytes.NewBufferString("Hello " + req.String()), nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("Bob"))
-	req.Header.Set(content.TypeKey, media.Error)
+	req.Header.Set(http.ContentTypeKey, media.Error)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, "text/plain; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 	test.RequireResponseBody(t, res, "Hello Bob")
 }
 
 func TestNewHandlerTreatsInternalErrorAcceptAsText(t *testing.T) {
-	handler := content.NewHandler(test.Content, func(_ context.Context) (*bytes.Buffer, error) {
+	handler := unary.NewHandler(test.UnaryContent, func(_ context.Context) (*bytes.Buffer, error) {
 		return bytes.NewBufferString("Hello Bob"), nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.Error)
+	req.Header.Set(http.AcceptKey, media.Error)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, "text/plain; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 	test.RequireResponseBody(t, res, "Hello Bob")
 }
 
 func TestNewHandlerReplacesExistingContentType(t *testing.T) {
-	handler := content.NewHandler(test.Content, func(_ context.Context) (*bytes.Buffer, error) {
+	handler := unary.NewHandler(test.UnaryContent, func(_ context.Context) (*bytes.Buffer, error) {
 		return bytes.NewBufferString("Hello Bob"), nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.Text)
+	req.Header.Set(http.AcceptKey, media.Text)
 	res := httptest.NewRecorder()
-	res.Header().Set(content.TypeKey, media.HTML)
+	res.Header().Set(http.ContentTypeKey, media.HTML)
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, []string{"text/plain; charset=utf-8"}, res.Header().Values(content.TypeKey))
+	require.Equal(t, []string{"text/plain; charset=utf-8"}, res.Header().Values(http.ContentTypeKey))
 	test.RequireResponseBody(t, res, "Hello Bob")
 }
 
 func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	enc := encoding.NewMap()
 	enc.Register("json", test.PartialEncoder{})
-	cont := content.NewContent(enc, test.Pool)
+	cont := unary.NewContent(enc, test.Pool)
 
-	handler := content.NewHandler(cont, func(_ context.Context) (*test.Response, error) {
+	handler := unary.NewHandler(cont, func(_ context.Context) (*test.Response, error) {
 		return &test.Response{Greeting: "Hello Bob"}, nil
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.TypeKey, media.JSON)
+	req.Header.Set(http.ContentTypeKey, media.JSON)
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
-	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 	test.RequireTrimmedResponseBody(t, res, "http: internal server error")
 	test.RequireResponseBodyNotContains(t, res, "partial")
-}
-
-func TestNotFoundHandlerWritesStatusError(t *testing.T) {
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
-	res := httptest.NewRecorder()
-
-	require.True(t, content.NotFoundHandler()(res, req))
-	require.Equal(t, http.StatusNotFound, res.Code)
-	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(content.TypeKey))
-	test.RequireTrimmedResponseBody(t, res, "http: not found")
 }

--- a/net/http/content/unary/media.go
+++ b/net/http/content/unary/media.go
@@ -1,4 +1,4 @@
-package content
+package unary
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
@@ -55,25 +55,6 @@ func unaryKind(subtype string) string {
 	}
 
 	return subtype
-}
-
-// NewMedia builds a Media from a media type string and encoder map.
-//
-// Encoder selection:
-//   - If the subtype is "error", it returns a Media without an encoder.
-//   - If no encoder is registered for the subtype, it falls back to JSON.
-//   - Otherwise it returns the encoder registered for the subtype.
-func NewMedia(mediaType string, enc *encoding.Map) Media {
-	if media, ok := knownMedia(mediaType, enc); ok {
-		return media
-	}
-
-	value, err := media.Parse(mediaType)
-	if err != nil {
-		return jsonMedia(enc)
-	}
-
-	return newMedia(value, enc)
 }
 
 // Media describes an HTTP media type and its associated encoder.

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -19,8 +19,8 @@
 // those values should install them with WithRequestResponse before invoking downstream logic.
 //
 // These helpers are typically used in tightly controlled handler pipelines (for example those created by
-// [github.com/alexfalkowski/go-service/v2/net/http/content.NewHandler] /
-// [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler]), which populate the context before invoking
+// [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewHandler] /
+// [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewRequestHandler]), which populate the context before invoking
 // downstream logic.
 //
 // # Forwarded IP trust boundary

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -4,7 +4,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -74,7 +73,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 	}
 
 	handler := func(res http.ResponseWriter, req *http.Request) {
-		res.Header().Set(content.TypeKey, htmlContentType)
+		res.Header().Set(http.ContentTypeKey, htmlContentType)
 
 		ctx := req.Context()
 		ctx = meta.WithRequestResponse(ctx, req, res)
@@ -101,7 +100,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 
 func writeNotFound(req *http.Request, res http.ResponseWriter) {
 	err := status.Error(http.StatusNotFound, http.StatusText(http.StatusNotFound))
-	res.Header().Set(content.TypeKey, htmlContentType)
+	res.Header().Set(http.ContentTypeKey, htmlContentType)
 	ctx := req.Context()
 	ctx = meta.WithRequestResponse(ctx, req, res)
 	ctx = meta.WithAttributes(ctx, meta.NewPair("mvcModelError", meta.Error(err)))

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
@@ -61,7 +60,7 @@ func TestStaticPathValueSetsContentType(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, "image/svg+xml", res.Header().Get(content.TypeKey))
+	require.Equal(t, "image/svg+xml", res.Header().Get(http.ContentTypeKey))
 }
 
 func TestStaticPathValueRejectsDirectory(t *testing.T) {
@@ -104,7 +103,7 @@ func TestStaticFileSetsContentType(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, "image/svg+xml", res.Header().Get(content.TypeKey))
+	require.Equal(t, "image/svg+xml", res.Header().Get(http.ContentTypeKey))
 }
 
 func TestStaticFileRejectsDirectory(t *testing.T) {
@@ -375,7 +374,7 @@ func TestRouteErrorIncludesSafeModelAndRawMetaInTemplate(t *testing.T) {
 	}))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.TypeKey, media.HTML)
+	req.Header.Set(http.ContentTypeKey, media.HTML)
 	ctx := status.WithRequestError(req.Context())
 	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
@@ -406,7 +405,7 @@ func TestRouteWritesStatusWhenRenderFails(t *testing.T) {
 	}))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.TypeKey, media.HTML)
+	req.Header.Set(http.ContentTypeKey, media.HTML)
 	ctx := status.WithRequestError(req.Context())
 	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
@@ -441,14 +440,14 @@ func TestRouteRenderErrorDoesNotUseNotFoundController(t *testing.T) {
 	}))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.TypeKey, media.HTML)
+	req.Header.Set(http.ContentTypeKey, media.HTML)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 	test.RequireEmptyResponseBody(t, res)
-	require.Equal(t, "text/html; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 }
 
 func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
@@ -470,7 +469,7 @@ func TestRouteErrorWritesRenderStatusWhenErrorViewFails(t *testing.T) {
 	}))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.TypeKey, media.HTML)
+	req.Header.Set(http.ContentTypeKey, media.HTML)
 	ctx := status.WithRequestError(req.Context())
 	req = req.WithContext(ctx)
 	res := httptest.NewRecorder()
@@ -509,7 +508,7 @@ func TestNotFoundHandlesNotFound(t *testing.T) {
 	mvc.NewHandler(mux).ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusNotFound, res.Code)
-	require.Equal(t, "text/html; charset=utf-8", res.Header().Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 	test.RequireResponseBodyContains(t, res, "404 Not Found")
 }
 
@@ -608,7 +607,7 @@ func TestFallback(t *testing.T) {
 			}
 
 			require.Equal(t, http.StatusNotFound, res.Code)
-			require.Equal(t, "text/html; charset=utf-8", res.Header().Get(content.TypeKey))
+			require.Equal(t, "text/html; charset=utf-8", res.Header().Get(http.ContentTypeKey))
 			test.RequireResponseBodyContains(t, res, "404 Not Found")
 		})
 	}

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -105,7 +104,7 @@ func staticStatusCode(err error) int {
 func setStaticContentType(res http.ResponseWriter, name string) {
 	mediaType := media.TypeByExtension(path.Ext(name))
 	if !strings.IsEmpty(mediaType) {
-		res.Header().Set(content.TypeKey, media.MustParse(mediaType).WithUTF8())
+		res.Header().Set(http.ContentTypeKey, media.MustParse(mediaType).WithUTF8())
 	}
 }
 

--- a/net/http/rest/client.go
+++ b/net/http/rest/client.go
@@ -51,9 +51,8 @@ func WithClientTimeout(timeout string) ClientOption {
 
 // NewClient constructs a REST client backed by net/http/client.
 //
-// NewClient depends on package-level registration (see [Register]) for the content codecs (cont)
-// and buffer pool (pool). [Register] must be called before NewClient; otherwise it will panic due to
-// nil dependencies.
+// NewClient depends on package-level registration (see [Register]) for unary and stream content plus
+// the buffer pool. [Register] must be called before NewClient; otherwise it will panic due to nil dependencies.
 //
 // Behavior:
 //   - It constructs a content-aware [client.Client] configured with the selected RoundTripper and unary
@@ -61,7 +60,7 @@ func WithClientTimeout(timeout string) ClientOption {
 //   - It disables automatic redirect following (returns redirect responses instead of following them).
 func NewClient(opts ...ClientOption) *Client {
 	os := options(opts...)
-	client := client.NewClient(cont, sm, pool,
+	client := client.NewClient(unaryContent, streamContent, pool,
 		client.WithRoundTripper(os.roundTripper),
 		client.WithTimeout(os.timeout),
 		client.WithRedirect(client.RedirectIgnore),

--- a/net/http/rest/client_test.go
+++ b/net/http/rest/client_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
@@ -15,10 +14,10 @@ import (
 )
 
 func TestNewClientUsesTimeout(t *testing.T) {
-	rest.Register(nil, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rest.Register(nil, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.Header().Set(content.TypeKey, media.Text)
+		res.Header().Set(http.ContentTypeKey, media.Text)
 		res.WriteHeader(http.StatusOK)
 		res.(http.Flusher).Flush()
 		<-req.Context().Done()

--- a/net/http/rest/doc.go
+++ b/net/http/rest/doc.go
@@ -1,6 +1,6 @@
 // Package rest provides REST-style HTTP handler registration and client helpers for go-service.
 //
-// This package is built on top of [github.com/alexfalkowski/go-service/v2/net/http/content]. It relies on package-level registration (see [Register])
+// This package is built on top of [github.com/alexfalkowski/go-service/v2/net/http/content/unary]. It relies on package-level registration (see [Register])
 // to supply the HTTP router, content codec helpers, and buffer pool that are used when wiring handlers and clients.
 //
 // # Server-side routing
@@ -12,8 +12,8 @@
 //
 // For example, calling Get("/health", handler) registers the route pattern "GET /health".
 //
-// The handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewHandler]
-// and [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
+// The handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewHandler]
+// and [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewRequestHandler], which:
 //   - decode request bodies (where applicable) from Content-Type, falling back to JSON when
 //     Content-Type is absent, and rejecting it with 415 when it is unparseable, unregistered, or
 //     intentionally undecodable, and

--- a/net/http/rest/example_test.go
+++ b/net/http/rest/example_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-sync"
@@ -20,7 +20,8 @@ func ExampleGet() {
 	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
 	streamMap := encodingstream.NewMap()
-	rest.Register(router, content.NewContent(encoding.NewMap(), pool), streamMap, pool, contentstream.Options{})
+	streamContent := contentstream.NewContent(streamMap, pool)
+	rest.Register(router, unary.NewContent(encoding.NewMap(), pool), streamContent, pool, contentstream.Options{})
 
 	rest.Get("/hello", func(context.Context) (*exampleResponse, error) {
 		return &exampleResponse{Message: "hello"}, nil
@@ -45,7 +46,8 @@ func ExampleStreamGet() {
 	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
 	streamMap := encodingstream.NewMap()
-	rest.Register(router, content.NewContent(encoding.NewMap(), pool), streamMap, pool, contentstream.Options{})
+	streamContent := contentstream.NewContent(streamMap, pool)
+	rest.Register(router, unary.NewContent(encoding.NewMap(), pool), streamContent, pool, contentstream.Options{})
 
 	rest.StreamGet("/hello", func(_ context.Context, stream *contentstream.Stream[exampleResponse]) error {
 		if err := stream.Send(&exampleResponse{Message: "hello"}); err != nil {
@@ -56,7 +58,7 @@ func ExampleStreamGet() {
 	})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)

--- a/net/http/rest/rest.go
+++ b/net/http/rest/rest.go
@@ -1,19 +1,18 @@
 package rest
 
 import (
-	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
-	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-sync"
 )
 
 var (
-	router *http.Router
-	cont   *content.Content
-	sm     *encodingstream.Map
-	pool   *sync.BufferPool
-	opts   contentstream.Options
+	router        *http.Router
+	unaryContent  *unary.Content
+	pool          *sync.BufferPool
+	streamContent *stream.Content
+	opts          stream.Options
 )
 
 // Register stores the dependencies used by server and client helpers in package-level variables.
@@ -27,18 +26,18 @@ var (
 //   - server-side helpers (Get/Post/etc.) register handlers on the registered router, and
 //   - client helpers (NewClient) build clients using the registered content codecs and buffer pool.
 //
-// c resolves single-value media types, while the streaming registry resolves media types for the
-// streaming route helpers and the embedded HTTP client.
+// unaryContent resolves single-value media types, and streamContent resolves streaming media types for the
+// streaming route helpers and embedded HTTP client. p also buffers client response bodies.
 //
 // so is passed through unchanged to this package's streaming route helpers (StreamRoute, StreamGet,
 // StreamRouteRequest, StreamPost, StreamPut, StreamPatch) via
 // [github.com/alexfalkowski/go-service/v2/net/http/content/stream.NewHandler] and
 // [github.com/alexfalkowski/go-service/v2/net/http/content/stream.NewRequestHandler]; see those
 // constructors for the timeout and per-value receive-size semantics.
-func Register(r *http.Router, c *content.Content, s *encodingstream.Map, p *sync.BufferPool, so contentstream.Options) {
+func Register(r *http.Router, uc *unary.Content, sc *stream.Content, p *sync.BufferPool, so stream.Options) {
 	router = r
-	cont = c
-	sm = s
+	unaryContent = uc
 	pool = p
+	streamContent = sc
 	opts = so
 }

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -2,8 +2,8 @@ package rest
 
 import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -18,7 +18,7 @@ import (
 //	Delete("/health", handler) // registers "DELETE /health"
 //
 // This helper delegates to Route.
-func Delete[Res any](pattern string, handler content.Handler[Res]) {
+func Delete[Res any](pattern string, handler unary.Handler[Res]) {
 	Route(strings.Join(strings.Space, http.MethodDelete, pattern), handler)
 }
 
@@ -26,7 +26,7 @@ func Delete[Res any](pattern string, handler content.Handler[Res]) {
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to Route.
-func Get[Res any](pattern string, handler content.Handler[Res]) {
+func Get[Res any](pattern string, handler unary.Handler[Res]) {
 	Route(strings.Join(strings.Space, http.MethodGet, pattern), handler)
 }
 
@@ -34,7 +34,7 @@ func Get[Res any](pattern string, handler content.Handler[Res]) {
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
-func Post[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
+func Post[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
 	RouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler)
 }
 
@@ -42,7 +42,7 @@ func Post[Req any, Res any](pattern string, handler content.RequestHandler[Req, 
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
-func Put[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
+func Put[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
 	RouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler)
 }
 
@@ -50,13 +50,13 @@ func Put[Req any, Res any](pattern string, handler content.RequestHandler[Req, R
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
-func Patch[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
+func Patch[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
 	RouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler)
 }
 
 // RouteRequest registers a handler under pattern that decodes a request and encodes a response.
 //
-// The handler is built using [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
+// The handler is built using [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewRequestHandler], which:
 //   - decodes the request body using Content-Type, falling back to JSON when Content-Type is absent and
 //     rejecting it with 415 when it is unparseable, unregistered, or intentionally undecodable,
 //   - decodes the request body into a newly allocated request model, and
@@ -64,23 +64,23 @@ func Patch[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 //
 // Registration:
 // The resulting handler is registered on the package-level router configured via [Register].
-// [Register] must be called before RouteRequest; otherwise router/cont will be nil and this function will panic.
-func RouteRequest[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
-	router.Handle(pattern, content.NewRequestHandler(cont, handler))
+// [Register] must be called before RouteRequest; otherwise router/unaryContent will be nil and this function will panic.
+func RouteRequest[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
+	router.Handle(pattern, unary.NewRequestHandler(unaryContent, handler))
 }
 
 // Route registers a handler under pattern that encodes a response.
 //
-// The handler is built using [github.com/alexfalkowski/go-service/v2/net/http/content.NewHandler], which:
+// The handler is built using [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewHandler], which:
 //   - selects an encoder based on the first Accept media type, falling back to Content-Type when
 //     Accept is absent, and
 //   - encodes the returned response model using the negotiated media type.
 //
 // Registration:
 // The resulting handler is registered on the package-level router configured via Register.
-// Register must be called before Route; otherwise router/cont will be nil and this function will panic.
-func Route[Res any](pattern string, handler content.Handler[Res]) {
-	router.Handle(pattern, content.NewHandler(cont, handler))
+// Register must be called before Route; otherwise router/unaryContent will be nil and this function will panic.
+func Route[Res any](pattern string, handler unary.Handler[Res]) {
+	router.Handle(pattern, unary.NewHandler(unaryContent, handler))
 }
 
 // StreamGet registers an HTTP GET handler under pattern for a send-only streaming response: the
@@ -148,14 +148,14 @@ func StreamPatch[Req any, Res any](pattern string, handler stream.RequestHandler
 // route is marked streaming on the router's route policy (see
 // [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
 // limiting is applied lazily instead of buffering the whole body.
-// [Register] must be called before StreamRouteRequest; otherwise router/cont will be nil and this
+// [Register] must be called before StreamRouteRequest; otherwise router/streamContent will be nil and this
 // function will panic.
 //
 // Inbound size limiting:
 // opts.MaxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
 // Recv, not the request body as a whole — see [stream.NewRequestHandler].
 func StreamRouteRequest[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
-	router.HandleStreaming(pattern, stream.NewRequestHandler(cont, sm, opts, handler))
+	router.HandleStreaming(pattern, stream.NewRequestHandler(streamContent, opts, handler))
 }
 
 // StreamRoute registers a handler under pattern for a send-only streaming response: the response
@@ -174,8 +174,8 @@ func StreamRouteRequest[Req any, Res any](pattern string, handler stream.Request
 // route is marked streaming on the router's route policy (see
 // [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
 // limiting is applied lazily instead of buffering the whole body.
-// Register must be called before StreamRoute; otherwise router/cont will be nil and this function will
+// Register must be called before StreamRoute; otherwise router/streamContent will be nil and this function will
 // panic.
 func StreamRoute[Res any](pattern string, handler stream.Handler[Res]) {
-	router.HandleStreaming(pattern, stream.NewHandler(cont, sm, opts, handler))
+	router.HandleStreaming(pattern, stream.NewHandler(streamContent, opts, handler))
 }

--- a/net/http/rest/server_test.go
+++ b/net/http/rest/server_test.go
@@ -9,19 +9,37 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetAcceptsUnaryHandler(t *testing.T) {
+	mux := http.NewServeMux()
+	router := http.NewRouter(mux, http.NewRoutePolicy())
+	rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
+
+	var handler unary.Handler[test.Response] = func(context.Context) (*test.Response, error) {
+		return &test.Response{Greeting: "Hello Bob"}, nil
+	}
+	rest.Get("/hello", handler)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+}
+
 func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
-	rest.Register(router, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	rest.StreamGet("/hello", func(_ context.Context, stream *stream.Stream[test.Response]) error {
 		if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
@@ -32,13 +50,13 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.NDJSON, res.Header().Get(content.TypeKey))
+	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
 	require.True(t, policy.IsStreaming(req))
 
 	scanner := bufio.NewScanner(res.Body)
@@ -50,7 +68,7 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 func TestStreamPostRejectsHTTP1(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rest.Register(router, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	rest.StreamPost("/hello", func(_ context.Context, _ *stream.RequestStream[test.Request, test.Response]) error {
 		return nil
@@ -58,8 +76,8 @@ func TestStreamPostRejectsHTTP1(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
@@ -83,7 +101,7 @@ func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
 			mux := http.NewServeMux()
 			policy := http.NewRoutePolicy()
 			router := http.NewRouter(mux, policy)
-			rest.Register(router, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+			rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 			tt.call("/hello", func(_ context.Context, stream *stream.RequestStream[test.Request, test.Response]) error {
 				for {
@@ -105,8 +123,8 @@ func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
 			body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
 			req := httptest.NewRequestWithContext(t.Context(), tt.method, "/hello", strings.NewReader(body))
 			req.ProtoMajor = 2
-			req.Header.Set(content.TypeKey, media.NDJSON)
-			req.Header.Set(content.AcceptKey, media.NDJSON)
+			req.Header.Set(http.ContentTypeKey, media.NDJSON)
+			req.Header.Set(http.AcceptKey, media.NDJSON)
 			res := httptest.NewRecorder()
 
 			mux.ServeHTTP(res, req)

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -81,16 +81,15 @@ func WithClientTimeout(timeout string) ClientOption {
 
 // NewClient constructs an RPC client backed by net/http/client.
 //
-// NewClient depends on package-level registration (see [Register]) for the content codecs (cont)
-// and buffer pool (pool). [Register] must be called before NewClient; otherwise it will panic due to
-// nil dependencies.
+// NewClient depends on package-level registration (see [Register]) for unary and stream content plus
+// the buffer pool. [Register] must be called before NewClient; otherwise it will panic due to nil dependencies.
 //
 // The returned client issues RPC-style POST requests to the provided base url using the configured
 // Content-Type, transport, and unary timeout options. Redirect following is disabled by default
 // (redirect responses are returned instead of being followed).
 func NewClient(url string, opts ...ClientOption) *Client {
 	os := options(opts...)
-	client := client.NewClient(cont, sm, pool,
+	client := client.NewClient(unaryContent, streamContent, pool,
 		client.WithRoundTripper(os.roundTripper),
 		client.WithTimeout(os.timeout),
 		client.WithRedirect(client.RedirectIgnore),

--- a/net/http/rpc/client_test.go
+++ b/net/http/rpc/client_test.go
@@ -21,7 +21,7 @@ func TestPostRequiresRequest(t *testing.T) {
 }
 
 func TestPostUsesConfiguredTimeout(t *testing.T) {
-	rpc.Register(nil, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rpc.Register(nil, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Type", media.JSON)
@@ -68,7 +68,7 @@ func TestPostRequiresNonNilTypedResponse(t *testing.T) {
 func TestPostUsesAccept(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rpc.Register(router, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rpc.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	server := httptest.NewServer(mux)

--- a/net/http/rpc/doc.go
+++ b/net/http/rpc/doc.go
@@ -1,6 +1,6 @@
 // Package rpc provides RPC-style HTTP handler registration and client helpers for go-service.
 //
-// This package is built on top of [github.com/alexfalkowski/go-service/v2/net/http/content]. It relies on package-level registration (see [Register])
+// This package is built on top of [github.com/alexfalkowski/go-service/v2/net/http/content/unary]. It relies on package-level registration (see [Register])
 // to supply the HTTP router, content codec helpers, and buffer pool that are used when wiring handlers and clients.
 //
 // # Server-side routing
@@ -12,7 +12,7 @@
 // For example, calling Route("/greet.v1.Greeter/SayHello", handler) registers the route pattern
 // "POST /greet.v1.Greeter/SayHello".
 //
-// Handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
+// Handlers are constructed using [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewRequestHandler], which:
 //   - decodes the request body into a request model from Content-Type, falling back to JSON when
 //     Content-Type is absent, and rejecting it with 415 when it is unparseable, unregistered, or
 //     intentionally undecodable, and

--- a/net/http/rpc/example_test.go
+++ b/net/http/rpc/example_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-sync"
 )
@@ -19,7 +19,8 @@ func ExampleClient_Post() {
 	router := http.NewRouter(mux, http.NewRoutePolicy())
 	pool := sync.NewBufferPool()
 	streamMap := encodingstream.NewMap()
-	rpc.Register(router, content.NewContent(encoding.NewMap(), pool), streamMap, pool, contentstream.Options{})
+	streamContent := contentstream.NewContent(streamMap, pool)
+	rpc.Register(router, unary.NewContent(encoding.NewMap(), pool), streamContent, pool, contentstream.Options{})
 
 	rpc.Route("/hello", func(_ context.Context, req *exampleRequest) (*exampleResponse, error) {
 		return &exampleResponse{Message: "hello " + req.Name}, nil

--- a/net/http/rpc/rpc.go
+++ b/net/http/rpc/rpc.go
@@ -1,19 +1,18 @@
 package rpc
 
 import (
-	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
-	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-sync"
 )
 
 var (
-	router *http.Router
-	cont   *content.Content
-	sm     *encodingstream.Map
-	pool   *sync.BufferPool
-	opts   contentstream.Options
+	router        *http.Router
+	unaryContent  *unary.Content
+	pool          *sync.BufferPool
+	streamContent *stream.Content
+	opts          stream.Options
 )
 
 // Register stores the dependencies used by server and client helpers in package-level variables.
@@ -23,16 +22,16 @@ var (
 // Important: Register must be called before using any server-side route helpers or client helpers in this
 // package. If it is not called, globals will be nil and helper calls will panic.
 //
-// c resolves single-value media types, while s resolves streaming media types for StreamRoute and
-// the embedded HTTP client.
+// unaryContent resolves single-value media types, and streamContent resolves streaming media types for StreamRoute
+// and the embedded HTTP client. p also buffers client response bodies.
 //
 // so is passed through unchanged to this package's streaming route helper (StreamRoute) via
 // [github.com/alexfalkowski/go-service/v2/net/http/content/stream.NewRequestHandler]; see that
 // constructor for the timeout and per-value receive-size semantics.
-func Register(r *http.Router, c *content.Content, s *encodingstream.Map, p *sync.BufferPool, so contentstream.Options) {
+func Register(r *http.Router, uc *unary.Content, sc *stream.Content, p *sync.BufferPool, so stream.Options) {
 	router = r
-	cont = c
-	sm = s
+	unaryContent = uc
 	pool = p
+	streamContent = sc
 	opts = so
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -2,8 +2,8 @@ package rpc
 
 import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
@@ -17,7 +17,7 @@ import (
 //
 //	Route("/greet.v1.Greeter/SayHello", handler) // registers "POST /greet.v1.Greeter/SayHello"
 //
-// The handler is constructed using [github.com/alexfalkowski/go-service/v2/net/http/content.NewRequestHandler], which:
+// The handler is constructed using [github.com/alexfalkowski/go-service/v2/net/http/content/unary.NewRequestHandler], which:
 //   - decodes the request body using Content-Type, falling back to JSON when Content-Type is absent and
 //     rejecting it with 415 when it is unparseable, unregistered, or intentionally undecodable,
 //   - decodes the request body into a newly allocated request model, and
@@ -25,11 +25,11 @@ import (
 //
 // Registration:
 // The resulting handler is registered on the package-level router configured via [Register].
-// [Register] must be called before Route; otherwise router/cont will be nil and this function will panic.
-func Route[Req any, Res any](pattern string, handler content.RequestHandler[Req, Res]) {
+// [Register] must be called before Route; otherwise router/unaryContent will be nil and this function will panic.
+func Route[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
 	router.Handle(
 		strings.Join(strings.Space, http.MethodPost, pattern),
-		content.NewRequestHandler(cont, handler),
+		unary.NewRequestHandler(unaryContent, handler),
 	)
 }
 
@@ -63,7 +63,7 @@ func Route[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 // route is marked streaming on the router's route policy (see
 // [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
 // limiting is applied lazily instead of buffering the whole body.
-// [Register] must be called before StreamRoute; otherwise router/cont will be nil and this function
+// [Register] must be called before StreamRoute; otherwise router/streamContent will be nil and this function
 // will panic.
 //
 // Inbound size limiting:
@@ -72,6 +72,6 @@ func Route[Req any, Res any](pattern string, handler content.RequestHandler[Req,
 func StreamRoute[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
 	router.HandleStreaming(
 		strings.Join(strings.Space, http.MethodPost, pattern),
-		stream.NewRequestHandler(cont, sm, opts, handler),
+		stream.NewRequestHandler(streamContent, opts, handler),
 	)
 }

--- a/net/http/rpc/server_test.go
+++ b/net/http/rpc/server_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
@@ -20,7 +19,7 @@ import (
 func TestStreamRouteRejectsHTTP1(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	rpc.Register(router, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rpc.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	rpc.StreamRoute("/hello", func(_ context.Context, _ *stream.RequestStream[test.Request, test.Response]) error {
 		return nil
@@ -28,8 +27,8 @@ func TestStreamRouteRejectsHTTP1(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 1
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)
@@ -41,7 +40,7 @@ func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
-	rpc.Register(router, test.Content, test.StreamEncoder, test.Pool, stream.Options{})
+	rpc.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	rpc.StreamRoute("/hello", func(_ context.Context, stream *stream.RequestStream[test.Request, test.Response]) error {
 		for {
@@ -63,8 +62,8 @@ func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
 	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
 	req.ProtoMajor = 2
-	req.Header.Set(content.TypeKey, media.NDJSON)
-	req.Header.Set(content.AcceptKey, media.NDJSON)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
 	mux.ServeHTTP(res, req)

--- a/net/http/status/error.go
+++ b/net/http/status/error.go
@@ -56,3 +56,12 @@ func WriteText(res http.ResponseWriter, text string) error {
 	_, err := fmt.Fprintln(res, text)
 	return err
 }
+
+// NotFoundHandler returns a not-found handler that writes the standard safe error response.
+func NotFoundHandler() http.NotFoundHandler {
+	return func(res http.ResponseWriter, req *http.Request) bool {
+		_ = WriteError(req.Context(), res, SafeError(http.StatusNotFound, nil))
+
+		return true
+	}
+}

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -65,6 +65,16 @@ func TestWriteErrorUsesSafeMessage(t *testing.T) {
 	test.RequireTrimmedResponseBody(t, res, "http: unauthorized")
 }
 
+func TestNotFoundHandlerWritesStatusError(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+	res := httptest.NewRecorder()
+
+	require.True(t, httpstatus.NotFoundHandler()(res, req))
+	require.Equal(t, http.StatusNotFound, res.Code)
+	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(http.ContentTypeKey))
+	test.RequireTrimmedResponseBody(t, res, "http: not found")
+}
+
 func TestDefaultMessage(t *testing.T) {
 	require.Equal(t, "http: bad request", httpstatus.DefaultMessage(http.StatusBadRequest))
 	require.Equal(t, "http: client closed request", httpstatus.DefaultMessage(http.StatusClientClosedRequest))

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -29,7 +28,7 @@ func TestTokenAuthUnary(t *testing.T) {
 			rpc.Route("/hello", test.SuccessSayHello)
 
 			header := http.Header{}
-			header.Set(content.TypeKey, media.JSON)
+			header.Set(http.ContentTypeKey, media.JSON)
 			header.Set("Request-Id", "test")
 			header.Set("X-Forwarded-For", "127.0.0.1")
 			header.Set("Geolocation", "geo:47,11")
@@ -53,7 +52,7 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 
 	url := world.PathServerURL("http", "hello")
@@ -70,7 +69,7 @@ func TestValidAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 	header.Set("X-Forwarded-For", "127.0.0.1")
 
@@ -99,7 +98,7 @@ func TestAccessDeniedUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 
 	url := world.PathServerURL("http", "hello")
 
@@ -129,7 +128,7 @@ func TestInvalidAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 
 	url := world.PathServerURL("http", "hello")
@@ -146,7 +145,7 @@ func TestAuthUnaryWithAppend(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 	header.Set("Authorization", "What Invalid")
 
@@ -164,7 +163,7 @@ func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 	header.Set("Authorization", "bearer test")
 
@@ -182,7 +181,7 @@ func TestMissingAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 
 	url := world.PathServerURL("http", "hello")
@@ -199,7 +198,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 
 	url := world.PathServerURL("http", "hello")
@@ -215,7 +214,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 
 	url := world.PathServerURL("http", "hello")
@@ -235,7 +234,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 	rpc.Route("/hello", test.SuccessSayHello)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 	header.Set("Request-Id", "test")
 
 	url := world.PathServerURL("http", "hello")
@@ -258,7 +257,7 @@ func TestBreakerAuthUnary(t *testing.T) {
 	for i := range 10 {
 		t.Run("attempt-"+strconv.Itoa(i+1), func(t *testing.T) {
 			header := http.Header{}
-			header.Set(content.TypeKey, media.JSON)
+			header.Set(http.ContentTypeKey, media.JSON)
 			header.Set("Request-Id", "test")
 
 			_, _, err = world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString(`{"name":"test"}`))

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
@@ -55,7 +54,7 @@ func BenchmarkMVC(b *testing.B) {
 		req, err := transporthttp.NewRequestWithContext(b.Context(), transporthttp.MethodGet, url, transporthttp.NoBody)
 		require.NoError(b, err)
 
-		req.Header.Set(content.TypeKey, media.HTML)
+		req.Header.Set(http.ContentTypeKey, media.HTML)
 
 		b.ResetTimer()
 
@@ -304,7 +303,7 @@ func BenchmarkRPCStream(b *testing.B) {
 	httpClient, err := world.NewHTTP()
 	require.NoError(b, err)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(httpClient.Transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(httpClient.Transport))
 	url := world.PathServerURL("https", "hello")
 
 	b.ResetTimer()
@@ -452,7 +451,7 @@ func benchmarkHTTPStream(b *testing.B, log *logger.Logger, trace, tlsEnabled boo
 
 	address, cleanup := startBenchmarkHTTPServer(b, log, trace, tlsEnabled, func(router *transporthttp.Router, cfg *transporthttp.Config) {
 		opts := stream.Options{ReadTimeout: cfg.GetReadTimeout(), WriteTimeout: cfg.GetWriteTimeout(), MaxReceiveSize: cfg.GetMaxReceiveSize()}
-		rest.Register(router, test.Content, test.StreamEncoder, test.Pool, opts)
+		rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, opts)
 		rest.StreamPost("/hello", streamHello)
 	})
 	httpClient, scheme, closeIdleConnections := newHTTPStreamClient(b, tlsEnabled)
@@ -550,7 +549,7 @@ func newHTTPStreamClient(b *testing.B, tlsEnabled bool) (*client.Client, string,
 		transport.Protocols.SetHTTP1(false)
 	}
 
-	return client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(transport)), scheme, transport.CloseIdleConnections
+	return client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(transport)), scheme, transport.CloseIdleConnections
 }
 
 func closeResponse(b *testing.B, resp *http.Response) {

--- a/transport/http/doc.go
+++ b/transport/http/doc.go
@@ -3,7 +3,7 @@
 // It provides constructors and Fx module wiring for HTTP servers and HTTP clients with standardized
 // concerns such as:
 //
-//   - content negotiation and request/response encoding ([github.com/alexfalkowski/go-service/v2/net/http/content])
+//   - content negotiation and request/response encoding ([github.com/alexfalkowski/go-service/v2/net/http/content/unary])
 //   - MVC view rendering support ([github.com/alexfalkowski/go-service/v2/net/http/mvc])
 //   - RPC and REST routing helpers ([github.com/alexfalkowski/go-service/v2/net/http/rpc], [github.com/alexfalkowski/go-service/v2/net/http/rest])
 //   - request metadata extraction and propagation ([github.com/alexfalkowski/go-service/v2/net/http/meta])

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	netserver "github.com/alexfalkowski/go-service/v2/net/server"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -62,7 +61,7 @@ func TestReadinessNoop(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, "SERVING", body)
-	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
 func TestReadinessCache(t *testing.T) {
@@ -126,7 +125,7 @@ func TestInvalidHealth(t *testing.T) {
 
 	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	require.Equal(t, "http: service unavailable", body)
-	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
 func TestMissingHealth(t *testing.T) {
@@ -145,7 +144,7 @@ func TestMissingHealth(t *testing.T) {
 			)
 
 			header := http.Header{}
-			header.Set(content.TypeKey, media.JSON)
+			header.Set(http.ContentTypeKey, media.JSON)
 
 			url := world.NamedServerURL("http", check)
 

--- a/transport/http/module.go
+++ b/transport/http/module.go
@@ -2,10 +2,9 @@ package http
 
 import (
 	"github.com/alexfalkowski/go-service/v2/di"
-	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
@@ -21,7 +20,7 @@ import (
 // It composes constructors and registrations required to run an HTTP server and to support common
 // handler styles used by go-service:
 //   - mux, route policy, and router construction ([http.NewServeMux], [http.NewRoutePolicy], [http.NewRouter])
-//   - content negotiation and encoding ([content.NewContent])
+//   - content negotiation and encoding ([unary.NewContent], [contentstream.NewContent])
 //   - MVC view rendering helpers ([mvc.NewFunctionMap], [mvc.Register])
 //   - RPC and REST routing ([rpc.Register], [rest.Register] — called from [registerRoutes] rather than
 //     as their own separate Fx invoke targets, so their [stream.Options] argument is a plain
@@ -46,7 +45,8 @@ var Module = di.Module(
 	di.Constructor(http.NewServeMux),
 	di.Constructor(http.NewRoutePolicy),
 	di.Constructor(http.NewRouter),
-	di.Constructor(content.NewContent),
+	di.Constructor(unary.NewContent),
+	di.Constructor(stream.NewContent),
 	di.Constructor(mvc.NewFunctionMap),
 	di.Register(mvc.Register),
 	di.Register(registerRoutes),
@@ -73,7 +73,7 @@ var Module = di.Module(
 // through the same options-aware precedence (options key, falling back to cfg.GetTimeout()) NewServer
 // uses for its own ReadTimeout/WriteTimeout, so a service that diverges options.read_timeout/
 // write_timeout from timeout gets a matching streaming budget instead of a silently different one.
-func registerRoutes(cfg *Config, router *http.Router, cont *content.Content, sm *encodingstream.Map, pool *sync.BufferPool, drain *server.Drain) {
+func registerRoutes(cfg *Config, router *http.Router, uc *unary.Content, sc *stream.Content, pool *sync.BufferPool, drain *server.Drain) {
 	var so stream.Options
 
 	if cfg.IsEnabled() {
@@ -85,6 +85,6 @@ func registerRoutes(cfg *Config, router *http.Router, cont *content.Content, sm 
 		}
 	}
 
-	rest.Register(router, cont, sm, pool, so)
-	rpc.Register(router, cont, sm, pool, so)
+	rest.Register(router, uc, sc, pool, so)
+	rpc.Register(router, uc, sc, pool, so)
 }

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -32,7 +31,7 @@ func TestRouteSuccess(t *testing.T) {
 	mvc.Patch("/hello", controller)
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.HTML)
+	header.Set(http.ContentTypeKey, media.HTML)
 
 	url := world.PathServerURL("http", "hello")
 
@@ -40,7 +39,7 @@ func TestRouteSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -56,7 +55,7 @@ func TestRoutePartialViewSuccess(t *testing.T) {
 	})
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.HTML)
+	header.Set(http.ContentTypeKey, media.HTML)
 
 	url := world.PathServerURL("http", "hello")
 
@@ -64,7 +63,7 @@ func TestRoutePartialViewSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -79,7 +78,7 @@ func TestRouteError(t *testing.T) {
 	})
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.HTML)
+	header.Set(http.ContentTypeKey, media.HTML)
 
 	url := world.PathServerURL("http", "hello")
 
@@ -87,7 +86,7 @@ func TestRouteError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -103,7 +102,7 @@ func TestNotFound(t *testing.T) {
 
 	header := http.Header{}
 	header.Set("Accept", media.HTML)
-	header.Set(content.TypeKey, media.HTML)
+	header.Set(http.ContentTypeKey, media.HTML)
 
 	url := world.PathServerURL("http", "missing")
 
@@ -111,7 +110,7 @@ func TestNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -126,14 +125,14 @@ func TestNotFoundUsesContentFallbackWithoutHTMLAccept(t *testing.T) {
 	}))
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 
 	url := world.PathServerURL("http", "missing")
 
 	res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodGet, header, http.NoBody)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 	require.Equal(t, "http: not found", body)
 }
 
@@ -148,7 +147,7 @@ func TestNotFoundHandlesHTMXRequest(t *testing.T) {
 	header := http.Header{}
 	header.Set("Accept", "*/*")
 	header.Set("Hx-Request", "true")
-	header.Set(content.TypeKey, media.HTML)
+	header.Set(http.ContentTypeKey, media.HTML)
 
 	url := world.PathServerURL("http", "missing")
 
@@ -156,7 +155,7 @@ func TestNotFoundHandlesHTMXRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/html; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 
 	_, err = html.Parse(strings.NewReader(body))
 	require.NoError(t, err)
@@ -168,7 +167,7 @@ func TestStaticFileSuccess(t *testing.T) {
 	mvc.StaticFile("/robots.txt", "static/robots.txt")
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.Text)
+	header.Set(http.ContentTypeKey, media.Text)
 
 	url := world.PathServerURL("http", "robots.txt")
 
@@ -176,7 +175,7 @@ func TestStaticFileSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
 func TestStaticFileError(t *testing.T) {
@@ -198,7 +197,7 @@ func TestStaticPathValueSuccess(t *testing.T) {
 	mvc.StaticPathValue("/{file}", "file", "static")
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.Text)
+	header.Set(http.ContentTypeKey, media.Text)
 
 	url := world.PathServerURL("http", "robots.txt")
 
@@ -206,7 +205,7 @@ func TestStaticPathValueSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, body)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
 func TestStaticPathValueError(t *testing.T) {

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
@@ -67,12 +66,12 @@ func TestRestNotFound(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 
 	res, body, err := world.GetBody(t.Context(), world.NamedServerURL("http", "missing"), header)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 	require.Equal(t, "http: not found", body)
 }
 
@@ -145,8 +144,8 @@ func TestRestRequestUsesAcceptForResponse(t *testing.T) {
 	defer test.Pool.Put(body)
 	require.NoError(t, test.Encoder.Get("json").Encode(body, &test.Request{Name: "Bob"}))
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
-	header.Set(content.AcceptKey, media.YAML)
+	header.Set(http.ContentTypeKey, media.JSON)
+	header.Set(http.AcceptKey, media.YAML)
 
 	res, responseBody, err := world.ResponseWithBody(
 		t.Context(),
@@ -157,7 +156,7 @@ func TestRestRequestUsesAcceptForResponse(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, media.YAML, res.Header.Get(content.TypeKey))
+	require.Equal(t, media.YAML, res.Header.Get(http.ContentTypeKey))
 	var response test.Response
 	require.NoError(t, test.Encoder.Get("yaml").Decode(strings.NewReader(responseBody), &response))
 	require.Equal(t, "Hello Bob", response.Greeting)
@@ -242,7 +241,7 @@ func TestRestStreamPostRefreshesReadDeadlineOverH2C(t *testing.T) {
 	config := test.NewInsecureTransportConfig()
 	config.HTTP.Timeout = 100 * time.Millisecond
 	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
-	rest.Register(world.Router, test.Content, test.StreamEncoder, test.Pool, stream.Options{
+	rest.Register(world.Router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{
 		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
 	})
 	rest.StreamPost("/hello", echoStreamServer)
@@ -251,7 +250,7 @@ func TestRestStreamPostRefreshesReadDeadlineOverH2C(t *testing.T) {
 	transport := http.Transport(nil)
 	transport.Protocols.SetHTTP1(false)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(transport))
 
 	url := world.PathServerURL("http", "hello")
 
@@ -268,7 +267,7 @@ func TestRestStreamPostSurvivesReceiveOnlyActivePhase(t *testing.T) {
 	config := test.NewInsecureTransportConfig()
 	config.HTTP.Timeout = 100 * time.Millisecond
 	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
-	rest.Register(world.Router, test.Content, test.StreamEncoder, test.Pool, stream.Options{
+	rest.Register(world.Router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{
 		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
 	})
 	rest.StreamPost("/hello", receiveOnlyActivePhaseServer)
@@ -277,7 +276,7 @@ func TestRestStreamPostSurvivesReceiveOnlyActivePhase(t *testing.T) {
 	transport := http.Transport(nil)
 	transport.Protocols.SetHTTP1(false)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(transport))
 
 	url := world.PathServerURL("http", "hello")
 
@@ -294,7 +293,7 @@ func TestRestStreamPostSurvivesSendOnlyActivePhase(t *testing.T) {
 	config := test.NewInsecureTransportConfig()
 	config.HTTP.Timeout = 100 * time.Millisecond
 	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
-	rest.Register(world.Router, test.Content, test.StreamEncoder, test.Pool, stream.Options{
+	rest.Register(world.Router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{
 		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
 	})
 	rest.StreamPost("/hello", sendOnlyActivePhaseServer)
@@ -303,7 +302,7 @@ func TestRestStreamPostSurvivesSendOnlyActivePhase(t *testing.T) {
 	transport := http.Transport(nil)
 	transport.Protocols.SetHTTP1(false)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(transport))
 
 	url := world.PathServerURL("http", "hello")
 

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -9,8 +9,8 @@ import (
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/client"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -69,7 +69,7 @@ func TestSuccessProtobufRPC(t *testing.T) {
 
 func TestErroneousProtobufRPC(t *testing.T) {
 	handlers := []struct {
-		handler content.RequestHandler[v1.SayHelloRequest, v1.SayHelloResponse]
+		handler unary.RequestHandler[v1.SayHelloRequest, v1.SayHelloResponse]
 		name    string
 	}{
 		{name: "mapped", handler: test.ErrorsProtobufSayHello},
@@ -109,7 +109,7 @@ func TestErroneousUnmarshalRPC(t *testing.T) {
 			url := world.PathServerURL("http", "hello")
 
 			header := http.Header{}
-			header.Set(content.TypeKey, mt.ContentType)
+			header.Set(http.ContentTypeKey, mt.ContentType)
 
 			res, body, err := world.ResponseWithBody(t.Context(), url, http.MethodPost, header, bytes.NewBufferString("an erroneous payload"))
 			require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestErroneousUnmarshalRPC(t *testing.T) {
 
 func TestErrorRPC(t *testing.T) {
 	handlers := []struct {
-		handler content.RequestHandler[test.Request, test.Response]
+		handler unary.RequestHandler[test.Request, test.Response]
 		name    string
 	}{
 		{name: "mapped", handler: test.ErrorSayHello},
@@ -137,7 +137,7 @@ func TestErrorRPC(t *testing.T) {
 					rpc.Route("/hello", handler.handler)
 
 					header := http.Header{}
-					header.Set(content.TypeKey, mt.ContentType)
+					header.Set(http.ContentTypeKey, mt.ContentType)
 
 					enc := test.Encoder.Get(mt.Kind)
 
@@ -167,12 +167,12 @@ func TestRPCNotFound(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 
 	res, body, err := world.ResponseWithBody(t.Context(), world.PathServerURL("http", "missing"), http.MethodPost, header, http.NoBody)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
-	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(content.TypeKey))
+	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 	require.Equal(t, "http: not found", body)
 }
 
@@ -251,7 +251,7 @@ func TestRPCStreamRouteRefreshesReadDeadlineOverHTTP2(t *testing.T) {
 	config := test.NewSecureTransportConfig()
 	config.HTTP.Timeout = 100 * time.Millisecond
 	world := test.NewWorld(t, test.WithWorldTransportConfig(config), test.WithWorldSecure(), test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
-	rpc.Register(world.Router, test.Content, test.StreamEncoder, test.Pool, stream.Options{
+	rpc.Register(world.Router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{
 		ReadTimeout: config.HTTP.GetReadTimeout(), WriteTimeout: config.HTTP.GetWriteTimeout(), MaxReceiveSize: config.HTTP.GetMaxReceiveSize(),
 	})
 	rpc.StreamRoute("/hello", echoStreamServer)
@@ -260,7 +260,7 @@ func TestRPCStreamRouteRefreshesReadDeadlineOverHTTP2(t *testing.T) {
 	httpClient, err := world.NewHTTP()
 	require.NoError(t, err)
 
-	c := client.NewClient(test.Content, test.StreamEncoder, test.Pool, client.WithRoundTripper(httpClient.Transport))
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(httpClient.Transport))
 
 	url := world.PathServerURL("https", "hello")
 

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -12,10 +12,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/http/body"
@@ -162,7 +162,7 @@ func NewServer(params ServerParams) (*Server, error) {
 		neg.Use(hd)
 	}
 
-	handler := http.NewNotFoundHandler(params.Mux, params.Pool, mvc.NotFoundHandler(), content.NotFoundHandler())
+	handler := http.NewNotFoundHandler(params.Mux, params.Pool, mvc.NotFoundHandler(), status.NotFoundHandler())
 	neg.UseHandler(compress.GzipHandler(handler))
 
 	handler = http.NewTelemetryHandler(neg, "http.server")

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/content"
+	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/runtime"
@@ -62,13 +62,13 @@ func TestServerMaxReceiveSize(t *testing.T) {
 	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
-	world.Handle("POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+	world.Handle("POST /hello", unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, _ *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "hello"}, nil
 	}))
 	world.Start()
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 
 	res, body, err := world.PostBody(
 		t.Context(),
@@ -86,13 +86,13 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
-	world.Handle("POST /hello", content.NewRequestHandler(test.Content, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+	world.Handle("POST /hello", unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, _ *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "hello"}, nil
 	}))
 	world.Start()
 
 	header := http.Header{}
-	header.Set(content.TypeKey, media.JSON)
+	header.Set(http.ContentTypeKey, media.JSON)
 
 	res, body, err := world.PostBody(
 		t.Context(),

--- a/transport/http/telemetry/logger/logger.go
+++ b/transport/http/telemetry/logger/logger.go
@@ -69,7 +69,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 	defer func() {
 		if value := recover(); value != nil {
 			// A streaming handler that already committed its response aborts via
-			// http.ErrAbortHandler (see net/http/content's streaming error contract) so net/http can
+			// http.ErrAbortHandler (see net/http/content/stream's error contract) so net/http can
 			// sever the in-flight connection. That is an intentional, expected outcome of a truncated
 			// stream, not a bug, so it must not be logged as a recovered panic — but the request still
 			// gets its ordinary outcome log line, carrying the diagnostic error finalizeStream recorded.


### PR DESCRIPTION
## What

- Split HTTP payload helpers into `net/http/content/unary` and `net/http/content/stream`, intentionally removing the root `content` package rather than retaining a compatibility façade.
- Give each helper its own `Content` owner: unary owns single-value codecs, while stream owns streaming codecs and the shared buffer pool used by stream handlers.
- Update REST, RPC, clients, migration guidance, and benchmarks; exact NDJSON stream media, Content-Type, and Accept resolution now avoid allocations.

## Why

- Separating the distinct codec registries makes dependency ownership explicit, removes unused unary buffer accessors, and makes unary and streaming APIs easier to read together.
- Preserve strict streaming negotiation for lists, wildcards, and quality exclusions while applying the same concrete-header fast-path principle used by unary payloads.

## Testing

- `make specs package=net/http/content/unary`, `make specs package=net/http/content/stream`, `make specs package=net/http/client`, `make specs package=net/http/rest`, `make specs package=net/http/rpc`, and `make specs package=transport/http` - passed.
- `make http-content-benchmarks` - passed; exact stream media, Content-Type, and Accept benchmarks report `0 B/op` and `0 allocs/op`.
- `make lint`, `make sec`, `make format`, and `git diff --check` - passed; the security scan found no reachable vulnerabilities.
- `make specs package=transport/http/health` was not rerun locally because its healthy-probe cases require the CI status sidecar at `localhost:6000`.

AI-assisted-by: [Codex](https://openai.com/codex/)
