### PR TITLE
feat(http): centralize route registration policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,15 +389,15 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   `WriteHeader` panics from manually constructed bogus codes unless a concrete
   public API path accepts untrusted status codes or starts promising validation.
 - HTTP operation route patterns registered through
-  `net/http.Router.HandleOperation`/`HandleOperationFunc` and
-  `net/http.RoutePolicy.Operation` are expected to include an HTTP method
-  prefix, such as `"GET /<name>/metrics"`, matching the supported callers in
-  `transport/http/health` and `transport/http/telemetry/metrics`.
-  `RoutePolicy.Operation` stores only the path portion, so a bare method-less
+  `net/http.Router.HandleRoute` with `net/http.WithRouteOperation` are expected
+  to include an HTTP method prefix, such as `"GET /<name>/metrics"`, matching
+  the supported callers in `transport/http/health` and
+  `transport/http/telemetry/metrics`. `HandleRoute` stores only the path portion
+  for operations, so a bare method-less
   pattern registers under the empty key and never matches; operation matching is
   intentionally path-only so method mismatches still reach the mux for normal
   method handling. Do not flag method-less operation patterns failing to match,
-  or the `Operation`-versus-`AllowUnauthenticated` handling asymmetry, as a bug;
+  or the `WithRouteOperation`-versus-`WithRouteUnauthenticated` handling asymmetry, as a bug;
   method-prefixing is the supported registration form. Report only concrete bugs
   where a method-prefixed operation pattern fails to match or the supported
   callers stop prefixing.

--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,30 @@ handler gets a `*stream.RequestStream[Req, Res]` with both `Send` and `Recv`. Cl
 matching `client.Stream`/`client.RequestStream` functions, which take the same kind of callback.
 See `net/http/client`'s `ExampleClient_RequestStream` for a complete HTTP/2 bidirectional client call.
 
+### HTTP route policy
+
+Register a raw HTTP handler with `http.Router.HandleRoute` and compose its policy in the same call:
+
+```go
+router.HandleRoute(
+	"GET /feed",
+	handler,
+	http.WithRouteOperation(),
+	http.WithRouteUnauthenticated(),
+)
+```
+
+REST and RPC route helpers accept HTTP route options. Streaming helpers add their inherent stream direction,
+and supplied streaming options are additive. MVC accepts only `mvc.WithRouteUnauthenticated` for its view routes.
+MVC static helpers keep their `StaticOption` signature; use
+`mvc.WithStaticUnauthenticated()` to opt a static route out of authentication.
+
+> [!IMPORTANT]
+> Route policy registration now happens only through `HandleRoute`. This intentionally removes the previous
+> `Router.Handle*` and mutating `RoutePolicy` registration APIs from v2. Migrate `Router.Handle` to `HandleRoute`
+> without options, and migrate specialized registration to `HandleRoute` with the corresponding `WithRoute*` option.
+> Replace `IsStreaming` checks with the separate `IsRequestStreaming` and `IsResponseStreaming` checks.
+
 > [!IMPORTANT]
 > Single-value helpers live in `github.com/alexfalkowski/go-service/v2/net/http/content/unary`; streaming helpers
 > live in `github.com/alexfalkowski/go-service/v2/net/http/content/stream`. Import `unary` for `Content`, `Media`,

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -314,8 +314,7 @@ func startDrainingApplication(t *testing.T) (context.CancelFunc, <-chan int) {
 	started := make(chan struct{})
 	opts := []di.Option{
 		module.Server,
-		di.Register(func(policy *http.RoutePolicy) {
-			policy.AllowUnauthenticated("GET /drain")
+		di.Register(func() {
 			rest.StreamGet("/drain", func(ctx context.Context, stream *stream.Stream[test.Response]) error {
 				if err := stream.Send(&test.Response{Greeting: "Hello Bob"}); err != nil {
 					return err
@@ -324,7 +323,7 @@ func startDrainingApplication(t *testing.T) (context.CancelFunc, <-chan int) {
 				<-ctx.Done()
 
 				return ctx.Err()
-			})
+			}, http.WithRouteUnauthenticated())
 		}),
 		di.Register(func(lc di.Lifecycle) {
 			lc.Append(di.Hook{

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -209,7 +209,7 @@ func (w *World) Start() *World {
 
 // HandleHello registers a simple HTTP hello endpoint on the world's mux.
 func (w *World) HandleHello() {
-	w.Handle("GET /hello", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.HandleRoute("GET /hello", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(strings.Bytes("hello!"))
 	}))
 }

--- a/net/http/handler_test.go
+++ b/net/http/handler_test.go
@@ -61,7 +61,7 @@ func testNotFoundHandler(t *testing.T, tt notFoundHandlerTest) {
 	mux := http.NewServeMux()
 	if tt.registerRoute {
 		router := http.NewRouter(mux, http.NewRoutePolicy())
-		router.Handle("GET /hello", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		router.HandleRoute("GET /hello", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 			res.WriteHeader(http.StatusOK)
 		}))
 	}

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptrace"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	"github.com/alexfalkowski/go-service/v2/config/options"
+	config "github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -306,9 +306,9 @@ func ParseTime(value string) (time.Time, error) {
 //
 // Protocols are configured via Protocols().
 //
-// Note: [options.NonNegativeDuration] uses MustParseDuration under the hood; invalid or negative option
+// Note: [opts.NonNegativeDuration] uses MustParseDuration under the hood; invalid or negative option
 // values will panic at server construction time.
-func NewServer(options options.Map, timeout time.Duration, handler Handler) *Server {
+func NewServer(options config.Map, timeout time.Duration, handler Handler) *Server {
 	return &http.Server{
 		Handler:           handler,
 		ReadTimeout:       options.NonNegativeDuration("read_timeout", timeout).Duration(),

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -163,7 +163,7 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
-	router.Handle("GET /users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	router.HandleRoute("GET /users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), mux)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)

--- a/net/http/mvc/options.go
+++ b/net/http/mvc/options.go
@@ -1,10 +1,27 @@
 package mvc
 
+import "github.com/alexfalkowski/go-service/v2/net/http"
+
+// RouteOption configures MVC route registration.
+type RouteOption func(*routeOptions)
+
+type routeOptions struct {
+	unauthenticated bool
+}
+
 // StaticOption configures static file response behavior.
 type StaticOption func(*staticOptions)
 
 type staticOptions struct {
 	cacheControl string
+	routeOptions
+}
+
+// WithRouteUnauthenticated marks an MVC route as not requiring transport token authentication.
+func WithRouteUnauthenticated() RouteOption {
+	return func(options *routeOptions) {
+		options.unauthenticated = true
+	}
 }
 
 // WithCacheControl sets the Cache-Control response header for a static route.
@@ -12,6 +29,21 @@ func WithCacheControl(value string) StaticOption {
 	return func(options *staticOptions) {
 		options.cacheControl = value
 	}
+}
+
+// WithStaticUnauthenticated marks a static route as not requiring transport token authentication.
+func WithStaticUnauthenticated() StaticOption {
+	return func(options *staticOptions) {
+		options.unauthenticated = true
+	}
+}
+
+func (options *routeOptions) httpOptions() []http.RouteOption {
+	if options.unauthenticated {
+		return []http.RouteOption{http.WithRouteUnauthenticated()}
+	}
+
+	return nil
 }
 
 func options(opts ...StaticOption) *staticOptions {

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -28,33 +28,34 @@ func NotFound[Model any](controller NotFoundController[Model]) bool {
 }
 
 // Delete registers an HTTP DELETE route that invokes controller.
-func Delete[Model any](pattern string, controller Controller[Model]) bool {
-	return Route(strings.Join(strings.Space, http.MethodDelete, pattern), controller)
+func Delete[Model any](pattern string, controller Controller[Model], options ...RouteOption) bool {
+	return Route(strings.Join(strings.Space, http.MethodDelete, pattern), controller, options...)
 }
 
 // Get registers an HTTP GET route that invokes controller.
-func Get[Model any](pattern string, controller Controller[Model]) bool {
-	return Route(strings.Join(strings.Space, http.MethodGet, pattern), controller)
+func Get[Model any](pattern string, controller Controller[Model], options ...RouteOption) bool {
+	return Route(strings.Join(strings.Space, http.MethodGet, pattern), controller, options...)
 }
 
 // Post registers an HTTP POST route that invokes controller.
-func Post[Model any](pattern string, controller Controller[Model]) bool {
-	return Route(strings.Join(strings.Space, http.MethodPost, pattern), controller)
+func Post[Model any](pattern string, controller Controller[Model], options ...RouteOption) bool {
+	return Route(strings.Join(strings.Space, http.MethodPost, pattern), controller, options...)
 }
 
 // Put registers an HTTP PUT route that invokes controller.
-func Put[Model any](pattern string, controller Controller[Model]) bool {
-	return Route(strings.Join(strings.Space, http.MethodPut, pattern), controller)
+func Put[Model any](pattern string, controller Controller[Model], options ...RouteOption) bool {
+	return Route(strings.Join(strings.Space, http.MethodPut, pattern), controller, options...)
 }
 
 // Patch registers an HTTP PATCH route that invokes controller.
-func Patch[Model any](pattern string, controller Controller[Model]) bool {
-	return Route(strings.Join(strings.Space, http.MethodPatch, pattern), controller)
+func Patch[Model any](pattern string, controller Controller[Model], options ...RouteOption) bool {
+	return Route(strings.Join(strings.Space, http.MethodPatch, pattern), controller, options...)
 }
 
 // Route registers a handler for pattern that invokes controller and renders the returned view.
 //
 // It returns false when MVC is not defined (see IsDefined).
+// Options apply MVC route registration policy.
 //
 // The handler sets the response Content-Type to HTML and stores the request and response writer in the
 // request context (via net/http/meta) before invoking the controller.
@@ -67,9 +68,14 @@ func Patch[Model any](pattern string, controller Controller[Model]) bool {
 // Controller errors and rendering failures are recorded as request-scoped operator diagnostics via
 // [github.com/alexfalkowski/go-service/v2/net/http/status.RecordError], surfaced through the HTTP access log.
 // When more than one error occurs, the first error is retained.
-func Route[Model any](pattern string, controller Controller[Model]) bool {
+func Route[Model any](pattern string, controller Controller[Model], options ...RouteOption) bool {
 	if !IsDefined() {
 		return false
+	}
+
+	routeOptions := &routeOptions{}
+	for _, option := range options {
+		option(routeOptions)
 	}
 
 	handler := func(res http.ResponseWriter, req *http.Request) {
@@ -94,7 +100,7 @@ func Route[Model any](pattern string, controller Controller[Model]) bool {
 		writeView(ctx, res, view, model, http.StatusOK)
 	}
 
-	router.Handle(pattern, http.HandlerFunc(handler))
+	router.HandleRoute(pattern, http.HandlerFunc(handler), routeOptions.httpOptions()...)
 	return true
 }
 

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -692,6 +692,48 @@ func TestStaticFileSetsContentLength(t *testing.T) {
 	test.RequireResponseBody(t, res, "hello")
 }
 
+func TestGetAppliesRouteOptions(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	mvc.Register(mvc.RegisterParams{
+		Router:      http.NewRouter(mux, policy),
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  test.FileSystem,
+		Pool:        test.Pool,
+		Layout:      test.Layout,
+	})
+
+	require.True(t, mvc.Get("/hello", func(_ context.Context) (*mvc.View, *test.Page, error) {
+		return mvc.NewFullView("views/hello.tmpl"), &test.Page{}, nil
+	}, mvc.WithRouteUnauthenticated()))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	require.True(t, policy.IsUnauthenticated(req))
+}
+
+func TestStaticFileAppliesRouteOptions(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	mvc.Register(mvc.RegisterParams{
+		Router:      http.NewRouter(mux, policy),
+		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+		FileSystem:  test.FileSystem,
+		Pool:        test.Pool,
+		Layout:      test.Layout,
+	})
+
+	require.True(t, mvc.StaticFile("/robots.txt", "static/robots.txt", mvc.WithStaticUnauthenticated()))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/robots.txt", http.NoBody)
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	require.True(t, policy.IsUnauthenticated(req))
+}
+
 type requestModel struct {
 	Method string
 	Path   string

--- a/net/http/mvc/static.go
+++ b/net/http/mvc/static.go
@@ -27,7 +27,7 @@ func StaticFile(pattern, name string, opts ...StaticOption) bool {
 		serveFile(req.Context(), res, name, options)
 	}
 
-	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
+	router.HandleRoute(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler), options.httpOptions()...)
 	return true
 }
 
@@ -56,7 +56,7 @@ func StaticPathValue(pattern, value, prefix string, opts ...StaticOption) bool {
 		serveFile(req.Context(), res, name, options)
 	}
 
-	router.Handle(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler))
+	router.HandleRoute(strings.Join(strings.Space, http.MethodGet, pattern), http.HandlerFunc(handler), options.httpOptions()...)
 	return true
 }
 

--- a/net/http/rest/server.go
+++ b/net/http/rest/server.go
@@ -18,40 +18,40 @@ import (
 //	Delete("/health", handler) // registers "DELETE /health"
 //
 // This helper delegates to Route.
-func Delete[Res any](pattern string, handler unary.Handler[Res]) {
-	Route(strings.Join(strings.Space, http.MethodDelete, pattern), handler)
+func Delete[Res any](pattern string, handler unary.Handler[Res], options ...http.RouteOption) {
+	Route(strings.Join(strings.Space, http.MethodDelete, pattern), handler, options...)
 }
 
 // Get registers an HTTP GET handler under pattern.
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to Route.
-func Get[Res any](pattern string, handler unary.Handler[Res]) {
-	Route(strings.Join(strings.Space, http.MethodGet, pattern), handler)
+func Get[Res any](pattern string, handler unary.Handler[Res], options ...http.RouteOption) {
+	Route(strings.Join(strings.Space, http.MethodGet, pattern), handler, options...)
 }
 
 // Post registers an HTTP POST handler under pattern.
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
-func Post[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
-	RouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler)
+func Post[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res], options ...http.RouteOption) {
+	RouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler, options...)
 }
 
 // Put registers an HTTP PUT handler under pattern.
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
-func Put[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
-	RouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler)
+func Put[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res], options ...http.RouteOption) {
+	RouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler, options...)
 }
 
 // Patch registers an HTTP PATCH handler under pattern.
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to RouteRequest.
-func Patch[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
-	RouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler)
+func Patch[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res], options ...http.RouteOption) {
+	RouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler, options...)
 }
 
 // RouteRequest registers a handler under pattern that decodes a request and encodes a response.
@@ -64,9 +64,10 @@ func Patch[Req any, Res any](pattern string, handler unary.RequestHandler[Req, R
 //
 // Registration:
 // The resulting handler is registered on the package-level router configured via [Register].
+// Options are forwarded to the router registration.
 // [Register] must be called before RouteRequest; otherwise router/unaryContent will be nil and this function will panic.
-func RouteRequest[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
-	router.Handle(pattern, unary.NewRequestHandler(unaryContent, handler))
+func RouteRequest[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res], options ...http.RouteOption) {
+	router.HandleRoute(pattern, unary.NewRequestHandler(unaryContent, handler), options...)
 }
 
 // Route registers a handler under pattern that encodes a response.
@@ -78,9 +79,10 @@ func RouteRequest[Req any, Res any](pattern string, handler unary.RequestHandler
 //
 // Registration:
 // The resulting handler is registered on the package-level router configured via Register.
+// Options are forwarded to the router registration.
 // Register must be called before Route; otherwise router/unaryContent will be nil and this function will panic.
-func Route[Res any](pattern string, handler unary.Handler[Res]) {
-	router.Handle(pattern, unary.NewHandler(unaryContent, handler))
+func Route[Res any](pattern string, handler unary.Handler[Res], options ...http.RouteOption) {
+	router.HandleRoute(pattern, unary.NewHandler(unaryContent, handler), options...)
 }
 
 // StreamGet registers an HTTP GET handler under pattern for a send-only streaming response: the
@@ -88,8 +90,8 @@ func Route[Res any](pattern string, handler unary.Handler[Res]) {
 //
 // The effective route pattern passed to the router is method-qualified (see Delete for details).
 // This helper delegates to StreamRoute.
-func StreamGet[Res any](pattern string, handler stream.Handler[Res]) {
-	StreamRoute(strings.Join(strings.Space, http.MethodGet, pattern), handler)
+func StreamGet[Res any](pattern string, handler stream.Handler[Res], options ...http.RouteOption) {
+	StreamRoute(strings.Join(strings.Space, http.MethodGet, pattern), handler, options...)
 }
 
 // StreamPost registers an HTTP POST handler under pattern for a bidirectional stream: both the
@@ -100,8 +102,8 @@ func StreamGet[Res any](pattern string, handler stream.Handler[Res]) {
 //
 // HTTP/2 requirement: see StreamRouteRequest. StreamGet and StreamRoute have no such requirement and
 // stay fully supported on HTTP/1.1.
-func StreamPost[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
-	StreamRouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler)
+func StreamPost[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res], options ...http.RouteOption) {
+	StreamRouteRequest(strings.Join(strings.Space, http.MethodPost, pattern), handler, options...)
 }
 
 // StreamPut registers an HTTP PUT handler under pattern for a bidirectional stream: both the request
@@ -111,8 +113,8 @@ func StreamPost[Req any, Res any](pattern string, handler stream.RequestHandler[
 // This helper delegates to StreamRouteRequest.
 //
 // HTTP/2 requirement: see StreamRouteRequest.
-func StreamPut[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
-	StreamRouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler)
+func StreamPut[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res], options ...http.RouteOption) {
+	StreamRouteRequest(strings.Join(strings.Space, http.MethodPut, pattern), handler, options...)
 }
 
 // StreamPatch registers an HTTP PATCH handler under pattern for a bidirectional stream: both the
@@ -122,8 +124,8 @@ func StreamPut[Req any, Res any](pattern string, handler stream.RequestHandler[R
 // This helper delegates to StreamRouteRequest.
 //
 // HTTP/2 requirement: see StreamRouteRequest.
-func StreamPatch[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
-	StreamRouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler)
+func StreamPatch[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res], options ...http.RouteOption) {
+	StreamRouteRequest(strings.Join(strings.Space, http.MethodPatch, pattern), handler, options...)
 }
 
 // StreamRouteRequest registers a handler under pattern for a bidirectional stream: both the request
@@ -146,16 +148,17 @@ func StreamPatch[Req any, Res any](pattern string, handler stream.RequestHandler
 // Registration:
 // The resulting handler is registered on the package-level router configured via [Register], and the
 // route is marked streaming on the router's route policy (see
-// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
+// [github.com/alexfalkowski/go-service/v2/net/http.WithRouteStreaming]) so inbound request body
 // limiting is applied lazily instead of buffering the whole body.
+// Options are additive to the route's bidirectional streaming policy.
 // [Register] must be called before StreamRouteRequest; otherwise router/streamContent will be nil and this
 // function will panic.
 //
 // Inbound size limiting:
 // opts.MaxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
 // Recv, not the request body as a whole — see [stream.NewRequestHandler].
-func StreamRouteRequest[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
-	router.HandleStreaming(pattern, stream.NewRequestHandler(streamContent, opts, handler))
+func StreamRouteRequest[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res], options ...http.RouteOption) {
+	router.HandleRoute(pattern, stream.NewRequestHandler(streamContent, opts, handler), append(options, http.WithRouteStreaming())...)
 }
 
 // StreamRoute registers a handler under pattern for a send-only streaming response: the response
@@ -172,10 +175,11 @@ func StreamRouteRequest[Req any, Res any](pattern string, handler stream.Request
 // Registration:
 // The resulting handler is registered on the package-level router configured via Register, and the
 // route is marked streaming on the router's route policy (see
-// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]). Its request body retains
+// [github.com/alexfalkowski/go-service/v2/net/http.WithRouteResponseStreaming]). Its request body retains
 // the usual cumulative request-body limit because it is not streamed.
+// Options are additive to the route's response streaming policy.
 // Register must be called before StreamRoute; otherwise router/streamContent will be nil and this function will
 // panic.
-func StreamRoute[Res any](pattern string, handler stream.Handler[Res]) {
-	router.HandleResponseStreaming(pattern, stream.NewHandler(streamContent, opts, handler))
+func StreamRoute[Res any](pattern string, handler stream.Handler[Res], options ...http.RouteOption) {
+	router.HandleRoute(pattern, stream.NewHandler(streamContent, opts, handler), append(options, http.WithRouteResponseStreaming())...)
 }

--- a/net/http/rest/server_test.go
+++ b/net/http/rest/server_test.go
@@ -20,13 +20,14 @@ import (
 
 func TestGetAcceptsUnaryHandler(t *testing.T) {
 	mux := http.NewServeMux()
-	router := http.NewRouter(mux, http.NewRoutePolicy())
+	policy := http.NewRoutePolicy()
+	router := http.NewRouter(mux, policy)
 	rest.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
 
 	var handler unary.Handler[test.Response] = func(context.Context) (*test.Response, error) {
 		return &test.Response{Greeting: "Hello Bob"}, nil
 	}
-	rest.Get("/hello", handler)
+	rest.Get("/hello", handler, http.WithRouteOperation(), http.WithRouteUnauthenticated())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 	res := httptest.NewRecorder()
@@ -34,6 +35,8 @@ func TestGetAcceptsUnaryHandler(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
+	require.True(t, policy.IsOperation(req))
+	require.True(t, policy.IsUnauthenticated(req))
 }
 
 func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
@@ -48,7 +51,7 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 		}
 
 		return stream.Send(&test.Response{Greeting: "Hello Alice"})
-	})
+	}, http.WithRouteOperation(), http.WithRouteUnauthenticated())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(http.AcceptKey, media.NDJSON)
@@ -58,8 +61,10 @@ func TestStreamGetSendsValuesAndMarksRouteStreaming(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
-	require.True(t, policy.IsStreaming(req))
+	require.True(t, policy.IsOperation(req))
+	require.True(t, policy.IsUnauthenticated(req))
 	require.False(t, policy.IsRequestStreaming(req))
+	require.True(t, policy.IsResponseStreaming(req))
 
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))
@@ -77,7 +82,7 @@ func TestStreamRouteLimitsRequestBody(t *testing.T) {
 	rest.StreamRoute("POST /hello", func(context.Context, *stream.Stream[test.Response]) error {
 		called = true
 		return nil
-	})
+	}, http.WithRouteOperation(), http.WithRouteUnauthenticated())
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", &test.UnknownLengthReader{Reader: strings.NewReader(strings.Repeat("a", 100))})
 	require.NoError(t, err)
@@ -88,6 +93,10 @@ func TestStreamRouteLimitsRequestBody(t *testing.T) {
 
 	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
 	require.False(t, called)
+	require.True(t, policy.IsOperation(req))
+	require.True(t, policy.IsUnauthenticated(req))
+	require.False(t, policy.IsRequestStreaming(req))
+	require.True(t, policy.IsResponseStreaming(req))
 }
 
 func TestStreamPostRejectsHTTP1(t *testing.T) {
@@ -114,7 +123,7 @@ func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
 	tests := []struct {
 		name   string
 		method string
-		call   func(string, stream.RequestHandler[test.Request, test.Response])
+		call   func(string, stream.RequestHandler[test.Request, test.Response], ...http.RouteOption)
 	}{
 		{name: "post", method: http.MethodPost, call: rest.StreamPost[test.Request, test.Response]},
 		{name: "put", method: http.MethodPut, call: rest.StreamPut[test.Request, test.Response]},
@@ -155,8 +164,8 @@ func TestStreamPostPutPatchRecvAndSendOverHTTP2(t *testing.T) {
 			mux.ServeHTTP(res, req)
 
 			require.Equal(t, http.StatusOK, res.Code)
-			require.True(t, policy.IsStreaming(req))
 			require.True(t, policy.IsRequestStreaming(req))
+			require.True(t, policy.IsResponseStreaming(req))
 
 			scanner := bufio.NewScanner(res.Body)
 			require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))

--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -2,12 +2,68 @@ package http
 
 import "github.com/alexfalkowski/go-service/v2/strings"
 
+// RouteOption configures an HTTP route.
+type RouteOption func(*routeOptions)
+
+type routeOptions struct {
+	operation         bool
+	unauthenticated   bool
+	requestStreaming  bool
+	responseStreaming bool
+}
+
+// WithRouteOperation marks a route as a service-owned operation path.
+//
+// Operation matching is path-only so method mismatches can reach the mux and receive normal method handling.
+func WithRouteOperation() RouteOption {
+	return func(options *routeOptions) {
+		options.operation = true
+	}
+}
+
+// WithRouteUnauthenticated marks a route as not requiring transport token authentication.
+func WithRouteUnauthenticated() RouteOption {
+	return func(options *routeOptions) {
+		options.unauthenticated = true
+	}
+}
+
+// WithRouteRequestStreaming marks a route whose request body is streamed incrementally rather than buffered whole.
+func WithRouteRequestStreaming() RouteOption {
+	return func(options *routeOptions) {
+		options.requestStreaming = true
+	}
+}
+
+// WithRouteResponseStreaming marks a route whose response body is streamed incrementally rather than buffered whole.
+func WithRouteResponseStreaming() RouteOption {
+	return func(options *routeOptions) {
+		options.responseStreaming = true
+	}
+}
+
+// WithRouteStreaming marks a route whose request and response bodies are streamed incrementally rather than buffered whole.
+func WithRouteStreaming() RouteOption {
+	return func(options *routeOptions) {
+		options.requestStreaming = true
+		options.responseStreaming = true
+	}
+}
+
+func options(opts ...RouteOption) *routeOptions {
+	options := &routeOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
 // NewRoutePolicy constructs an empty route policy registry.
 func NewRoutePolicy() *RoutePolicy {
 	return &RoutePolicy{
-		operations:      map[string]struct{}{},
-		unauthenticated: map[string]struct{}{},
-		streams:         map[string]streamPolicy{},
+		operations: map[string]struct{}{},
+		routes:     map[string]routePolicy{},
 	}
 }
 
@@ -17,36 +73,14 @@ func NewRoutePolicy() *RoutePolicy {
 // inferring intent from path substrings. RoutePolicy is intended to be populated during startup before serving
 // requests.
 type RoutePolicy struct {
-	operations      map[string]struct{}
-	unauthenticated map[string]struct{}
-	streams         map[string]streamPolicy
+	operations map[string]struct{}
+	routes     map[string]routePolicy
 }
 
-type streamPolicy struct {
-	request  bool
-	response bool
-}
-
-// Operation marks pattern as a service-owned operation path.
-//
-// Operation matching is path-only so method mismatches can reach the mux and receive normal method handling.
-func (r *RoutePolicy) Operation(pattern string) {
-	r.operations[routePatternPath(pattern)] = struct{}{}
-}
-
-// AllowUnauthenticated marks pattern as not requiring transport token authentication.
-func (r *RoutePolicy) AllowUnauthenticated(pattern string) {
-	r.unauthenticated[pattern] = struct{}{}
-}
-
-// Streaming marks pattern as a route whose request body, response body, or both are streamed
-// incrementally rather than buffered whole.
-func (r *RoutePolicy) Streaming(pattern string) {
-	r.streams[pattern] = streamPolicy{request: true, response: true}
-}
-
-func (r *RoutePolicy) responseStreaming(pattern string) {
-	r.streams[pattern] = streamPolicy{response: true}
+type routePolicy struct {
+	unauthenticated   bool
+	requestStreaming  bool
+	responseStreaming bool
 }
 
 // IsOperation reports whether req targets a registered operation path.
@@ -58,40 +92,40 @@ func (r *RoutePolicy) IsOperation(req *Request) bool {
 // IsUnauthenticated reports whether req targets a route that does not require transport token authentication.
 func (r *RoutePolicy) IsUnauthenticated(req *Request) bool {
 	if !strings.IsEmpty(req.Pattern) {
-		_, ok := r.unauthenticated[req.Pattern]
-		return ok
+		return r.routes[req.Pattern].unauthenticated
 	}
 
-	if _, ok := r.unauthenticated[routeRequestPattern(req)]; ok {
+	if r.routes[routeRequestPattern(req)].unauthenticated {
 		return true
 	}
 
-	_, ok := r.unauthenticated[req.URL.Path]
-	return ok
-}
-
-// IsStreaming reports whether req targets a route whose request body, response body, or both are
-// streamed incrementally rather than buffered whole.
-func (r *RoutePolicy) IsStreaming(req *Request) bool {
-	policy := r.stream(req)
-	return policy.request || policy.response
+	return r.routes[req.URL.Path].unauthenticated
 }
 
 // IsRequestStreaming reports whether req targets a route whose request body is streamed incrementally rather than buffered whole.
 func (r *RoutePolicy) IsRequestStreaming(req *Request) bool {
-	return r.stream(req).request
+	if !strings.IsEmpty(req.Pattern) {
+		return r.routes[req.Pattern].requestStreaming
+	}
+
+	if r.routes[routeRequestPattern(req)].requestStreaming {
+		return true
+	}
+
+	return r.routes[req.URL.Path].requestStreaming
 }
 
-func (r *RoutePolicy) stream(req *Request) streamPolicy {
+// IsResponseStreaming reports whether req targets a route whose response body is streamed incrementally rather than buffered whole.
+func (r *RoutePolicy) IsResponseStreaming(req *Request) bool {
 	if !strings.IsEmpty(req.Pattern) {
-		return r.streams[req.Pattern]
+		return r.routes[req.Pattern].responseStreaming
 	}
 
-	if policy, ok := r.streams[routeRequestPattern(req)]; ok {
-		return policy
+	if r.routes[routeRequestPattern(req)].responseStreaming {
+		return true
 	}
 
-	return r.streams[req.URL.Path]
+	return r.routes[req.URL.Path].responseStreaming
 }
 
 // NewRouter constructs a Router backed by mux and routePolicy.
@@ -105,39 +139,22 @@ type Router struct {
 	routePolicy *RoutePolicy
 }
 
-// Handle registers handler for pattern on the Router's mux.
-func (r *Router) Handle(pattern string, handler Handler) {
+// HandleRoute applies options to the route policy and registers handler for pattern on the Router's mux.
+func (r *Router) HandleRoute(pattern string, handler Handler, opts ...RouteOption) {
+	options := options(opts...)
+
+	if options.operation {
+		r.routePolicy.operations[routePatternPath(pattern)] = struct{}{}
+	}
+	if options.unauthenticated || options.requestStreaming || options.responseStreaming {
+		r.routePolicy.routes[pattern] = routePolicy{
+			unauthenticated:   options.unauthenticated,
+			requestStreaming:  options.requestStreaming,
+			responseStreaming: options.responseStreaming,
+		}
+	}
+
 	r.mux.Handle(pattern, handler)
-}
-
-// HandleOperation registers handler and marks pattern as a service-owned operation path.
-func (r *Router) HandleOperation(pattern string, handler Handler) {
-	r.routePolicy.Operation(pattern)
-	r.Handle(pattern, handler)
-}
-
-// HandleOperationFunc registers handler and marks pattern as a service-owned operation path.
-func (r *Router) HandleOperationFunc(pattern string, handler HandlerFunc) {
-	r.HandleOperation(pattern, handler)
-}
-
-// HandleUnauthenticated registers handler and marks pattern as not requiring transport token authentication.
-func (r *Router) HandleUnauthenticated(pattern string, handler Handler) {
-	r.routePolicy.AllowUnauthenticated(pattern)
-	r.Handle(pattern, handler)
-}
-
-// HandleStreaming registers handler and marks pattern as a route whose request body, response body,
-// or both are streamed incrementally rather than buffered whole.
-func (r *Router) HandleStreaming(pattern string, handler Handler) {
-	r.routePolicy.Streaming(pattern)
-	r.Handle(pattern, handler)
-}
-
-// HandleResponseStreaming registers handler and marks pattern as a route whose response body is streamed incrementally.
-func (r *Router) HandleResponseStreaming(pattern string, handler Handler) {
-	r.routePolicy.responseStreaming(pattern)
-	r.Handle(pattern, handler)
 }
 
 func routePatternPath(pattern string) string {

--- a/net/http/routes_test.go
+++ b/net/http/routes_test.go
@@ -8,74 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRoutePolicyClassifiesOperationPaths(t *testing.T) {
-	policy := http.NewRoutePolicy()
-	policy.Operation("GET /service/metrics")
-
-	tests := []struct {
-		name  string
-		path  string
-		match bool
-	}{
-		{name: "registered operation path", path: "/service/metrics", match: true},
-		{name: "nested metrics path", path: "/service/admin/metrics", match: false},
-		{name: "application metrics path", path: "/admin/metrics", match: false},
-		{name: "trailing slash", path: "/service/metrics/", match: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, tt.path, http.NoBody)
-
-			require.Equal(t, tt.match, policy.IsOperation(req))
-		})
-	}
-}
-
-func TestRoutePolicyClassifiesUnauthenticatedRequests(t *testing.T) {
-	policy := http.NewRoutePolicy()
-	policy.AllowUnauthenticated("POST /events")
-
-	runRouteMatchCases(t, []routeMatchCase{
-		{name: "registered event receiver", method: http.MethodPost, path: "/events", match: true},
-		{name: "wrong method", method: http.MethodGet, path: "/events", match: false},
-		{name: "application event path", method: http.MethodPost, path: "/admin/events", match: false},
-		{name: "nested event path", method: http.MethodPost, path: "/events/foo", match: false},
-	}, policy.IsUnauthenticated)
-}
-
-func TestRoutePolicyClassifiesStreamingRequests(t *testing.T) {
-	policy := http.NewRoutePolicy()
-	policy.Streaming("POST /stream")
-
-	runRouteMatchCases(t, []routeMatchCase{
-		{name: "registered streaming route", method: http.MethodPost, path: "/stream", match: true},
-		{name: "wrong method", method: http.MethodGet, path: "/stream", match: false},
-		{name: "application streaming path", method: http.MethodPost, path: "/admin/stream", match: false},
-		{name: "nested streaming path", method: http.MethodPost, path: "/stream/foo", match: false},
-	}, policy.IsStreaming)
-}
-
-func TestRoutePolicyClassifiesRequestStreamingRequests(t *testing.T) {
-	policy := http.NewRoutePolicy()
-	policy.Streaming("POST /stream")
-
-	runRouteMatchCases(t, []routeMatchCase{
-		{name: "registered request streaming route", method: http.MethodPost, path: "/stream", match: true},
-		{name: "wrong method", method: http.MethodGet, path: "/stream", match: false},
-		{name: "application streaming path", method: http.MethodPost, path: "/admin/stream", match: false},
-		{name: "nested streaming path", method: http.MethodPost, path: "/stream/foo", match: false},
-	}, policy.IsRequestStreaming)
-}
-
 func TestRouterRegistersHandlerAndPolicy(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
 	router := http.NewRouter(mux, policy)
 
-	router.HandleUnauthenticated("POST /events/{tenant}", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	router.HandleRoute("POST /events/{tenant}", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		res.WriteHeader(http.StatusAccepted)
-	}))
+	}), http.WithRouteUnauthenticated())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/events/acme", http.NoBody)
 	res := httptest.NewRecorder()
@@ -87,41 +27,90 @@ func TestRouterRegistersHandlerAndPolicy(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, res.Code)
 }
 
-func TestRouterRegistersHandlerAndStreamingPolicy(t *testing.T) {
-	mux := http.NewServeMux()
-	policy := http.NewRoutePolicy()
-	router := http.NewRouter(mux, policy)
+func TestRouterAppliesRouteOptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		options           []http.RouteOption
+		operation         bool
+		unauthenticated   bool
+		requestStreaming  bool
+		responseStreaming bool
+	}{
+		{name: "operation", options: []http.RouteOption{http.WithRouteOperation()}, operation: true},
+		{name: "unauthenticated", options: []http.RouteOption{http.WithRouteUnauthenticated()}, unauthenticated: true},
+		{name: "request streaming", options: []http.RouteOption{http.WithRouteRequestStreaming()}, requestStreaming: true},
+		{name: "response streaming", options: []http.RouteOption{http.WithRouteResponseStreaming()}, responseStreaming: true},
+		{name: "streaming", options: []http.RouteOption{http.WithRouteStreaming()}, requestStreaming: true, responseStreaming: true},
+		{name: "combined streaming", options: []http.RouteOption{http.WithRouteRequestStreaming(), http.WithRouteResponseStreaming()}, requestStreaming: true, responseStreaming: true},
+		{
+			name:              "combined policy and streaming",
+			options:           []http.RouteOption{http.WithRouteOperation(), http.WithRouteUnauthenticated(), http.WithRouteResponseStreaming()},
+			operation:         true,
+			unauthenticated:   true,
+			responseStreaming: true,
+		},
+	}
 
-	router.HandleStreaming("POST /stream/{id}", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.WriteHeader(http.StatusOK)
-	}))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/stream/acme", http.NoBody)
-	res := httptest.NewRecorder()
-
-	mux.ServeHTTP(res, req)
-
-	require.Equal(t, "POST /stream/{id}", req.Pattern)
-	require.True(t, policy.IsStreaming(req))
-	require.True(t, policy.IsRequestStreaming(req))
-	require.Equal(t, http.StatusOK, res.Code)
-}
-
-type routeMatchCase struct {
-	name   string
-	method string
-	path   string
-	match  bool
-}
-
-func runRouteMatchCases(t *testing.T, cases []routeMatchCase, check func(*http.Request) bool) {
-	t.Helper()
-
-	for _, tt := range cases {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, http.NoBody)
+			mux := http.NewServeMux()
+			policy := http.NewRoutePolicy()
+			router := http.NewRouter(mux, policy)
+			pattern := "POST /stream/{id}"
+			path := "/stream/acme"
+			if tt.operation {
+				pattern = "POST /stream"
+				path = "/stream"
+			}
 
-			require.Equal(t, tt.match, check(req))
+			router.HandleRoute(pattern, http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+				res.WriteHeader(http.StatusOK)
+			}), tt.options...)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, http.NoBody)
+			res := httptest.NewRecorder()
+			mux.ServeHTTP(res, req)
+
+			require.Equal(t, pattern, req.Pattern)
+			require.Equal(t, tt.operation, policy.IsOperation(req))
+			require.Equal(t, tt.unauthenticated, policy.IsUnauthenticated(req))
+			require.Equal(t, tt.requestStreaming, policy.IsRequestStreaming(req))
+			require.Equal(t, tt.responseStreaming, policy.IsResponseStreaming(req))
+			require.Equal(t, http.StatusOK, res.Code)
+		})
+	}
+}
+
+func TestRoutePolicyFallsBackForEachRouteProperty(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []http.RouteOption
+		check    func(*http.RoutePolicy, *http.Request) bool
+		fallback http.RouteOption
+	}{
+		{
+			name:     "unauthenticated",
+			options:  []http.RouteOption{http.WithRouteResponseStreaming()},
+			check:    (*http.RoutePolicy).IsUnauthenticated,
+			fallback: http.WithRouteUnauthenticated(),
+		},
+		{
+			name:     "response streaming",
+			options:  []http.RouteOption{http.WithRouteUnauthenticated()},
+			check:    (*http.RoutePolicy).IsResponseStreaming,
+			fallback: http.WithRouteResponseStreaming(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := http.NewRoutePolicy()
+			router := http.NewRouter(http.NewServeMux(), policy)
+			router.HandleRoute("POST /events", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), tt.options...)
+			router.HandleRoute("/events", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), tt.fallback)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/events", http.NoBody)
+			require.True(t, tt.check(policy, req))
 		})
 	}
 }

--- a/net/http/rpc/server.go
+++ b/net/http/rpc/server.go
@@ -25,11 +25,13 @@ import (
 //
 // Registration:
 // The resulting handler is registered on the package-level router configured via [Register].
+// Options are forwarded to the router registration.
 // [Register] must be called before Route; otherwise router/unaryContent will be nil and this function will panic.
-func Route[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res]) {
-	router.Handle(
+func Route[Req any, Res any](pattern string, handler unary.RequestHandler[Req, Res], options ...http.RouteOption) {
+	router.HandleRoute(
 		strings.Join(strings.Space, http.MethodPost, pattern),
 		unary.NewRequestHandler(unaryContent, handler),
+		options...,
 	)
 }
 
@@ -61,17 +63,19 @@ func Route[Req any, Res any](pattern string, handler unary.RequestHandler[Req, R
 // Registration:
 // The resulting handler is registered on the package-level router configured via [Register], and the
 // route is marked streaming on the router's route policy (see
-// [github.com/alexfalkowski/go-service/v2/net/http.RoutePolicy.Streaming]) so inbound request body
+// [github.com/alexfalkowski/go-service/v2/net/http.WithRouteStreaming]) so inbound request body
 // limiting is applied lazily instead of buffering the whole body.
+// Options are additive to the route's bidirectional streaming policy.
 // [Register] must be called before StreamRoute; otherwise router/streamContent will be nil and this function
 // will panic.
 //
 // Inbound size limiting:
 // opts.MaxReceiveSize (set via [Register]) bounds each value decoded by the resulting stream's
 // Recv, not the request body as a whole — see [stream.NewRequestHandler].
-func StreamRoute[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res]) {
-	router.HandleStreaming(
+func StreamRoute[Req any, Res any](pattern string, handler stream.RequestHandler[Req, Res], options ...http.RouteOption) {
+	router.HandleRoute(
 		strings.Join(strings.Space, http.MethodPost, pattern),
 		stream.NewRequestHandler(streamContent, opts, handler),
+		append(options, http.WithRouteStreaming())...,
 	)
 }

--- a/net/http/rpc/server_test.go
+++ b/net/http/rpc/server_test.go
@@ -36,6 +36,21 @@ func TestStreamRouteRejectsHTTP1(t *testing.T) {
 	require.Equal(t, http.StatusHTTPVersionNotSupported, res.Code)
 }
 
+func TestRouteAppliesRouteOptions(t *testing.T) {
+	mux := http.NewServeMux()
+	policy := http.NewRoutePolicy()
+	router := http.NewRouter(mux, policy)
+	rpc.Register(router, test.UnaryContent, test.StreamContent, test.Pool, stream.Options{})
+
+	rpc.Route("/hello", test.SuccessSayHello, http.WithRouteOperation(), http.WithRouteUnauthenticated())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	require.True(t, policy.IsOperation(req))
+	require.True(t, policy.IsUnauthenticated(req))
+	require.False(t, policy.IsRequestStreaming(req))
+	require.False(t, policy.IsResponseStreaming(req))
+}
+
 func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
 	mux := http.NewServeMux()
 	policy := http.NewRoutePolicy()
@@ -57,7 +72,7 @@ func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
 				return err
 			}
 		}
-	})
+	}, http.WithRouteOperation(), http.WithRouteUnauthenticated())
 
 	body := "{\"Name\":\"Bob\"}\n{\"Name\":\"Alice\"}\n"
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
@@ -69,7 +84,10 @@ func TestStreamRouteRecvAndSendOverHTTP2(t *testing.T) {
 	mux.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	require.True(t, policy.IsStreaming(req))
+	require.True(t, policy.IsOperation(req))
+	require.True(t, policy.IsUnauthenticated(req))
+	require.True(t, policy.IsRequestStreaming(req))
+	require.True(t, policy.IsResponseStreaming(req))
 
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeGreeting(t, scanner))

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -111,7 +111,7 @@ func TestAccessDeniedUnary(t *testing.T) {
 func TestAuthDoesNotBypassApplicationMetricsPath(t *testing.T) {
 	world := test.NewWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldHTTP())
 
-	world.Handle("GET /admin/metrics", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	world.HandleRoute("GET /admin/metrics", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		_, _ = res.Write([]byte("secret"))
 	}))
 	world.Start()

--- a/transport/http/benchmark_test.go
+++ b/transport/http/benchmark_test.go
@@ -423,7 +423,7 @@ func benchmarkHTTP(b *testing.B, log *logger.Logger, trace, tlsEnabled bool) {
 	b.ReportAllocs()
 
 	address, cleanup := startBenchmarkHTTPServer(b, log, trace, tlsEnabled, func(router *transporthttp.Router, _ *transporthttp.Config) {
-		router.Handle("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		router.HandleRoute("GET /hello", transporthttp.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	})
 	httpClient, scheme, closeIdleConnections := newBenchmarkHTTPClient(b, tlsEnabled)
 	url := fmt.Sprintf("%s://%s/hello", scheme, address)

--- a/transport/http/body/body_test.go
+++ b/transport/http/body/body_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestHandlerBuffersNonStreamingRoutes(t *testing.T) {
 	routePolicy := http.NewRoutePolicy()
-	routePolicy.Streaming("POST /stream")
+	http.NewRouter(http.NewServeMux(), routePolicy).HandleRoute("POST /stream", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), http.WithRouteStreaming())
 	handler := body.NewHandler(routePolicy, 1024)
 
 	t.Run("skips empty body buffering", func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestHandlerBuffersNonStreamingRoutes(t *testing.T) {
 
 func TestHandlerDoesNotLimitRequestStreamingRoutesMidStream(t *testing.T) {
 	routePolicy := http.NewRoutePolicy()
-	routePolicy.Streaming("POST /stream")
+	http.NewRouter(http.NewServeMux(), routePolicy).HandleRoute("POST /stream", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), http.WithRouteStreaming())
 	handler := body.NewHandler(routePolicy, 64)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/stream", &test.UnknownLengthReader{Reader: strings.NewReader(strings.Repeat("a", 100))})
@@ -66,7 +66,7 @@ func TestHandlerDoesNotLimitRequestStreamingRoutesMidStream(t *testing.T) {
 
 func TestHandlerRejectsStreamingRouteContentLengthOverLimit(t *testing.T) {
 	routePolicy := http.NewRoutePolicy()
-	routePolicy.Streaming("POST /stream")
+	http.NewRouter(http.NewServeMux(), routePolicy).HandleRoute("POST /stream", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), http.WithRouteStreaming())
 	handler := body.NewHandler(routePolicy, 64)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/stream", strings.NewReader(strings.Repeat("a", 100)))

--- a/transport/http/events/receiver.go
+++ b/transport/http/events/receiver.go
@@ -58,5 +58,5 @@ func (r *Receiver) Register(ctx context.Context, path string, receiver ReceiverF
 	})
 	handler = hooks.NewHandler(r.hook, handler)
 
-	r.router.HandleUnauthenticated(strings.Join(strings.Space, http.MethodPost, path), handler)
+	r.router.HandleRoute(strings.Join(strings.Space, http.MethodPost, path), handler, http.WithRouteUnauthenticated())
 }

--- a/transport/http/health/health.go
+++ b/transport/http/health/health.go
@@ -56,7 +56,7 @@ func Register(params RegisterParams) {
 }
 
 func resister(pattern string, params RegisterParams) {
-	params.Router.HandleOperationFunc("GET "+http.Pattern(params.Name, pattern), func(res http.ResponseWriter, req *http.Request) {
+	params.Router.HandleRoute("GET "+http.Pattern(params.Name, pattern), http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if pattern == "/readyz" {
 			if err := params.Drain.Error(); err != nil {
 				_ = status.WriteError(req.Context(), res, status.ServiceUnavailableError(err))
@@ -75,5 +75,5 @@ func resister(pattern string, params RegisterParams) {
 		}
 
 		_ = status.WriteText(res, "SERVING")
-	})
+	}), http.WithRouteOperation())
 }

--- a/transport/http/limiter/limiter_test.go
+++ b/transport/http/limiter/limiter_test.go
@@ -80,7 +80,7 @@ func TestHandlerBypassesOperationPathWithNoLimiterOnContext(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, server.Close(t.Context())) })
 
 	routePolicy := http.NewRoutePolicy()
-	routePolicy.Operation("GET /healthz")
+	http.NewRouter(http.NewServeMux(), routePolicy).HandleRoute("GET /healthz", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), http.WithRouteOperation())
 
 	handler := httplimiter.NewHandler(routePolicy, server)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/healthz", http.NoBody)

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -86,7 +86,7 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 0)),
 		test.WithWorldHTTP(),
 	)
-	world.Handle("GET /admin/metrics", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	world.HandleRoute("GET /admin/metrics", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		_, _ = res.Write([]byte("secret"))
 	}))
 	world.Start()

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -62,7 +62,7 @@ func TestServerMaxReceiveSize(t *testing.T) {
 	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
-	world.Handle("POST /hello", unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+	world.HandleRoute("POST /hello", unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, _ *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "hello"}, nil
 	}))
 	world.Start()
@@ -86,7 +86,7 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 	cfg.HTTP.MaxReceiveSize = 64
 
 	world := test.NewWorld(t, test.WithWorldTransportConfig(cfg), test.WithWorldHTTP())
-	world.Handle("POST /hello", unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, _ *test.Request) (*test.Response, error) {
+	world.HandleRoute("POST /hello", unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, _ *test.Request) (*test.Response, error) {
 		return &test.Response{Greeting: "hello"}, nil
 	}))
 	world.Start()
@@ -108,24 +108,24 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 func TestServerRecoversPanic(t *testing.T) {
 	capture := &test.CaptureHandler{}
 	world := test.NewWorld(t, test.WithWorldHTTP(), test.WithWorldLogger(&logger.Logger{Logger: slog.New(capture)}))
-	world.Handle("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	world.HandleRoute("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test panic")
 	}))
-	world.Handle("GET /panic-after-informational", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	world.HandleRoute("GET /panic-after-informational", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		res.WriteHeader(http.StatusEarlyHints)
 		panic("test panic after informational response")
 	}))
-	world.Handle("GET /panic-after-write", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+	world.HandleRoute("GET /panic-after-write", http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		res.WriteHeader(http.StatusOK)
 		_, _ = res.Write([]byte("partial"))
 		res.(interface{ Flush() }).Flush()
 		res.WriteHeader(http.StatusEarlyHints)
 		panic("test panic after commit")
 	}))
-	world.HandleOperationFunc("GET /panic-operation", func(http.ResponseWriter, *http.Request) {
+	world.HandleRoute("GET /panic-operation", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test operation panic")
-	})
-	world.Handle("GET /panic-after-error", http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+	}), http.WithRouteOperation())
+	world.HandleRoute("GET /panic-after-error", http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		_ = status.WriteError(req.Context(), res, status.BadRequestError(test.ErrInvalid))
 		res.(interface{ Flush() }).Flush()
 		panic("test panic after error")

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -70,7 +70,7 @@ func TestHandlerSkipsOperationPath(t *testing.T) {
 	var logs bytes.Buffer
 	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
 	policy := http.NewRoutePolicy()
-	policy.Operation("GET /test/metrics")
+	http.NewRouter(http.NewServeMux(), policy).HandleRoute("GET /test/metrics", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), http.WithRouteOperation())
 	handler := httplogger.NewHandler(policy, &logger.Logger{Logger: slogLogger})
 	res := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test/metrics", http.NoBody)

--- a/transport/http/telemetry/metrics/metrics.go
+++ b/transport/http/telemetry/metrics/metrics.go
@@ -21,6 +21,6 @@ import (
 // The handler is provided by `promhttp.Handler()` and serves the Prometheus text exposition format.
 func Register(name env.Name, cfg *metrics.Config, router *http.Router) {
 	if cfg.IsEnabled() && cfg.IsPrometheus() {
-		router.HandleOperation("GET "+http.Pattern(name, "/metrics"), prometheus.Handler())
+		router.HandleRoute("GET "+http.Pattern(name, "/metrics"), prometheus.Handler(), http.WithRouteOperation())
 	}
 }

--- a/transport/http/token/token_test.go
+++ b/transport/http/token/token_test.go
@@ -93,7 +93,7 @@ func TestAccessHandler(t *testing.T) {
 	for _, tt := range accessHandlerTests {
 		t.Run(tt.name, func(t *testing.T) {
 			policy := http.NewRoutePolicy()
-			policy.Operation("GET /service/healthz")
+			http.NewRouter(http.NewServeMux(), policy).HandleRoute("GET /service/healthz", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), http.WithRouteOperation())
 			handler := token.NewAccessHandler(policy, tt.controller)
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, http.NoBody)
 			require.NoError(t, err)


### PR DESCRIPTION
## What

- Consolidate HTTP route policy registration in `HandleRoute` and route options across raw handlers, REST, RPC, MVC, static assets, streaming helpers, health checks, metrics, and webhook receivers.
- Replace the previous v2 router and mutable route-policy registration APIs with explicit registration-time policy, including independent request and response streaming flags.
- Document the intentional source-incompatible migration path for downstream callers.

## Why

- Keeping policy with handler registration makes route behavior explicit and prevents separately registered policy from drifting from the route it governs.
- The new model lets shared route helpers consistently propagate authentication, operation, and streaming policy.

## Testing

- `make specs package=cli`, `make specs package=net/http`, `make specs package=net/http/meta`, `make specs package=net/http/mvc`, `make specs package=net/http/rest`, `make specs package=net/http/rpc`, `make specs package=transport/http`, `make specs package=transport/http/body`, `make specs package=transport/http/events`, `make specs package=transport/http/health`, `make specs package=transport/http/limiter`, `make specs package=transport/http/telemetry/logger`, `make specs package=transport/http/telemetry/metrics`, and `make specs package=transport/http/token` - passed
- `make lint` - passed
- `make sec` - passed; govulncheck reported no reachable vulnerabilities and Trivy reported no repository vulnerabilities or secrets.
- The supplied implementation was reviewed test-after; no pre-implementation red run was observed.

AI-assisted-by: [Codex](https://openai.com/codex/)
