### PR TITLE
feat(grpc): bound default live streams per connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,7 @@ transport:
 > - Address may use `<network>://<address>` (for example `tcp://:8000`) or a raw listen address such as `:8000`, which defaults to the `tcp` network.
 > - If address is omitted, defaults are `tcp://:8080` (HTTP) and `tcp://:9090` (gRPC).
 > - `transport.grpc.timeout` bounds unary RPC handlers and feeds gRPC server keepalive/connection defaults; it does not cap stream lifetime. Long-lived streams remain open until client cancellation or stream-specific controls apply.
+> - gRPC limits each client connection to 64 concurrent streams by default. Set `transport.grpc.options.max_concurrent_streams` to a positive base-10 integer to override it, or to `"0"` to explicitly retain upstream's unbounded behavior.
 > - `max_receive_size` limits inbound payload size. A zero value uses the default `4MB`.
 > - For HTTP, `max_receive_size` applies per request body, except for bidirectional streaming routes (see [HTTP streaming (NDJSON)](#http-streaming-ndjson)), where it applies per decoded value instead, with no cumulative total. For gRPC, it applies per inbound unary request and per inbound stream message.
 > - MVC does not enforce its own body-size caps; supported HTTP server wiring applies `max_receive_size` before MVC handlers run, and go-service HTTP clients apply their configured response-size cap when reading responses.

--- a/net/grpc/doc.go
+++ b/net/grpc/doc.go
@@ -31,13 +31,15 @@
 //
 // NewServer also supports the following low-level server tuning keys:
 //
-//   - max_concurrent_streams: base-10 unsigned integer string
+//   - max_concurrent_streams: base-10 unsigned integer string; defaults to 64
 //   - max_header_list_size: SI size string such as 16MB
 //   - initial_window_size: SI size string such as 1MB
 //   - initial_conn_window_size: SI size string such as 4MB
 //   - max_send_msg_size: SI size string such as 16MB
 //
-// The timeout argument is also used as the keepalive ping Timeout. Request
+// The `max_concurrent_streams` default bounds live streams per client connection.
+// Set it to `0` to explicitly retain the upstream unbounded behavior. The timeout
+// argument is also used as the keepalive ping Timeout. Request
 // handler timeouts are applied by higher-level transport wiring, not by
 // NewServer itself.
 //

--- a/net/grpc/grpc.go
+++ b/net/grpc/grpc.go
@@ -413,7 +413,7 @@ func WithKeepaliveParams(ping, timeout time.Duration) DialOption {
 //
 // Additional low-level server tuning may be provided through options using:
 //
-//   - max_concurrent_streams
+//   - max_concurrent_streams (defaults to 64; set to 0 for the upstream unbounded behavior)
 //   - max_header_list_size
 //   - initial_window_size
 //   - initial_conn_window_size
@@ -440,9 +440,7 @@ func NewServer(options options.Map, timeout time.Duration, opts ...ServerOption)
 		Timeout:               timeout.Duration(),
 	}))
 	serverOptions = append(serverOptions, grpc.ConnectionTimeout(options.NonNegativeDuration("connection_timeout", timeout).Duration()))
-	if _, ok := options["max_concurrent_streams"]; ok {
-		serverOptions = append(serverOptions, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 0)))
-	}
+	serverOptions = append(serverOptions, grpc.MaxConcurrentStreams(options.Uint32("max_concurrent_streams", 64)))
 
 	if _, ok := options["max_header_list_size"]; ok {
 		serverOptions = append(serverOptions, grpc.MaxHeaderListSize(options.Uint32Size("max_header_list_size", 0)))

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -329,6 +329,69 @@ func TestWatchStaysOpenPastServerTimeout(t *testing.T) {
 	requireWatchStaysOpenUntilCancelAfter(t, cancel, wc, 2*time.Second)
 }
 
+func TestWatchDefaultConcurrentStreamLimit(t *testing.T) {
+	const maximumWatchStreams = 64
+
+	world := newGRPCHealthWorld(t, test.StatusURL("200"))
+	requireGRPCReady(t, world)
+
+	conn := test.RequireGRPCConn(t, world)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := health.NewClient(conn)
+	req := &health.Request{Service: test.Name.String()}
+	cancels := make([]context.CancelFunc, 0, maximumWatchStreams)
+	defer func() {
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}()
+
+	for range maximumWatchStreams {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancels = append(cancels, cancel)
+
+		wc, err := client.Watch(ctx, req)
+		require.NoError(t, err)
+
+		resp, err := wc.Recv()
+		require.NoError(t, err)
+		require.Equal(t, health.Serving, resp.GetStatus())
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		wc, err := client.Watch(ctx, req)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		_, err = wc.Recv()
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.FailNow(t, "watch exceeded the default concurrent stream limit", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	cancels[0]()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch did not proceed after a stream closed")
+	}
+}
+
 func TestWatchServerLimiter(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),


### PR DESCRIPTION
## What

- Limit each gRPC client connection to 64 concurrent streams by default while preserving an explicit `max_concurrent_streams: "0"` opt-out for upstream unbounded behavior.
- Document the default and configuration override in the README and gRPC package documentation.
- Cover stream admission at the default limit and release after a stream closes.

## Why

- Bound per-connection live streams by default to prevent one client connection from consuming unbounded server resources, while retaining an explicit compatibility escape hatch for deployments that need the upstream behavior.

## Testing

- `make package=transport/grpc/health specs` - passed
- `make package=net/grpc specs` - passed
- `make lint` - passed
- `make sec` - passed; govulncheck found no reachable vulnerabilities and Trivy found no repository vulnerabilities or secrets.
- Scoped Go tests cover 64 active health watch streams, block the 65th, and admit it after an existing stream is cancelled; full CI remains responsible for complete-suite coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
