### PR TITLE
feat(unary): reject toml request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ Built-in text/object payload media types include:
 
 - `application/json`
 - `application/hjson`
-- `application/yaml`, `application/yml`
+- `application/yaml`
 - `application/toml`
 - `application/octet-stream`, `text/plain`
 
@@ -1123,11 +1123,11 @@ Built-in protobuf-oriented media type aliases include:
 >   is rejected with HTTP 415 rather than decoded as a different format than the caller declared.
 > - `text/error` is reserved for error responses and should not be sent by clients as a request content type.
 >
-> `application/vnd.msgpack` and `application/gob` can be resolved as media types and remain valid
+> `application/toml`, `application/vnd.msgpack`, and `application/gob` can be resolved as media types and remain valid
 > response codecs, but REST/RPC request-body decoding — for both single-value and streaming
 > (NDJSON) requests — rejects them with HTTP 415. This follows the decoder-bounds rule documented in
 > `net/http/content/unary`'s package documentation: a codec is admissible for decoding untrusted input only
-> when it is both ratio-bounded and depth-bounded, which msgpack and gob are not.
+> when it is both ratio-bounded and depth-bounded, which TOML, msgpack, and gob are not.
 
 ### HTTP streaming (NDJSON)
 

--- a/internal/test/http.go
+++ b/internal/test/http.go
@@ -29,8 +29,6 @@ func MessageMediaTypes() []MessageMediaType {
 		{Name: "json", ContentType: media.JSON, Kind: "json"},
 		{Name: "hjson", ContentType: media.HumanJSON, Kind: "hjson"},
 		{Name: "yaml", ContentType: media.YAML, Kind: "yaml"},
-		{Name: "yml", ContentType: "application/yml", Kind: "yaml"},
-		{Name: "toml", ContentType: media.TOML, Kind: "toml"},
 	}
 }
 

--- a/net/http/content/policy/doc.go
+++ b/net/http/content/policy/doc.go
@@ -1,0 +1,5 @@
+// Package policy classifies HTTP content codecs for untrusted request decoding.
+//
+// Unary and streaming handlers use this package after resolving a registered codec. CanDecode rejects
+// codecs without ratio and nesting bounds while leaving codec registration and response encoding unchanged.
+package policy

--- a/net/http/content/policy/policy.go
+++ b/net/http/content/policy/policy.go
@@ -1,15 +1,16 @@
-// Package policy defines HTTP content rules shared by unary and streaming request decoding.
 package policy
 
-const (
-	gobKind         = "gob"
-	messagePackKind = "msgpack"
-)
+var undecodableKinds = map[string]struct{}{
+	"gob":     {},
+	"msgpack": {},
+	"toml":    {},
+}
 
 // CanDecode reports whether kind is permitted to decode an untrusted HTTP request body.
 //
 // Unknown kinds are a separate concern: callers must first establish that a codec exists. This policy
 // only rejects registered codecs whose decoders are neither ratio-bounded nor depth-bounded.
 func CanDecode(kind string) bool {
-	return kind != gobKind && kind != messagePackKind
+	_, found := undecodableKinds[kind]
+	return !found
 }

--- a/net/http/content/policy/policy_test.go
+++ b/net/http/content/policy/policy_test.go
@@ -14,6 +14,7 @@ func TestCanDecode(t *testing.T) {
 	}{
 		{kind: "json", want: true},
 		{kind: "yaml", want: true},
+		{kind: "toml", want: false},
 		{kind: "", want: true},
 		{kind: "gob", want: false},
 		{kind: "msgpack", want: false},

--- a/net/http/content/unary/content_test.go
+++ b/net/http/content/unary/content_test.go
@@ -159,8 +159,8 @@ func TestNewFromContentTypeFallsBackFromInternalErrorMedia(t *testing.T) {
 	require.Same(t, test.Encoder.Get("bytes"), media.Encoder)
 }
 
-func TestNewFromRequestBodyRejectsUnsafeBinaryMedia(t *testing.T) {
-	for _, mediaType := range []string{"application/gob", media.MessagePack, media.MessagePack + "; profile=test"} {
+func TestNewFromRequestBodyRejectsUnsafeMedia(t *testing.T) {
+	for _, mediaType := range []string{"application/gob", media.MessagePack, media.MessagePack + "; profile=test", media.TOML, media.TOML + "; profile=test"} {
 		t.Run(mediaType, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 			req.Header.Set(http.ContentTypeKey, mediaType)
@@ -175,7 +175,7 @@ func TestNewFromRequestBodyRejectsUnsafeBinaryMedia(t *testing.T) {
 }
 
 func TestNewFromRequestBodyRejectsUnknownContentType(t *testing.T) {
-	for _, mediaType := range []string{"application/cbor", "/"} {
+	for _, mediaType := range []string{"application/cbor", "application/yml", "/"} {
 		t.Run(mediaType, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
 			req.Header.Set(http.ContentTypeKey, mediaType)
@@ -296,9 +296,9 @@ func TestNewFromAcceptResolvesJSONForWildcardOrUnknown(t *testing.T) {
 
 func TestEveryEncoderKindIsClassified(t *testing.T) {
 	// Every kind in the default registry must be explicitly classified, so a new codec cannot become
-	// request-decodable without a decision. See undecodableKinds in media.go.
+	// request-decodable without a decision. See policy.CanDecode.
 	classified := map[string]bool{
-		"json": true, "hjson": true, "yaml": true, "toml": true, "bytes": true,
+		"json": true, "hjson": true, "yaml": true, "toml": false, "bytes": true,
 		"protobuf": true, "prototext": true, "protojson": true,
 		"msgpack": false, "gob": false,
 	}
@@ -362,7 +362,6 @@ func mediaTests() []mediaTest {
 		{name: "json", mediaType: media.JSON, subtype: "json", kind: "json"},
 		{name: "hjson", mediaType: media.HumanJSON, subtype: "hjson", kind: "hjson"},
 		{name: "yaml", mediaType: media.YAML, subtype: "yaml", kind: "yaml"},
-		{name: "yml", mediaType: "application/yml", subtype: "yml", kind: "yaml"},
 		{name: "toml", mediaType: media.TOML, subtype: "toml", kind: "toml"},
 		{name: "msgpack", mediaType: media.MessagePack, subtype: "msgpack", kind: "msgpack"},
 		{name: "protobuf", mediaType: media.Protobuf, subtype: "protobuf", kind: "protobuf"},

--- a/net/http/content/unary/doc.go
+++ b/net/http/content/unary/doc.go
@@ -42,7 +42,7 @@
 // domain object rather than caller-controlled bytes. Request/response size limits bound input bytes
 // only, so they do not mitigate amplification and are not a substitute for these bounds.
 //
-// json, yaml and protobuf satisfy this rule. msgpack and gob do not, so [Media.CanDecodeRequest] and
+// json, yaml and protobuf satisfy this rule. toml, msgpack and gob do not, so [Media.CanDecodeRequest] and
 // [github.com/alexfalkowski/go-service/v2/net/http/content/stream.NewFromContentType] rejects them for
 // request decoding even though both remain valid
 // media types and valid response codecs (see [Content.NewFromMedia] and the go-service HTTP client,

--- a/net/http/content/unary/handler_test.go
+++ b/net/http/content/unary/handler_test.go
@@ -16,29 +16,41 @@ import (
 )
 
 func TestNewRequestHandlerUsesAcceptForResponse(t *testing.T) {
-	handler := unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, req *test.Request) (*test.Response, error) {
-		return &test.Response{Greeting: "Hello " + req.Name}, nil
-	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(`{"name":"Bob"}`))
-	req.Header.Set(http.ContentTypeKey, media.JSON)
-	req.Header.Set(http.AcceptKey, media.YAML)
-	res := httptest.NewRecorder()
-
-	handler.ServeHTTP(res, req)
-
-	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, media.YAML, res.Header().Get(http.ContentTypeKey))
-	var response test.Response
-	require.NoError(t, test.Encoder.Get("yaml").Decode(res.Body, &response))
-	require.Equal(t, "Hello Bob", response.Greeting)
-}
-
-func TestNewRequestHandlerRejectsUnsafeBinaryRequestBody(t *testing.T) {
 	for _, tc := range []struct {
 		mediaType string
 		kind      string
 	}{
+		{mediaType: media.TOML, kind: "toml"},
+		{mediaType: media.YAML, kind: "yaml"},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			handler := unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, req *test.Request) (*test.Response, error) {
+				return &test.Response{Greeting: "Hello " + req.Name}, nil
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(`{"name":"Bob"}`))
+			req.Header.Set(http.ContentTypeKey, media.JSON)
+			req.Header.Set(http.AcceptKey, tc.mediaType)
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusOK, res.Code)
+			require.Equal(t, tc.mediaType, res.Header().Get(http.ContentTypeKey))
+			var response test.Response
+			require.NoError(t, test.Encoder.Get(tc.kind).Decode(res.Body, &response))
+			require.Equal(t, "Hello Bob", response.Greeting)
+		})
+	}
+}
+
+func TestNewRequestHandlerRejectsUnsafeRequestBody(t *testing.T) {
+	for _, tc := range []struct {
+		mediaType string
+		kind      string
+	}{
+		{mediaType: media.TOML, kind: "toml"},
+		{mediaType: media.TOML + "; profile=test", kind: "toml"},
 		{mediaType: "application/gob", kind: "gob"},
 		{mediaType: media.MessagePack + "; profile=test", kind: "msgpack"},
 	} {

--- a/net/http/content/unary/media.go
+++ b/net/http/content/unary/media.go
@@ -44,7 +44,6 @@ var unaryKinds = map[string]string{
 	"pbjson":       "protojson",
 	"octet-stream": "bytes",
 	"plain":        "bytes",
-	"yml":          "yaml",
 }
 
 // unaryKind resolves subtype to its registered encoding.Map kind, defaulting to subtype itself when no
@@ -76,7 +75,7 @@ func (t Media) IsError() bool {
 // CanDecodeRequest reports whether the media type is allowed for decoding HTTP request bodies.
 //
 // A nil Encoder means the media type resolved to no codec at all, which is never decodable. Otherwise
-// the codec must satisfy the decoder-bounds rule; see undecodableKinds.
+// the codec must satisfy the decoder-bounds rule; see [policy.CanDecode].
 //
 // This answers for the media type this Media actually holds. A Media produced by the outbound JSON
 // fallback therefore reports JSON's answer, because JSON is genuinely what it holds; only

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -185,7 +185,7 @@ func TestAllowedRPC(t *testing.T) {
 }
 
 func TestDisallowedRPC(t *testing.T) {
-	for _, mt := range []string{media.JSON, media.HumanJSON, media.YAML, "application/yml", media.TOML, "application/gob", media.MessagePack, "test"} {
+	for _, mt := range []string{media.JSON, media.HumanJSON, media.YAML, media.TOML, "application/gob", media.MessagePack, "test"} {
 		t.Run(mt, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)),
@@ -212,19 +212,18 @@ func TestDisallowedRPC(t *testing.T) {
 }
 
 func TestInvalidRPCRequest(t *testing.T) {
-	for _, mt := range []string{"gob"} {
+	for _, mt := range []string{"gob", "toml", "yml"} {
 		t.Run(mt, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
 
 			rpc.Route("/hello", test.SuccessSayHello)
-			httpClient, err := world.NewHTTP()
+			header := http.Header{}
+			header.Set(http.ContentTypeKey, "application/"+mt)
+			res, body, err := world.ResponseWithBody(t.Context(), world.PathServerURL("http", "hello"), http.MethodPost, header, http.NoBody)
+
 			require.NoError(t, err)
-
-			client := rpc.NewClient(world.ServerURL("http"),
-				rpc.WithClientContentType("application/"+mt),
-				rpc.WithClientRoundTripper(httpClient.Transport))
-
-			require.Error(t, client.Post(t.Context(), "/hello", nil, &test.Response{}))
+			require.Equal(t, http.StatusUnsupportedMediaType, res.StatusCode)
+			require.Equal(t, "http: unsupported media type", body)
 		})
 	}
 }


### PR DESCRIPTION
## What

- Reject TOML request bodies with HTTP 415 while retaining TOML as a supported HTTP response codec.
- Remove the non-standard `application/yml` HTTP alias so `application/yaml` is the only supported YAML media type.
- Document the decoder-bounds policy and cover unary and RPC request handling, including parameterized TOML and invalid YML media types.

## Why

- TOML decoders do not provide the ratio and nesting bounds required for decoding untrusted HTTP request bodies, so accepting them could permit unsafe resource use.
- `application/yml` is not the registered YAML media type and supporting it created a misleading public HTTP contract.

## Testing

- `make package=net/http/content/policy specs` - passed
- `make package=net/http/content/unary specs` - passed; includes the `application/yml` rejection regression test.
- `make package=transport/http specs` - passed; verifies RPC responds with HTTP 415 for `application/yml`.
- `make lint` - passed
- `make sec` - passed; scanners found no reachable vulnerabilities.
- Full integration, fuzz, benchmark, and coverage suites remain CI-owned.

AI-assisted-by: [Codex](https://openai.com/codex/)
