### PR TITLE
feat(stream): negotiate complete parameterless media ranges

### DIFF
--- a/net/http/content/stream/content.go
+++ b/net/http/content/stream/content.go
@@ -59,8 +59,10 @@ func (c *Content) NewFromMedia(mediaType string) (Media, error) {
 // codec without an encoder is unsupported. A nil Content returns [ErrUnsupportedMedia].
 //
 // An Accept list is satisfiable for the server's producible streaming media type if it contains an
-// exact match, or a matching wildcard ("*/*", or "type/*" where type matches the producible type's own
-// major type), anywhere in the list. Per RFC 9110 §12.5.1, the most specific reference present controls
+// exact match without non-quality parameters, or a matching wildcard ("*/*", or "type/*" where type
+// matches the producible type's own major type) without non-quality parameters, anywhere in the list.
+// The canonical NDJSON representation has no media parameters, so a range that requires one cannot match it.
+// Per RFC 9110 §12.5.1, the most specific reference present controls
 // regardless of list order: an exact subtype match takes precedence over any wildcard, and a "type/*"
 // wildcard takes precedence over the bare "*/*" wildcard. Only that controlling reference's explicit
 // q=0 exclusion (see [github.com/alexfalkowski/go-service/v2/net/http/accept.IsZeroQuality]) decides
@@ -78,9 +80,9 @@ func (c *Content) NewFromAccept(req *http.Request) (Media, error) {
 		return Media{}, ErrUnsupportedMedia
 	}
 
-	header := req.Header.Get(http.AcceptKey)
-	if !strings.IsEmpty(header) {
-		return c.newFromAcceptHeader(header)
+	accept := req.Header.Values(http.AcceptKey)
+	if !strings.IsEmpty(strings.Join(strings.Empty, accept...)) {
+		return c.newFromAcceptHeader(strings.Join(", ", accept...))
 	}
 
 	mediaType := req.Header.Get(http.ContentTypeKey)
@@ -89,23 +91,6 @@ func (c *Content) NewFromAccept(req *http.Request) (Media, error) {
 	}
 
 	return c.newEncoderMedia(mediaType)
-}
-
-func (c *Content) newFromAcceptHeader(header string) (Media, error) {
-	if resolved, ok := knownMedia(header, c.enc); ok {
-		return encoderMedia(resolved, nil)
-	}
-
-	mediaType, ok := matchStreamAccept(header)
-	if !ok {
-		return Media{}, ErrUnsupportedMedia
-	}
-
-	return c.newEncoderMedia(mediaType)
-}
-
-func (c *Content) newEncoderMedia(mediaType string) (Media, error) {
-	return encoderMedia(c.NewFromMedia(mediaType))
 }
 
 // NewFromContentType parses the request Content-Type header and resolves a streaming decoder.
@@ -139,4 +124,21 @@ func (c *Content) NewFromContentType(req *http.Request) (Media, error) {
 	}
 
 	return m, nil
+}
+
+func (c *Content) newFromAcceptHeader(header string) (Media, error) {
+	if resolved, ok := knownMedia(header, c.enc); ok {
+		return encoderMedia(resolved, nil)
+	}
+
+	mediaType, ok := matchStreamAccept(header)
+	if !ok {
+		return Media{}, ErrUnsupportedMedia
+	}
+
+	return c.newEncoderMedia(mediaType)
+}
+
+func (c *Content) newEncoderMedia(mediaType string) (Media, error) {
+	return encoderMedia(c.NewFromMedia(mediaType))
 }

--- a/net/http/content/stream/media.go
+++ b/net/http/content/stream/media.go
@@ -1,6 +1,8 @@
 package stream
 
 import (
+	"mime"
+
 	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/accept"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
@@ -69,22 +71,22 @@ func encoderMedia(resolved Media, err error) (Media, error) {
 // matchStreamAccept reports whether header, an Accept header value, is satisfiable for a registered
 // streamKinds entry, and if so, which media type to resolve.
 //
-// It finds the most specific reference to the producible type present anywhere in the list — an exact
-// subtype match, else a "type/*" wildcard [accept.IsWildcard] reports as satisfied by [ndjsonType]
-// ("text/*" does not satisfy an "application/x-ndjson" route the way "*/*" or "application/*" does),
-// else the bare "*/*" wildcard — and returns satisfiable only if that one reference is not
-// [accept.IsZeroQuality]; a less specific reference's own quality, zero or not, is irrelevant once a
-// more specific reference is found. This matches RFC 9110 §12.5.1's "most specific reference" rule
-// regardless of list order. When satisfiable, it returns the exact match's media type if the
-// controlling reference was one, otherwise [media.NDJSON]. An unparsable item is skipped rather than
-// rejecting the whole list, the same way an unparsable single Accept value already falls through to
-// [Content.NewFromMedia]'s own rejection when nothing else in the list matches.
+// It finds the most specific reference to the parameterless producible type present anywhere in the list —
+// an exact subtype match without non-quality parameters, else a "type/*" wildcard [accept.IsWildcard]
+// reports as satisfied by [ndjsonType] without non-quality parameters ("text/*" does not satisfy an
+// "application/x-ndjson" route the way "*/*" or "application/*" does), else the bare "*/*" wildcard —
+// and returns satisfiable only if that one reference is not [accept.IsZeroQuality]; a less specific
+// reference's own quality, zero or not, is irrelevant once a more specific reference is found. This matches
+// RFC 9110 §12.5.1's "most specific reference" rule regardless of list order. When satisfiable, it returns
+// the exact match's media type if the controlling reference was one, otherwise [media.NDJSON]. An
+// unparsable item is skipped rather than rejecting the whole list, the same way an unparsable single Accept
+// value already falls through to [Content.NewFromMedia]'s own rejection when nothing else in the list matches.
 func matchStreamAccept(header string) (string, bool) {
 	var exact, major, bare mediaRangeMatch
 
 	for _, item := range accept.Items(header) {
-		value, err := media.Parse(item)
-		if err != nil {
+		value, ok := parseParameterlessAcceptRange(item)
+		if !ok {
 			continue
 		}
 
@@ -116,6 +118,28 @@ func matchStreamAccept(header string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+func parseParameterlessAcceptRange(item string) (media.Type, bool) {
+	value, err := media.Parse(item)
+	if err != nil || hasNonQualityParameters(item) {
+		return media.Type{}, false
+	}
+
+	return value, true
+}
+
+// hasNonQualityParameters reports whether item requires media parameters the canonical parameterless
+// representation does not provide.
+func hasNonQualityParameters(item string) bool {
+	_, parameters, err := mime.ParseMediaType(item)
+	if err != nil {
+		return false
+	}
+
+	delete(parameters, "q")
+
+	return len(parameters) != 0
 }
 
 // mediaRangeMatch is the controlling media range found so far for one specificity tier (exact subtype,

--- a/net/http/content/stream/media_test.go
+++ b/net/http/content/stream/media_test.go
@@ -152,6 +152,7 @@ func TestNewFromAcceptResolvesWildcardOrExactMatchAnywhereInList(t *testing.T) {
 		{name: "exact match overrides a co-present zero quality bare wildcard", accept: "*/*;q=0, " + media.NDJSON},
 		{name: "subtype wildcard overrides a co-present zero quality bare wildcard", accept: "*/*;q=0, application/*"},
 		{name: "subtype wildcard overrides wrong-major zero quality type", accept: "text/x-ndjson;q=0, application/*"},
+		{name: "parameterized exact exclusion does not override parameterless exact match", accept: media.NDJSON + "; profile=v2;q=0, " + media.NDJSON},
 	}
 
 	for _, tt := range tests {
@@ -174,6 +175,31 @@ func TestNewFromAcceptResolvesWildcardOrExactMatchAnywhereInList(t *testing.T) {
 	}
 }
 
+func TestNewFromAcceptResolvesMatchOnLaterAcceptFieldLine(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
+	req.Header.Add(http.AcceptKey, media.JSON)
+	req.Header.Add(http.AcceptKey, media.NDJSON)
+
+	m, err := test.StreamContent.NewFromAccept(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, m.NewEncoder)
+	require.Equal(t, media.NDJSON, m.String())
+}
+
+func TestNewFromAcceptUsesContentTypeFallbackForEmptyAcceptFieldLines(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/hello", nil)
+	req.Header.Add(http.AcceptKey, "")
+	req.Header.Add(http.AcceptKey, "")
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+
+	m, err := test.StreamContent.NewFromAccept(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, m.NewEncoder)
+	require.Equal(t, media.NDJSON, m.String())
+}
+
 func TestNewFromAcceptRejectsConcreteOnlyUnsatisfiableAccept(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -186,6 +212,7 @@ func TestNewFromAcceptRejectsConcreteOnlyUnsatisfiableAccept(t *testing.T) {
 		{name: "subtype wildcard with mismatched major type", accept: "text/*"},
 		{name: "bare wildcard with zero quality", accept: "*/*;q=0"},
 		{name: "exact match with zero quality", accept: media.NDJSON + ";q=0"},
+		{name: "exact match with unsupported parameter", accept: media.NDJSON + "; profile=v2"},
 		{name: "zero quality wildcard alongside unproducible concrete type", accept: media.JSON + ", */*;q=0"},
 		{name: "zero quality exact match overrides a co-present bare wildcard", accept: media.NDJSON + ";q=0, */*"},
 		{name: "zero quality exact match overrides a co-present bare wildcard, reversed", accept: "*/*, " + media.NDJSON + ";q=0"},


### PR DESCRIPTION
## What

- Combine every HTTP `Accept` field line when selecting the streaming response media type, and reject ranges that require media parameters unavailable on the canonical parameterless NDJSON representation.

## Why

- This preserves HTTP list semantics and prevents a client that requires a media profile from receiving a representation that does not satisfy that requirement.

## Testing

- `make specs package=net/http/content/stream` - passed
- `make lint package=net/http/content/stream` - passed
- Added coverage for a later Accept field line, empty Accept field-line fallback, and parameterized exact media ranges.

AI-assisted-by: [Codex](https://openai.com/codex/)
