### PR TITLE
feat(unary): reject unavailable response encoders before handler execution

### DIFF
--- a/net/http/content/unary/errors.go
+++ b/net/http/content/unary/errors.go
@@ -7,3 +7,5 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // decoder-bounds rule in the package documentation), the media type does not parse, or the media type
 // parses but resolves to no registered codec. See [Content.NewFromRequestBody].
 var ErrUnsupportedRequestMedia = errors.New("unary: unsupported request media")
+
+var errUnavailableResponseCodec = errors.New("unary: unavailable response codec")

--- a/net/http/content/unary/handler.go
+++ b/net/http/content/unary/handler.go
@@ -78,6 +78,12 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 		ctx = meta.WithRequestResponse(ctx, req, res)
 		res.Header().Set(http.ContentTypeKey, mediaType.WithUTF8())
 
+		if mediaType.Encoder == nil {
+			_ = status.WriteError(ctx, res, errUnavailableResponseCodec)
+
+			return
+		}
+
 		data, err := handler(ctx)
 		if err != nil {
 			_ = status.WriteError(ctx, res, err)

--- a/net/http/content/unary/handler_test.go
+++ b/net/http/content/unary/handler_test.go
@@ -145,3 +145,27 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	test.RequireTrimmedResponseBody(t, res, "http: internal server error")
 	test.RequireResponseBodyNotContains(t, res, "partial")
 }
+
+func TestNewHandlerRejectsUnavailableResponseCodec(t *testing.T) {
+	enc := encoding.NewMap()
+	enc.Register("json", nil)
+	cont := unary.NewContent(enc, test.Pool)
+
+	called := false
+	handler := unary.NewHandler(cont, func(_ context.Context) (*test.Response, error) {
+		called = true
+
+		return &test.Response{Greeting: "Hello Bob"}, nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.JSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.False(t, called)
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, "text/error; charset=utf-8", res.Header().Get(http.ContentTypeKey))
+	test.RequireTrimmedResponseBody(t, res, "http: internal server error")
+}


### PR DESCRIPTION
## What

- Return a controlled internal-server error when the negotiated unary response codec is unavailable, before application code runs.
- Preserve the existing response-error rendering behavior while preventing handler-side effects for an unrenderable response.

## Why

- Avoid completing a side-effecting request that must fail because its negotiated response cannot be encoded, which could otherwise lead to duplicate work on a client retry.

## Testing

- `make package=net/http/content/unary specs` - passed
- `make package=net/http/content/unary golangci-lint` - passed
- `make field-alignment` - passed
- The focused regression test verifies the handler is not called and the response remains a 500 when the JSON encoder is nil.
- Full CI continues to run the repository-wide validation suite.

AI-assisted-by: [Codex](https://openai.com/codex/)
