### PR TITLE
feat(grpc): avoid breaker failures from expired caller deadlines

### DIFF
--- a/transport/grpc/breaker/breaker.go
+++ b/transport/grpc/breaker/breaker.go
@@ -31,7 +31,8 @@ type Settings = breaker.Settings
 //
 // The interceptor counts failures based on gRPC status codes. By default it treats a subset of transient/server
 // codes as failures (see [WithFailureCodes] and the defaults in `defaultOpts`). Calls that return other codes
-// do not contribute to opening the breaker.
+// do not contribute to opening the breaker. A context that is already deadline-exceeded before the invocation
+// bypasses breaker accounting, because it provides no downstream-health signal.
 //
 // # Error mapping
 //
@@ -49,6 +50,10 @@ func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
 	r := &registry{opts: o, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}
 
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, callOpts ...grpc.CallOption) error {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return invoker(ctx, fullMethod, req, resp, conn, callOpts...)
+		}
+
 		cb := r.get(fullMethod)
 		_, err := cb.Execute(func() (any, error) {
 			return nil, invoker(ctx, fullMethod, req, resp, conn, callOpts...)

--- a/transport/grpc/breaker/breaker_test.go
+++ b/transport/grpc/breaker/breaker_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
-	basebreaker "github.com/alexfalkowski/go-service/v2/transport/breaker"
+	"github.com/alexfalkowski/go-service/v2/time"
+	transportbreaker "github.com/alexfalkowski/go-service/v2/transport/breaker"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/breaker"
+	"github.com/alexfalkowski/go-service/v2/transport/grpc/retry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,6 +136,85 @@ func TestUnaryClientInterceptorDoesNotOpenOnCallerCancellation(t *testing.T) {
 	}
 }
 
+func TestUnaryClientInterceptorDoesNotOpenOnExpiredCallerDeadline(t *testing.T) {
+	interceptor := breaker.UnaryClientInterceptor(
+		breaker.WithSettings(settings()),
+	)
+
+	expired, cancel := context.WithTimeout(t.Context(), 0)
+	t.Cleanup(cancel)
+	<-expired.Done()
+
+	calls := 0
+	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.DeadlineExceeded, "caller deadline exceeded")
+	}
+
+	err := interceptor(expired, "/test.Service/GetBook", nil, nil, nil, invoker)
+	require.Error(t, err)
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestUnaryClientInterceptorOpensOnRemoteDeadline(t *testing.T) {
+	interceptor := breaker.UnaryClientInterceptor(
+		breaker.WithSettings(settings()),
+	)
+
+	calls := 0
+	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return status.Error(codes.DeadlineExceeded, "remote deadline exceeded")
+	}
+
+	err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+	require.Error(t, err)
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, invoker)
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 1, calls)
+}
+
+func TestUnaryClientInterceptorOpensOnAttemptDeadline(t *testing.T) {
+	interceptor := breaker.UnaryClientInterceptor(
+		breaker.WithSettings(settings()),
+	)
+	retryConfig := test.NewGRPCRetryConfig(1, time.Nanosecond)
+	retryConfig.Timeout = 10 * time.Millisecond
+	retrying := retry.UnaryClientInterceptor(retryConfig)
+
+	calls := 0
+	attempt := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, callOpts ...grpc.CallOption) error {
+		return interceptor(ctx, fullMethod, req, resp, conn, func(ctx context.Context, _ string, _ any, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			calls++
+			<-ctx.Done()
+			return status.Error(codes.DeadlineExceeded, "attempt deadline exceeded")
+		}, callOpts...)
+	}
+	err := retrying(t.Context(), "/test.Service/GetBook", nil, nil, nil, attempt)
+	require.Error(t, err)
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	err = interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+		calls++
+		return nil
+	})
+	require.Error(t, err)
+	require.True(t, status.IsLocalError(err))
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 1, calls)
+}
+
 func TestUnaryClientInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
 	interceptor := breaker.UnaryClientInterceptor(
 		breaker.WithSettings(settings()),
@@ -171,9 +252,9 @@ func TestUnaryClientInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
 	})
 }
 
-func settings(isSuccessful ...func(error) bool) breaker.Settings {
-	settings := breaker.Settings{
-		ReadyToTrip: func(counts basebreaker.Counts) bool {
+func settings(isSuccessful ...func(error) bool) transportbreaker.Settings {
+	settings := transportbreaker.Settings{
+		ReadyToTrip: func(counts transportbreaker.Counts) bool {
 			return counts.ConsecutiveFailures >= 1
 		},
 	}

--- a/transport/grpc/breaker/config.go
+++ b/transport/grpc/breaker/config.go
@@ -31,7 +31,8 @@ type Config struct {
 	// When empty, gRPC breakers use their default failure classification. When set, only these configured
 	// non-OK status codes are counted as breaker failures; include the defaults here as well when custom
 	// configuration should extend rather than replace the default list. [codes.Canceled] is always counted
-	// as a success even when included here, so a caller aborting an in-flight call never trips the breaker.
+	// as a success even when included here, so a caller aborting an in-flight call never trips the breaker. An
+	// already-expired caller deadline likewise bypasses breaker accounting before invocation.
 	Codes []codes.Code `yaml:"codes,omitempty" json:"codes,omitempty" toml:"codes,omitempty" validate:"omitempty,dive,gt=0,lte=16"`
 }
 

--- a/transport/grpc/breaker/options.go
+++ b/transport/grpc/breaker/options.go
@@ -44,7 +44,8 @@ func WithSettings(s Settings) Option {
 // If an invocation returns an error whose status code is contained in this set, the breaker counts it as a
 // failure. Errors with status codes not in this set are counted as successes. [codes.Canceled] is always
 // counted as a success regardless of this set, matching the caller-cancellation handling in the HTTP client
-// breaker: a caller aborting an in-flight call should not trip the breaker against a healthy upstream.
+// breaker: a caller aborting an in-flight call should not trip the breaker against a healthy upstream. An
+// already-expired caller deadline bypasses breaker accounting before invocation for the same reason.
 func WithFailureCodes(cs ...codes.Code) Option {
 	return optionFunc(func(o *opts) {
 		o.failureCodes = make(map[codes.Code]struct{}, len(cs))


### PR DESCRIPTION
## What

- Exclude calls whose caller deadline had already expired before invocation from gRPC client breaker accounting, while continuing to classify remote and retry-attempt deadlines as downstream failures.
- Preserve existing gRPC breaker configuration and public API shape, with GoDoc that distinguishes caller-side deadline expiry from an upstream health signal.

## Why

- A deadline that elapsed before the client attempts an RPC cannot indicate downstream health, so counting it can open the breaker and reject unrelated healthy calls.

## Testing

- `make package=transport/grpc/breaker specs` - passed
- `make package=transport/grpc/breaker lint` - passed
- `make coverage` - passed; `UnaryClientInterceptor` reached 100% coverage and the package reached 98% statement coverage.
- `git diff --check` - passed
- CI will additionally run generated-output freshness, security checks, full specs, bounded fuzzing, benchmarks, and repository-wide coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
