### PR TITLE
feat(http): preserve request limits for response streams

### DIFF
--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -172,10 +172,10 @@ func StreamRouteRequest[Req any, Res any](pattern string, handler stream.Request
 // Registration:
 // The resulting handler is registered on the package-level router configured via Register, and the
 // route is marked streaming on the router's route policy (see
-// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
-// limiting is applied lazily instead of buffering the whole body.
+// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]). Its request body retains
+// the usual cumulative request-body limit because it is not streamed.
 // Register must be called before StreamRoute; otherwise router/streamContent will be nil and this function will
 // panic.
 func StreamRoute[Res any](pattern string, handler stream.Handler[Res]) {
-	router.HandleStreaming(pattern, stream.NewHandler(streamContent, opts, handler))
+	router.HandleResponseStreaming(pattern, stream.NewHandler(streamContent, opts, handler))
 }

--- a/net/http/rest/server_test.go
+++ b/net/http/rest/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/rest"
 	"github.com/alexfalkowski/go-service/v2/strings"
+	"github.com/alexfalkowski/go-service/v2/transport/http/body"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,11 +59,35 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
 	require.True(t, policy.IsStreaming(req))
+	require.False(t, policy.IsRequestStreaming(req))
 
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))
 	require.Equal(t, "Hello Alice", decodeGreeting(t, scanner))
 	require.False(t, scanner.Scan())
+}
+
+func TestStreamRouteLimitsRequestBody(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	router := http.NewRouter(mux, policy)
+	rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
+
+	called := false
+	rest.StreamRoute("POST /hello", func(context.Context, *stream.Stream[test.Response]) error {
+		called = true
+		return nil
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", &test.UnknownLengthReader{Reader: strings.NewReader(strings.Repeat("a", 100))})
+	require.NoError(t, err)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	body.NewHandler(policy, 64).ServeHTTP(res, req, mux.ServeHTTP)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+	require.False(t, called)
 }
 
 func TestStreamPostRejectsHTTP1(t *testing.T) {
@@ -131,6 +156,7 @@ func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, res.Code)
 			require.True(t, policy.IsStreaming(req))
+			require.True(t, policy.IsRequestStreaming(req))
 
 			scanner := bufio.NewScanner(res.Body)
 			require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))

--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -7,7 +7,7 @@ func NewRoutePolicy() *RoutePolicy {
 	return &RoutePolicy{
 		operations:      map[string]struct{}{},
 		unauthenticated: map[string]struct{}{},
-		streaming:       map[string]struct{}{},
+		streams:         map[string]streamPolicy{},
 	}
 }
 
@@ -19,7 +19,12 @@ func NewRoutePolicy() *RoutePolicy {
 type RoutePolicy struct {
 	operations      map[string]struct{}
 	unauthenticated map[string]struct{}
-	streaming       map[string]struct{}
+	streams         map[string]streamPolicy
+}
+
+type streamPolicy struct {
+	request  bool
+	response bool
 }
 
 // Operation marks pattern as a service-owned operation path.
@@ -37,7 +42,11 @@ func (r *RoutePolicy) AllowUnauthenticated(pattern string) {
 // Streaming marks pattern as a route whose request body, response body, or both are streamed
 // incrementally rather than buffered whole.
 func (r *RoutePolicy) Streaming(pattern string) {
-	r.streaming[pattern] = struct{}{}
+	r.streams[pattern] = streamPolicy{request: true, response: true}
+}
+
+func (r *RoutePolicy) responseStreaming(pattern string) {
+	r.streams[pattern] = streamPolicy{response: true}
 }
 
 // IsOperation reports whether req targets a registered operation path.
@@ -64,17 +73,25 @@ func (r *RoutePolicy) IsUnauthenticated(req *Request) bool {
 // IsStreaming reports whether req targets a route whose request body, response body, or both are
 // streamed incrementally rather than buffered whole.
 func (r *RoutePolicy) IsStreaming(req *Request) bool {
+	policy := r.stream(req)
+	return policy.request || policy.response
+}
+
+// IsRequestStreaming reports whether req targets a route whose request body is streamed incrementally rather than buffered whole.
+func (r *RoutePolicy) IsRequestStreaming(req *Request) bool {
+	return r.stream(req).request
+}
+
+func (r *RoutePolicy) stream(req *Request) streamPolicy {
 	if !strings.IsEmpty(req.Pattern) {
-		_, ok := r.streaming[req.Pattern]
-		return ok
+		return r.streams[req.Pattern]
 	}
 
-	if _, ok := r.streaming[routeRequestPattern(req)]; ok {
-		return true
+	if policy, ok := r.streams[routeRequestPattern(req)]; ok {
+		return policy
 	}
 
-	_, ok := r.streaming[req.URL.Path]
-	return ok
+	return r.streams[req.URL.Path]
 }
 
 // NewRouter constructs a Router backed by mux and routePolicy.
@@ -114,6 +131,12 @@ func (r *Router) HandleUnauthenticated(pattern string, handler Handler) {
 // or both are streamed incrementally rather than buffered whole.
 func (r *Router) HandleStreaming(pattern string, handler Handler) {
 	r.routePolicy.Streaming(pattern)
+	r.Handle(pattern, handler)
+}
+
+// HandleResponseStreaming registers handler and marks pattern as a route whose response body is streamed incrementally.
+func (r *Router) HandleResponseStreaming(pattern string, handler Handler) {
+	r.routePolicy.responseStreaming(pattern)
 	r.Handle(pattern, handler)
 }
 

--- a/net/http/routes_test.go
+++ b/net/http/routes_test.go
@@ -56,6 +56,18 @@ func TestRoutePolicyClassifiesStreamingRequests(t *testing.T) {
 	}, policy.IsStreaming)
 }
 
+func TestRoutePolicyClassifiesRequestStreamingRequests(t *testing.T) {
+	policy := http.NewRoutePolicy()
+	policy.Streaming("POST /stream")
+
+	runRouteMatchCases(t, []routeMatchCase{
+		{name: "registered request streaming route", method: http.MethodPost, path: "/stream", match: true},
+		{name: "wrong method", method: http.MethodGet, path: "/stream", match: false},
+		{name: "application streaming path", method: http.MethodPost, path: "/admin/stream", match: false},
+		{name: "nested streaming path", method: http.MethodPost, path: "/stream/foo", match: false},
+	}, policy.IsRequestStreaming)
+}
+
 func TestRouterRegistersHandlerAndPolicy(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
@@ -91,6 +103,7 @@ func TestRouterRegistersHandlerAndStreamingPolicy(t *testing.T) {
 
 	require.Equal(t, "POST /stream/{id}", req.Pattern)
 	require.True(t, policy.IsStreaming(req))
+	require.True(t, policy.IsRequestStreaming(req))
 	require.Equal(t, http.StatusOK, res.Code)
 }
 

--- a/transport/http/body/body.go
+++ b/transport/http/body/body.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/body"
 )
 
-// NewHandler constructs request body size limiting middleware that never buffers routes marked streaming in routePolicy,
+// NewHandler constructs request body size limiting middleware that never buffers request-streaming routes in routePolicy,
 // and buffers every other route.
 //
 // The limit is expressed in bytes and is passed to the underlying
@@ -20,7 +20,7 @@ func NewHandler(routePolicy *http.RoutePolicy, limit int64) *Handler {
 // Handler limits request bodies before downstream handlers decode them.
 //
 // Accepted non-empty bodies are buffered and replaced with a fresh readable body for downstream
-// handlers, unless routePolicy marks the request's route as streaming, in which case the body is
+// handlers, unless routePolicy marks the request's route as request streaming, in which case the body is
 // never buffered and no cumulative limit is enforced as it is read (see
 // [github.com/alexfalkowski/go-service/v2/net/http/body.NewLazyHandler]). Empty bodies are passed
 // through unchanged.
@@ -36,14 +36,14 @@ type Handler struct {
 // cannot be read, ServeHTTP writes a bad-request response and does not call
 // next. Otherwise, it delegates to next with a readable request body.
 //
-// When routePolicy marks req's route as streaming, ServeHTTP never buffers the body (see
+// When routePolicy marks req's route as request streaming, ServeHTTP never buffers the body (see
 // [github.com/alexfalkowski/go-service/v2/net/http/body.NewLazyHandler]): it still rejects a request
 // whose declared Content-Length exceeds the limit before next runs, but otherwise delegates to next
 // without enforcing any cumulative limit as next reads the body. A streaming route's per-value cap, if
 // any, is applied by next itself (see
 // [github.com/alexfalkowski/go-service/v2/net/http/content/stream.RequestStream.Recv]), not by ServeHTTP.
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	if h.routePolicy != nil && h.routePolicy.IsStreaming(req) {
+	if h.routePolicy != nil && h.routePolicy.IsRequestStreaming(req) {
 		body.NewLazyHandler(next, h.limit).ServeHTTP(res, req)
 		return
 	}

--- a/transport/http/body/body_test.go
+++ b/transport/http/body/body_test.go
@@ -44,7 +44,7 @@ func TestHandlerBuffersNonStreamingRoutes(t *testing.T) {
 	})
 }
 
-func TestHandlerDoesNotLimitStreamingRoutesMidStream(t *testing.T) {
+func TestHandlerDoesNotLimitRequestStreamingRoutesMidStream(t *testing.T) {
 	routePolicy := http.NewRoutePolicy()
 	routePolicy.Streaming("POST /stream")
 	handler := body.NewHandler(routePolicy, 64)

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -102,10 +102,10 @@ type ServerParams struct {
 //   - optional token verification ([github.com/alexfalkowski/go-service/v2/transport/http/token]) when `params.Verifier` is non-nil
 //   - optional rate limiting ([github.com/alexfalkowski/go-service/v2/transport/http/limiter]) when `params.Limiter` is non-nil
 //   - optional access control ([github.com/alexfalkowski/go-service/v2/transport/http/token]) when `params.Access` is non-nil
-//   - inbound request body size limiting ([github.com/alexfalkowski/go-service/v2/transport/http/body]); routes
-//     registered as streaming (see `params.RoutePolicy`) are never buffered by this middleware, and
-//     bidirectional streaming routes cap each decoded request value independently at the content layer
-//     instead (see [github.com/alexfalkowski/go-service/v2/net/http/content/stream.RequestStream.Recv])
+//   - inbound request body size limiting ([github.com/alexfalkowski/go-service/v2/transport/http/body]);
+//     bidirectional streaming routes (see `params.RoutePolicy`) are never buffered by this middleware and
+//     cap each decoded request value independently at the content layer instead (see
+//     [github.com/alexfalkowski/go-service/v2/net/http/content/stream.RequestStream.Recv])
 //   - optional user-provided handlers (`params.Handlers`, in the order supplied)
 //   - gzip compression wrapping the final mux handler, including not-found fallbacks
 //     ([github.com/alexfalkowski/go-service/v2/net/http/compress.GzipHandler] with [http.NewNotFoundHandler])
@@ -113,9 +113,10 @@ type ServerParams struct {
 // Route policy from `params.RoutePolicy` controls middleware bypasses. Registered operation routes
 // (health/metrics/etc.) bypass logging, token verification, rate limiting, and access control.
 // Registered unauthenticated routes bypass token verification and access control only. Registered
-// streaming routes are never buffered by the inbound body middleware (see
+// bidirectional streaming routes are never buffered by the inbound body middleware (see
 // [github.com/alexfalkowski/go-service/v2/transport/http/body.NewHandler]); they keep the
-// declared-Content-Length short-circuit but no cumulative mid-stream limit.
+// declared-Content-Length short-circuit but no cumulative mid-stream limit. Response-only streaming
+// routes retain the normal cumulative request-body limit.
 //
 // TLS:
 //


### PR DESCRIPTION
## What

- Distinguish request and response streaming routes so send-only streams retain the normal cumulative inbound request-body limit.
- Clarify REST and transport documentation that only bidirectional request streams use lazy, per-value body limiting.

## Why

- Prevent response-only streaming endpoints from bypassing the configured `max_receive_size`, restoring the documented request-limit behavior.

## Testing

- `make package=net/http specs` - passed
- `make package=net/http/rest specs` - passed
- `make package=transport/http specs` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
