### PR TITLE
feat(stream): refresh deadlines after sent messages

### DIFF
--- a/net/http/content/stream/benchmark_test.go
+++ b/net/http/content/stream/benchmark_test.go
@@ -20,6 +20,14 @@ func BenchmarkNewFromMediaNDJSON(b *testing.B) {
 	}
 }
 
+// BenchmarkNewFromMediaWithParameters tracks the parser path for parameterized NDJSON media types.
+func BenchmarkNewFromMediaWithParameters(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia, _ = test.StreamContent.NewFromMedia(media.NDJSON + "; profile=test")
+	}
+}
+
 // BenchmarkNewFromAcceptNDJSON tracks response media negotiation for a common NDJSON stream.
 func BenchmarkNewFromAcceptNDJSON(b *testing.B) {
 	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/hello", nil)
@@ -31,10 +39,32 @@ func BenchmarkNewFromAcceptNDJSON(b *testing.B) {
 	}
 }
 
+// BenchmarkNewFromAcceptWithRanges tracks Accept-list parsing and wildcard matching for a browser-style request.
+func BenchmarkNewFromAcceptWithRanges(b *testing.B) {
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/hello", nil)
+	req.Header.Set(http.AcceptKey, "text/html,application/xhtml+xml,*/*;q=0.8")
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia, _ = test.StreamContent.NewFromAccept(req)
+	}
+}
+
 // BenchmarkNewFromContentTypeNDJSON tracks strict request media negotiation for an NDJSON stream.
 func BenchmarkNewFromContentTypeNDJSON(b *testing.B) {
 	req := httptest.NewRequestWithContext(b.Context(), http.MethodPost, "/hello", nil)
 	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkMedia, _ = test.StreamContent.NewFromContentType(req)
+	}
+}
+
+// BenchmarkNewFromContentTypeWithParameters tracks the parser path for a parameterized NDJSON request body.
+func BenchmarkNewFromContentTypeWithParameters(b *testing.B) {
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodPost, "/hello", nil)
+	req.Header.Set(http.ContentTypeKey, media.NDJSON+"; charset=utf-8")
 
 	b.ReportAllocs()
 	for b.Loop() {

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -558,6 +558,26 @@ func TestNewHandlerSendExtendDeadlineFailure(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 }
 
+func TestNewHandlerSendRefreshesWriteDeadline(t *testing.T) {
+	calls := 0
+	opts := contentstream.Options{WriteTimeout: time.MustParseDuration("1s")}
+	handler := contentstream.NewHandler(test.StreamContent, opts, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "hi"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := &test.DeadlineResponseWriter{SetWriteDeadlineFunc: func() error {
+		calls++
+
+		return nil
+	}}
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, 2, calls)
+}
+
 func TestNewHandlerSendCommitFailure(t *testing.T) {
 	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "hi"})

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -700,6 +700,39 @@ func TestNewRequestHandlerSendExtendReadDeadlineFailure(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, res.Code)
 }
 
+func TestNewRequestHandlerSendRefreshesDeadlines(t *testing.T) {
+	readCalls := 0
+	writeCalls := 0
+	opts := contentstream.Options{ReadTimeout: time.MustParseDuration("1s"), WriteTimeout: time.MustParseDuration("1s")}
+	handler := contentstream.NewRequestHandler(
+		test.StreamContent,
+		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			return stream.Send(&test.Response{Greeting: "hi"})
+		})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := &test.DeadlineResponseWriter{
+		SetReadDeadlineFunc: func() error {
+			readCalls++
+
+			return nil
+		},
+		SetWriteDeadlineFunc: func() error {
+			writeCalls++
+
+			return nil
+		},
+	}
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, 2, readCalls)
+	require.Equal(t, 2, writeCalls)
+}
+
 func TestNewRequestHandlerRecvFirstCallIsBoundedByReadTimeout(t *testing.T) {
 	done := make(chan struct{})
 	t.Cleanup(func() { <-done })

--- a/net/http/content/stream/stream.go
+++ b/net/http/content/stream/stream.go
@@ -62,7 +62,6 @@ func (s *Stream[Res]) Send(res *Res) error {
 
 	if s.draining() {
 		s.err = ErrDraining
-
 		return s.err
 	}
 
@@ -71,12 +70,7 @@ func (s *Stream[Res]) Send(res *Res) error {
 		return err
 	}
 
-	if err := s.extendWriteDeadline(); err != nil {
-		s.err = err
-		return err
-	}
-
-	if err := s.extendReadDeadline(); err != nil {
+	if err := s.extendDeadlines(); err != nil {
 		s.err = err
 		return err
 	}
@@ -92,6 +86,11 @@ func (s *Stream[Res]) Send(res *Res) error {
 	}
 
 	if err := s.controller.Flush(); err != nil {
+		s.err = err
+		return err
+	}
+
+	if err := s.extendDeadlines(); err != nil {
 		s.err = err
 		return err
 	}
@@ -133,6 +132,14 @@ func (s *Stream[Res]) extendWriteDeadline() error {
 	}
 
 	return s.controller.SetWriteDeadline(time.Now().Add(s.writeTimeout.Duration()))
+}
+
+func (s *Stream[Res]) extendDeadlines() error {
+	if err := s.extendWriteDeadline(); err != nil {
+		return err
+	}
+
+	return s.extendReadDeadline()
 }
 
 // extendReadDeadline extends the request read deadline. It is a no-op for a send-only [Stream] built


### PR DESCRIPTION
## What

- Refresh read and write inactivity deadlines after every successfully flushed response message, so active bidirectional requests retain both directions of their timeout budget.
- Add send-only and bidirectional coverage that verifies deadlines are refreshed before sending and after the response flush.

## Why

- A long-lived response can be active even when the peer is not sending a request value. Refreshing the deadlines after a successful message prevents an active connection from being closed by a deadline set before that message was written.
- This preserves the existing HTTP streaming error contract: a trailing deadline-extension failure occurs after commit and aborts the committed response.

## Testing

- `make package=net/http/content/stream specs` - passed
- `make package=net/http/content/stream lint` - passed
- `git diff --check` - passed
- Added deterministic send-only and bidirectional tests for pre-send and post-flush deadline refreshes. The focused suite covers 112 tests; the full suite remains CI coverage.
- The trailing post-flush deadline-refresh failure is not isolated by a new test; existing committed-response failure coverage exercises the same abort contract.

AI-assisted-by: [Codex](https://openai.com/codex/)
