### PR TITLE
test(feature): consolidate related test cases

### DIFF
--- a/cache/driver/errors/errors_test.go
+++ b/cache/driver/errors/errors_test.go
@@ -9,17 +9,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsMissingError(t *testing.T) {
-	require.True(t, errors.IsMissingError(errors.ErrMissing))
-	require.True(t, errors.IsMissingError(redis.Nil))
-	require.True(t, errors.IsMissingError(goerrors.Prefix("wrapped", redis.Nil)))
-	require.False(t, errors.IsMissingError(errors.ErrExpired))
-	require.False(t, errors.IsMissingError(nil))
-}
+func TestErrorClassification(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		missing bool
+		expired bool
+	}{
+		{name: "missing", err: errors.ErrMissing, missing: true},
+		{name: "redis missing", err: redis.Nil, missing: true},
+		{name: "wrapped redis missing", err: goerrors.Prefix("wrapped", redis.Nil), missing: true},
+		{name: "expired", err: errors.ErrExpired, expired: true},
+		{name: "wrapped expired", err: goerrors.Prefix("wrapped", errors.ErrExpired), expired: true},
+		{name: "nil"},
+	}
 
-func TestIsExpiredError(t *testing.T) {
-	require.True(t, errors.IsExpiredError(errors.ErrExpired))
-	require.True(t, errors.IsExpiredError(goerrors.Prefix("wrapped", errors.ErrExpired)))
-	require.False(t, errors.IsExpiredError(errors.ErrMissing))
-	require.False(t, errors.IsExpiredError(nil))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.missing, errors.IsMissingError(test.err))
+			require.Equal(t, test.expired, errors.IsExpiredError(test.err))
+		})
+	}
 }

--- a/compress/s2/s2_test.go
+++ b/compress/s2/s2_test.go
@@ -49,19 +49,19 @@ func TestDecompressRejectsTooLarge(t *testing.T) {
 func TestDecompressRejectsInvalidData(t *testing.T) {
 	t.Parallel()
 
-	cmp := s2.NewCompressor()
+	for _, tt := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "non-compressed data", data: strings.Bytes("invalid")},
+		{name: "invalid decoded length", data: []byte{0x80}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errors.ErrTooLarge)
-}
-
-func TestDecompressReturnsDecodedLenError(t *testing.T) {
-	t.Parallel()
-
-	cmp := s2.NewCompressor()
-
-	_, err := cmp.Decompress([]byte{0x80}, bytes.KB)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errors.ErrTooLarge)
+			_, err := s2.NewCompressor().Decompress(tt.data, bytes.KB)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, errors.ErrTooLarge)
+		})
+	}
 }

--- a/compress/snappy/snappy_test.go
+++ b/compress/snappy/snappy_test.go
@@ -49,19 +49,19 @@ func TestDecompressRejectsTooLarge(t *testing.T) {
 func TestDecompressRejectsInvalidData(t *testing.T) {
 	t.Parallel()
 
-	cmp := snappy.NewCompressor()
+	for _, tt := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "non-compressed data", data: strings.Bytes("invalid")},
+		{name: "invalid decoded length", data: []byte{0x80}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := cmp.Decompress(strings.Bytes("invalid"), bytes.KB)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errors.ErrTooLarge)
-}
-
-func TestDecompressReturnsDecodedLenError(t *testing.T) {
-	t.Parallel()
-
-	cmp := snappy.NewCompressor()
-
-	_, err := cmp.Decompress([]byte{0x80}, bytes.KB)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errors.ErrTooLarge)
+			_, err := snappy.NewCompressor().Decompress(tt.data, bytes.KB)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, errors.ErrTooLarge)
+		})
+	}
 }

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -56,13 +56,34 @@ func TestNewConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewConfigDefaults(t *testing.T) {
+func TestNewConfigWithOptionalTLSMaterial(t *testing.T) {
 	tests := []struct {
-		config *config.Config
-		name   string
+		config       *config.Config
+		name         string
+		certificates int
+		rootCAs      bool
+		serverName   string
 	}{
 		{name: "nil"},
 		{name: "empty", config: &config.Config{}},
+		{
+			name: "key pair only",
+			config: &config.Config{
+				Cert: test.FilePath("certs/client-cert.pem"),
+				Key:  test.FilePath("certs/client-key.pem"),
+			},
+			certificates: 1,
+		},
+		{
+			name:    "CA only",
+			config:  &config.Config{CA: test.FilePath("certs/rootCA.pem")},
+			rootCAs: true,
+		},
+		{
+			name:       "server name only",
+			config:     &config.Config{ServerName: "localhost"},
+			serverName: "localhost",
+		},
 	}
 
 	for _, tt := range tests {
@@ -71,38 +92,15 @@ func TestNewConfigDefaults(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, tlsConfig)
 			require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
-			require.Empty(t, tlsConfig.Certificates)
-			require.Nil(t, tlsConfig.RootCAs)
-			require.Empty(t, tlsConfig.ServerName)
+			require.Len(t, tlsConfig.Certificates, tt.certificates)
+			if tt.rootCAs {
+				require.NotNil(t, tlsConfig.RootCAs)
+			} else {
+				require.Nil(t, tlsConfig.RootCAs)
+			}
+			require.Equal(t, tt.serverName, tlsConfig.ServerName)
 		})
 	}
-}
-
-func TestNewConfigWithKeyPairOnly(t *testing.T) {
-	tlsConfig, err := client.NewConfig(test.FS, &config.Config{
-		Cert: test.FilePath("certs/client-cert.pem"),
-		Key:  test.FilePath("certs/client-key.pem"),
-	})
-	require.NoError(t, err)
-	require.Len(t, tlsConfig.Certificates, 1)
-	require.Nil(t, tlsConfig.RootCAs)
-}
-
-func TestNewConfigWithCAOnly(t *testing.T) {
-	tlsConfig, err := client.NewConfig(test.FS, &config.Config{CA: test.FilePath("certs/rootCA.pem")})
-	require.NoError(t, err)
-	require.Empty(t, tlsConfig.Certificates)
-	require.NotNil(t, tlsConfig.RootCAs)
-}
-
-func TestNewConfigWithServerNameOnly(t *testing.T) {
-	tlsConfig, err := client.NewConfig(test.FS, &config.Config{ServerName: "localhost"})
-	require.NoError(t, err)
-	require.NotNil(t, tlsConfig)
-	require.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
-	require.Empty(t, tlsConfig.Certificates)
-	require.Nil(t, tlsConfig.RootCAs)
-	require.Equal(t, "localhost", tlsConfig.ServerName)
 }
 
 func TestNewConfigInvalidKeyPair(t *testing.T) {

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -123,14 +123,23 @@ func TestNewConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewConfigDefaults(t *testing.T) {
+func TestNewConfigWithOptionalTLSMaterial(t *testing.T) {
 	tests := []struct {
-		config *config.Config
-		name   string
+		config       *config.Config
+		name         string
+		certificates int
 	}{
 		{name: "nil"},
 		{name: "empty", config: &config.Config{}},
 		{name: "server name", config: &config.Config{ServerName: "localhost"}},
+		{
+			name: "key pair only",
+			config: &config.Config{
+				Cert: test.FilePath("certs/cert.pem"),
+				Key:  test.FilePath("certs/key.pem"),
+			},
+			certificates: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -139,30 +148,11 @@ func TestNewConfigDefaults(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, tlsConfig)
 			require.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
-			require.Empty(t, tlsConfig.Certificates)
+			require.Len(t, tlsConfig.Certificates, tt.certificates)
 			require.Nil(t, tlsConfig.ClientCAs)
 			require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
 		})
 	}
-}
-
-func TestNewConfigWithKeyPairOnly(t *testing.T) {
-	tlsConfig, err := server.NewConfig(test.FS, &config.Config{
-		Cert: test.FilePath("certs/cert.pem"),
-		Key:  test.FilePath("certs/key.pem"),
-	})
-	require.NoError(t, err)
-	require.Len(t, tlsConfig.Certificates, 1)
-	require.Nil(t, tlsConfig.ClientCAs)
-	require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
-}
-
-func TestNewConfigWithCAOnly(t *testing.T) {
-	tlsConfig, err := server.NewConfig(test.FS, &config.Config{CA: test.FilePath("certs/rootCA.pem")})
-	require.ErrorIs(t, err, server.ErrMissingKeyPair)
-	require.Empty(t, tlsConfig.Certificates)
-	require.Nil(t, tlsConfig.ClientCAs)
-	require.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
 }
 
 func TestNewConfigRejectsIncompleteKeyPair(t *testing.T) {
@@ -170,6 +160,7 @@ func TestNewConfigRejectsIncompleteKeyPair(t *testing.T) {
 		config *config.Config
 		name   string
 	}{
+		{name: "CA only", config: &config.Config{CA: test.FilePath("certs/rootCA.pem")}},
 		{name: "cert only", config: &config.Config{Cert: test.FilePath("certs/cert.pem")}},
 		{name: "key only", config: &config.Config{Key: test.FilePath("certs/key.pem")}},
 	}

--- a/crypto/aes/aes_test.go
+++ b/crypto/aes/aes_test.go
@@ -48,38 +48,29 @@ func TestValidCipher(t *testing.T) {
 func TestInvalidCipherConfig(t *testing.T) {
 	t.Setenv("AES_EMPTY", "")
 
-	t.Run("missing key", func(t *testing.T) {
-		gen := rand.NewGenerator(rand.NewReader())
+	tests := []struct {
+		name        string
+		config      *aes.Config
+		wantErr     error
+		errContains string
+	}{
+		{name: "missing key", config: &aes.Config{}, wantErr: errors.ErrMissingKey},
+		{name: "empty key source", config: &aes.Config{Key: "env:AES_EMPTY"}, wantErr: errors.ErrMissingKey},
+		{name: "missing key source", config: &aes.Config{Key: "env:AES_MISSING"}, errContains: "env:AES_MISSING"},
+		{name: "invalid key", config: &aes.Config{Key: test.FilePath("secrets/aes_invalid")}, wantErr: errors.ErrInvalidKeySize},
+	}
 
-		cipher, err := aes.NewCipher(gen, test.FS, &aes.Config{})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-		require.Nil(t, cipher)
-	})
-
-	t.Run("empty key source", func(t *testing.T) {
-		gen := rand.NewGenerator(rand.NewReader())
-
-		cipher, err := aes.NewCipher(gen, test.FS, &aes.Config{Key: "env:AES_EMPTY"})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-		require.Nil(t, cipher)
-	})
-
-	t.Run("missing key source", func(t *testing.T) {
-		gen := rand.NewGenerator(rand.NewReader())
-
-		cipher, err := aes.NewCipher(gen, test.FS, &aes.Config{Key: "env:AES_MISSING"})
-		require.Error(t, err)
-		require.ErrorContains(t, err, "env:AES_MISSING")
-		require.Nil(t, cipher)
-	})
-
-	t.Run("invalid key", func(t *testing.T) {
-		gen := rand.NewGenerator(rand.NewReader())
-
-		cipher, err := aes.NewCipher(gen, test.FS, &aes.Config{Key: test.FilePath("secrets/aes_invalid")})
-		require.ErrorIs(t, err, errors.ErrInvalidKeySize)
-		require.Nil(t, cipher)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cipher, err := aes.NewCipher(rand.NewGenerator(rand.NewReader()), test.FS, tt.config)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.ErrorContains(t, err, tt.errContains)
+			}
+			require.Nil(t, cipher)
+		})
+	}
 }
 
 func TestInvalidCipher(t *testing.T) {

--- a/crypto/hmac/hmac_test.go
+++ b/crypto/hmac/hmac_test.go
@@ -52,24 +52,28 @@ func TestValidSigner(t *testing.T) {
 func TestSignerMissingKey(t *testing.T) {
 	t.Setenv("HMAC_EMPTY", "")
 
-	t.Run("missing key", func(t *testing.T) {
-		signer, err := hmac.NewSigner(test.FS, &hmac.Config{})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-		require.Nil(t, signer)
-	})
+	tests := []struct {
+		name        string
+		config      *hmac.Config
+		wantErr     error
+		errContains string
+	}{
+		{name: "missing key", config: &hmac.Config{}, wantErr: errors.ErrMissingKey},
+		{name: "empty key source", config: &hmac.Config{Key: "env:HMAC_EMPTY"}, wantErr: errors.ErrMissingKey},
+		{name: "missing key source", config: &hmac.Config{Key: "env:HMAC_MISSING"}, errContains: "env:HMAC_MISSING"},
+	}
 
-	t.Run("empty key source", func(t *testing.T) {
-		signer, err := hmac.NewSigner(test.FS, &hmac.Config{Key: "env:HMAC_EMPTY"})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-		require.Nil(t, signer)
-	})
-
-	t.Run("missing key source", func(t *testing.T) {
-		signer, err := hmac.NewSigner(test.FS, &hmac.Config{Key: "env:HMAC_MISSING"})
-		require.Error(t, err)
-		require.ErrorContains(t, err, "env:HMAC_MISSING")
-		require.Nil(t, signer)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer, err := hmac.NewSigner(test.FS, tt.config)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.ErrorContains(t, err, tt.errContains)
+			}
+			require.Nil(t, signer)
+		})
+	}
 }
 
 func TestInvalidSigner(t *testing.T) {

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -63,25 +63,33 @@ func TestValid(t *testing.T) {
 func TestInvalidConfig(t *testing.T) {
 	t.Setenv("SSH_EMPTY", "")
 
-	t.Run("missing signer private key", func(t *testing.T) {
-		_, err := ssh.NewSigner(test.FS, &ssh.Config{})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-	})
+	newSigner := func(config *ssh.Config) error {
+		_, err := ssh.NewSigner(test.FS, config)
 
-	t.Run("missing verifier public key", func(t *testing.T) {
-		_, err := ssh.NewVerifier(test.FS, &ssh.Config{})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-	})
+		return err
+	}
+	newVerifier := func(config *ssh.Config) error {
+		_, err := ssh.NewVerifier(test.FS, config)
 
-	t.Run("empty signer private key source", func(t *testing.T) {
-		_, err := ssh.NewSigner(test.FS, &ssh.Config{Private: "env:SSH_EMPTY"})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-	})
+		return err
+	}
 
-	t.Run("empty verifier public key source", func(t *testing.T) {
-		_, err := ssh.NewVerifier(test.FS, &ssh.Config{Public: "env:SSH_EMPTY"})
-		require.ErrorIs(t, err, errors.ErrMissingKey)
-	})
+	tests := []struct {
+		name        string
+		constructor func(*ssh.Config) error
+		config      *ssh.Config
+	}{
+		{name: "missing signer private key", constructor: newSigner, config: &ssh.Config{}},
+		{name: "missing verifier public key", constructor: newVerifier, config: &ssh.Config{}},
+		{name: "empty signer private key source", constructor: newSigner, config: &ssh.Config{Private: "env:SSH_EMPTY"}},
+		{name: "empty verifier public key source", constructor: newVerifier, config: &ssh.Config{Public: "env:SSH_EMPTY"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.constructor(tt.config), errors.ErrMissingKey)
+		})
+	}
 }
 
 func TestInvalidPublicKeyConfig(t *testing.T) {

--- a/database/sql/config/config_test.go
+++ b/database/sql/config/config_test.go
@@ -27,21 +27,6 @@ func TestConfigValidation(t *testing.T) {
 				Writer: &config.Pool{Settings: &config.PoolSettings{MaxOpenConns: 1, MaxIdleConns: 1}},
 			},
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			requireConfigValidation(t, tt.cfg, tt.err)
-		})
-	}
-}
-
-func TestPoolValidation(t *testing.T) {
-	tests := []struct {
-		cfg  *config.Config
-		name string
-		err  bool
-	}{
 		{
 			name: "missing reader pool settings",
 			cfg: &config.Config{

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -24,12 +24,21 @@ var debugPaths = []string{
 	"debug/pprof/trace",
 }
 
-func TestInsecureDebug(t *testing.T) {
-	requireDebugEndpoints(t, "http", test.WithWorldDebug())
-}
+func TestDebugEndpoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		scheme  string
+		options []test.WorldOption
+	}{
+		{name: "insecure", scheme: "http", options: []test.WorldOption{test.WithWorldDebug()}},
+		{name: "secure", scheme: "https", options: []test.WorldOption{test.WithWorldSecure(), test.WithWorldDebug()}},
+	}
 
-func TestSecureDebug(t *testing.T) {
-	requireDebugEndpoints(t, "https", test.WithWorldSecure(), test.WithWorldDebug())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireDebugEndpoints(t, tt.scheme, tt.options...)
+		})
+	}
 }
 
 func TestInvalidServer(t *testing.T) {

--- a/meta/value_test.go
+++ b/meta/value_test.go
@@ -33,10 +33,6 @@ func TestValue(t *testing.T) {
 	}
 }
 
-func TestErrorWithNil(t *testing.T) {
-	require.Equal(t, meta.Blank(), meta.Error(nil))
-}
-
 func TestError(t *testing.T) {
 	value := meta.Error(&test.MessageError{Message: "boom"})
 
@@ -45,10 +41,20 @@ func TestError(t *testing.T) {
 	require.False(t, value.IsEmpty())
 }
 
-func TestErrorWithTypedNil(t *testing.T) {
-	var err error = (*test.MessageError)(nil)
+func TestErrorWithNil(t *testing.T) {
+	var typedNil error = (*test.MessageError)(nil)
 
-	require.Equal(t, meta.Blank(), meta.Error(err))
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "nil"},
+		{name: "typed nil", err: typedNil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, meta.Blank(), meta.Error(test.err))
+		})
+	}
 }
 
 func TestStringerConversions(t *testing.T) {
@@ -72,26 +78,25 @@ func TestStringerConversions(t *testing.T) {
 	}
 }
 
-func TestToStringWithNil(t *testing.T) {
-	require.Equal(t, meta.Blank(), meta.ToString(nil))
-}
-
-func TestToStringWithTypedNil(t *testing.T) {
+func TestStringerConversionsWithNil(t *testing.T) {
 	var stringer fmt.Stringer = (*test.Stringer)(nil)
 
-	require.Equal(t, meta.Blank(), meta.ToString(stringer))
-}
+	tests := []struct {
+		name    string
+		convert func(fmt.Stringer) meta.Value
+		value   fmt.Stringer
+	}{
+		{name: "to string with nil", convert: meta.ToString},
+		{name: "to string with typed nil", convert: meta.ToString, value: stringer},
+		{name: "to redacted with typed nil", convert: meta.ToRedacted, value: stringer},
+		{name: "to ignored with typed nil", convert: meta.ToIgnored, value: stringer},
+	}
 
-func TestToRedactedWithTypedNil(t *testing.T) {
-	var stringer fmt.Stringer = (*test.Stringer)(nil)
-
-	require.Equal(t, meta.Blank(), meta.ToRedacted(stringer))
-}
-
-func TestToIgnoredWithTypedNil(t *testing.T) {
-	var stringer fmt.Stringer = (*test.Stringer)(nil)
-
-	require.Equal(t, meta.Blank(), meta.ToIgnored(stringer))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, meta.Blank(), test.convert(test.value))
+		})
+	}
 }
 
 func TestRedactedWithMultiByteValue(t *testing.T) {

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -7,18 +7,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseInvalidMediaType(t *testing.T) {
+func TestParseRejectsInvalidMediaTypes(t *testing.T) {
 	t.Parallel()
 
-	_, err := media.Parse("json")
-	require.ErrorIs(t, err, media.ErrInvalidType)
-}
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "missing type", value: "json"},
+		{name: "invalid parameter", value: "text/plain; charset"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestParseInvalidMediaTypeParameter(t *testing.T) {
-	t.Parallel()
-
-	_, err := media.Parse("text/plain; charset")
-	require.ErrorIs(t, err, media.ErrInvalidType)
+			_, err := media.Parse(tc.value)
+			require.ErrorIs(t, err, media.ErrInvalidType)
+		})
+	}
 }
 
 func TestParseNormalizesMediaTypeCase(t *testing.T) {

--- a/transport/access_test.go
+++ b/transport/access_test.go
@@ -4,18 +4,24 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewAccessControllerWithoutAccessConfig(t *testing.T) {
-	controller, err := transport.NewAccessController(nil, test.FS)
-	require.NoError(t, err)
-	require.Nil(t, controller)
-}
-
-func TestNewAccessControllerWithAccessConfig(t *testing.T) {
-	controller, err := transport.NewAccessController(test.NewAccessConfig(), test.FS)
-	require.NoError(t, err)
-	require.NotNil(t, controller)
+func TestNewAccessController(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		config         *access.Config
+		wantController bool
+	}{
+		{name: "without access config"},
+		{name: "with access config", config: test.NewAccessConfig(), wantController: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			controller, err := transport.NewAccessController(tc.config, test.FS)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantController, controller != nil)
+		})
+	}
 }

--- a/transport/retry/config_test.go
+++ b/transport/retry/config_test.go
@@ -31,59 +31,64 @@ func TestConfigRejectsAttemptsAboveMax(t *testing.T) {
 	require.Error(t, test.Validator.Struct(&retry.Config{Attempts: retry.MaxAttempts + 1}))
 }
 
-func TestConfigGetTimeout(t *testing.T) {
+func TestConfigGetDurations(t *testing.T) {
 	tests := []struct {
-		cfg  *retry.Config
-		name string
-		want time.Duration
+		cfg            *retry.Config
+		name           string
+		wantTimeout    time.Duration
+		wantBackoff    time.Duration
+		wantMaxBackoff time.Duration
 	}{
-		{name: "nil", want: time.DefaultTimeout},
-		{name: "zero", cfg: &retry.Config{}, want: time.DefaultTimeout},
-		{name: "negative", cfg: &retry.Config{Timeout: -time.Second}, want: time.DefaultTimeout},
-		{name: "explicit", cfg: &retry.Config{Timeout: time.Second}, want: time.Second},
+		{name: "nil", wantTimeout: time.DefaultTimeout, wantBackoff: retry.DefaultBackoff},
+		{name: "zero", cfg: &retry.Config{}, wantTimeout: time.DefaultTimeout, wantBackoff: retry.DefaultBackoff},
+		{
+			name:        "negative timeout",
+			cfg:         &retry.Config{Timeout: -time.Second},
+			wantTimeout: time.DefaultTimeout,
+			wantBackoff: retry.DefaultBackoff,
+		},
+		{
+			name:           "negative backoff",
+			cfg:            &retry.Config{Backoff: -time.Second},
+			wantTimeout:    time.DefaultTimeout,
+			wantBackoff:    retry.DefaultBackoff,
+			wantMaxBackoff: 0,
+		},
+		{
+			name:           "negative max backoff",
+			cfg:            &retry.Config{MaxBackoff: -time.Second},
+			wantTimeout:    time.DefaultTimeout,
+			wantBackoff:    retry.DefaultBackoff,
+			wantMaxBackoff: 0,
+		},
+		{
+			name:           "explicit timeout",
+			cfg:            &retry.Config{Timeout: time.Second},
+			wantTimeout:    time.Second,
+			wantBackoff:    retry.DefaultBackoff,
+			wantMaxBackoff: 0,
+		},
+		{
+			name:           "explicit backoff",
+			cfg:            &retry.Config{Backoff: time.Second},
+			wantTimeout:    time.DefaultTimeout,
+			wantBackoff:    time.Second,
+			wantMaxBackoff: 0,
+		},
+		{
+			name:           "explicit max backoff",
+			cfg:            &retry.Config{MaxBackoff: time.Second},
+			wantTimeout:    time.DefaultTimeout,
+			wantBackoff:    retry.DefaultBackoff,
+			wantMaxBackoff: time.Second,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.cfg.GetTimeout())
-		})
-	}
-}
-
-func TestConfigGetBackoff(t *testing.T) {
-	tests := []struct {
-		cfg  *retry.Config
-		name string
-		want time.Duration
-	}{
-		{name: "nil", want: retry.DefaultBackoff},
-		{name: "zero", cfg: &retry.Config{}, want: retry.DefaultBackoff},
-		{name: "negative", cfg: &retry.Config{Backoff: -time.Second}, want: retry.DefaultBackoff},
-		{name: "explicit", cfg: &retry.Config{Backoff: time.Second}, want: time.Second},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.cfg.GetBackoff())
-		})
-	}
-}
-
-func TestConfigGetMaxBackoff(t *testing.T) {
-	tests := []struct {
-		cfg  *retry.Config
-		name string
-		want time.Duration
-	}{
-		{name: "nil", want: 0},
-		{name: "zero", cfg: &retry.Config{}, want: 0},
-		{name: "negative", cfg: &retry.Config{MaxBackoff: -time.Second}, want: 0},
-		{name: "explicit", cfg: &retry.Config{MaxBackoff: time.Second}, want: time.Second},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.cfg.GetMaxBackoff())
+			require.Equal(t, tt.wantTimeout, tt.cfg.GetTimeout())
+			require.Equal(t, tt.wantBackoff, tt.cfg.GetBackoff())
+			require.Equal(t, tt.wantMaxBackoff, tt.cfg.GetMaxBackoff())
 		})
 	}
 }
@@ -114,55 +119,25 @@ func TestConfigGetStrategy(t *testing.T) {
 	}
 }
 
-func TestConfigMaxAttempts(t *testing.T) {
+func TestConfigAttempts(t *testing.T) {
 	tests := []struct {
-		name      string
-		attempts  uint64
-		nilConfig bool
-		want      uint64
+		cfg          *retry.Config
+		name         string
+		wantAttempts uint64
+		wantRetries  uint64
 	}{
-		{name: "nil", nilConfig: true, want: 0},
-		{name: "zero", want: 0},
-		{name: "one", attempts: 1, want: 1},
-		{name: "three", attempts: 3, want: 3},
-		{name: "above max", attempts: retry.MaxAttempts + 1, want: retry.MaxAttempts},
+		{name: "nil"},
+		{name: "zero", cfg: &retry.Config{}},
+		{name: "one", cfg: &retry.Config{Attempts: 1}, wantAttempts: 1},
+		{name: "two", cfg: &retry.Config{Attempts: 2}, wantAttempts: 2, wantRetries: 1},
+		{name: "three", cfg: &retry.Config{Attempts: 3}, wantAttempts: 3, wantRetries: 2},
+		{name: "above max", cfg: &retry.Config{Attempts: retry.MaxAttempts + 1}, wantAttempts: retry.MaxAttempts, wantRetries: retry.MaxAttempts - 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var cfg *retry.Config
-			if !tt.nilConfig {
-				cfg = &retry.Config{Attempts: tt.attempts}
-			}
-
-			require.Equal(t, tt.want, cfg.MaxAttempts())
-		})
-	}
-}
-
-func TestConfigMaxRetries(t *testing.T) {
-	tests := []struct {
-		name      string
-		attempts  uint64
-		nilConfig bool
-		want      uint64
-	}{
-		{name: "nil", nilConfig: true, want: 0},
-		{name: "zero", want: 0},
-		{name: "one", attempts: 1, want: 0},
-		{name: "two", attempts: 2, want: 1},
-		{name: "three", attempts: 3, want: 2},
-		{name: "above max", attempts: retry.MaxAttempts + 1, want: retry.MaxAttempts - 1},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cfg *retry.Config
-			if !tt.nilConfig {
-				cfg = &retry.Config{Attempts: tt.attempts}
-			}
-
-			require.Equal(t, tt.want, cfg.MaxRetries())
+			require.Equal(t, tt.wantAttempts, tt.cfg.MaxAttempts())
+			require.Equal(t, tt.wantRetries, tt.cfg.MaxRetries())
 		})
 	}
 }


### PR DESCRIPTION
## What

- Consolidate related Go test cases across cache, compression, configuration, crypto, transport, and utility packages while preserving their existing behavioral coverage.
- Extend grouped TLS and retry cases so optional TLS material and derived retry values remain explicitly covered.

## Why

- Reduce duplicated test setup and make related edge-case expectations easier to maintain without changing library behavior or public contracts.

## Testing

- `make specs package=<each changed package>` - passed for all 14 changed packages with race detection and atomic coverage.
- `make lint` - passed.
- `git diff --check` - passed.
- `make generate-stale` - inspected; its dirty-tree diff check reported the intended test edits, while no `internal/test` generated paths changed.
- Full specs, security checks, fuzzes, benchmarks, and coverage remain CI coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
