### PR TITLE
feat(stream): finalize codecs during graceful shutdown

### DIFF
--- a/internal/test/path.go
+++ b/internal/test/path.go
@@ -1,6 +1,6 @@
 package test
 
-import "runtime"
+import "github.com/alexfalkowski/go-service/v2/runtime"
 
 // Path resolves a fixture path relative to the repository's `test/` directory.
 //

--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -82,6 +82,7 @@ func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http
 			controller:   http.NewResponseController(res),
 			writeTimeout: opts.WriteTimeout,
 			limiter:      meta.Limiter(ctx),
+			drain:        opts.Drain,
 		}
 		handleResponse(ctx, res, stream, handler(ctx, stream))
 	}
@@ -190,6 +191,7 @@ func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler Re
 				readTimeout:  opts.ReadTimeout,
 				writeTimeout: opts.WriteTimeout,
 				limiter:      meta.Limiter(ctx),
+				drain:        opts.Drain,
 			},
 			decoder:        decoder,
 			capped:         capped,
@@ -210,7 +212,7 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, stream *RequestS
 
 // handleResponse applies the streaming error contract after a stream handler returns.
 //
-// If the response was never committed, a handler error is rendered as an ordinary HTTP error via
+// If the response was never committed, a handler or finalization error is rendered as an ordinary HTTP error via
 // [status.WriteError] (a nil error leaves an empty, implicitly-200 response). If the response was
 // committed, any handler error — or a failure finalizing the encoder on the success path — is
 // recorded for operator diagnostics and the response is aborted via panic([http.ErrAbortHandler]),
@@ -223,9 +225,14 @@ func handleResponse[Res any](ctx context.Context, res http.ResponseWriter, s *St
 	}
 
 	if !s.committed() {
+		closeErr := s.close()
 		if err != nil {
+			err = errors.Join(err, closeErr)
 			_ = status.WriteError(ctx, res, err)
+		} else if closeErr != nil {
+			_ = status.WriteError(ctx, res, closeErr)
 		}
+
 		return
 	}
 
@@ -240,7 +247,9 @@ func handleResponse[Res any](ctx context.Context, res http.ResponseWriter, s *St
 
 func drainResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if !s.committed() {
+		status.RecordError(ctx, s.close())
 		_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
+
 		return
 	}
 

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -10,12 +10,15 @@ import (
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -76,6 +79,105 @@ func TestNewHandlerReturnsErrorBeforeFirstSendAsHTTPError(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
 	require.Equal(t, media.Error+"; charset=utf-8", res.Header().Get(http.ContentTypeKey))
+}
+
+func TestNewHandlerClosesEncoderBeforeFirstSend(t *testing.T) {
+	encoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+			return status.Error(http.StatusBadRequest, test.ErrFailed.Error())
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, 1, encoder.closes)
+}
+
+func TestNewHandlerReturnsCloseErrorBeforeFirstSendAsHTTPError(t *testing.T) {
+	encoder := &closeTracker{err: test.ErrFailed}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+			return nil
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, 1, encoder.closes)
+}
+
+func TestNewHandlerPreservesHandlerErrorWhenEncoderCloseFails(t *testing.T) {
+	closeErr := errors.New("encoder close")
+	encoder := &closeTracker{err: closeErr}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+			return status.SafeError(http.StatusBadRequest, test.ErrFailed)
+		},
+	)
+
+	req := httptest.NewRequestWithContext(status.WithRequestError(t.Context()), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, 1, encoder.closes)
+	require.ErrorIs(t, status.RequestError(req.Context()), test.ErrFailed)
+	require.ErrorIs(t, status.RequestError(req.Context()), closeErr)
+}
+
+func TestNewHandlerClosesEncoderBeforeFirstSendOnDrain(t *testing.T) {
+	encoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	drain := make(chan struct{})
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{Drain: drain}, func(ctx context.Context, _ *contentstream.Stream[test.Response]) error {
+			close(drain)
+			<-ctx.Done()
+
+			return ctx.Err()
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, res.Code)
+	require.Equal(t, 1, encoder.closes)
 }
 
 func TestNewHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
@@ -228,6 +330,31 @@ func TestNewHandlerDoesNotSendAfterDrain(t *testing.T) {
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
 	require.False(t, scanner.Scan())
+}
+
+func TestNewHandlerRejectsSendWhenDrainStarts(t *testing.T) {
+	previous := runtime.MaxProcs(1)
+	t.Cleanup(func() { runtime.MaxProcs(previous) })
+	drain := server.NewDrain()
+	var sendErr error
+	handler := contentstream.NewHandler(
+		test.StreamContent,
+		contentstream.Options{Drain: drain.Done()}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+			drain.Start()
+			sendErr = stream.Send(&test.Response{Greeting: "sent after drain"})
+
+			return sendErr
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.ErrorIs(t, sendErr, contentstream.ErrDraining)
+	require.Equal(t, http.StatusServiceUnavailable, res.Code)
 }
 
 func TestNewHandlerReturnsServiceUnavailableOnDrainBeforeCommit(t *testing.T) {

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/net/server"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -54,6 +56,39 @@ func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T
 		handler.ServeHTTP(res, req)
 	})
 
+	require.Equal(t, 1, encoder.closes)
+	require.Equal(t, 1, decoder.closes)
+}
+
+func TestNewRequestHandlerClosesCodecsAfterReceiveOnlyHandler(t *testing.T) {
+	encoder := &closeTracker{}
+	decoder := &closeTracker{decodeErr: io.EOF}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewRequestHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			_, err := stream.Recv()
+			if stream.IsFinished(err) {
+				return nil
+			}
+
+			return err
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, 1, encoder.closes)
 	require.Equal(t, 1, decoder.closes)
 }
@@ -193,6 +228,37 @@ func TestNewRequestHandlerRecvRejectsValueWhenDrainStartsAfterDecode(t *testing.
 
 	handler.ServeHTTP(res, req)
 
+	require.ErrorIs(t, recvErr, contentstream.ErrDraining)
+	require.Equal(t, http.StatusServiceUnavailable, res.Code)
+}
+
+func TestNewRequestHandlerRejectsBufferedValueWhenDrainStarts(t *testing.T) {
+	previous := runtime.MaxProcs(1)
+	t.Cleanup(func() { runtime.MaxProcs(previous) })
+	drain := server.NewDrain()
+	var (
+		received *test.Request
+		recvErr  error
+	)
+	handler := contentstream.NewRequestHandler(
+		test.StreamContent,
+		contentstream.Options{Drain: drain.Done()}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			drain.Start()
+			received, recvErr = stream.Recv()
+
+			return recvErr
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader("{\"Name\":\"received after drain\"}\n"))
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Nil(t, received)
 	require.ErrorIs(t, recvErr, contentstream.ErrDraining)
 	require.Equal(t, http.StatusServiceUnavailable, res.Code)
 }
@@ -907,8 +973,9 @@ func (b *drainBody) Close() error {
 }
 
 type closeTracker struct {
-	closes int
-	err    error
+	closes    int
+	decodeErr error
+	err       error
 }
 
 type trackedEncoder struct {
@@ -922,15 +989,15 @@ func (*trackedEncoder) Encode(any) error {
 func (e *trackedEncoder) Close() error {
 	e.tracker.closes++
 
-	return nil
+	return e.tracker.err
 }
 
 type trackedDecoder struct {
 	tracker *closeTracker
 }
 
-func (*trackedDecoder) Decode(any) error {
-	return nil
+func (d *trackedDecoder) Decode(any) error {
+	return d.tracker.decodeErr
 }
 
 func (d *trackedDecoder) Close() error {

--- a/net/http/content/stream/stream.go
+++ b/net/http/content/stream/stream.go
@@ -24,6 +24,7 @@ type Stream[Res any] struct {
 	writer     *commitWriter
 	controller *http.ResponseController
 	limiter    meta.RateLimiter
+	drain      <-chan struct{}
 	// readTimeout is zero for a send-only [Stream] built by [NewHandler]; [NewRequestHandler]
 	// sets it, letting Send extend both deadlines for a bidirectional stream (see [Stream.Send]).
 	readTimeout  time.Duration
@@ -151,7 +152,7 @@ func (s *Stream[Res]) committed() bool {
 }
 
 func (s *Stream[Res]) draining() bool {
-	return errors.Is(context.Cause(s.ctx), ErrDraining)
+	return isDraining(s.drain) || errors.Is(context.Cause(s.ctx), ErrDraining)
 }
 
 func (s *Stream[Res]) close() error {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2,9 +2,26 @@ package runtime
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
 )
+
+// MaxProcs sets the maximum number of CPUs that can execute Go code simultaneously and returns the previous setting.
+//
+// MaxProcs wraps the standard library's runtime.GOMAXPROCS so callers can stay on the project-owned runtime surface.
+func MaxProcs(n int) int {
+	return runtime.GOMAXPROCS(n)
+}
+
+// Caller reports file and line information for a stack frame.
+//
+// Caller wraps the standard library's runtime.Caller so callers can stay on the project-owned runtime surface while
+// preserving its skip semantics.
+func Caller(skip int) (pc uintptr, file string, line int, ok bool) {
+	// Account for this wrapper's frame so skip still addresses the caller's stack.
+	return runtime.Caller(skip + 1)
+}
 
 // ErrRecovered is a sentinel error used to mark errors produced by ConvertRecover.
 //

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12,6 +12,13 @@ func TestMustPanicsWithError(t *testing.T) {
 	require.Panics(t, func() { runtime.Must(test.ErrFailed) })
 }
 
+func TestCallerPreservesSkipSemantics(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+
+	require.True(t, ok)
+	require.Contains(t, file, "runtime_test.go")
+}
+
 func TestRecover(t *testing.T) {
 	tests := []struct {
 		value   any


### PR DESCRIPTION
## What

- Ensure HTTP streaming handlers finalize codecs before writing an uncommitted error response and stop Send/Recv work as soon as graceful draining begins.
- Preserve the project runtime caller helper's standard skip semantics, with a documented wrapper-frame offset and regression coverage for fixture paths.

## Why

- Graceful shutdown must not emit or accept additional messages after draining starts, and codec finalization failures must remain observable before headers commit.
- Preserving caller-frame semantics keeps shared fixture paths rooted in this repository instead of resolving outside it.

## Testing

- `make specs package=net/http/content/stream` - passed
- `make specs package=runtime` - passed; includes the caller skip-semantics regression test.
- `make specs package=config` - passed; verifies fixture-path consumers resolve repository fixtures.
- `make lint` - passed
- `git diff --check` - passed
- Local validation is scoped to changed packages; full CI, integration, fuzz, benchmark, generated-fixture freshness, and security jobs remain CI coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
