### PR TITLE
feat(stream): finalize codecs independently of handler outcomes

### DIFF
--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -24,6 +24,7 @@ import (
 // through [status.WriteError]. A handler error returned after the first successful Send aborts the
 // response via panic([http.ErrAbortHandler]) instead, since the response is already committed — see
 // [Stream.Send] and [handleResponse].
+// Codec finalization runs when the handler returns or panics; its error does not change the response outcome.
 //
 // Drain:
 // When opts.Drain starts before the handler is invoked, this handler returns 503. Otherwise it cancels
@@ -84,6 +85,8 @@ func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http
 			limiter:      meta.Limiter(ctx),
 			drain:        opts.Drain,
 		}
+		defer stream.close()
+
 		handleResponse(ctx, res, stream, handler(ctx, stream))
 	}
 }
@@ -197,6 +200,8 @@ func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler Re
 			capped:         capped,
 			maxReceiveSize: opts.MaxReceiveSize.Bytes(),
 		}
+		defer stream.close()
+
 		handleResponse(ctx, res, &stream.Stream, handler(ctx, stream))
 	}
 }
@@ -212,12 +217,12 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, stream *RequestS
 
 // handleResponse applies the streaming error contract after a stream handler returns.
 //
-// If the response was never committed, a handler or finalization error is rendered as an ordinary HTTP error via
+// If the response was never committed, a handler error is rendered as an ordinary HTTP error via
 // [status.WriteError] (a nil error leaves an empty, implicitly-200 response). If the response was
-// committed, any handler error — or a failure finalizing the encoder on the success path — is
-// recorded for operator diagnostics and the response is aborted via panic([http.ErrAbortHandler]),
-// which [transport/http.recoveryHandler] and the access logger already special-case for a committed
-// response.
+// committed, a handler error is recorded for operator diagnostics and the response is aborted via
+// panic([http.ErrAbortHandler]), which [transport/http.recoveryHandler] and the access logger already
+// special-case for a committed response. Codec finalization is deferred by the constructors and does not
+// change the response outcome.
 func handleResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if s.draining() {
 		drainResponse(ctx, res, s, err)
@@ -225,41 +230,25 @@ func handleResponse[Res any](ctx context.Context, res http.ResponseWriter, s *St
 	}
 
 	if !s.committed() {
-		closeErr := s.close()
 		if err != nil {
-			err = errors.Join(err, closeErr)
 			_ = status.WriteError(ctx, res, err)
-		} else if closeErr != nil {
-			_ = status.WriteError(ctx, res, closeErr)
 		}
-
 		return
 	}
 
 	if err != nil {
 		abortResponse(ctx, err)
 	}
-
-	if closeErr := s.close(); closeErr != nil {
-		abortResponse(ctx, closeErr)
-	}
 }
 
 func drainResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if !s.committed() {
-		status.RecordError(ctx, s.close())
 		_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
-
 		return
 	}
 
-	closeErr := s.close()
 	if err != nil && !errors.Is(err, ErrDraining) && !errors.Is(err, ctx.Err()) {
 		abortResponse(ctx, err)
-	}
-
-	if closeErr != nil {
-		abortResponse(ctx, closeErr)
 	}
 }
 

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -104,7 +104,7 @@ func TestNewHandlerClosesEncoderBeforeFirstSend(t *testing.T) {
 	require.Equal(t, 1, encoder.closes)
 }
 
-func TestNewHandlerReturnsCloseErrorBeforeFirstSendAsHTTPError(t *testing.T) {
+func TestNewHandlerIgnoresEncoderCloseErrorBeforeFirstSend(t *testing.T) {
 	encoder := &closeTracker{err: test.ErrFailed}
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
@@ -123,7 +123,7 @@ func TestNewHandlerReturnsCloseErrorBeforeFirstSendAsHTTPError(t *testing.T) {
 
 	handler.ServeHTTP(res, req)
 
-	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, 1, encoder.closes)
 }
 
@@ -150,7 +150,7 @@ func TestNewHandlerPreservesHandlerErrorWhenEncoderCloseFails(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, res.Code)
 	require.Equal(t, 1, encoder.closes)
 	require.ErrorIs(t, status.RequestError(req.Context()), test.ErrFailed)
-	require.ErrorIs(t, status.RequestError(req.Context()), closeErr)
+	require.NotErrorIs(t, status.RequestError(req.Context()), closeErr)
 }
 
 func TestNewHandlerClosesEncoderBeforeFirstSendOnDrain(t *testing.T) {
@@ -214,6 +214,97 @@ func TestNewHandlerAbortsAfterCommit(t *testing.T) {
 
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
+}
+
+func TestNewHandlerClosesEncoderBeforeAbortAfterCommit(t *testing.T) {
+	encoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			return test.ErrFailed
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	require.Equal(t, 1, encoder.closes)
+}
+
+func TestNewHandlerClosesEncoderAfterCommitPanic(t *testing.T) {
+	encoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			panic(test.ErrFailed)
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, test.ErrFailed, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	require.Equal(t, 1, encoder.closes)
+}
+
+func TestNewHandlerPreservesPanicDiagnosticWhenEncoderCloseFails(t *testing.T) {
+	closeErr := errors.New("encoder close")
+	encoder := &closeTracker{err: closeErr}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, _ *contentstream.Stream[test.Response]) error {
+			panic(test.ErrFailed)
+		},
+	)
+
+	req := httptest.NewRequestWithContext(status.WithRequestError(t.Context()), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	func() {
+		defer func() {
+			if value := recover(); value != nil {
+				_ = status.WriteError(req.Context(), res, status.SafeError(http.StatusInternalServerError, runtime.ConvertRecover(value)))
+			}
+		}()
+
+		handler.ServeHTTP(res, req)
+	}()
+
+	require.Equal(t, http.StatusInternalServerError, res.Code)
+	require.Equal(t, 1, encoder.closes)
+	require.ErrorIs(t, status.RequestError(req.Context()), runtime.ErrRecovered)
+	require.ErrorIs(t, status.RequestError(req.Context()), test.ErrFailed)
+	require.NotErrorIs(t, status.RequestError(req.Context()), closeErr)
 }
 
 func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -60,6 +59,72 @@ func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T
 	require.Equal(t, 1, decoder.closes)
 }
 
+func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommit(t *testing.T) {
+	encoder := &closeTracker{}
+	decoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewRequestHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			return test.ErrFailed
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	require.Equal(t, 1, encoder.closes)
+	require.Equal(t, 1, decoder.closes)
+}
+
+func TestNewRequestHandlerClosesCodecsAfterCommitPanic(t *testing.T) {
+	encoder := &closeTracker{}
+	decoder := &closeTracker{}
+	sm := encodingstream.NewMap()
+	codec := sm.Get("json")
+	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
+	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	sm.Register("json", codec)
+	handler := contentstream.NewRequestHandler(
+		contentstream.NewContent(sm, test.Pool),
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
+				return err
+			}
+
+			panic(test.ErrFailed)
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	require.PanicsWithValue(t, test.ErrFailed, func() {
+		handler.ServeHTTP(res, req)
+	})
+
+	require.Equal(t, 1, encoder.closes)
+	require.Equal(t, 1, decoder.closes)
+}
+
 func TestNewRequestHandlerClosesCodecsAfterReceiveOnlyHandler(t *testing.T) {
 	encoder := &closeTracker{}
 	decoder := &closeTracker{decodeErr: io.EOF}
@@ -93,20 +158,19 @@ func TestNewRequestHandlerClosesCodecsAfterReceiveOnlyHandler(t *testing.T) {
 	require.Equal(t, 1, decoder.closes)
 }
 
-func TestNewRequestHandlerClosesDecoderWhenEncoderCloseFails(t *testing.T) {
-	exporter := test.EnableIsolatedSpanExporter(t)
-	decoder := &closeTracker{err: errors.New("decoder close")}
+func TestNewRequestHandlerIgnoresCodecCloseErrors(t *testing.T) {
+	decoder := &closeTracker{err: test.ErrFailed}
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return test.CloseErrEncoder{} }
 	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
 	sm.Register("json", codec)
-	handler := http.NewTelemetryHandler(contentstream.NewRequestHandler(
+	handler := contentstream.NewRequestHandler(
 		contentstream.NewContent(sm, test.Pool),
 		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			return stream.Send(&test.Response{Greeting: "Hello Bob"})
 		},
-	), "http.server")
+	)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
 	req.ProtoMajor = 2
@@ -114,14 +178,10 @@ func TestNewRequestHandlerClosesDecoderWhenEncoderCloseFails(t *testing.T) {
 	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
-	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
-		handler.ServeHTTP(res, req)
-	})
+	handler.ServeHTTP(res, req)
 
+	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, 1, decoder.closes)
-	spans := exporter.Spans()
-	require.Len(t, spans, 1)
-	require.Equal(t, test.ErrFailed.Error(), spans[0].Status().Description)
 }
 
 func TestNewRequestHandlerReturnsServiceUnavailableOnDrainBeforeHandler(t *testing.T) {


### PR DESCRIPTION
## What

- Finalize response and request codecs after handlers return, abort, or panic so cleanup always runs.
- Make codec finalization errors non-authoritative: they no longer replace a handler error, trigger a new abort, or change an otherwise successful HTTP result. This is an intentional compatibility change for custom codec implementations.

## Why

- Handler outcomes and panic diagnostics must remain authoritative while codec resources are still finalized on every exit path.
- Custom codec authors that previously relied on `Close` errors becoming HTTP failures or aborts should surface those failures within normal handler/encoding behavior instead.

## Testing

- `make specs package=net/http/content/stream` - passed
- `make lint` - passed
- `make sec` - passed
- Added coverage for codec cleanup after committed handler errors and panics, and for ignored finalization errors in both handler shapes.

AI-assisted-by: [Codex](https://openai.com/codex/)
