### PR TITLE
test(feature): stabilize timing-sensitive assertions

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/cache"
@@ -135,107 +136,110 @@ func TestGetOrPersistSingleWinner(t *testing.T) {
 }
 
 func TestGetOrPersistReleasesWaiterOnItsOwnCancellation(t *testing.T) {
-	drv := &blockingGetDriver{gets: make(chan string, 16)}
-	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldCacheDriver(drv))
+	synctest.Test(t, func(t *testing.T) {
+		drv := &blockingGetDriver{gets: make(chan string, 16)}
+		cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldCacheDriver(drv))
 
-	leaderStarted := make(chan struct{})
-	release := make(chan struct{})
-	leaderErr := make(chan error, 1)
-	leaderValue := "unchanged"
-	go func() {
-		leaderErr <- world.GetOrPersist(context.Background(), "test", &leaderValue, time.Minute, func() error {
-			close(leaderStarted)
-			<-release
-			leaderValue = "leader"
+		leaderStarted := make(chan struct{})
+		release := make(chan struct{})
+		leaderErr := make(chan error, 1)
+		leaderValue := "unchanged"
+		go func() {
+			leaderErr <- world.GetOrPersist(context.Background(), "test", &leaderValue, time.Minute, func() error {
+				close(leaderStarted)
+				<-release
+				leaderValue = "leader"
 
-			return nil
-		})
-	}()
+				return nil
+			})
+		}()
 
-	<-leaderStarted
-	<-drv.gets // leader's initial Get
-	<-drv.gets // leader's single-flight recheck Get
+		<-leaderStarted
+		<-drv.gets // leader's initial Get
+		<-drv.gets // leader's single-flight recheck Get
 
-	dupCtx, dupCancel := context.WithCancel(context.Background())
-	dupErr := make(chan error, 1)
-	dupValue := "unchanged"
-	go func() {
-		dupErr <- world.GetOrPersist(dupCtx, "test", &dupValue, time.Minute, func() error {
-			dupValue = "duplicate"
+		dupCtx, dupCancel := context.WithCancel(context.Background())
+		dupErr := make(chan error, 1)
+		dupValue := "unchanged"
+		go func() {
+			dupErr <- world.GetOrPersist(dupCtx, "test", &dupValue, time.Minute, func() error {
+				dupValue = "duplicate"
 
-			return nil
-		})
-	}()
+				return nil
+			})
+		}()
 
-	<-drv.gets // duplicate missed and joined the in-flight fill
-	dupCancel()
+		<-drv.gets // duplicate missed and joined the in-flight fill
+		dupCancel()
 
-	select {
-	case err := <-dupErr:
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(5 * time.Second):
-		t.Fatal("duplicate blocked on the shared fill instead of returning on its own cancellation")
-	}
-	require.Equal(t, "unchanged", dupValue)
+		select {
+		case err := <-dupErr:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("duplicate blocked on the shared fill instead of returning on its own cancellation")
+		}
+		require.Equal(t, "unchanged", dupValue)
 
-	close(release)
-	require.NoError(t, <-leaderErr)
-	require.Equal(t, "leader", leaderValue)
+		close(release)
+		require.NoError(t, <-leaderErr)
+		require.Equal(t, "leader", leaderValue)
+	})
 }
 
 func TestGetOrPersistLeaderCancellationFailsWaiters(t *testing.T) {
-	drv := &blockingGetDriver{gets: make(chan string, 16)}
-	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldCacheDriver(drv))
+	synctest.Test(t, func(t *testing.T) {
+		drv := &blockingGetDriver{gets: make(chan string, 16)}
+		cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
+		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldCacheDriver(drv))
 
-	leaderStarted := make(chan struct{})
-	release := make(chan struct{})
-	leaderCtx, leaderCancel := context.WithCancel(context.Background())
-	leaderErr := make(chan error, 1)
-	leaderValue := "unchanged"
-	go func() {
-		leaderErr <- world.GetOrPersist(leaderCtx, "test", &leaderValue, time.Minute, func() error {
-			close(leaderStarted)
-			<-release
-			leaderValue = "leader"
+		leaderStarted := make(chan struct{})
+		release := make(chan struct{})
+		leaderCtx, leaderCancel := context.WithCancel(context.Background())
+		leaderErr := make(chan error, 1)
+		leaderValue := "unchanged"
+		go func() {
+			leaderErr <- world.GetOrPersist(leaderCtx, "test", &leaderValue, time.Minute, func() error {
+				close(leaderStarted)
+				<-release
+				leaderValue = "leader"
 
-			return nil
-		})
-	}()
+				return nil
+			})
+		}()
 
-	<-leaderStarted
-	<-drv.gets
-	<-drv.gets
+		<-leaderStarted
+		<-drv.gets
+		<-drv.gets
 
-	followerCalled := make(chan struct{}, 1)
-	followerErr := make(chan error, 1)
-	followerValue := "unchanged"
-	go func() {
-		followerErr <- world.GetOrPersist(context.Background(), "test", &followerValue, time.Minute, func() error {
-			followerCalled <- struct{}{}
+		followerCalled := make(chan struct{}, 1)
+		followerErr := make(chan error, 1)
+		followerValue := "unchanged"
+		go func() {
+			followerErr <- world.GetOrPersist(context.Background(), "test", &followerValue, time.Minute, func() error {
+				followerCalled <- struct{}{}
 
-			return nil
-		})
-	}()
+				return nil
+			})
+		}()
 
-	<-drv.gets // follower missed and is joining the shared fill
-	// Give the follower time to park on the shared fill before it publishes.
-	time.Sleep(100 * time.Millisecond)
+		<-drv.gets // follower missed and is joining the shared fill
+		synctest.Wait()
 
-	// The shared fill runs under the leader context, so canceling the leader and
-	// then letting the fill publish fails the still-live follower too.
-	leaderCancel()
-	close(release)
+		// The shared fill runs under the leader context, so canceling the leader and
+		// then letting the fill publish fails the still-live follower too.
+		leaderCancel()
+		close(release)
 
-	require.ErrorIs(t, <-followerErr, context.Canceled)
-	require.ErrorIs(t, <-leaderErr, context.Canceled)
+		require.ErrorIs(t, <-followerErr, context.Canceled)
+		require.ErrorIs(t, <-leaderErr, context.Canceled)
 
-	select {
-	case <-followerCalled:
-		t.Fatal("follower ran its own loader instead of sharing the leader's fill")
-	default:
-	}
+		select {
+		case <-followerCalled:
+			t.Fatal("follower ran its own loader instead of sharing the leader's fill")
+		default:
+		}
+	})
 }
 
 func TestGenericGetOrPersistDisabledCache(t *testing.T) {
@@ -591,18 +595,19 @@ func TestGetMissesAfterCacheFormatChange(t *testing.T) {
 }
 
 func TestExpiredCache(t *testing.T) {
-	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
-	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
-	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Nanosecond))
+	synctest.Test(t, func(t *testing.T) {
+		cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
+		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
+		require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Nanosecond))
 
-	// Simulate expiry.
-	time.Sleep(time.Second)
+		time.Sleep(2 * time.Nanosecond)
 
-	_, ok, err := cache.Get[string](t.Context(), "test")
-	require.NoError(t, err)
-	require.False(t, ok)
+		_, ok, err := cache.Get[string](t.Context(), "test")
+		require.NoError(t, err)
+		require.False(t, ok)
 
-	require.NoError(t, world.Remove(t.Context(), "test"))
+		require.NoError(t, world.Remove(t.Context(), "test"))
+	})
 }
 
 func TestErroneousCache(t *testing.T) {

--- a/cache/driver/internal/ttlcache/ttlcache_test.go
+++ b/cache/driver/internal/ttlcache/ttlcache_test.go
@@ -2,13 +2,13 @@ package ttlcache_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/cache"
 	"github.com/alexfalkowski/go-service/v2/cache/config"
 	drivererrors "github.com/alexfalkowski/go-service/v2/cache/driver/errors"
 	cachettl "github.com/alexfalkowski/go-service/v2/cache/driver/internal/ttlcache"
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
@@ -56,16 +56,15 @@ func TestDriverPings(t *testing.T) {
 }
 
 func TestDriverExpiresEntries(t *testing.T) {
-	d := cachettl.NewDriver(config.DefaultMaxEntries)
+	synctest.Test(t, func(t *testing.T) {
+		d := cachettl.NewDriver(config.DefaultMaxEntries)
 
-	require.NoError(t, d.Save(t.Context(), "key", "value", time.Nanosecond))
+		require.NoError(t, d.Save(t.Context(), "key", "value", time.Nanosecond))
+		time.Sleep(2 * time.Nanosecond)
 
-	var missing error
-	require.Eventually(t, func() bool {
-		_, missing = d.Get(t.Context(), "key")
-		return drivererrors.IsMissingError(missing)
-	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
-	require.ErrorIs(t, missing, drivererrors.ErrMissing)
+		_, err := d.Get(t.Context(), "key")
+		require.ErrorIs(t, err, drivererrors.ErrMissing)
+	})
 }
 
 func TestDriverEvictsEntryAtCapacity(t *testing.T) {
@@ -91,17 +90,18 @@ func TestDriverEvictsEntryAtCapacity(t *testing.T) {
 }
 
 func TestDriverCleansExpiredEntriesOnSave(t *testing.T) {
-	d := cachettl.NewDriver(1)
+	synctest.Test(t, func(t *testing.T) {
+		d := cachettl.NewDriver(1)
 
-	require.NoError(t, d.Save(t.Context(), "expired", "old", time.Nanosecond))
-	require.Eventually(t, func() bool {
+		require.NoError(t, d.Save(t.Context(), "expired", "old", time.Nanosecond))
+		time.Sleep(2 * time.Nanosecond)
 		require.NoError(t, d.Save(t.Context(), "new", "value", 0))
 
 		_, err := d.Get(t.Context(), "expired")
-		return errors.Is(err, drivererrors.ErrMissing)
-	}, time.Second.Duration(), (10 * time.Millisecond).Duration())
+		require.ErrorIs(t, err, drivererrors.ErrMissing)
 
-	value, err := d.Get(t.Context(), "new")
-	require.NoError(t, err)
-	require.Equal(t, "value", value)
+		value, err := d.Get(t.Context(), "new")
+		require.NoError(t, err)
+		require.Equal(t, "value", value)
+	})
 }

--- a/health/server_test.go
+++ b/health/server_test.go
@@ -2,6 +2,7 @@ package health_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-health/v2/server"
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -13,19 +14,21 @@ import (
 )
 
 func TestNewServerStopsWithLifecycle(t *testing.T) {
-	checker := newLifecycleChecker()
-	reg := server.NewRegistration("lifecycle", time.Millisecond.Duration(), checker)
-	lc := fxtest.NewLifecycle(t)
-	srv := health.NewServer(lc)
+	synctest.Test(t, func(t *testing.T) {
+		checker := newLifecycleChecker()
+		reg := server.NewRegistration("lifecycle", time.Millisecond.Duration(), checker)
+		lc := fxtest.NewLifecycle(t)
+		srv := health.NewServer(lc)
 
-	srv.Register("test", reg)
-	require.NoError(t, srv.Observe("test", "healthz", "lifecycle"))
+		srv.Register("test", reg)
+		require.NoError(t, srv.Observe("test", "healthz", "lifecycle"))
 
-	require.NoError(t, lc.Start(t.Context()))
-	checker.waitForRunning(t)
+		require.NoError(t, lc.Start(t.Context()))
+		checker.waitForRunning(t)
 
-	require.NoError(t, lc.Stop(t.Context()))
-	checker.waitForStopped(t)
+		require.NoError(t, lc.Stop(t.Context()))
+		checker.waitForStopped(t)
+	})
 }
 
 type lifecycleChecker struct {

--- a/net/http/body/body_test.go
+++ b/net/http/body/body_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
@@ -93,40 +94,42 @@ func TestNewLazyHandlerDoesNotEnforceLimitMidStream(t *testing.T) {
 }
 
 func TestNewLazyHandlerStreamsBodyIncrementally(t *testing.T) {
-	pipeReader, pipeWriter := io.Pipe()
+	synctest.Test(t, func(t *testing.T) {
+		pipeReader, pipeWriter := io.Pipe()
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", pipeReader)
-	require.NoError(t, err)
-	req.ContentLength = -1
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/test", pipeReader)
+		require.NoError(t, err)
+		req.ContentLength = -1
 
-	res := httptest.NewRecorder()
-	lines := make(chan string, 2)
-	done := make(chan struct{})
+		res := httptest.NewRecorder()
+		lines := make(chan string, 2)
+		done := make(chan struct{})
 
-	handler := body.NewLazyHandler(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
-		reader := bufio.NewReader(req.Body)
+		handler := body.NewLazyHandler(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			reader := bufio.NewReader(req.Body)
 
-		for range 2 {
-			line, lineErr := reader.ReadString('\n')
-			require.NoError(t, lineErr)
-			lines <- line
-		}
+			for range 2 {
+				line, lineErr := reader.ReadString('\n')
+				require.NoError(t, lineErr)
+				lines <- line
+			}
 
-		close(done)
-	}), 1024)
+			close(done)
+		}), 1024)
 
-	go handler.ServeHTTP(res, req)
+		go handler.ServeHTTP(res, req)
 
-	_, err = pipeWriter.Write([]byte("one\n"))
-	require.NoError(t, err)
-	requireLine(t, lines, "one\n")
+		_, err = pipeWriter.Write([]byte("one\n"))
+		require.NoError(t, err)
+		requireLine(t, lines, "one\n")
 
-	_, err = pipeWriter.Write([]byte("two\n"))
-	require.NoError(t, err)
-	requireLine(t, lines, "two\n")
+		_, err = pipeWriter.Write([]byte("two\n"))
+		require.NoError(t, err)
+		requireLine(t, lines, "two\n")
 
-	require.NoError(t, pipeWriter.Close())
-	requireDone(t, done)
+		require.NoError(t, pipeWriter.Close())
+		requireDone(t, done)
+	})
 }
 
 func requireLine(tb testing.TB, lines chan string, want string) {

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -563,33 +564,35 @@ func TestStreamClosesResponseBodyOnHandlerPanic(t *testing.T) {
 }
 
 func TestRequestStreamClosesPipeOnHandlerPanic(t *testing.T) {
-	readDone := make(chan error, 1)
+	synctest.Test(t, func(t *testing.T) {
+		readDone := make(chan error, 1)
 
-	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		go func() {
-			_, _, err := io.ReadAll(req.Body)
-			readDone <- err
-		}()
+		rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			go func() {
+				_, _, err := io.ReadAll(req.Body)
+				readDone <- err
+			}()
 
-		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody, Request: req}, nil
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody, Request: req}, nil
+		})
+
+		c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
+
+		require.PanicsWithValue(t, "boom", func() {
+			_ = c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
+				func(_ context.Context, _ *client.RequestResponseStream) error {
+					panic("boom")
+				})
+		})
+
+		select {
+		case err := <-readDone:
+			require.ErrorIs(t, err, runtime.ErrRecovered)
+			require.EqualError(t, err, "recovered: boom")
+		case <-time.After(2 * time.Second):
+			t.Fatal("pipe reader never unblocked after handler panic")
+		}
 	})
-
-	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
-
-	require.PanicsWithValue(t, "boom", func() {
-		_ = c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
-			func(_ context.Context, _ *client.RequestResponseStream) error {
-				panic("boom")
-			})
-	})
-
-	select {
-	case err := <-readDone:
-		require.ErrorIs(t, err, runtime.ErrRecovered)
-		require.EqualError(t, err, "recovered: boom")
-	case <-time.After(2 * time.Second):
-		t.Fatal("pipe reader never unblocked after handler panic")
-	}
 }
 
 func TestStreamSurvivesSlowValuesWithConfiguredUnaryTimeout(t *testing.T) {

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -211,53 +212,55 @@ func TestNewRequestHandlerReturnsServiceUnavailableOnDrainBeforeHandler(t *testi
 }
 
 func TestNewRequestHandlerUnblocksRecvOnDrain(t *testing.T) {
-	drain := make(chan struct{})
-	pipeReader, pipeWriter := io.Pipe()
-	defer pipeWriter.Close()
-	started := make(chan struct{})
-	recvErr := make(chan error, 1)
-	handler := contentstream.NewRequestHandler(
-		test.StreamContent,
-		contentstream.Options{Drain: drain},
-		func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
-			close(started)
+	synctest.Test(t, func(t *testing.T) {
+		drain := make(chan struct{})
+		pipeReader, pipeWriter := io.Pipe()
+		defer pipeWriter.Close()
+		started := make(chan struct{})
+		recvErr := make(chan error, 1)
+		handler := contentstream.NewRequestHandler(
+			test.StreamContent,
+			contentstream.Options{Drain: drain},
+			func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+				close(started)
 
-			_, err := stream.Recv()
-			recvErr <- err
+				_, err := stream.Recv()
+				recvErr <- err
 
-			return err
-		},
-	)
+				return err
+			},
+		)
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
-	req.ProtoMajor = 2
-	req.ContentLength = -1
-	req.Header.Set(http.ContentTypeKey, media.NDJSON)
-	req.Header.Set(http.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-	done := make(chan struct{})
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
+		req.ProtoMajor = 2
+		req.ContentLength = -1
+		req.Header.Set(http.ContentTypeKey, media.NDJSON)
+		req.Header.Set(http.AcceptKey, media.NDJSON)
+		res := httptest.NewRecorder()
+		done := make(chan struct{})
 
-	go func() {
-		handler.ServeHTTP(res, req)
-		close(done)
-	}()
+		go func() {
+			handler.ServeHTTP(res, req)
+			close(done)
+		}()
 
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "timed out waiting for handler to start receiving")
-	}
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			require.FailNow(t, "timed out waiting for handler to start receiving")
+		}
 
-	close(drain)
+		close(drain)
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		require.FailNow(t, "timed out waiting for drain to unblock receive")
-	}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			require.FailNow(t, "timed out waiting for drain to unblock receive")
+		}
 
-	require.ErrorIs(t, <-recvErr, contentstream.ErrDraining)
-	require.Equal(t, http.StatusServiceUnavailable, res.Code)
+		require.ErrorIs(t, <-recvErr, contentstream.ErrDraining)
+		require.Equal(t, http.StatusServiceUnavailable, res.Code)
+	})
 }
 
 func TestNewRequestHandlerRecvRejectsValueWhenDrainStartsAfterDecode(t *testing.T) {
@@ -481,43 +484,45 @@ func TestNewRequestHandlerRecvUnderCapSucceeds(t *testing.T) {
 }
 
 func TestNewRequestHandlerRecvDeliversScalarValueAtExactCap(t *testing.T) {
-	pipeReader, pipeWriter := io.Pipe()
+	synctest.Test(t, func(t *testing.T) {
+		pipeReader, pipeWriter := io.Pipe()
 
-	opts := contentstream.Options{MaxReceiveSize: bytes.Size(2)}
-	handler := contentstream.NewRequestHandler(test.StreamContent, opts, func(_ context.Context, stream *contentstream.RequestStream[int, int]) error {
-		req, err := stream.Recv()
-		if err != nil {
-			return err
+		opts := contentstream.Options{MaxReceiveSize: bytes.Size(2)}
+		handler := contentstream.NewRequestHandler(test.StreamContent, opts, func(_ context.Context, stream *contentstream.RequestStream[int, int]) error {
+			req, err := stream.Recv()
+			if err != nil {
+				return err
+			}
+
+			return stream.Send(req)
+		})
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
+		req.ProtoMajor = 2
+		req.ContentLength = -1
+		req.Header.Set(http.ContentTypeKey, media.NDJSON)
+		req.Header.Set(http.AcceptKey, media.NDJSON)
+		res := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		go func() {
+			handler.ServeHTTP(res, req)
+			close(done)
+		}()
+
+		_, err := pipeWriter.Write([]byte("42"))
+		require.NoError(t, err)
+		require.NoError(t, pipeWriter.Close())
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "timed out waiting for handler to finish")
 		}
 
-		return stream.Send(req)
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "42\n", res.Body.String())
 	})
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
-	req.ProtoMajor = 2
-	req.ContentLength = -1
-	req.Header.Set(http.ContentTypeKey, media.NDJSON)
-	req.Header.Set(http.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
-
-	done := make(chan struct{})
-	go func() {
-		handler.ServeHTTP(res, req)
-		close(done)
-	}()
-
-	_, err := pipeWriter.Write([]byte("42"))
-	require.NoError(t, err)
-	require.NoError(t, pipeWriter.Close())
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for handler to finish")
-	}
-
-	require.Equal(t, http.StatusOK, res.Code)
-	require.Equal(t, "42\n", res.Body.String())
 }
 
 func TestNewRequestHandlerRecvRejectsValueOverCap(t *testing.T) {
@@ -633,57 +638,59 @@ func TestNewRequestHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavior(t *
 }
 
 func TestNewRequestHandlerRecvCapIsPerValueNotCumulative(t *testing.T) {
-	const values = 10
+	synctest.Test(t, func(t *testing.T) {
+		const values = 10
 
-	var names []string
+		var names []string
 
-	pipeReader, pipeWriter := io.Pipe()
+		pipeReader, pipeWriter := io.Pipe()
 
-	opts := contentstream.Options{MaxReceiveSize: 24}
-	handler := contentstream.NewRequestHandler(
-		test.StreamContent,
-		opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
-			for {
-				req, err := stream.Recv()
-				if err != nil {
-					if stream.IsFinished(err) {
-						return nil
+		opts := contentstream.Options{MaxReceiveSize: 24}
+		handler := contentstream.NewRequestHandler(
+			test.StreamContent,
+			opts, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+				for {
+					req, err := stream.Recv()
+					if err != nil {
+						if stream.IsFinished(err) {
+							return nil
+						}
+
+						return err
 					}
 
-					return err
+					names = append(names, req.Name)
 				}
+			})
 
-				names = append(names, req.Name)
-			}
-		})
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
+		req.ProtoMajor = 2
+		req.ContentLength = -1
+		req.Header.Set(http.ContentTypeKey, media.NDJSON)
+		req.Header.Set(http.AcceptKey, media.NDJSON)
+		res := httptest.NewRecorder()
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", pipeReader)
-	req.ProtoMajor = 2
-	req.ContentLength = -1
-	req.Header.Set(http.ContentTypeKey, media.NDJSON)
-	req.Header.Set(http.AcceptKey, media.NDJSON)
-	res := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() {
+			handler.ServeHTTP(res, req)
+			close(done)
+		}()
 
-	done := make(chan struct{})
-	go func() {
-		handler.ServeHTTP(res, req)
-		close(done)
-	}()
+		for range values {
+			_, err := pipeWriter.Write([]byte("{\"Name\":\"Bob\"}\n"))
+			require.NoError(t, err)
+		}
+		require.NoError(t, pipeWriter.Close())
 
-	for range values {
-		_, err := pipeWriter.Write([]byte("{\"Name\":\"Bob\"}\n"))
-		require.NoError(t, err)
-	}
-	require.NoError(t, pipeWriter.Close())
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "timed out waiting for handler to finish")
+		}
 
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for handler to finish")
-	}
-
-	require.Equal(t, http.StatusOK, res.Code)
-	require.Len(t, names, values)
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Len(t, names, values)
+	})
 }
 
 func TestNewRequestHandlerRecvChargesOneLimiterTokenPerMessage(t *testing.T) {

--- a/net/server/register_test.go
+++ b/net/server/register_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -68,30 +69,32 @@ func TestRegisterStartsAllServices(t *testing.T) {
 }
 
 func TestRegisterStopsServicesConcurrently(t *testing.T) {
-	lc := fxtest.NewLifecycle(t)
-	first := newBlockingShutdownServer()
-	second := newShutdownContextServer()
-	sh := test.NewShutdowner()
+	synctest.Test(t, func(t *testing.T) {
+		lc := fxtest.NewLifecycle(t)
+		first := newBlockingShutdownServer()
+		second := newShutdownContextServer()
+		sh := test.NewShutdowner()
 
-	server.Register(server.RegisterParams{
-		Lifecycle: lc,
-		Drain:     server.NewDrain(),
-		Services: []*server.Service{
-			server.NewService("first", first, nil, sh),
-			server.NewService("second", second, nil, sh),
-		},
+		server.Register(server.RegisterParams{
+			Lifecycle: lc,
+			Drain:     server.NewDrain(),
+			Services: []*server.Service{
+				server.NewService("first", first, nil, sh),
+				server.NewService("second", second, nil, sh),
+			},
+		})
+
+		require.NoError(t, lc.Start(t.Context()))
+		waitForRegisteredService(t, first.Done)
+		waitForRegisteredService(t, second.Done)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+		defer cancel()
+
+		err := lc.Stop(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.NoError(t, <-second.ShutdownErrs)
 	})
-
-	require.NoError(t, lc.Start(t.Context()))
-	waitForRegisteredService(t, first.Done)
-	waitForRegisteredService(t, second.Done)
-
-	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
-	defer cancel()
-
-	err := lc.Stop(ctx)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.NoError(t, <-second.ShutdownErrs)
 }
 
 func TestRegisterStartsDrainBeforeStoppingServices(t *testing.T) {

--- a/net/server/service_test.go
+++ b/net/server/service_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -13,60 +14,66 @@ import (
 )
 
 func TestStartRequestsShutdownOnServeError(t *testing.T) {
-	lc := fxtest.NewLifecycle(t)
-	l, err := test.NewLogger(lc, test.NewJSONLoggerConfig())
-	require.NoError(t, err)
-	sh := test.NewShutdowner()
-	srv := test.NewObservableServer(test.ErrFailed, nil)
-	svc := server.NewService("test", srv, l, sh)
+	synctest.Test(t, func(t *testing.T) {
+		lc := fxtest.NewLifecycle(t)
+		l, err := test.NewLogger(lc, test.NewJSONLoggerConfig())
+		require.NoError(t, err)
+		sh := test.NewShutdowner()
+		srv := test.NewObservableServer(test.ErrFailed, nil)
+		svc := server.NewService("test", srv, l, sh)
 
-	svc.Start()
+		svc.Start()
 
-	select {
-	case <-srv.Done:
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timeout waiting for server to serve")
-	}
+		select {
+		case <-srv.Done:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "timeout waiting for server to serve")
+		}
 
-	select {
-	case <-sh.Done():
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timeout waiting for shutdown")
-	}
+		select {
+		case <-sh.Done():
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "timeout waiting for shutdown")
+		}
 
-	require.True(t, sh.Called())
+		require.True(t, sh.Called())
+	})
 }
 
 func TestStartDoesNotShutdownOnNilServeReturn(t *testing.T) {
-	sh := test.NewShutdowner()
-	srv := test.NewObservableServer(nil, nil)
-	svc := server.NewService("test", srv, nil, sh)
+	synctest.Test(t, func(t *testing.T) {
+		sh := test.NewShutdowner()
+		srv := test.NewObservableServer(nil, nil)
+		svc := server.NewService("test", srv, nil, sh)
 
-	svc.Start()
+		svc.Start()
 
-	select {
-	case <-srv.Done:
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timeout waiting for server to serve")
-	}
+		select {
+		case <-srv.Done:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "timeout waiting for server to serve")
+		}
 
-	require.False(t, sh.Called())
+		require.False(t, sh.Called())
 
-	require.NoError(t, svc.Stop(t.Context()))
+		require.NoError(t, svc.Stop(t.Context()))
+	})
 }
 
 func TestStartReturnsWhileServeIsRunning(t *testing.T) {
-	sh := test.NewShutdowner()
-	srv := newBlockingServer()
-	svc := server.NewService("test", srv, nil, sh)
+	synctest.Test(t, func(t *testing.T) {
+		sh := test.NewShutdowner()
+		srv := newBlockingServer()
+		svc := server.NewService("test", srv, nil, sh)
 
-	startDone := startService(svc)
+		startDone := startService(svc)
 
-	requireStartReturned(t, startDone, srv)
-	requireServeStarted(t, srv)
+		requireStartReturned(t, startDone, srv)
+		requireServeStarted(t, srv)
 
-	require.NoError(t, svc.Stop(t.Context()))
-	require.False(t, sh.Called())
+		require.NoError(t, svc.Stop(t.Context()))
+		require.False(t, sh.Called())
+	})
 }
 
 func TestInvalidStop(t *testing.T) {

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -2,24 +2,23 @@ package time_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewTimer(t *testing.T) {
-	timer := time.NewTimer(time.Nanosecond)
-	require.NotNil(t, timer)
-	t.Cleanup(func() {
-		timer.Stop()
-	})
+	synctest.Test(t, func(t *testing.T) {
+		timer := time.NewTimer(time.Nanosecond)
+		require.NotNil(t, timer)
+		t.Cleanup(func() {
+			timer.Stop()
+		})
 
-	select {
-	case tm := <-timer.C:
+		tm := <-timer.C
 		require.False(t, tm.IsZero())
-	case <-time.After(time.Second):
-		require.FailNow(t, "timed out waiting for timer")
-	}
+	})
 }
 
 func TestUntil(t *testing.T) {

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -2,6 +2,7 @@ package ssh_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	crypto "github.com/alexfalkowski/go-service/v2/crypto/errors"
 	cryptossh "github.com/alexfalkowski/go-service/v2/crypto/ssh"
@@ -155,19 +156,21 @@ func TestInvalidAudience(t *testing.T) {
 }
 
 func TestInvalidExpired(t *testing.T) {
-	cfg := test.NewToken("ssh").SSH
-	cfg.Expiration = time.Nanosecond
-	token := ssh.NewToken(cfg, test.FS)
+	synctest.Test(t, func(t *testing.T) {
+		cfg := test.NewToken("ssh").SSH
+		cfg.Expiration = time.Nanosecond
+		token := ssh.NewToken(cfg, test.FS)
 
-	tkn, err := token.Generate("/service.Method", strings.Empty)
-	require.NoError(t, err)
-	require.NotEmpty(t, tkn)
+		tkn, err := token.Generate("/service.Method", strings.Empty)
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
 
-	time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond)
 
-	sub, err := token.Verify(tkn, "/service.Method")
-	require.Empty(t, sub)
-	require.ErrorIs(t, err, errors.ErrInvalidTime)
+		sub, err := token.Verify(tkn, "/service.Method")
+		require.Empty(t, sub)
+		require.ErrorIs(t, err, errors.ErrInvalidTime)
+	})
 }
 
 func TestInvalidLifetimeExceedsConfig(t *testing.T) {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -2,6 +2,7 @@ package retry_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -133,23 +134,25 @@ func TestUnaryClientInterceptorConfiguredCodesReplaceDefaults(t *testing.T) {
 }
 
 func TestUnaryClientInterceptorCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
-	cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Timeout: time.Second, Attempts: config.MaxAttempts}
-	interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+	synctest.Test(t, func(t *testing.T) {
+		cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Timeout: time.Second, Attempts: config.MaxAttempts}
+		interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
 
-	calls := 0
-	start := time.Now()
-	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
-		calls++
-		return status.Error(codes.Unavailable, "unavailable")
+		calls := 0
+		start := time.Now()
+		err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+			calls++
+			return status.Error(codes.Unavailable, "unavailable")
+		})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Equal(t, int(config.MaxAttempts), calls)
+		// Uncapped exponential growth from a 2ms base across 9 retries sums to ~1022ms; capping
+		// at 10ms bounds the same schedule to well under that, so a generous bound below the
+		// uncapped total still proves the cap is applied.
+		require.Less(t, elapsed, 400*time.Millisecond)
 	})
-	elapsed := time.Since(start)
-
-	require.Error(t, err)
-	require.Equal(t, int(config.MaxAttempts), calls)
-	// Uncapped exponential growth from a 2ms base across 9 retries sums to ~1022ms; capping
-	// at 10ms bounds the same schedule to well under that, so a generous bound below the
-	// uncapped total still proves the cap is applied.
-	require.Less(t, elapsed, 400*time.Millisecond)
 }
 
 func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -2,6 +2,7 @@ package breaker_test
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -86,59 +87,61 @@ func TestRoundTripperClosesBodyWhenBreakerIsOpen(t *testing.T) {
 }
 
 func TestRoundTripperMapsHalfOpenProbeSaturationToTooManyRequests(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	transportErr := errors.New("transport unavailable")
-	failed := false
-	rt := breaker.NewRoundTripper(
-		test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
-			if !failed {
-				failed = true
-				return nil, transportErr
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		transportErr := errors.New("transport unavailable")
+		failed := false
+		rt := breaker.NewRoundTripper(
+			test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+				if !failed {
+					failed = true
+					return nil, transportErr
+				}
+
+				close(started)
+				<-release
+
+				return test.ResponseWithStatus(http.StatusOK), nil
+			}),
+			breaker.WithSettings(breaker.Settings{
+				MaxRequests: 1,
+				Timeout:     time.Millisecond.Duration(),
+				ReadyToTrip: func(counts breaker.Counts) bool {
+					return counts.ConsecutiveFailures >= 1
+				},
+			}),
+		)
+		first, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(first)
+		require.Nil(t, res)
+		require.ErrorIs(t, err, transportErr)
+
+		<-time.After(10 * time.Millisecond)
+
+		probe, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+		require.NoError(t, err)
+		probeErr := make(chan error, 1)
+		go func() {
+			res, err := rt.RoundTrip(probe)
+			if res != nil {
+				_ = res.Body.Close()
 			}
+			probeErr <- err
+		}()
+		<-started
 
-			close(started)
-			<-release
+		saturated, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+		require.NoError(t, err)
+		res, err = rt.RoundTrip(saturated)
+		require.Nil(t, res)
+		require.ErrorIs(t, err, breaker.ErrTooManyRequests)
+		require.Equal(t, http.StatusTooManyRequests, status.Code(err))
 
-			return test.ResponseWithStatus(http.StatusOK), nil
-		}),
-		breaker.WithSettings(breaker.Settings{
-			MaxRequests: 1,
-			Timeout:     time.Millisecond.Duration(),
-			ReadyToTrip: func(counts breaker.Counts) bool {
-				return counts.ConsecutiveFailures >= 1
-			},
-		}),
-	)
-	first, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-	require.NoError(t, err)
-	res, err := rt.RoundTrip(first)
-	require.Nil(t, res)
-	require.ErrorIs(t, err, transportErr)
-
-	<-time.After(10 * time.Millisecond)
-
-	probe, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-	require.NoError(t, err)
-	probeErr := make(chan error, 1)
-	go func() {
-		res, err := rt.RoundTrip(probe)
-		if res != nil {
-			_ = res.Body.Close()
-		}
-		probeErr <- err
-	}()
-	<-started
-
-	saturated, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-	require.NoError(t, err)
-	res, err = rt.RoundTrip(saturated)
-	require.Nil(t, res)
-	require.ErrorIs(t, err, breaker.ErrTooManyRequests)
-	require.Equal(t, http.StatusTooManyRequests, status.Code(err))
-
-	close(release)
-	require.NoError(t, <-probeErr)
+		close(release)
+		require.NoError(t, <-probeErr)
+	})
 }
 
 func TestRoundTripperOpensOnFailureStatus(t *testing.T) {

--- a/transport/http/retry/retry_test.go
+++ b/transport/http/retry/retry_test.go
@@ -3,6 +3,7 @@ package retry_test
 import (
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
@@ -133,27 +134,29 @@ func TestRoundTripperClampsAttemptsAboveMax(t *testing.T) {
 }
 
 func TestRoundTripperCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
-	calls := 0
-	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
-		calls++
-		return test.ResponseWithStatus(http.StatusTooManyRequests), nil
+	synctest.Test(t, func(t *testing.T) {
+		calls := 0
+		rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return test.ResponseWithStatus(http.StatusTooManyRequests), nil
+		})
+		cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Attempts: config.MaxAttempts}
+		retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+		start := time.Now()
+		res, err := retrying.RoundTrip(req)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+		require.Equal(t, int(config.MaxAttempts), calls)
+		// Uncapped exponential growth from a 2ms base across 9 retries sums to ~1022ms; capping
+		// at 10ms bounds the same schedule to well under that, so a generous bound below the
+		// uncapped total still proves the cap is applied.
+		require.Less(t, elapsed, 400*time.Millisecond)
 	})
-	cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Attempts: config.MaxAttempts}
-	retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-
-	start := time.Now()
-	res, err := retrying.RoundTrip(req)
-	elapsed := time.Since(start)
-
-	require.NoError(t, err)
-	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
-	require.Equal(t, int(config.MaxAttempts), calls)
-	// Uncapped exponential growth from a 2ms base across 9 retries sums to ~1022ms; capping
-	// at 10ms bounds the same schedule to well under that, so a generous bound below the
-	// uncapped total still proves the cap is applied.
-	require.Less(t, elapsed, 400*time.Millisecond)
 }
 
 func TestRoundTripperDoesNotPanicWithOmittedBackoff(t *testing.T) {
@@ -171,15 +174,17 @@ func TestRoundTripperDoesNotPanicWithOmittedBackoff(t *testing.T) {
 }
 
 func TestRoundTripperRetriesWithDefaultBackoff(t *testing.T) {
-	rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
-	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, 0), rt)
+	synctest.Test(t, func(t *testing.T) {
+		rt := &test.StatusSequenceRoundTripper{Codes: []int{http.StatusTooManyRequests, http.StatusOK}}
+		retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, 0), rt)
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
 
-	res, err := retrying.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, 2, rt.Calls)
+		res, err := retrying.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 2, rt.Calls)
+	})
 }
 
 func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsMinimumBackoff(t *testing.T) {
@@ -231,33 +236,35 @@ func TestRoundTripperHonorsGrownBackoffForRetryAfter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			calls := 0
-			rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
-				calls++
-				switch calls {
-				case 1:
-					return test.ResponseWithStatus(http.StatusTooManyRequests), nil
-				case 2:
-					res := test.ResponseWithStatus(http.StatusTooManyRequests)
-					res.Header.Set("Retry-After", tt.retryAfter)
+			synctest.Test(t, func(t *testing.T) {
+				calls := 0
+				rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					switch calls {
+					case 1:
+						return test.ResponseWithStatus(http.StatusTooManyRequests), nil
+					case 2:
+						res := test.ResponseWithStatus(http.StatusTooManyRequests)
+						res.Header.Set("Retry-After", tt.retryAfter)
 
-					return res, nil
-				default:
-					return test.ResponseWithStatus(http.StatusOK), nil
-				}
+						return res, nil
+					default:
+						return test.ResponseWithStatus(http.StatusOK), nil
+					}
+				})
+
+				// Exponential growth from a 750ms base gives ~750ms before attempt 2 and ~1.5s before
+				// attempt 3; the second attempt's gate must compare against the latter, not the base.
+				cfg := config.Config{Strategy: "exponential", Backoff: 750 * time.Millisecond, Attempts: 3}
+				retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
+
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+				res, err := retrying.RoundTrip(req)
+				require.NoError(t, err)
+				require.Equal(t, tt.finalCode, res.StatusCode)
+				require.Equal(t, tt.calls, calls)
 			})
-
-			// Exponential growth from a 750ms base gives ~750ms before attempt 2 and ~1.5s before
-			// attempt 3; the second attempt's gate must compare against the latter, not the base.
-			cfg := config.Config{Strategy: "exponential", Backoff: 750 * time.Millisecond, Attempts: 3}
-			retrying := retry.NewRoundTripper(retry.NewConfig(&cfg), rt)
-
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-
-			res, err := retrying.RoundTrip(req)
-			require.NoError(t, err)
-			require.Equal(t, tt.finalCode, res.StatusCode)
-			require.Equal(t, tt.calls, calls)
 		})
 	}
 }
@@ -283,26 +290,28 @@ func TestRoundTripperDoesNotRetryWhenRetryAfterExceedsCappedBackoff(t *testing.T
 }
 
 func TestRoundTripperRetriesWhenRetryAfterDoesNotExceedBackoff(t *testing.T) {
-	calls := 0
-	rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
-		calls++
-		if calls == 1 {
-			res := test.ResponseWithStatus(http.StatusTooManyRequests)
-			res.Header.Set("Retry-After", "1")
+	synctest.Test(t, func(t *testing.T) {
+		calls := 0
+		rt := test.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				res := test.ResponseWithStatus(http.StatusTooManyRequests)
+				res.Header.Set("Retry-After", "1")
 
-			return res, nil
-		}
+				return res, nil
+			}
 
-		return test.ResponseWithStatus(http.StatusOK), nil
+			return test.ResponseWithStatus(http.StatusOK), nil
+		})
+		retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, 2*time.Second), rt)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+
+		res, err := retrying.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 2, calls)
 	})
-	retrying := retry.NewRoundTripper(test.NewHTTPRetryConfig(2, 2*time.Second), rt)
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
-
-	res, err := retrying.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, 2, calls)
 }
 
 func TestRoundTripperRetriesWhenRetryAfterIsInvalid(t *testing.T) {


### PR DESCRIPTION
## What

- Replace wall-clock polling and sleeps with `testing/synctest` bubbles in timing-sensitive concurrency, lifecycle, stream, retry, cache, and token coverage while retaining each test's asserted behavior.

## Why

- Remove timing-related flake risk from the affected tests without changing production behavior or public interfaces.

## Testing

- `make package=<path> specs` for all 12 affected packages - passed
- `make lint` - passed
- Scoped validation covers every changed package; CI remains responsible for the complete suite.

AI-assisted-by: [Codex](https://openai.com/codex/)
