### PR TITLE
feat(http): guard unavailable codecs and streaming panic cleanup

### DIFF
--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -273,11 +273,14 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 		// With the default encoder registry, responseMedia.Encoder is never nil here: the only media
 		// type NewFromMedia resolves without an encoder is text/error, and mediaStatusError above always
 		// turns that into an error before this point. That is not a structural guarantee, though —
-		// nil-registering "json" makes NewFromMedia return a non-error Media with a nil Encoder — so a
-		// caller supplying a customized registry can still reach a nil dereference here. Response
+		// nil-registering "json" makes NewFromMedia return a non-error Media with a nil Encoder. Response
 		// decoding is intentionally not subject to the request-decode policy that guards
 		// Content.NewFromRequestBody (a configured response endpoint is a different trust context from
 		// an inbound request body); see the decoder-bounds rule in net/http/content/unary's documentation.
+		if responseMedia.Encoder == nil {
+			return errors.Prefix("http: decode", unary.ErrUnsupportedMedia)
+		}
+
 		if err := responseMedia.Encoder.Decode(responseBody, opts.Response); err != nil {
 			return errors.Prefix("http: decode", err)
 		}
@@ -297,6 +300,10 @@ func (c *Client) newRequest(ctx context.Context, method, url string, opts Option
 
 	body := io.Reader(http.NoBody)
 	if opts.HasRequest() {
+		if requestMedia.Encoder == nil {
+			return nil, errors.Prefix("http: encode", unary.ErrUnsupportedMedia)
+		}
+
 		var requestBody bytes.Buffer
 		if err := requestMedia.Encoder.Encode(&requestBody, opts.Request); err != nil {
 			return nil, errors.Prefix("http: encode", err)

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -332,6 +332,25 @@ func TestDoReturnsEncodeErrorFromNewRequest(t *testing.T) {
 	require.ErrorIs(t, err, test.ErrFailed)
 }
 
+func TestDoRejectsUnavailableRequestCodec(t *testing.T) {
+	enc := encoding.NewMap()
+	enc.Register("json", nil)
+	unaryContent := unary.NewContent(enc, test.Pool)
+
+	roundTripped := false
+	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		roundTripped = true
+		return nil, test.ErrFailed
+	})
+	c := client.NewClient(unaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
+
+	err := c.Post(t.Context(), "http://example.com", client.Options{ContentType: media.JSON, Request: &test.Request{Name: "Bob"}})
+
+	require.ErrorIs(t, err, unary.ErrUnsupportedMedia)
+	require.EqualError(t, err, "http: encode: unary: unsupported media")
+	require.False(t, roundTripped)
+}
+
 func TestDoReturnsNewRequestError(t *testing.T) {
 	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
 
@@ -384,6 +403,26 @@ func TestDoReturnsDecodeError(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, test.ErrFailed)
+}
+
+func TestDoRejectsUnavailableResponseCodec(t *testing.T) {
+	enc := encoding.NewMap()
+	enc.Register("json", nil)
+	unaryContent := unary.NewContent(enc, test.Pool)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(http.ContentTypeKey, media.JSON)
+		_, _ = io.WriteString(res, "{}")
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(unaryContent, test.StreamContent, test.Pool)
+
+	var res test.Response
+	err := c.Get(t.Context(), server.URL, client.Options{Response: &res})
+
+	require.ErrorIs(t, err, unary.ErrUnsupportedMedia)
+	require.EqualError(t, err, "http: decode: unary: unsupported media")
 }
 
 func TestStreamReturnsCopyErrorFromCheckResponseStatus(t *testing.T) {

--- a/net/http/client/stream.go
+++ b/net/http/client/stream.go
@@ -9,14 +9,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
-
-// errHandlerPanicked stands in for a recovered [StreamHandler]/[RequestStreamHandler] panic when
-// [RequestResponseStream.finish] needs a non-nil handlerErr to close the pipe with CloseWithError
-// instead of the clean-success path (see [callHandler] and [Client.RequestStream]). It is never
-// returned to a caller: the original panic value is always re-raised after cleanup.
-var errHandlerPanicked = errors.New("client: handler panicked")
 
 // StreamHandler handles a client-side receive-only stream: the response streams, the request does
 // not. It is the client-side counterpart of a call to a send-only streaming route (see
@@ -191,12 +186,11 @@ func (c *Client) Stream(ctx context.Context, method, url string, opts Options, h
 // See [Client.Stream]: the underlying [http.Client] never has a [http.Client.Timeout].
 func (c *Client) RequestStream(ctx context.Context, method, url string, opts Options, handler RequestStreamHandler) error {
 	reqMedia, err := c.streamContent.NewFromMedia(opts.ContentType)
-	if err == nil && reqMedia.NewEncoder == nil {
-		err = contentstream.ErrUnsupportedMedia
-	}
-
 	if err != nil {
 		return errors.Prefix("http: stream media", err)
+	}
+	if reqMedia.NewEncoder == nil {
+		return errors.Prefix("http: stream media", contentstream.ErrUnsupportedMedia)
 	}
 
 	reader, writer := io.Pipe()
@@ -230,12 +224,13 @@ func (c *Client) RequestStream(ctx context.Context, method, url string, opts Opt
 	}
 
 	panicValue, handlerErr := callHandler(func() error { return handler(ctx, stream) })
-	if panicValue != nil && handlerErr == nil {
+	if panicValue != nil {
 		// finish branches on a nil handlerErr by finalizing the encoder and closing the pipe cleanly,
 		// as if the handler had succeeded. A panic is not success: force the error branch
 		// (CloseWithError) so a transport still reading the request body sees a failure, not a clean
-		// end of stream, matching how a returned handler error is already treated.
-		handlerErr = errHandlerPanicked
+		// end of stream, matching how a returned handler error is already treated. ConvertRecover
+		// preserves the panic value for the reader while marking the error as recovered.
+		handlerErr = runtime.ConvertRecover(panicValue)
 	}
 
 	finishErr := stream.finish(handlerErr)

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/content/unary"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
@@ -583,7 +584,9 @@ func TestRequestStreamClosesPipeOnHandlerPanic(t *testing.T) {
 	})
 
 	select {
-	case <-readDone:
+	case err := <-readDone:
+		require.ErrorIs(t, err, runtime.ErrRecovered)
+		require.EqualError(t, err, "recovered: boom")
 	case <-time.After(2 * time.Second):
 		t.Fatal("pipe reader never unblocked after handler panic")
 	}

--- a/net/http/content/unary/errors.go
+++ b/net/http/content/unary/errors.go
@@ -8,4 +8,5 @@ import "github.com/alexfalkowski/go-service/v2/errors"
 // parses but resolves to no registered codec. See [Content.NewFromRequestBody].
 var ErrUnsupportedRequestMedia = errors.New("unary: unsupported request media")
 
-var errUnavailableResponseCodec = errors.New("unary: unavailable response codec")
+// ErrUnsupportedMedia is returned when a selected unary media type has no registered codec.
+var ErrUnsupportedMedia = errors.New("unary: unsupported media")

--- a/net/http/content/unary/handler.go
+++ b/net/http/content/unary/handler.go
@@ -81,7 +81,7 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 		res.Header().Set(http.ContentTypeKey, media.MustParse(mediaType.String()).WithUTF8())
 
 		if mediaType.Encoder == nil {
-			_ = status.WriteError(ctx, res, errUnavailableResponseCodec)
+			_ = status.WriteError(ctx, res, ErrUnsupportedMedia)
 
 			return
 		}


### PR DESCRIPTION
## What

- Return controlled errors instead of panicking when a unary request or response selects an unavailable codec.
- Preserve the original panic for callers while propagating a recovered error to a streaming request body's reader during cleanup.

## Why

- Custom codec registries should fail predictably without sending invalid requests, attempting unsafe decoding, or treating a panicked streaming handler as a clean request completion.

## Testing

- `make package=net/http/client specs` - passed
- `make package=net/http/content/unary specs` - passed
- `make field-alignment` - passed
- `make package=net/http/client golangci-lint` - passed
- `make package=net/http/content/unary golangci-lint` - passed
- Added coverage for unavailable unary request and response codecs, plus the recovered pipe-reader error after a streaming handler panic.
- Full CI provides repository-wide integration, security, fuzz, benchmark, and coverage checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
