### PR TITLE
feat(net): bound telemetry metadata and standardize interceptor providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,8 @@ Telemetry config root is `telemetry.Config`:
 telemetry:
   attributes:
     k8s.namespace.name: payments
+  metadata:
+    max_value_size: 4KB
   logger: ...
   metrics: ...
   propagation: ...
@@ -583,6 +585,23 @@ and traces. They are not source strings. Fixed go-service identity attributes
 such as `host.id`, `service.instance.id`, `service.name`, `service.version`,
 and `deployment.environment.name` take precedence if the same key is
 configured.
+
+### Metadata
+
+Request and service metadata is copied from the context to go-service logger
+records and trace attributes. Configure the maximum size of each exported value:
+
+```yaml
+telemetry:
+  metadata:
+    max_value_size: 4KB
+```
+
+When `max_value_size` is omitted or `0`, each value defaults to 1,024 bytes.
+Values are truncated on a UTF-8 boundary only in telemetry; the original value
+remains in the request context and transport metadata. Choose a value that fits
+the service's log and trace payload budgets: the limit applies to every
+metadata-bearing log record and span.
 
 ### Propagation
 

--- a/cache/telemetry/telemetry_test.go
+++ b/cache/telemetry/telemetry_test.go
@@ -20,7 +20,7 @@ func TestInstrumentTracingDisablesRawCommandStatements(t *testing.T) {
 	})
 
 	exporter := &test.SpanExporter{}
-	provider := tracer.NewProvider(tracer.WithSyncer(exporter))
+	provider := tracer.NewProvider(1024, tracer.WithSyncer(exporter))
 	tracer.SetProvider(provider)
 	t.Cleanup(func() {
 		require.NoError(t, provider.Shutdown(context.Background()))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -384,6 +384,7 @@ func verifySQLConfig(t *testing.T, cfg *config.Config) {
 func verifyTelemetryConfig(t *testing.T, cfg *config.Config) {
 	t.Helper()
 
+	require.Equal(t, 4*bytes.KB, cfg.Telemetry.Metadata.MaxValueSize)
 	require.Equal(t, "text", cfg.Telemetry.Logger.Kind)
 	require.Equal(t, "info", cfg.Telemetry.Logger.Level)
 	require.Equal(t, "payments", cfg.Telemetry.Attributes["k8s.namespace.name"])

--- a/config/module.go
+++ b/config/module.go
@@ -26,7 +26,7 @@ var Module = di.Module(
 	di.Constructor(environmentConfig), di.Constructor(cacheConfig),
 	di.Constructor(debugConfig), di.Constructor(idConfig), di.Constructor(timeConfig),
 	di.Constructor(pgConfig), di.Constructor(featureConfig), di.Constructor(hooksConfig),
-	di.Constructor(attributeMap),
+	di.Constructor(attributeMap), di.Constructor(metadataLimit),
 	di.Constructor(loggerConfig), di.Constructor(tracerConfig), di.Constructor(metricsConfig),
 	di.Constructor(propagationConfig),
 	di.Constructor(accessConfig), di.Constructor(grpcConfig), di.Constructor(httpConfig),

--- a/config/telemetry.go
+++ b/config/telemetry.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
@@ -14,6 +15,14 @@ func attributeMap(cfg *Config) attributes.Map {
 		return cfg.Telemetry.Attributes
 	}
 	return nil
+}
+
+func metadataLimit(cfg *Config) meta.Limit {
+	if cfg.Telemetry.IsEnabled() {
+		return cfg.Telemetry.Metadata.GetMaxValueSize()
+	}
+
+	return 0
 }
 
 func loggerConfig(cfg *Config, fs *os.FS) *logger.Config {

--- a/internal/test/limiter.go
+++ b/internal/test/limiter.go
@@ -3,6 +3,7 @@ package test
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/method"
 	grpc "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 	http "github.com/alexfalkowski/go-service/v2/transport/http/limiter"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
@@ -23,12 +24,12 @@ func NewHTTPServerLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *limiter.Con
 
 // NewGRPCClientLimiter returns a gRPC client limiter and any construction error.
 func NewGRPCClientLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *limiter.Config) (*grpc.Client, error) {
-	return grpc.NewClientLimiter(lc, keys, cfg)
+	return grpc.NewClient(lc, keys, cfg)
 }
 
 // NewGRPCServerLimiter returns a gRPC server limiter and any construction error.
-func NewGRPCServerLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *limiter.Config) (*grpc.Server, error) {
-	return grpc.NewServerLimiter(lc, keys, cfg)
+func NewGRPCServerLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *limiter.Config, policy *method.Policy) (*grpc.Server, error) {
+	return grpc.NewServer(lc, keys, cfg, policy)
 }
 
 // AllowAllLimiter is a [github.com/alexfalkowski/go-service/v2/net/http/meta.RateLimiter] test double

--- a/internal/test/tracer.go
+++ b/internal/test/tracer.go
@@ -37,7 +37,7 @@ func EnableSpanExporter(tb testing.TB) *SpanExporter {
 	tb.Helper()
 
 	exporter := &SpanExporter{}
-	provider := tracer.NewProvider(tracer.WithSyncer(exporter))
+	provider := tracer.NewProvider(1024, tracer.WithSyncer(exporter))
 	tracer.SetProvider(provider)
 
 	tb.Cleanup(func() {

--- a/internal/test/world.go
+++ b/internal/test/world.go
@@ -74,7 +74,7 @@ func NewWorld(tb testing.TB, opts ...WorldOption) *World {
 	meter, err := meter(lc, router, os)
 	require.NoError(tb, err)
 
-	grpcServerLimiter, err := NewGRPCServerLimiter(lc, LimiterKeyMap, os.serverLimiter)
+	grpcServerLimiter, err := NewGRPCServerLimiter(lc, LimiterKeyMap, os.serverLimiter, grpcPolicy)
 	require.NoError(tb, err)
 	httpServerLimiter, err := NewHTTPServerLimiter(lc, LimiterKeyMap, os.serverLimiter)
 	require.NoError(tb, err)

--- a/meta/doc.go
+++ b/meta/doc.go
@@ -26,10 +26,11 @@
 //   - [Strings]: keys unchanged
 //   - [SnakeStrings]: keys converted to snake_case
 //   - [CamelStrings]: keys converted to lowerCamelCase
+//   - [Attributes]: lowerCamelCase keys with bounded values for telemetry sinks
 //
 // Export helpers skip attributes whose rendered string is empty. A prefix may be prepended to each exported key.
 //
 // Start with [WithAttributes], [NewPair], the typed With* pair helpers, and [Attribute] for arbitrary
 // attributes. Use [Value] constructors ([String], [Blank], [Ignored], [Redacted]) for controlling rendering,
-// and [Strings], [SnakeStrings], or [CamelStrings] for exporting attributes.
+// and [Strings], [SnakeStrings], [CamelStrings], or [Attributes] for exporting attributes.
 package meta

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1,6 +1,9 @@
 package meta
 
 import (
+	"unicode/utf8"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
@@ -57,6 +60,31 @@ func CamelStrings(ctx context.Context, prefix string) Map {
 	return attributes(ctx).Strings(prefix, strings.ToLowerCamel)
 }
 
+// Limit bounds the length of an exported metadata value.
+//
+// Standard telemetry wiring resolves this value from telemetry configuration.
+// Values are truncated at a valid UTF-8 boundary, while the original context
+// metadata remains unchanged.
+type Limit bytes.Size
+
+// Bytes returns the limit as a byte count.
+func (l Limit) Bytes() int {
+	return int(l)
+}
+
+// Attributes returns context metadata as lowerCamelCase string attributes.
+//
+// Attribute values are bounded by limit so one metadata value cannot dominate a
+// log record or telemetry payload. Metadata retained in ctx is not truncated.
+func Attributes(ctx context.Context, limit Limit) Map {
+	attrs := CamelStrings(ctx, NoPrefix)
+	for key, value := range attrs {
+		attrs[key] = truncate(value, limit)
+	}
+
+	return attrs
+}
+
 // Strings returns all stored attributes as a string map with keys unchanged.
 //
 // The prefix parameter is prepended to each exported key (if non-empty).
@@ -67,4 +95,19 @@ func Strings(ctx context.Context, prefix string) Map {
 
 func identity(s string) string {
 	return s
+}
+
+func truncate(value string, limit Limit) string {
+	size := limit.Bytes()
+	if len(value) <= size {
+		return value
+	}
+
+	truncated := value[:size]
+	for !utf8.ValidString(truncated) {
+		_, size := utf8.DecodeLastRuneInString(truncated)
+		truncated = truncated[:len(truncated)-size]
+	}
+
+	return truncated
 }

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -29,6 +29,15 @@ func TestStrings(t *testing.T) {
 	})
 }
 
+func TestAttributesBoundsCamelCasedValues(t *testing.T) {
+	ctx := meta.WithAttributes(t.Context(),
+		meta.NewPair("request-id", meta.String("abcd")),
+		meta.NewPair("secret", meta.Ignored("hidden")),
+	)
+
+	require.Equal(t, meta.Map{"requestId": "abc"}, meta.Attributes(ctx, meta.Limit(3)))
+}
+
 func TestWithAttributesReturnsSameContextWithoutPairs(t *testing.T) {
 	ctx := t.Context()
 

--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -11,7 +11,18 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// UnaryClientInterceptor returns a gRPC unary client interceptor that injects metadata into outgoing requests.
+// NewClient constructs a metadata interceptor provider for a gRPC client.
+func NewClient(userAgent env.UserAgent, generator id.Generator) *Client {
+	return &Client{userAgent: userAgent, generator: generator}
+}
+
+// Client provides gRPC client interceptors that inject request metadata.
+type Client struct {
+	generator id.Generator
+	userAgent env.UserAgent
+}
+
+// UnaryInterceptor returns a gRPC unary client interceptor that injects metadata into outgoing requests.
 //
 // It ensures "user-agent" and "request-id" are present in outgoing metadata,
 // preferring values already present in the context or outgoing metadata, and
@@ -20,9 +31,9 @@ import (
 // Existing outgoing metadata values for these keys are replaced so repeated
 // interceptor invocation does not accumulate duplicates or preserve stale
 // values ahead of the resolved value.
-func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grpc.UnaryClientInterceptor {
+func (c *Client) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		md, ua, requestID := clientMetadata(ctx, userAgent, generator)
+		md, ua, requestID := clientMetadata(ctx, c.userAgent, c.generator)
 
 		ctx = meta.WithAttributes(ctx,
 			meta.WithTransport(meta.Ignored("grpc")),
@@ -35,7 +46,7 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 	}
 }
 
-// StreamClientInterceptor returns a gRPC stream client interceptor that injects metadata into outgoing requests.
+// StreamInterceptor returns a gRPC stream client interceptor that injects metadata into outgoing requests.
 //
 // It ensures "user-agent" and "request-id" are present in outgoing metadata,
 // preferring values already present in the context or outgoing metadata, and
@@ -44,9 +55,9 @@ func UnaryClientInterceptor(userAgent env.UserAgent, generator id.Generator) grp
 // Existing outgoing metadata values for these keys are replaced so repeated
 // interceptor invocation does not accumulate duplicates or preserve stale
 // values ahead of the resolved value.
-func StreamClientInterceptor(userAgent env.UserAgent, generator id.Generator) grpc.StreamClientInterceptor {
+func (c *Client) StreamInterceptor() grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		md, ua, requestID := clientMetadata(ctx, userAgent, generator)
+		md, ua, requestID := clientMetadata(ctx, c.userAgent, c.generator)
 
 		ctx = meta.WithAttributes(ctx,
 			meta.WithTransport(meta.Ignored("grpc")),

--- a/net/grpc/meta/doc.go
+++ b/net/grpc/meta/doc.go
@@ -49,8 +49,7 @@
 // strips or overwrites client-supplied forwarding metadata before traffic
 // reaches the service.
 //
-// Start with [UnaryServerInterceptor] / [StreamServerInterceptor] for
-// server-side extraction and [UnaryClientInterceptor] /
-// [StreamClientInterceptor] for client-side injection. Use [ExtractIncoming]
-// and [ExtractOutgoing] when you need mutable copies of metadata maps.
+// Start with [NewServer] for server-side extraction and [NewClient] for
+// client-side injection. Use [ExtractIncoming] and [ExtractOutgoing] when you
+// need mutable copies of metadata maps.
 package meta

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -2,6 +2,7 @@ package meta_test
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/env"
@@ -26,7 +27,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).UnaryInterceptor()
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		md, ok := grpcmeta.FromOutgoingContext(ctx)
@@ -47,7 +48,7 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		"user-agent", "",
 		"request-id", "",
 	))
-	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).UnaryInterceptor()
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		md, ok := grpcmeta.FromOutgoingContext(ctx)
@@ -67,7 +68,7 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 
 func TestUnaryClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
 	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
-	interceptor := grpcmeta.UnaryClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).UnaryInterceptor()
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		md, ok := grpcmeta.FromOutgoingContext(ctx)
@@ -89,7 +90,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		"user-agent", "stale-agent",
 		"request-id", "stale-id",
 	))
-	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).StreamInterceptor()
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		md, ok := grpcmeta.FromOutgoingContext(ctx)
 		require.True(t, ok)
@@ -114,7 +115,7 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		"user-agent", "",
 		"request-id", "",
 	))
-	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).StreamInterceptor()
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		md, ok := grpcmeta.FromOutgoingContext(ctx)
 		require.True(t, ok)
@@ -138,7 +139,7 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 
 func TestStreamClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
 	ctx := grpcmeta.NewOutgoingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
-	interceptor := grpcmeta.StreamClientInterceptor(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).StreamInterceptor()
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		md, ok := grpcmeta.FromOutgoingContext(ctx)
 		require.True(t, ok)
@@ -158,7 +159,7 @@ func TestStreamClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
 func TestUnaryServerInterceptorStampsSpanWithMeta(t *testing.T) {
 	exporter := test.EnableIsolatedSpanExporter(t)
 
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), 1024).UnaryInterceptor()
 	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{}), "request")
 
 	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(context.Context, any) (any, error) {
@@ -177,10 +178,37 @@ func TestUnaryServerInterceptorStampsSpanWithMeta(t *testing.T) {
 	require.Equal(t, "request-id", values[meta.RequestIDKey])
 }
 
+func TestUnaryServerInterceptorBoundsSpanMetaWithoutChangingRequestID(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+	requestID := "aaé"
+
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 3).UnaryInterceptor()
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("request-id", requestID))
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(ctx, "request")
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
+		require.Equal(t, requestID, meta.RequestID(ctx).Value())
+
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	span.End()
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+
+	values := make(map[string]string)
+	for _, attr := range spans[0].Attributes() {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "aa", values[meta.RequestIDKey])
+	require.True(t, utf8.ValidString(values[meta.RequestIDKey]))
+}
+
 func TestStreamServerInterceptorStampsSpanWithMeta(t *testing.T) {
 	exporter := test.EnableIsolatedSpanExporter(t)
 
-	interceptor := grpcmeta.StreamServerInterceptor(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), 1024).StreamInterceptor()
 	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{}), "request")
 	stream := &test.MetaServerStream{Ctx: ctx}
 
@@ -201,7 +229,7 @@ func TestStreamServerInterceptorStampsSpanWithMeta(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
@@ -218,7 +246,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{})
 
@@ -233,7 +261,7 @@ func TestUnaryServerInterceptorHandlesPeerWithoutAddr(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorPreservesIncomingRequestID(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
@@ -246,7 +274,7 @@ func TestUnaryServerInterceptorPreservesIncomingRequestID(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
 
@@ -261,7 +289,7 @@ func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorPrefersForwardedIPAddr(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("x-forwarded-for", "203.0.113.10, 10.0.0.1"))
 	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
 
@@ -276,7 +304,7 @@ func TestUnaryServerInterceptorPrefersForwardedIPAddr(t *testing.T) {
 }
 
 func TestUnaryServerInterceptorStoresGeolocationAsIgnored(t *testing.T) {
-	interceptor := grpcmeta.UnaryServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("geolocation", "geo:47,11"))
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {
@@ -293,7 +321,7 @@ func TestUnaryServerInterceptorStoresGeolocationAsIgnored(t *testing.T) {
 }
 
 func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
-	interceptor := grpcmeta.StreamServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).StreamInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Map{})
 	stream := &test.MetaServerStream{Ctx: ctx}
 
@@ -309,7 +337,7 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 }
 
 func TestStreamServerInterceptorPreservesIncomingRequestID(t *testing.T) {
-	interceptor := grpcmeta.StreamServerInterceptor(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).StreamInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("request-id", "caller-id"))
 	stream := &test.MetaServerStream{Ctx: ctx}
 
@@ -325,7 +353,7 @@ func TestStreamServerInterceptorPreservesIncomingRequestID(t *testing.T) {
 func TestStreamServerInterceptorExtractsOperationMetadata(t *testing.T) {
 	policy := method.NewPolicy()
 	policy.Operation(health.WatchFullMethodName)
-	interceptor := grpcmeta.StreamServerInterceptor(policy, env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"))
+	interceptor := grpcmeta.NewServer(policy, env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).StreamInterceptor()
 	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs(
 		"authorization", "invalid",
 		"user-agent", "watch-agent",

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -19,7 +19,27 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-// UnaryServerInterceptor returns a gRPC unary server interceptor that extracts metadata into the context.
+// NewServer constructs a metadata interceptor provider for a gRPC server.
+func NewServer(policy *method.Policy, userAgent env.UserAgent, version env.Version, generator id.Generator, limit meta.Limit) *Server {
+	return &Server{
+		policy:    policy,
+		userAgent: userAgent,
+		version:   version,
+		generator: generator,
+		limit:     limit,
+	}
+}
+
+// Server provides gRPC server interceptors that extract request metadata.
+type Server struct {
+	generator id.Generator
+	policy    *method.Policy
+	userAgent env.UserAgent
+	version   env.Version
+	limit     meta.Limit
+}
+
+// UnaryInterceptor returns a gRPC unary server interceptor that extracts metadata into the context.
 //
 // Requests with ignorable unary methods bypass extraction.
 //
@@ -39,16 +59,16 @@ import (
 //
 // If the Authorization header is present but invalid, the interceptor returns a
 // [codes.InvalidArgument] gRPC status error.
-func UnaryServerInterceptor(policy *method.Policy, userAgent env.UserAgent, version env.Version, generator id.Generator) grpc.UnaryServerInterceptor {
-	serviceVersion := version.String()
+func (s *Server) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	serviceVersion := s.version.String()
 
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if policy.IsOperation(info.FullMethod) {
+		if s.policy.IsOperation(info.FullMethod) {
 			return handler(ctx, req)
 		}
 
-		ua := serverUserAgent(ctx, userAgent)
-		id := serverRequestID(ctx, generator)
+		ua := serverUserAgent(ctx, s.userAgent)
+		id := serverRequestID(ctx, s.generator)
 
 		ipKind, ipAddr := serverIPAddr(ctx)
 		geolocation := serverGeolocation(ctx)
@@ -67,7 +87,7 @@ func UnaryServerInterceptor(policy *method.Policy, userAgent env.UserAgent, vers
 			meta.WithGeolocation(geolocation),
 			meta.WithAuthorization(auth),
 		)
-		stampSpan(ctx)
+		stampSpan(ctx, s.limit)
 
 		_ = grpc.SetHeader(ctx, serverResponseHeaders(serviceVersion, id.Value()))
 
@@ -75,22 +95,22 @@ func UnaryServerInterceptor(policy *method.Policy, userAgent env.UserAgent, vers
 	}
 }
 
-// StreamServerInterceptor returns a gRPC stream server interceptor that extracts metadata into the stream context.
+// StreamInterceptor returns a gRPC stream server interceptor that extracts metadata into the stream context.
 //
 // Stream methods always run metadata extraction. This keeps long-lived operation streams, such as health Watch,
 // visible to downstream stream interceptors that need request metadata for resource controls.
 //
-// The interceptor performs the same metadata-to-context projection as [UnaryServerInterceptor], but applies it to
+// The interceptor performs the same metadata-to-context projection as [Server.UnaryInterceptor], but applies it to
 // the wrapped stream context, stores "grpc" as the ignored transport attribute, and emits response headers
 // through the stream API.
-func StreamServerInterceptor(policy *method.Policy, userAgent env.UserAgent, version env.Version, generator id.Generator) grpc.StreamServerInterceptor {
-	serviceVersion := version.String()
+func (s *Server) StreamInterceptor() grpc.StreamServerInterceptor {
+	serviceVersion := s.version.String()
 
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := stream.Context()
-		ua := serverUserAgent(ctx, userAgent)
+		ua := serverUserAgent(ctx, s.userAgent)
 
-		id := serverRequestID(ctx, generator)
+		id := serverRequestID(ctx, s.generator)
 
 		ipKind, ipAddr := serverIPAddr(ctx)
 		geolocation := serverGeolocation(ctx)
@@ -98,7 +118,7 @@ func StreamServerInterceptor(policy *method.Policy, userAgent env.UserAgent, ver
 		// Operation streams still need metadata for limiting, but they keep the same auth bypass as unary
 		// operation methods.
 		var auth meta.Value
-		if policy.IsOperation(info.FullMethod) {
+		if s.policy.IsOperation(info.FullMethod) {
 			auth = meta.Blank()
 		} else {
 			a, err := serverAuthorization(ctx)
@@ -117,7 +137,7 @@ func StreamServerInterceptor(policy *method.Policy, userAgent env.UserAgent, ver
 			meta.WithGeolocation(geolocation),
 			meta.WithAuthorization(auth),
 		)
-		stampSpan(ctx)
+		stampSpan(ctx, s.limit)
 
 		_ = stream.SetHeader(serverResponseHeaders(serviceVersion, id.Value()))
 
@@ -134,8 +154,8 @@ func StreamServerInterceptor(policy *method.Policy, userAgent env.UserAgent, ver
 // The tracer's metadata span processor cannot cover the server span, because
 // its context has no metadata yet when the span starts; child spans (database,
 // cache, ...) are stamped by that processor instead.
-func stampSpan(ctx context.Context) {
-	attributes.Record(ctx, attributes.Strings(meta.CamelStrings(ctx, meta.NoPrefix))...)
+func stampSpan(ctx context.Context, limit meta.Limit) {
+	attributes.Record(ctx, attributes.Strings(meta.Attributes(ctx, limit))...)
 }
 
 func serverResponseHeaders(serviceVersion, requestID string) Map {

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -3,6 +3,7 @@ package meta_test
 import (
 	"net/http/httptest"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -112,7 +113,7 @@ func TestRoundTripperStoresServiceMethod(t *testing.T) {
 }
 
 func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
-	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil, 1024)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -128,7 +129,7 @@ func TestHandlerAppendDoesNotOverwriteRequestID(t *testing.T) {
 func TestHandlerStampsSpanWithMeta(t *testing.T) {
 	exporter := test.EnableIsolatedSpanExporter(t)
 
-	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil, 1024)
 	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "request")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)
@@ -147,8 +148,36 @@ func TestHandlerStampsSpanWithMeta(t *testing.T) {
 	require.Equal(t, "request-id", values[meta.RequestIDKey])
 }
 
+func TestHandlerBoundsSpanMetaWithoutChangingRequestID(t *testing.T) {
+	exporter := test.EnableIsolatedSpanExporter(t)
+	requestID := "aaé"
+
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), nil, 3)
+	ctx, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "request")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/users/123", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Request-Id", requestID)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		require.Equal(t, requestID, meta.RequestID(req.Context()).Value())
+	})
+	span.End()
+
+	spans := exporter.Spans()
+	require.Len(t, spans, 1)
+
+	values := make(map[string]string)
+	for _, attr := range spans[0].Attributes() {
+		values[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "aa", values[meta.RequestIDKey])
+	require.True(t, utf8.ValidString(values[meta.RequestIDKey]))
+	require.Equal(t, requestID, res.Header().Get("Request-Id"))
+}
+
 func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
-	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil, 1024)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -164,7 +193,7 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 	mux := http.NewServeMux()
 	router := http.NewRouter(mux, http.NewRoutePolicy())
 	router.HandleRoute("GET /users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), mux)
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), mux, 1024)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/123", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()
@@ -178,7 +207,7 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 }
 
 func TestHandlerStoresGeolocationAsIgnored(t *testing.T) {
-	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil)
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil, 1024)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	req.Header.Set("Geolocation", "geo:47,11")

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -20,8 +20,8 @@ import (
 // It is designed to be used early in the server middleware chain so downstream middleware and handlers can
 // rely on a populated context (for example, logging, auth, rate limiting, and tracing). When mux is non-nil,
 // the handler uses it to resolve the matched route pattern before downstream middleware runs.
-func NewHandler(userAgent env.UserAgent, version env.Version, generator id.Generator, mux *http.ServeMux) *Handler {
-	return &Handler{userAgent: userAgent, serviceVersion: version.String(), generator: generator, mux: mux}
+func NewHandler(userAgent env.UserAgent, version env.Version, generator id.Generator, mux *http.ServeMux, limit meta.Limit) *Handler {
+	return &Handler{userAgent: userAgent, serviceVersion: version.String(), generator: generator, mux: mux, limit: limit}
 }
 
 // Handler extracts request metadata and stores it in the request context.
@@ -34,6 +34,7 @@ type Handler struct {
 	mux            *http.ServeMux
 	userAgent      env.UserAgent
 	serviceVersion string
+	limit          meta.Limit
 }
 
 // ServeHTTP extracts metadata from req and stores it in the request context.
@@ -82,7 +83,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 		meta.WithGeolocation(geolocation),
 		meta.WithAuthorization(auth),
 	)
-	stampSpan(ctx)
+	h.stampSpan(ctx)
 
 	next(res, req.WithContext(ctx))
 }
@@ -93,8 +94,8 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request, next htt
 // The tracer's metadata span processor cannot cover the server span, because
 // its context has no metadata yet when the span starts; child spans (database,
 // cache, ...) are stamped by that processor instead.
-func stampSpan(ctx context.Context) {
-	attributes.Record(ctx, attributes.Strings(meta.CamelStrings(ctx, meta.NoPrefix))...)
+func (h *Handler) stampSpan(ctx context.Context) {
+	attributes.Record(ctx, attributes.Strings(meta.Attributes(ctx, h.limit))...)
 }
 
 func serverSetResponseHeaders(header http.Header, serviceVersion, requestID string) {

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
@@ -13,6 +15,7 @@ import (
 // their overall configuration. Each field points at a per-signal configuration
 // struct:
 //
+//   - Metadata configures context metadata copied to log records and spans.
 //   - Logger configures application/system logging and any configured log exporters.
 //   - Metrics configures metrics collection/readers/exporters.
 //   - Propagation configures context propagation formats.
@@ -31,6 +34,9 @@ type Config struct {
 	// duplicate keys.
 	Attributes attributes.Map `yaml:"attributes,omitempty" json:"attributes,omitempty" toml:"attributes,omitempty"`
 
+	// Metadata configures request and service metadata exported to logs and traces.
+	Metadata *MetadataConfig `yaml:"metadata,omitempty" json:"metadata,omitempty" toml:"metadata,omitempty"`
+
 	// Logger configures application/system logging output and exporters.
 	Logger *logger.Config `yaml:"logger,omitempty" json:"logger,omitempty" toml:"logger,omitempty"`
 
@@ -42,6 +48,27 @@ type Config struct {
 
 	// Tracer configures distributed tracing (spans) and exporting.
 	Tracer *tracer.Config `yaml:"tracer,omitempty" json:"tracer,omitempty" toml:"tracer,omitempty"`
+}
+
+// MetadataConfig configures the metadata values exported to logs and traces.
+//
+// A zero MaxValueSize uses the 1,024-byte default. The original context
+// metadata is not modified.
+type MetadataConfig struct {
+	// MaxValueSize caps each exported metadata value. It accepts the repository's
+	// decimal byte-size syntax, such as "4KB".
+	MaxValueSize bytes.Size `yaml:"max_value_size,omitempty" json:"max_value_size,omitempty" toml:"max_value_size,omitempty" validate:"config_size"`
+}
+
+// GetMaxValueSize returns the configured metadata value size limit.
+//
+// A nil receiver or zero value returns the 1,024-byte default.
+func (c *MetadataConfig) GetMaxValueSize() meta.Limit {
+	if c == nil || c.MaxValueSize == 0 {
+		return meta.Limit(1024)
+	}
+
+	return meta.Limit(c.MaxValueSize)
 }
 
 // IsEnabled reports whether telemetry configuration is present.

--- a/telemetry/config_test.go
+++ b/telemetry/config_test.go
@@ -1,0 +1,25 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataConfigGetMaxValueSize(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		config *telemetry.MetadataConfig
+		want   bytes.Size
+	}{
+		{name: "nil", want: 1024},
+		{name: "zero", config: &telemetry.MetadataConfig{}, want: 1024},
+		{name: "configured", config: &telemetry.MetadataConfig{MaxValueSize: 4 * bytes.KB}, want: 4 * bytes.KB},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, bytes.Size(test.config.GetMaxValueSize()))
+		})
+	}
+}

--- a/telemetry/logger/doc.go
+++ b/telemetry/logger/doc.go
@@ -38,9 +38,9 @@
 // This ensures common request/service metadata and errors show up consistently across
 // handlers/exporters.
 //
-// Metadata values are capped at 1024 bytes before being attached to the log
-// record. Truncation preserves UTF-8 validity so multi-byte characters are not
-// split.
+// Metadata values use telemetry.metadata.max_value_size, which defaults to
+// 1,024 bytes. Truncation preserves UTF-8 validity so multi-byte characters
+// are not split.
 //
 // # Trace correlation
 //

--- a/telemetry/logger/logger.go
+++ b/telemetry/logger/logger.go
@@ -7,29 +7,28 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
 )
 
-const (
-	// LevelError is the error log level.
-	//
-	// It is an alias of slog.LevelError, provided so callers can depend on the
-	// go-service logger package while using standard slog levels.
-	LevelError = slog.LevelError
+// LevelError is the error log level.
+//
+// It is an alias of slog.LevelError, provided so callers can depend on the
+// go-service logger package while using standard slog levels.
+const LevelError = slog.LevelError
 
-	// LevelInfo is the info log level.
-	//
-	// It is an alias of slog.LevelInfo, provided so callers can depend on the
-	// go-service logger package while using standard slog levels.
-	LevelInfo = slog.LevelInfo
+// LevelInfo is the info log level.
+//
+// It is an alias of slog.LevelInfo, provided so callers can depend on the
+// go-service logger package while using standard slog levels.
+const LevelInfo = slog.LevelInfo
 
-	// LevelWarn is the warning log level.
-	//
-	// It is an alias of slog.LevelWarn, provided so callers can depend on the
-	// go-service logger package while using standard slog levels.
-	LevelWarn = slog.LevelWarn
-)
+// LevelWarn is the warning log level.
+//
+// It is an alias of slog.LevelWarn, provided so callers can depend on the
+// go-service logger package while using standard slog levels.
+const LevelWarn = slog.LevelWarn
 
 // Attr is an alias of [slog.Attr].
 //
@@ -129,6 +128,9 @@ type LoggerParams struct {
 	// Stdout-oriented logger kinds attach it as an "environment" attribute. The
 	// OTLP logger uses it when constructing the OpenTelemetry resource.
 	Environment env.Environment
+
+	// Limit bounds metadata values appended to log records.
+	Limit meta.Limit
 }
 
 // NewLogger constructs the configured slog logger, installs it as the
@@ -163,7 +165,7 @@ func NewLogger(params LoggerParams) (*Logger, error) {
 	}
 
 	slog.SetDefault(logger)
-	return &Logger{logger}, nil
+	return &Logger{Logger: logger, limit: params.Limit}, nil
 }
 
 // Logger wraps [slog.Logger] and adds go-service logging helpers.
@@ -182,6 +184,7 @@ func NewLogger(params LoggerParams) (*Logger, error) {
 // attributes automatically.
 type Logger struct {
 	*slog.Logger
+	limit meta.Limit
 }
 
 // Info logs at [LevelInfo].
@@ -247,7 +250,7 @@ func (l *Logger) LogAttrs(ctx context.Context, level slog.Level, msg Message, at
 		return
 	}
 
-	attrs = append(attrs, Meta(ctx)...)
+	attrs = append(attrs, Meta(ctx, l.limit)...)
 	attrs = append(attrs, Error(msg.Error))
 
 	l.Logger.LogAttrs(ctx, level, msg.Text, attrs...)

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -111,11 +111,11 @@ func TestMetaTruncatesLongValues(t *testing.T) {
 		meta.WithRequestID(meta.String(value)),
 	)
 
-	attrs := logger.Meta(ctx)
+	attrs := logger.Meta(ctx, 7)
 
 	require.Len(t, attrs, 1)
 	require.Equal(t, meta.RequestIDKey, attrs[0].Key)
-	require.Len(t, attrs[0].Value.String(), 1024)
+	require.Len(t, attrs[0].Value.String(), 7)
 }
 
 func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
@@ -123,7 +123,7 @@ func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
 		t.Context(),
 		meta.WithRequestID(meta.String(strings.Repeat("a", 2048))),
 	)
-	attrs := logger.Meta(ctx)
+	attrs := logger.Meta(ctx, 3)
 	require.Len(t, attrs, 1)
 
 	maxLength := len(attrs[0].Value.String())
@@ -142,7 +142,7 @@ func TestMetaTruncatesLongValuesAtUTF8Boundary(t *testing.T) {
 				meta.WithRequestID(meta.String(tt.value)),
 			)
 
-			attrs := logger.Meta(ctx)
+			attrs := logger.Meta(ctx, 3)
 			truncated := attrs[0].Value.String()
 
 			require.Len(t, attrs, 1)
@@ -258,7 +258,16 @@ func TestDisabledLogger(t *testing.T) {
 
 func TestLogAddsMetadataAndError(t *testing.T) {
 	handler := &test.CaptureHandler{}
-	log := &logger.Logger{Logger: slog.New(handler)}
+	original := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+	log, err := logger.NewLogger(logger.LoggerParams{
+		Config: &logger.Config{Kind: "json"},
+		Limit:  1024,
+	})
+	require.NoError(t, err)
+	log.Logger = slog.New(handler)
 	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
 
 	log.Log(ctx, logger.NewText("plain"), logger.String("component", "test"))

--- a/telemetry/logger/meta.go
+++ b/telemetry/logger/meta.go
@@ -2,44 +2,26 @@ package logger
 
 import (
 	"log/slog"
-	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/meta"
 )
-
-// maxMetaValueLength keeps context metadata useful in logs without allowing one
-// value to dominate every record.
-const maxMetaValueLength = 1024
 
 // Meta extracts context metadata and returns it as slog attributes.
 //
 // It reads metadata stored in the provided context (via the `meta` package) and converts
 // it to camel-cased string key/value attributes with no prefix.
 //
-// Metadata values longer than 1024 bytes are truncated at a valid UTF-8 boundary.
+// Metadata values are bounded by limit at a valid UTF-8 boundary.
 //
 // The returned attributes are intended to be appended to log records to provide
 // consistent request/service context across log lines.
-func Meta(ctx context.Context) []slog.Attr {
-	metadata := meta.CamelStrings(ctx, meta.NoPrefix)
-	fields := make([]slog.Attr, 0, len(metadata))
-	for k, v := range metadata {
-		fields = append(fields, slog.String(k, truncateMetaValue(v)))
+func Meta(ctx context.Context, limit meta.Limit) []slog.Attr {
+	attrs := meta.Attributes(ctx, limit)
+	fields := make([]slog.Attr, 0, len(attrs))
+	for key, value := range attrs {
+		fields = append(fields, slog.String(key, value))
 	}
+
 	return fields
-}
-
-func truncateMetaValue(value string) string {
-	if len(value) <= maxMetaValueLength {
-		return value
-	}
-
-	truncated := value[:maxMetaValueLength]
-	for !utf8.ValidString(truncated) {
-		_, size := utf8.DecodeLastRuneInString(truncated)
-		truncated = truncated[:len(truncated)-size]
-	}
-
-	return truncated
 }

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -30,7 +30,9 @@
 // by any instrumentation (server, database, cache, ...) carry the same context
 // used to correlate them with logs. The server/root span is created before that
 // metadata is available, so the transport metadata middleware stamps it
-// directly.
+// directly. Metadata values use telemetry.metadata.max_value_size, which
+// defaults to 1,024 bytes; full values remain in the request context and on
+// transport metadata.
 //
 // This package does not configure propagation. Propagation is configured at the top-level
 // telemetry package ([github.com/alexfalkowski/go-service/v2/telemetry.RegisterPropagation]), which sets the global

--- a/telemetry/tracer/meta.go
+++ b/telemetry/tracer/meta.go
@@ -13,27 +13,16 @@ import (
 // converts it to camel-cased string key/value attributes with no prefix, so a
 // span carries the request/service context (request id, user id, ip, ...) used
 // to correlate it with logs. It returns no attributes when ctx carries none.
-func Meta(ctx context.Context) []attributes.KeyValue {
-	return attributes.Strings(meta.CamelStrings(ctx, meta.NoPrefix))
+func Meta(ctx context.Context, limit meta.Limit) []attributes.KeyValue {
+	return attributes.Strings(meta.Attributes(ctx, limit))
 }
 
-// newMetaProcessor constructs a span processor that copies context metadata
-// onto every span as it starts.
-//
-// It lets spans created by any instrumentation (server, database, cache, ...)
-// carry the same request/service context as the logs (see [Meta]) without each
-// instrumentation having to wire metadata itself. Metadata is read from the
-// span's starting context, so the server/root span, whose context is not yet
-// populated when it starts, is stamped explicitly by the transport metadata
-// middleware instead.
-func newMetaProcessor() sdk.SpanProcessor {
-	return &metaProcessor{}
+type metaProcessor struct {
+	limit meta.Limit
 }
 
-type metaProcessor struct{}
-
-func (*metaProcessor) OnStart(parent context.Context, span sdk.ReadWriteSpan) {
-	if attrs := Meta(parent); len(attrs) > 0 {
+func (p *metaProcessor) OnStart(parent context.Context, span sdk.ReadWriteSpan) {
+	if attrs := Meta(parent, p.limit); len(attrs) > 0 {
 		span.SetAttributes(attrs...)
 	}
 }

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/env"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -97,8 +98,8 @@ func SpanFromContext(ctx context.Context) Span {
 // It always installs the metadata span processor (see [Meta]) so spans created
 // by any instrumentation carry the request/service context used to correlate
 // them with logs.
-func NewProvider(opts ...ProviderOption) *SDKProvider {
-	opts = append([]ProviderOption{sdk.WithSpanProcessor(newMetaProcessor())}, opts...)
+func NewProvider(limit meta.Limit, opts ...ProviderOption) *SDKProvider {
+	opts = append([]ProviderOption{sdk.WithSpanProcessor(&metaProcessor{limit: limit})}, opts...)
 
 	return sdk.NewTracerProvider(opts...)
 }
@@ -144,6 +145,9 @@ type TracerParams struct {
 	// Environment is the deployment environment name used for the resource's
 	// deployment.environment.name attribute.
 	Environment env.Environment
+
+	// Limit bounds metadata values attached to spans.
+	Limit meta.Limit
 }
 
 // Register configures and installs a global OpenTelemetry tracer provider.
@@ -198,7 +202,7 @@ func Register(params TracerParams) error {
 			providerOpts = append(providerOpts, sdk.WithSampler(sampler))
 		}
 
-		provider := NewProvider(providerOpts...)
+		provider := NewProvider(params.Limit, providerOpts...)
 		setProvider(provider, true)
 
 		params.Lifecycle.Append(di.Hook{

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -2,11 +2,13 @@ package tracer_test
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/alexfalkowski/go-service/v2/context"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
@@ -21,7 +23,7 @@ func TestMeta(t *testing.T) {
 		meta.WithUserID(meta.String("user-id")),
 	)
 
-	attrs := tracer.Meta(ctx)
+	attrs := tracer.Meta(ctx, 1024)
 
 	values := make(map[string]string, len(attrs))
 	for _, attr := range attrs {
@@ -33,7 +35,31 @@ func TestMeta(t *testing.T) {
 }
 
 func TestMetaWithoutAttributesIsEmpty(t *testing.T) {
-	require.Empty(t, tracer.Meta(t.Context()))
+	require.Empty(t, tracer.Meta(t.Context(), 1024))
+}
+
+func TestMetaBoundsValuesAtUTF8Boundary(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{name: "exact limit", value: strings.Repeat("a", 3), expected: strings.Repeat("a", 3)},
+		{name: "over limit", value: strings.Repeat("a", 4), expected: strings.Repeat("a", 3)},
+		{name: "multibyte", value: "aaé", expected: "aa"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String(tt.value)))
+
+			attrs := tracer.Meta(ctx, 3)
+
+			require.Len(t, attrs, 1)
+			require.Equal(t, tt.expected, attrs[0].Value.AsString())
+			require.True(t, utf8.ValidString(attrs[0].Value.AsString()))
+		})
+	}
 }
 
 func TestMetaSpanProcessorStampsChildSpans(t *testing.T) {
@@ -65,7 +91,7 @@ func TestIsEnabled(t *testing.T) {
 	tracer.SetProvider(nil)
 	require.False(t, tracer.IsEnabled())
 
-	provider := tracer.NewProvider()
+	provider := tracer.NewProvider(1024)
 	tracer.SetProvider(provider)
 	require.True(t, tracer.IsEnabled())
 	require.NoError(t, provider.Shutdown(t.Context()))

--- a/test/configs/config.hjson
+++ b/test/configs/config.hjson
@@ -98,6 +98,9 @@
       "k8s.namespace.name": payments
       "service.instance.id": "instance-1"
     }
+    metadata: {
+      max_value_size: 4KB
+    }
     logger: {
       kind: text
       level: info

--- a/test/configs/config.toml
+++ b/test/configs/config.toml
@@ -85,6 +85,9 @@ level = "info"
 "k8s.namespace.name" = "payments"
 "service.instance.id" = "instance-1"
 
+[telemetry.metadata]
+max_value_size = "4KB"
+
 [telemetry.metrics]
 kind = "prometheus"
 interval = "30s"

--- a/test/configs/config.yaml
+++ b/test/configs/config.yaml
@@ -68,6 +68,8 @@ telemetry:
   attributes:
     k8s.namespace.name: payments
     service.instance.id: instance-1
+  metadata:
+    max_value_size: 4KB
   logger:
     kind: text
     level: info

--- a/transport/grpc/breaker/breaker.go
+++ b/transport/grpc/breaker/breaker.go
@@ -16,7 +16,22 @@ import (
 // half-open probing, etc.) without importing the lower-level breaker package directly.
 type Settings = breaker.Settings
 
-// UnaryClientInterceptor returns a gRPC unary client interceptor guarded by circuit breakers.
+// NewClient returns a gRPC client guarded by circuit breakers.
+func NewClient(options ...Option) *Client {
+	o := defaultOpts()
+	for _, option := range options {
+		option.apply(o)
+	}
+
+	return &Client{registry: &registry{opts: o, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}}
+}
+
+// Client provides gRPC client circuit-breaking interceptors.
+type Client struct {
+	registry *registry
+}
+
+// UnaryInterceptor returns a gRPC unary client interceptor guarded by circuit breakers.
 //
 // The interceptor wraps the outgoing unary invocation (`invoker`) in a circuit breaker execution.
 // When the breaker is closed, calls flow through normally. When the breaker transitions open, new calls
@@ -41,20 +56,13 @@ type Settings = breaker.Settings
 // a locally marked gRPC `ResourceExhausted` status error so retry middleware returns it terminally.
 //
 // All other errors from the invoker are returned as-is.
-func UnaryClientInterceptor(options ...Option) grpc.UnaryClientInterceptor {
-	o := defaultOpts()
-	for _, option := range options {
-		option.apply(o)
-	}
-
-	r := &registry{opts: o, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}
-
+func (c *Client) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, callOpts ...grpc.CallOption) error {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return invoker(ctx, fullMethod, req, resp, conn, callOpts...)
 		}
 
-		cb := r.get(fullMethod)
+		cb := c.registry.get(fullMethod)
 		_, err := cb.Execute(func() (any, error) {
 			return nil, invoker(ctx, fullMethod, req, resp, conn, callOpts...)
 		})

--- a/transport/grpc/breaker/breaker_test.go
+++ b/transport/grpc/breaker/breaker_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnaryClientInterceptorUsesConfigFailureCodes(t *testing.T) {
-	interceptor := breaker.UnaryClientInterceptor(
+func TestClientUnaryInterceptorUsesConfigFailureCodes(t *testing.T) {
+	interceptor := breaker.NewClient(
 		breaker.NewConfig(test.NewBreaker(1), codes.InvalidArgument).Options()...,
-	)
+	).UnaryInterceptor()
 
 	calls := 0
 	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -37,11 +37,11 @@ func TestUnaryClientInterceptorUsesConfigFailureCodes(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotOpenOnNonFailureCode(t *testing.T) {
-	interceptor := breaker.UnaryClientInterceptor(
+func TestClientUnaryInterceptorDoesNotOpenOnNonFailureCode(t *testing.T) {
+	interceptor := breaker.NewClient(
 		breaker.WithSettings(settings()),
 		breaker.WithFailureCodes(codes.Unavailable),
-	)
+	).UnaryInterceptor()
 
 	calls := 0
 	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -59,7 +59,7 @@ func TestUnaryClientInterceptorDoesNotOpenOnNonFailureCode(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
+func TestClientUnaryInterceptorOpensOnClassifiedFailures(t *testing.T) {
 	tests := map[string]struct {
 		isSuccessful func(error) bool
 		code         codes.Code
@@ -80,10 +80,10 @@ func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			interceptor := breaker.UnaryClientInterceptor(
+			interceptor := breaker.NewClient(
 				breaker.WithSettings(settings(test.isSuccessful)),
 				breaker.WithFailureCodes(codes.Unavailable),
-			)
+			).UnaryInterceptor()
 
 			calls := 0
 			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -104,7 +104,7 @@ func TestUnaryClientInterceptorOpensOnClassifiedFailures(t *testing.T) {
 	}
 }
 
-func TestUnaryClientInterceptorDoesNotOpenOnCallerCancellation(t *testing.T) {
+func TestClientUnaryInterceptorDoesNotOpenOnCallerCancellation(t *testing.T) {
 	tests := map[string][]breaker.Option{
 		"canceled configured as a failure code": {
 			breaker.WithSettings(settings()),
@@ -117,7 +117,7 @@ func TestUnaryClientInterceptorDoesNotOpenOnCallerCancellation(t *testing.T) {
 
 	for name, opts := range tests {
 		t.Run(name, func(t *testing.T) {
-			interceptor := breaker.UnaryClientInterceptor(opts...)
+			interceptor := breaker.NewClient(opts...).UnaryInterceptor()
 
 			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 				return status.Error(codes.Canceled, "canceled")
@@ -136,10 +136,10 @@ func TestUnaryClientInterceptorDoesNotOpenOnCallerCancellation(t *testing.T) {
 	}
 }
 
-func TestUnaryClientInterceptorDoesNotOpenOnExpiredCallerDeadline(t *testing.T) {
-	interceptor := breaker.UnaryClientInterceptor(
+func TestClientUnaryInterceptorDoesNotOpenOnExpiredCallerDeadline(t *testing.T) {
+	interceptor := breaker.NewClient(
 		breaker.WithSettings(settings()),
-	)
+	).UnaryInterceptor()
 
 	expired, cancel := context.WithTimeout(t.Context(), 0)
 	t.Cleanup(cancel)
@@ -163,10 +163,10 @@ func TestUnaryClientInterceptorDoesNotOpenOnExpiredCallerDeadline(t *testing.T) 
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorOpensOnRemoteDeadline(t *testing.T) {
-	interceptor := breaker.UnaryClientInterceptor(
+func TestClientUnaryInterceptorOpensOnRemoteDeadline(t *testing.T) {
+	interceptor := breaker.NewClient(
 		breaker.WithSettings(settings()),
-	)
+	).UnaryInterceptor()
 
 	calls := 0
 	invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -185,13 +185,13 @@ func TestUnaryClientInterceptorOpensOnRemoteDeadline(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorOpensOnAttemptDeadline(t *testing.T) {
-	interceptor := breaker.UnaryClientInterceptor(
+func TestClientUnaryInterceptorOpensOnAttemptDeadline(t *testing.T) {
+	interceptor := breaker.NewClient(
 		breaker.WithSettings(settings()),
-	)
+	).UnaryInterceptor()
 	retryConfig := test.NewGRPCRetryConfig(1, time.Nanosecond)
 	retryConfig.Timeout = 10 * time.Millisecond
-	retrying := retry.UnaryClientInterceptor(retryConfig)
+	retrying := retry.NewClient(retryConfig).UnaryInterceptor()
 
 	calls := 0
 	attempt := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, callOpts ...grpc.CallOption) error {
@@ -215,11 +215,11 @@ func TestUnaryClientInterceptorOpensOnAttemptDeadline(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
-	interceptor := breaker.UnaryClientInterceptor(
+func TestClientUnaryInterceptorIsolatesBreakersByFullMethod(t *testing.T) {
+	interceptor := breaker.NewClient(
 		breaker.WithSettings(settings()),
 		breaker.WithFailureCodes(codes.Unavailable),
-	)
+	).UnaryInterceptor()
 
 	calls := make(map[string]int)
 	invoker := func(_ context.Context, fullMethod string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {

--- a/transport/grpc/breaker/doc.go
+++ b/transport/grpc/breaker/doc.go
@@ -20,5 +20,5 @@
 // interceptor returns a locally marked gRPC ResourceExhausted status error. Retry middleware treats
 // the local marker as terminal while preserving the status code and wrapped breaker cause.
 //
-// Start with [UnaryClientInterceptor].
+// Start with [NewClient].
 package breaker

--- a/transport/grpc/breaker/options.go
+++ b/transport/grpc/breaker/options.go
@@ -5,9 +5,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/breaker"
 )
 
-// Option configures the gRPC circuit breaker interceptor returned by [UnaryClientInterceptor].
+// Option configures the gRPC circuit breaker client returned by [NewClient].
 //
-// Options are applied in the order provided to [UnaryClientInterceptor]. If multiple options configure
+// Options are applied in the order provided to [NewClient]. If multiple options configure
 // the same field, the last one wins.
 type Option interface {
 	apply(opts *opts)

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -336,28 +336,28 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 	resolved := options(opts...)
 	unary := []grpc.UnaryClientInterceptor{}
 
-	unary = append(unary, meta.UnaryClientInterceptor(resolved.userAgent, resolved.generator))
+	unary = append(unary, meta.NewClient(resolved.userAgent, resolved.generator).UnaryInterceptor())
 	unary = append(unary, resolved.unary...)
 	unary = append(unary, grpc.TimeoutUnaryClientInterceptor(resolved.timeout))
 
 	if resolved.logger != nil {
-		unary = append(unary, logger.UnaryClientInterceptor(resolved.logger))
+		unary = append(unary, logger.NewClient(resolved.logger).UnaryInterceptor())
 	}
 
 	if resolved.retry != nil {
-		unary = append(unary, retry.UnaryClientInterceptor(resolved.retry, resolved.retryPolicies...))
+		unary = append(unary, retry.NewClient(resolved.retry, resolved.retryPolicies...).UnaryInterceptor())
 	}
 
 	if resolved.limiter != nil {
-		unary = append(unary, limiter.UnaryClientInterceptor(resolved.limiter))
+		unary = append(unary, resolved.limiter.UnaryInterceptor())
 	}
 
 	if resolved.breaker != nil {
-		unary = append(unary, breaker.UnaryClientInterceptor(resolved.breaker.Options()...))
+		unary = append(unary, breaker.NewClient(resolved.breaker.Options()...).UnaryInterceptor())
 	}
 
 	if resolved.gen != nil {
-		unary = append(unary, token.UnaryClientInterceptor(resolved.id, resolved.gen))
+		unary = append(unary, token.NewClient(resolved.id, resolved.gen).UnaryInterceptor())
 	}
 
 	return unary
@@ -365,21 +365,21 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 
 func streamDialOption(opts *clientOpts) grpc.DialOption {
 	stream := []grpc.StreamClientInterceptor{}
-	stream = append(stream, meta.StreamClientInterceptor(opts.userAgent, opts.generator))
+	stream = append(stream, meta.NewClient(opts.userAgent, opts.generator).StreamInterceptor())
 	stream = append(stream, opts.stream...)
 
 	if opts.logger != nil {
-		stream = append(stream, logger.StreamClientInterceptor(opts.logger))
+		stream = append(stream, logger.NewClient(opts.logger).StreamInterceptor())
 	}
 
 	// gRPC chains stream interceptors outermost-first, so keep the limiter before token injection
 	// to shed over-quota stream opens before token generation does key loading or signing work.
 	if opts.limiter != nil {
-		stream = append(stream, limiter.StreamClientInterceptor(opts.limiter))
+		stream = append(stream, opts.limiter.StreamInterceptor())
 	}
 
 	if opts.gen != nil {
-		stream = append(stream, token.StreamClientInterceptor(opts.id, opts.gen))
+		stream = append(stream, token.NewClient(opts.id, opts.gen).StreamInterceptor())
 	}
 
 	return grpc.WithChainStreamInterceptor(stream...)

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -47,7 +47,7 @@ func TestClientEmptyTLSConfigUsesTLS(t *testing.T) {
 }
 
 func TestRetryDoesNotReenterClientLimiter(t *testing.T) {
-	clientLimiter, err := grpclimiter.NewClientLimiter(
+	clientLimiter, err := grpclimiter.NewClient(
 		test.NoopLifecycle{},
 		limiter.NewKeyMap(),
 		test.NewLimiterConfig("user-agent", "1m", 0),
@@ -55,13 +55,13 @@ func TestRetryDoesNotReenterClientLimiter(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, clientLimiter.Close(t.Context())) })
 
-	limiting := grpclimiter.UnaryClientInterceptor(clientLimiter)
+	limiting := clientLimiter.UnaryInterceptor()
 	err = limiting(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 		return nil
 	})
 	require.NoError(t, err)
 
-	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted))
+	retrying := grpcretry.NewClient(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted)).UnaryInterceptor()
 	limiterCalls := 0
 	downstreamCalls := 0
 	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
@@ -81,7 +81,7 @@ func TestRetryDoesNotReenterClientLimiter(t *testing.T) {
 }
 
 func TestRetryDoesNotReenterClosedClientLimiter(t *testing.T) {
-	clientLimiter, err := grpclimiter.NewClientLimiter(
+	clientLimiter, err := grpclimiter.NewClient(
 		test.NoopLifecycle{},
 		limiter.NewKeyMap(),
 		test.NewLimiterConfig("user-agent", "1m", 10),
@@ -89,8 +89,8 @@ func TestRetryDoesNotReenterClosedClientLimiter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, clientLimiter.Close(t.Context()))
 
-	limiting := grpclimiter.UnaryClientInterceptor(clientLimiter)
-	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.Internal))
+	limiting := clientLimiter.UnaryInterceptor()
+	retrying := grpcretry.NewClient(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.Internal)).UnaryInterceptor()
 	limiterCalls := 0
 	downstreamCalls := 0
 	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
@@ -110,16 +110,16 @@ func TestRetryDoesNotReenterClosedClientLimiter(t *testing.T) {
 }
 
 func TestRetryDoesNotReenterClientBreaker(t *testing.T) {
-	breaking := grpcbreaker.UnaryClientInterceptor(
+	breaking := grpcbreaker.NewClient(
 		grpcbreaker.NewConfig(test.NewBreaker(1), codes.Unavailable).Options()...,
-	)
+	).UnaryInterceptor()
 	err := breaking(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
 		return status.Error(codes.Unavailable, "unavailable")
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.Unavailable, status.Code(err))
 
-	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted))
+	retrying := grpcretry.NewClient(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted)).UnaryInterceptor()
 	breakerCalls := 0
 	downstreamCalls := 0
 	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {
@@ -140,7 +140,7 @@ func TestRetryDoesNotReenterClientBreaker(t *testing.T) {
 }
 
 func TestRetryPreservesRemoteResourceExhausted(t *testing.T) {
-	clientLimiter, err := grpclimiter.NewClientLimiter(
+	clientLimiter, err := grpclimiter.NewClient(
 		test.NoopLifecycle{},
 		limiter.NewKeyMap(),
 		test.NewLimiterConfig("user-agent", "1m", 2),
@@ -148,8 +148,8 @@ func TestRetryPreservesRemoteResourceExhausted(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, clientLimiter.Close(t.Context())) })
 
-	limiting := grpclimiter.UnaryClientInterceptor(clientLimiter)
-	retrying := grpcretry.UnaryClientInterceptor(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted))
+	limiting := clientLimiter.UnaryInterceptor()
+	retrying := grpcretry.NewClient(test.NewGRPCRetryConfig(3, time.Nanosecond, codes.ResourceExhausted)).UnaryInterceptor()
 	limiterCalls := 0
 	downstreamCalls := 0
 	invoker := func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, opts ...grpc.CallOption) error {

--- a/transport/grpc/limiter.go
+++ b/transport/grpc/limiter.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/method"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
 )
 
@@ -13,11 +14,12 @@ import (
 // If cfg is disabled, it returns (nil, nil) so downstream wiring can treat rate limiting as not configured.
 //
 // The returned limiter is registered with the provided lifecycle. The `keys` map controls how request contexts
-// are turned into limiter keys (for example, per user-agent or per client IP).
-func NewServerLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *Config) (*limiter.Server, error) {
+// are turned into limiter keys (for example, per user-agent or per client IP), and policy controls which
+// unary methods bypass limiting.
+func NewServerLimiter(lc di.Lifecycle, keys limiter.KeyMap, cfg *Config, policy *method.Policy) (*limiter.Server, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
 
-	return limiter.NewServerLimiter(lc, keys, cfg.Limiter)
+	return limiter.NewServer(lc, keys, cfg.Limiter, policy)
 }

--- a/transport/grpc/limiter/client.go
+++ b/transport/grpc/limiter/client.go
@@ -8,13 +8,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
 
-// NewClientLimiter constructs a gRPC client-side rate limiter.
+// NewClient constructs a gRPC client-side rate limiter.
 //
 // If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
 //
 // The returned limiter is backed by [limiter.NewLimiter] and is registered with the provided lifecycle.
 // The `keys` map controls how request contexts are turned into limiter keys.
-func NewClientLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Client, error) {
+func NewClient(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Client, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
@@ -32,7 +32,7 @@ type Client struct {
 	*limiter.Limiter
 }
 
-// UnaryClientInterceptor returns a gRPC unary client interceptor that enforces rate limiting.
+// UnaryInterceptor returns a gRPC unary client interceptor that enforces rate limiting.
 //
 // The interceptor calls `limiter.TakeDecision(ctx)` before invoking the RPC:
 //
@@ -41,9 +41,9 @@ type Client struct {
 //   - Otherwise, it invokes the underlying `invoker`.
 //
 // Callers should only install this interceptor when limiter is non-nil.
-func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
+func (c *Client) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		decision, err := take(ctx, limiter.Limiter)
+		decision, err := take(ctx, c.Limiter)
 		if err != nil {
 			return status.LocalError(err)
 		}
@@ -56,7 +56,7 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 	}
 }
 
-// StreamClientInterceptor returns a gRPC stream client interceptor that enforces rate limiting.
+// StreamInterceptor returns a gRPC stream client interceptor that enforces rate limiting.
 //
 // The interceptor calls `limiter.TakeDecision(ctx)` before opening the stream, then meters each sent and received
 // stream message:
@@ -66,9 +66,9 @@ func UnaryClientInterceptor(limiter *Client) grpc.UnaryClientInterceptor {
 //   - Otherwise, it invokes the underlying `streamer`.
 //
 // Callers should only install this interceptor when limiter is non-nil.
-func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
+func (c *Client) StreamInterceptor() grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		decision, err := take(ctx, limiter.Limiter)
+		decision, err := take(ctx, c.Limiter)
 		if err != nil {
 			return nil, status.LocalError(err)
 		}
@@ -82,7 +82,7 @@ func StreamClientInterceptor(limiter *Client) grpc.StreamClientInterceptor {
 			return nil, err
 		}
 
-		return &clientStream{ClientStream: stream, ctx: ctx, limiter: limiter.Limiter}, nil
+		return &clientStream{ClientStream: stream, ctx: ctx, limiter: c.Limiter}, nil
 	}
 }
 

--- a/transport/grpc/limiter/doc.go
+++ b/transport/grpc/limiter/doc.go
@@ -21,6 +21,5 @@
 // terminally. Server-side denials remain ordinary remote ResourceExhausted
 // statuses and may be retried by configured clients.
 //
-// Start with [UnaryServerInterceptor] or [StreamServerInterceptor] for server-side limiting and
-// [UnaryClientInterceptor] or [StreamClientInterceptor] for client-side limiting.
+// Start with [NewServer] for server-side limiting or [NewClient] for client-side limiting.
 package limiter

--- a/transport/grpc/limiter/server.go
+++ b/transport/grpc/limiter/server.go
@@ -9,13 +9,14 @@ import (
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
 )
 
-// NewServerLimiter constructs a gRPC server-side rate limiter.
+// NewServer constructs a gRPC server-side rate limiter.
 //
 // If cfg is disabled, it returns (nil, nil) so callers can treat the limiter as not configured.
 //
 // The returned limiter is backed by [limiter.NewLimiter] and is registered with the provided lifecycle.
-// The `keys` map controls how request contexts are turned into limiter keys (for example, per user-agent).
-func NewServerLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Server, error) {
+// The `keys` map controls how request contexts are turned into limiter keys (for example, per user-agent),
+// and policy controls which unary methods bypass limiting.
+func NewServer(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config, policy *method.Policy) (*Server, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
@@ -25,15 +26,16 @@ func NewServerLimiter(lc di.Lifecycle, keys KeyMap, cfg *limiter.Config) (*Serve
 		return nil, err
 	}
 
-	return &Server{rateLimiter}, nil
+	return &Server{Limiter: rateLimiter, policy: policy}, nil
 }
 
 // Server wraps *[limiter.Limiter] for gRPC server integration.
 type Server struct {
 	*limiter.Limiter
+	policy *method.Policy
 }
 
-// UnaryServerInterceptor returns a gRPC unary server interceptor that enforces rate limiting.
+// UnaryInterceptor returns a gRPC unary server interceptor that enforces rate limiting.
 //
 // Operation unary methods bypass limiting.
 // Stream RPCs do not bypass limiting because long-lived streams, such as health Watch, can hold server resources
@@ -47,13 +49,13 @@ type Server struct {
 //   - Otherwise, it invokes the handler.
 //
 // Callers should only install this interceptor when limiter is non-nil.
-func UnaryServerInterceptor(policy *method.Policy, limiter *Server) grpc.UnaryServerInterceptor {
+func (s *Server) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if policy.IsOperation(info.FullMethod) {
+		if s.policy.IsOperation(info.FullMethod) {
 			return handler(ctx, req)
 		}
 
-		decision, err := take(ctx, limiter.Limiter)
+		decision, err := take(ctx, s.Limiter)
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +69,7 @@ func UnaryServerInterceptor(policy *method.Policy, limiter *Server) grpc.UnarySe
 	}
 }
 
-// StreamServerInterceptor returns a gRPC stream server interceptor that enforces rate limiting.
+// StreamInterceptor returns a gRPC stream server interceptor that enforces rate limiting.
 //
 // Unlike unary RPCs, operation streams are limited. This keeps long-lived streams, such as health Watch, from
 // bypassing the resource controls that protect regular service streams.
@@ -84,9 +86,9 @@ func UnaryServerInterceptor(policy *method.Policy, limiter *Server) grpc.UnarySe
 //   - Otherwise, it invokes the handler.
 //
 // Callers should only install this interceptor when limiter is non-nil.
-func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
+func (s *Server) StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		decision, err := take(stream.Context(), limiter.Limiter)
+		decision, err := take(stream.Context(), s.Limiter)
 		if err != nil {
 			return err
 		}
@@ -96,7 +98,7 @@ func StreamServerInterceptor(limiter *Server) grpc.StreamServerInterceptor {
 			return serverLimitError(decision)
 		}
 
-		return handler(srv, &serverStream{ServerStream: stream, limiter: limiter.Limiter})
+		return handler(srv, &serverStream{ServerStream: stream, limiter: s.Limiter})
 	}
 }
 

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/method"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/time"
 	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
@@ -63,10 +64,10 @@ func TestServerLimiterStream(t *testing.T) {
 }
 
 func TestServerLimiterStreamHeader(t *testing.T) {
-	limiter, err := grpclimiter.NewServerLimiter(fxtest.NewLifecycle(t), limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0))
+	limiter, err := grpclimiter.NewServer(fxtest.NewLifecycle(t), limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 0), method.NewPolicy())
 	require.NoError(t, err)
 	ctx := grpcmeta.WithAttributes(t.Context(), grpcmeta.WithUserAgent(grpcmeta.String("test-agent")))
-	interceptor := grpclimiter.StreamServerInterceptor(limiter)
+	interceptor := limiter.StreamInterceptor()
 
 	allowed := &test.MetaServerStream{Ctx: ctx}
 	err = interceptor(nil, allowed, &grpc.StreamServerInfo{FullMethod: "/greet.v1.GreeterService/SayStreamHello"}, func(any, grpc.ServerStream) error {

--- a/transport/grpc/recovery/doc.go
+++ b/transport/grpc/recovery/doc.go
@@ -1,0 +1,4 @@
+// Package recovery provides gRPC server interceptors that turn panics into application errors.
+//
+// Start with [NewServer].
+package recovery

--- a/transport/grpc/recovery/recovery.go
+++ b/transport/grpc/recovery/recovery.go
@@ -1,0 +1,29 @@
+package recovery
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
+)
+
+// NewServer constructs a gRPC panic recovery interceptor server.
+//
+// handler converts a recovered panic value into the error returned to the RPC caller. If handler is nil, the
+// interceptor returns the upstream default panic error.
+func NewServer(handler func(any) error) *Server {
+	return &Server{handler: handler}
+}
+
+// Server provides gRPC server interceptors that recover panics.
+type Server struct {
+	handler func(any) error
+}
+
+// UnaryInterceptor returns a gRPC unary server interceptor that recovers panics.
+func (s *Server) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(s.handler))
+}
+
+// StreamInterceptor returns a gRPC stream server interceptor that recovers panics.
+func (s *Server) StreamInterceptor() grpc.StreamServerInterceptor {
+	return recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(s.handler))
+}

--- a/transport/grpc/recovery/recovery_test.go
+++ b/transport/grpc/recovery/recovery_test.go
@@ -1,0 +1,34 @@
+package recovery_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/transport/grpc/recovery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerUnaryInterceptorRecoversPanic(t *testing.T) {
+	want := errors.New("recovered")
+	interceptor := recovery.NewServer(func(any) error { return want }).UnaryInterceptor()
+
+	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, func(context.Context, any) (any, error) {
+		panic("panic")
+	})
+
+	require.ErrorIs(t, err, want)
+}
+
+func TestServerStreamInterceptorRecoversPanic(t *testing.T) {
+	want := errors.New("recovered")
+	interceptor := recovery.NewServer(func(any) error { return want }).StreamInterceptor()
+
+	err := interceptor(nil, &test.MetaServerStream{Ctx: t.Context()}, &grpc.StreamServerInfo{}, func(any, grpc.ServerStream) error {
+		panic("panic")
+	})
+
+	require.ErrorIs(t, err, want)
+}

--- a/transport/grpc/retry/doc.go
+++ b/transport/grpc/retry/doc.go
@@ -4,7 +4,7 @@
 // client-side interceptors) and centralizes retry-related defaults used by the
 // transport stack.
 //
-// Default policy: if no policy is passed to UnaryClientInterceptor, only side-effect-safe unary RPCs are
+// Default policy: if no policy is passed to [NewClient], only side-effect-safe unary RPCs are
 // eligible for retry. This includes AIP-style read methods and requests carrying a request-id. In go-service,
 // request-id identifies the logical request and is stable across retry attempts, so services that retry writes
 // should deduplicate by request-id. Callers that need different retry eligibility can pass an explicit policy.
@@ -18,5 +18,5 @@
 // terminal. An unmarked response with the same gRPC code remains governed by
 // the configured retry codes.
 //
-// Start with [Config] and [UnaryClientInterceptor].
+// Start with [Config] and [NewClient].
 package retry

--- a/transport/grpc/retry/retry.go
+++ b/transport/grpc/retry/retry.go
@@ -43,7 +43,18 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 	return StandardReadMethods(ctx, fullMethod, req) || HasRequestID(ctx, fullMethod, req)
 }
 
-// UnaryClientInterceptor returns a gRPC unary client interceptor that retries failed calls.
+// NewClient returns a gRPC client that retries failed calls.
+func NewClient(cfg *Config, policies ...Policy) *Client {
+	return &Client{cfg: cfg, policies: policies}
+}
+
+// Client provides gRPC client retry interceptors.
+type Client struct {
+	cfg      *Config
+	policies []Policy
+}
+
+// UnaryInterceptor returns a gRPC unary client interceptor that retries failed calls.
 //
 // Behavior:
 //   - It checks whether the logical RPC is eligible for retry using policies.
@@ -66,17 +77,17 @@ func IdempotentMethods(ctx context.Context, fullMethod string, req any) bool {
 // Notes:
 // This interceptor does not automatically retry on every error; application-level errors that map to other
 // status codes will not be retried by default.
-func UnaryClientInterceptor(cfg *Config, policies ...Policy) grpc.UnaryClientInterceptor {
-	policy := composePolicy(policies)
-	maxAttempts := cfg.MaxAttempts()
-	timeout := cfg.GetTimeout()
-	backoff := cfg.GetBackoff()
-	maxBackoff := cfg.GetMaxBackoff()
+func (c *Client) UnaryInterceptor() grpc.UnaryClientInterceptor {
+	policy := composePolicy(c.policies)
+	maxAttempts := c.cfg.MaxAttempts()
+	timeout := c.cfg.GetTimeout()
+	backoff := c.cfg.GetBackoff()
+	maxBackoff := c.cfg.GetMaxBackoff()
 	if maxBackoff > 0 && maxBackoff < backoff {
 		backoff = maxBackoff
 	}
-	strategy := cfg.GetStrategy()
-	codes := retryableCodes(cfg)
+	strategy := c.cfg.GetStrategy()
+	codes := retryableCodes(c.cfg)
 
 	invoke := func(ctx context.Context, attempt func(context.Context) error) error {
 		if maxAttempts == 0 {

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -31,8 +31,8 @@ func TestNewConfigReturnsGRPCConfig(t *testing.T) {
 	require.Nil(t, retry.NewConfig(nil))
 }
 
-func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(1, time.Millisecond))
+func TestClientUnaryInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(1, time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/SayHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -44,8 +44,8 @@ func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsOne(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsZero(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(0, time.Millisecond))
+func TestClientUnaryInterceptorDoesNotRetryWhenAttemptsIsZero(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(0, time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -57,8 +57,8 @@ func TestUnaryClientInterceptorDoesNotRetryWhenAttemptsIsZero(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorClampsAttemptsAboveMax(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(config.MaxAttempts+1, time.Nanosecond))
+func TestClientUnaryInterceptorClampsAttemptsAboveMax(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(config.MaxAttempts+1, time.Nanosecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -70,8 +70,8 @@ func TestUnaryClientInterceptorClampsAttemptsAboveMax(t *testing.T) {
 	require.Equal(t, int(config.MaxAttempts), calls)
 }
 
-func TestUnaryClientInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond))
+func TestClientUnaryInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -87,8 +87,8 @@ func TestUnaryClientInterceptorRetriesSafeMethodWhenAttemptsIsTwo(t *testing.T) 
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorRetriesConfiguredCode(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted))
+func TestClientUnaryInterceptorRetriesConfiguredCode(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -104,8 +104,8 @@ func TestUnaryClientInterceptorRetriesConfiguredCode(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotRetryLocalStatusError(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted))
+func TestClientUnaryInterceptorDoesNotRetryLocalStatusError(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -120,8 +120,8 @@ func TestUnaryClientInterceptorDoesNotRetryLocalStatusError(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorConfiguredCodesReplaceDefaults(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted))
+func TestClientUnaryInterceptorConfiguredCodesReplaceDefaults(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond, codes.ResourceExhausted)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -133,10 +133,10 @@ func TestUnaryClientInterceptorConfiguredCodesReplaceDefaults(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
+func TestClientUnaryInterceptorCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		cfg := config.Config{Strategy: "exponential", Backoff: 2 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Timeout: time.Second, Attempts: config.MaxAttempts}
-		interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+		interceptor := retry.NewClient(retry.NewConfig(&cfg)).UnaryInterceptor()
 
 		calls := 0
 		start := time.Now()
@@ -155,8 +155,8 @@ func TestUnaryClientInterceptorCapsGrowingBackoffWithMaxBackoff(t *testing.T) {
 	})
 }
 
-func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 0))
+func TestClientUnaryInterceptorRetriesWithDefaultBackoff(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, 0)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -172,8 +172,8 @@ func TestUnaryClientInterceptorRetriesWithDefaultBackoff(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsMinimumBackoff(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 10*time.Millisecond))
+func TestClientUnaryInterceptorDoesNotRetryWhenRetryInfoDelayExceedsMinimumBackoff(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, 10*time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -185,7 +185,7 @@ func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsMinimumBacko
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorHonorsGrownBackoffForRetryInfo(t *testing.T) {
+func TestClientUnaryInterceptorHonorsGrownBackoffForRetryInfo(t *testing.T) {
 	tests := []struct {
 		name  string
 		delay time.Duration
@@ -201,7 +201,7 @@ func TestUnaryClientInterceptorHonorsGrownBackoffForRetryInfo(t *testing.T) {
 			// Exponential growth from a 10ms base gives ~10ms before attempt 2 and ~20ms before
 			// attempt 3; the second attempt's gate must compare against the latter, not the base.
 			cfg := config.Config{Strategy: "exponential", Backoff: 10 * time.Millisecond, Attempts: 3}
-			interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+			interceptor := retry.NewClient(retry.NewConfig(&cfg)).UnaryInterceptor()
 
 			calls := 0
 			err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -226,9 +226,9 @@ func TestUnaryClientInterceptorHonorsGrownBackoffForRetryInfo(t *testing.T) {
 	}
 }
 
-func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsCappedBackoff(t *testing.T) {
+func TestClientUnaryInterceptorDoesNotRetryWhenRetryInfoDelayExceedsCappedBackoff(t *testing.T) {
 	cfg := config.Config{Strategy: "exponential", Backoff: 100 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, Timeout: time.Second, Attempts: 2}
-	interceptor := retry.UnaryClientInterceptor(retry.NewConfig(&cfg))
+	interceptor := retry.NewClient(retry.NewConfig(&cfg)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -240,7 +240,7 @@ func TestUnaryClientInterceptorDoesNotRetryWhenRetryInfoDelayExceedsCappedBackof
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *testing.T) {
+func TestClientUnaryInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *testing.T) {
 	tests := map[string]time.Duration{
 		"minimum": 8 * time.Millisecond,
 		"zero":    0,
@@ -249,7 +249,7 @@ func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *
 
 	for name, delay := range tests {
 		t.Run(name, func(t *testing.T) {
-			interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 10*time.Millisecond))
+			interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, 10*time.Millisecond)).UnaryInterceptor()
 
 			calls := 0
 			err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -267,8 +267,8 @@ func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayDoesNotExceedBackoff(t *
 	}
 }
 
-func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayIsMissing(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, 10*time.Millisecond))
+func TestClientUnaryInterceptorRetriesWhenRetryInfoDelayIsMissing(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, 10*time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -287,8 +287,8 @@ func TestUnaryClientInterceptorRetriesWhenRetryInfoDelayIsMissing(t *testing.T) 
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorSetsDeadlineForEachAttempt(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond))
+func TestClientUnaryInterceptorSetsDeadlineForEachAttempt(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
@@ -306,8 +306,8 @@ func TestUnaryClientInterceptorSetsDeadlineForEachAttempt(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotRetryUnsafeMethodByDefault(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond))
+func TestClientUnaryInterceptorDoesNotRetryUnsafeMethodByDefault(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -319,8 +319,8 @@ func TestUnaryClientInterceptorDoesNotRetryUnsafeMethodByDefault(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotRetryDataLossByDefault(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond))
+func TestClientUnaryInterceptorDoesNotRetryDataLossByDefault(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond)).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -332,7 +332,7 @@ func TestUnaryClientInterceptorDoesNotRetryDataLossByDefault(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorDoesNotRetryContextStatusCodesByDefault(t *testing.T) {
+func TestClientUnaryInterceptorDoesNotRetryContextStatusCodesByDefault(t *testing.T) {
 	tests := []struct {
 		name string
 		code codes.Code
@@ -343,7 +343,7 @@ func TestUnaryClientInterceptorDoesNotRetryContextStatusCodesByDefault(t *testin
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond))
+			interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond)).UnaryInterceptor()
 
 			calls := 0
 			err := interceptor(t.Context(), "/test.Service/GetBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -357,8 +357,8 @@ func TestUnaryClientInterceptorDoesNotRetryContextStatusCodesByDefault(t *testin
 	}
 }
 
-func TestUnaryClientInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond), retry.StandardReadMethods)
+func TestClientUnaryInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond), retry.StandardReadMethods).UnaryInterceptor()
 
 	calls := 0
 	err := interceptor(t.Context(), "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -370,7 +370,7 @@ func TestUnaryClientInterceptorDoesNotRetryWhenPolicyDeniesMethod(t *testing.T) 
 	require.Equal(t, 1, calls)
 }
 
-func TestUnaryClientInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
+func TestClientUnaryInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
 	tests := []struct {
 		name       string
 		fullMethod string
@@ -381,7 +381,7 @@ func TestUnaryClientInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond), retry.StandardReadMethods)
+			interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond), retry.StandardReadMethods).UnaryInterceptor()
 
 			calls := 0
 			err := interceptor(t.Context(), tt.fullMethod, nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -399,7 +399,7 @@ func TestUnaryClientInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
 	}
 }
 
-func TestUnaryClientInterceptorComposesMultiplePolicies(t *testing.T) {
+func TestClientUnaryInterceptorComposesMultiplePolicies(t *testing.T) {
 	allow := retry.Policy(func(context.Context, string, any) bool { return true })
 	deny := retry.Policy(func(context.Context, string, any) bool { return false })
 
@@ -414,7 +414,7 @@ func TestUnaryClientInterceptorComposesMultiplePolicies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond), tt.policies...)
+			interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond), tt.policies...).UnaryInterceptor()
 
 			calls := 0
 			err := interceptor(t.Context(), "/test.Service/CreateBook", nil, nil, nil, func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
@@ -435,8 +435,8 @@ func TestUnaryClientInterceptorComposesMultiplePolicies(t *testing.T) {
 	}
 }
 
-func TestUnaryClientInterceptorRetriesWhenPolicyAllowsRequestID(t *testing.T) {
-	interceptor := retry.UnaryClientInterceptor(test.NewGRPCRetryConfig(2, time.Millisecond), retry.IdempotentMethods)
+func TestClientUnaryInterceptorRetriesWhenPolicyAllowsRequestID(t *testing.T) {
+	interceptor := retry.NewClient(test.NewGRPCRetryConfig(2, time.Millisecond), retry.IdempotentMethods).UnaryInterceptor()
 
 	ctx := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("request-id")))
 	calls := 0

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -9,11 +9,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/config"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	grpcserver "github.com/alexfalkowski/go-service/v2/net/grpc/server"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/telemetry"
@@ -23,9 +24,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/alexfalkowski/go-service/v2/token/access"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
+	"github.com/alexfalkowski/go-service/v2/transport/grpc/recovery"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/telemetry/logger"
 	"github.com/alexfalkowski/go-service/v2/transport/grpc/token"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 )
 
 // ServerParams defines dependencies for constructing a gRPC transport [Server].
@@ -47,20 +48,20 @@ type ServerParams struct {
 	// Shutdowner is used by the underlying *[server.Service] to coordinate shutdown.
 	Shutdowner di.Shutdowner
 
+	// ID generates request IDs when one is not already present.
+	ID id.Generator
+
+	// Verifier enables server-side token verification when non-nil.
+	Verifier token.Verifier
+
+	// Access enables server-side access control when non-nil.
+	Access access.Controller
+
 	// Config controls gRPC server enablement, address, timeouts, TLS, and low-level gRPC options.
 	Config *Config
 
 	// Logger enables gRPC server logging interceptors when non-nil.
 	Logger *logger.Logger
-
-	// UserAgent is the service user agent used by metadata interceptors.
-	UserAgent env.UserAgent
-
-	// Version is the service version reported via metadata interceptors.
-	Version env.Version
-
-	// ID generates request IDs when one is not already present.
-	ID id.Generator
 
 	// MethodPolicy stores gRPC method behavior used by server middleware.
 	MethodPolicy *grpc.MethodPolicy
@@ -68,11 +69,11 @@ type ServerParams struct {
 	// Limiter enables server-side rate limiting when non-nil.
 	Limiter *limiter.Server
 
-	// Verifier enables server-side token verification when non-nil.
-	Verifier token.Verifier
+	// UserAgent is the service user agent used by metadata interceptors.
+	UserAgent env.UserAgent
 
-	// Access enables server-side access control when non-nil.
-	Access access.Controller
+	// Version is the service version reported via metadata interceptors.
+	Version env.Version
 
 	// Unary are additional unary server interceptors to append after the standard chain.
 	Unary []grpc.UnaryServerInterceptor `optional:"true"`
@@ -85,6 +86,9 @@ type ServerParams struct {
 	// This is an escape hatch for passing options not modeled by this package, such as
 	// grpc.InTapHandle, a second grpc.StatsHandler, or grpc.UnknownServiceHandler.
 	Options []grpc.ServerOption `optional:"true"`
+
+	// Limit bounds metadata values attached to server spans.
+	Limit meta.Limit
 }
 
 // NewServer constructs a gRPC transport [Server] when the transport is enabled.
@@ -180,27 +184,27 @@ func (s *Server) GetService() *grpcserver.Service {
 
 func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInterceptor) grpc.ServerOption {
 	uis := []grpc.UnaryServerInterceptor{
-		recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)),
-		meta.UnaryServerInterceptor(params.MethodPolicy, params.UserAgent, params.Version, params.ID),
+		recovery.NewServer(recoveryHandler).UnaryInterceptor(),
+		grpcmeta.NewServer(params.MethodPolicy, params.UserAgent, params.Version, params.ID, params.Limit).UnaryInterceptor(),
 		grpc.TimeoutUnaryServerInterceptor(params.Config.GetTimeout()),
 	}
 
 	if params.Logger != nil {
-		uis = append(uis, logger.UnaryServerInterceptor(params.MethodPolicy, params.Logger))
+		uis = append(uis, logger.NewServer(params.MethodPolicy, params.Logger).UnaryInterceptor())
 	}
 
-	uis = append(uis, recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)))
+	uis = append(uis, recovery.NewServer(recoveryHandler).UnaryInterceptor())
 
 	if params.Verifier != nil {
-		uis = append(uis, token.UnaryServerInterceptor(params.MethodPolicy, params.Verifier))
+		uis = append(uis, token.NewServer(params.MethodPolicy, params.Verifier, nil).UnaryInterceptor())
 	}
 
 	if params.Limiter != nil {
-		uis = append(uis, limiter.UnaryServerInterceptor(params.MethodPolicy, params.Limiter))
+		uis = append(uis, params.Limiter.UnaryInterceptor())
 	}
 
 	if params.Access != nil {
-		uis = append(uis, token.UnaryAccessServerInterceptor(params.MethodPolicy, params.Access))
+		uis = append(uis, token.NewServer(params.MethodPolicy, nil, params.Access).UnaryAccessInterceptor())
 	}
 
 	uis = append(uis, interceptors...)
@@ -210,26 +214,26 @@ func unaryServerOption(params ServerParams, interceptors ...grpc.UnaryServerInte
 
 func streamServerOption(params ServerParams, interceptors ...grpc.StreamServerInterceptor) grpc.ServerOption {
 	sis := []grpc.StreamServerInterceptor{
-		recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)),
-		meta.StreamServerInterceptor(params.MethodPolicy, params.UserAgent, params.Version, params.ID),
+		recovery.NewServer(recoveryHandler).StreamInterceptor(),
+		grpcmeta.NewServer(params.MethodPolicy, params.UserAgent, params.Version, params.ID, params.Limit).StreamInterceptor(),
 	}
 
 	if params.Logger != nil {
-		sis = append(sis, logger.StreamServerInterceptor(params.MethodPolicy, params.Logger))
+		sis = append(sis, logger.NewServer(params.MethodPolicy, params.Logger).StreamInterceptor())
 	}
 
-	sis = append(sis, recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler)))
+	sis = append(sis, recovery.NewServer(recoveryHandler).StreamInterceptor())
 
 	if params.Verifier != nil {
-		sis = append(sis, token.StreamServerInterceptor(params.MethodPolicy, params.Verifier))
+		sis = append(sis, token.NewServer(params.MethodPolicy, params.Verifier, nil).StreamInterceptor())
 	}
 
 	if params.Limiter != nil {
-		sis = append(sis, limiter.StreamServerInterceptor(params.Limiter))
+		sis = append(sis, params.Limiter.StreamInterceptor())
 	}
 
 	if params.Access != nil {
-		sis = append(sis, token.StreamAccessServerInterceptor(params.MethodPolicy, params.Access))
+		sis = append(sis, token.NewServer(params.MethodPolicy, nil, params.Access).StreamAccessInterceptor())
 	}
 
 	sis = append(sis, interceptors...)

--- a/transport/grpc/telemetry/logger/client.go
+++ b/transport/grpc/telemetry/logger/client.go
@@ -11,7 +11,17 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-// UnaryClientInterceptor returns a gRPC unary client interceptor that logs the RPC outcome.
+// NewClient constructs gRPC client logging interceptors.
+func NewClient(log *Logger) *Client {
+	return &Client{log: log}
+}
+
+// Client provides gRPC client interceptors that log RPC outcomes.
+type Client struct {
+	log *Logger
+}
+
+// UnaryInterceptor returns a gRPC unary client interceptor that logs the RPC outcome.
 //
 // Logged attributes include:
 //   - system: "grpc"
@@ -31,7 +41,7 @@ import (
 // The raw gRPC client target is intentionally included to identify the configured downstream endpoint in
 // operator logs. Client targets are expected to be configuration-controlled service addresses and must not
 // contain credentials, tokens, request data, or other secrets.
-func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
+func (c *Client) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		service, method := grpc.ParseServiceMethod(fullMethod)
 		start := time.Now()
@@ -46,13 +56,13 @@ func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 		code := status.Code(err)
 		attrs = append(attrs, logger.String(meta.CodeKey, code.String()))
 
-		log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(conn.Target()+fullMethod), err), attrs...)
+		c.log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(conn.Target()+fullMethod), err), attrs...)
 
 		return err
 	}
 }
 
-// StreamClientInterceptor returns a gRPC stream client interceptor that logs stream creation and terminal failures.
+// StreamInterceptor returns a gRPC stream client interceptor that logs stream creation and terminal failures.
 //
 // It logs whether the client stream was opened successfully. When the stream opens successfully, the returned
 // stream is wrapped so later RecvMsg and SendMsg failures are logged as terminal stream-operation failures.
@@ -75,7 +85,7 @@ func UnaryClientInterceptor(log *Logger) grpc.UnaryClientInterceptor {
 // The raw gRPC client target is intentionally included to identify the configured downstream endpoint in
 // operator logs. Client targets are expected to be configuration-controlled service addresses and must not
 // contain credentials, tokens, request data, or other secrets.
-func StreamClientInterceptor(log *Logger) grpc.StreamClientInterceptor {
+func (c *Client) StreamInterceptor() grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		service, method := grpc.ParseServiceMethod(fullMethod)
 		start := time.Now()
@@ -90,7 +100,7 @@ func StreamClientInterceptor(log *Logger) grpc.StreamClientInterceptor {
 		code := status.Code(err)
 		attrs = append(attrs, logger.String(meta.CodeKey, code.String()))
 
-		log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(conn.Target()+fullMethod), err), attrs...)
+		c.log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(conn.Target()+fullMethod), err), attrs...)
 
 		if err != nil || stream == nil {
 			return stream, err
@@ -99,7 +109,7 @@ func StreamClientInterceptor(log *Logger) grpc.StreamClientInterceptor {
 		return &clientStream{
 			ClientStream: stream,
 			ctx:          ctx,
-			log:          log,
+			log:          c.log,
 			message:      conn.Target() + fullMethod,
 			service:      service,
 			method:       method,

--- a/transport/grpc/telemetry/logger/doc.go
+++ b/transport/grpc/telemetry/logger/doc.go
@@ -7,6 +7,7 @@
 // Logged attributes include system ("grpc"), service/method (derived from the full method name),
 // duration, and gRPC status code. Log level is derived from the status code (see CodeToLevel).
 //
-// Start with [UnaryServerInterceptor] / [StreamServerInterceptor] for server-side logging and
-// [UnaryClientInterceptor] / [StreamClientInterceptor] for client-side logging.
+// Use [NewServer] to construct server-side logging interceptors ([Server.UnaryInterceptor] /
+// [Server.StreamInterceptor]) and [NewClient] to construct client-side logging interceptors
+// ([Client.UnaryInterceptor] / [Client.StreamInterceptor]).
 package logger

--- a/transport/grpc/telemetry/logger/logger_test.go
+++ b/transport/grpc/telemetry/logger/logger_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnaryServerInterceptorLogs(t *testing.T) {
+func TestServerUnaryInterceptorLogs(t *testing.T) {
 	var logs bytes.Buffer
-	interceptor := grpclogger.UnaryServerInterceptor(method.NewPolicy(), newLogger(&logs))
+	interceptor := grpclogger.NewServer(method.NewPolicy(), newLogger(&logs)).UnaryInterceptor()
 
 	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.GreeterService/SayHello"}, func(context.Context, any) (any, error) {
 		return "ok", nil
@@ -37,9 +37,9 @@ func TestUnaryServerInterceptorLogs(t *testing.T) {
 	require.Contains(t, logs.String(), `"code":"OK"`)
 }
 
-func TestUnaryServerInterceptorLogsSafeErrorCause(t *testing.T) {
+func TestServerUnaryInterceptorLogsSafeErrorCause(t *testing.T) {
 	var logs bytes.Buffer
-	interceptor := grpclogger.UnaryServerInterceptor(method.NewPolicy(), newLogger(&logs))
+	interceptor := grpclogger.NewServer(method.NewPolicy(), newLogger(&logs)).UnaryInterceptor()
 
 	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.GreeterService/SayHello"}, func(context.Context, any) (any, error) {
 		return nil, status.SafeError(codes.Unauthenticated, errors.New("jwt: signature invalid"))
@@ -58,11 +58,11 @@ func TestUnaryServerInterceptorLogsSafeErrorCause(t *testing.T) {
 	require.Equal(t, "grpc: unauthenticated", s.Message())
 }
 
-func TestUnaryServerInterceptorSkipsOperationMethod(t *testing.T) {
+func TestServerUnaryInterceptorSkipsOperationMethod(t *testing.T) {
 	var logs bytes.Buffer
 	policy := method.NewPolicy()
 	policy.Operation(health.CheckFullMethodName)
-	interceptor := grpclogger.UnaryServerInterceptor(policy, newLogger(&logs))
+	interceptor := grpclogger.NewServer(policy, newLogger(&logs)).UnaryInterceptor()
 	called := false
 
 	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: health.CheckFullMethodName}, func(context.Context, any) (any, error) {
@@ -76,9 +76,9 @@ func TestUnaryServerInterceptorSkipsOperationMethod(t *testing.T) {
 	require.Empty(t, logs.String())
 }
 
-func TestStreamServerInterceptorLogs(t *testing.T) {
+func TestServerStreamInterceptorLogs(t *testing.T) {
 	var logs bytes.Buffer
-	interceptor := grpclogger.StreamServerInterceptor(method.NewPolicy(), newLogger(&logs))
+	interceptor := grpclogger.NewServer(method.NewPolicy(), newLogger(&logs)).StreamInterceptor()
 	stream := &test.MetaServerStream{Ctx: t.Context()}
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.GreeterService/SayStreamHello"}, func(any, grpc.ServerStream) error {
@@ -96,9 +96,9 @@ func TestStreamServerInterceptorLogs(t *testing.T) {
 	require.Contains(t, logs.String(), `"error":"rpc error: code = NotFound desc = missing"`)
 }
 
-func TestUnaryClientInterceptorLogs(t *testing.T) {
+func TestClientUnaryInterceptorLogs(t *testing.T) {
 	var logs bytes.Buffer
-	interceptor := grpclogger.UnaryClientInterceptor(newLogger(&logs))
+	interceptor := grpclogger.NewClient(newLogger(&logs)).UnaryInterceptor()
 	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
 	require.NoError(t, err)
 	defer func() {
@@ -120,9 +120,9 @@ func TestUnaryClientInterceptorLogs(t *testing.T) {
 	require.Contains(t, logs.String(), `"error":"rpc error: code = Unavailable desc = unavailable"`)
 }
 
-func TestStreamClientInterceptorLogs(t *testing.T) {
+func TestClientStreamInterceptorLogs(t *testing.T) {
 	var logs bytes.Buffer
-	interceptor := grpclogger.StreamClientInterceptor(newLogger(&logs))
+	interceptor := grpclogger.NewClient(newLogger(&logs)).StreamInterceptor()
 	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
 	require.NoError(t, err)
 	defer func() {
@@ -147,7 +147,7 @@ func TestStreamClientInterceptorLogs(t *testing.T) {
 	require.Contains(t, logs.String(), `"error":"rpc error: code = InvalidArgument desc = invalid"`)
 }
 
-func TestStreamClientInterceptorLogsStreamOperationError(t *testing.T) {
+func TestClientStreamInterceptorLogsStreamOperationError(t *testing.T) {
 	t.Run("recv", func(t *testing.T) {
 		requireStreamClientOperationError(t,
 			&grpc.StreamDesc{ServerStreams: true},
@@ -173,9 +173,9 @@ func TestStreamClientInterceptorLogsStreamOperationError(t *testing.T) {
 	})
 }
 
-func TestStreamClientInterceptorDoesNotLogRecvMsgEOF(t *testing.T) {
+func TestClientStreamInterceptorDoesNotLogRecvMsgEOF(t *testing.T) {
 	var logs bytes.Buffer
-	interceptor := grpclogger.StreamClientInterceptor(newLogger(&logs))
+	interceptor := grpclogger.NewClient(newLogger(&logs)).StreamInterceptor()
 	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
 	require.NoError(t, err)
 	defer func() {
@@ -224,7 +224,7 @@ func requireStreamClientOperationError(t *testing.T, desc *grpc.StreamDesc, clie
 	t.Helper()
 
 	var logs bytes.Buffer
-	interceptor := grpclogger.StreamClientInterceptor(newLogger(&logs))
+	interceptor := grpclogger.NewClient(newLogger(&logs)).StreamInterceptor()
 	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
 	require.NoError(t, err)
 	defer func() {

--- a/transport/grpc/telemetry/logger/server.go
+++ b/transport/grpc/telemetry/logger/server.go
@@ -10,7 +10,18 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-// UnaryServerInterceptor returns a gRPC unary server interceptor that logs the RPC outcome.
+// NewServer constructs gRPC server logging interceptors.
+func NewServer(policy *method.Policy, log *Logger) *Server {
+	return &Server{policy: policy, log: log}
+}
+
+// Server provides gRPC server interceptors that log RPC outcomes.
+type Server struct {
+	log    *Logger
+	policy *method.Policy
+}
+
+// UnaryInterceptor returns a gRPC unary server interceptor that logs the RPC outcome.
 //
 // Operation methods bypass logging.
 //
@@ -27,9 +38,9 @@ import (
 // The raw error is intentionally attached to the log record for backend observability. Client-facing
 // responses remain controlled by the gRPC status/error path; logs are expected to be protected operator
 // telemetry.
-func UnaryServerInterceptor(policy *method.Policy, log *Logger) grpc.UnaryServerInterceptor {
+func (s *Server) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if policy.IsOperation(info.FullMethod) {
+		if s.policy.IsOperation(info.FullMethod) {
 			return handler(ctx, req)
 		}
 
@@ -46,13 +57,13 @@ func UnaryServerInterceptor(policy *method.Policy, log *Logger) grpc.UnaryServer
 		code := status.Code(err)
 		attrs = append(attrs, logger.String(meta.CodeKey, code.String()))
 
-		log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(info.FullMethod), err), attrs...)
+		s.log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(info.FullMethod), err), attrs...)
 
 		return resp, err
 	}
 }
 
-// StreamServerInterceptor returns a gRPC stream server interceptor that logs the RPC outcome.
+// StreamInterceptor returns a gRPC stream server interceptor that logs the RPC outcome.
 //
 // Operation methods bypass logging.
 //
@@ -69,9 +80,9 @@ func UnaryServerInterceptor(policy *method.Policy, log *Logger) grpc.UnaryServer
 // The raw error is intentionally attached to the log record for backend observability. Client-facing
 // responses remain controlled by the gRPC status/error path; logs are expected to be protected operator
 // telemetry.
-func StreamServerInterceptor(policy *method.Policy, log *Logger) grpc.StreamServerInterceptor {
+func (s *Server) StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if policy.IsOperation(info.FullMethod) {
+		if s.policy.IsOperation(info.FullMethod) {
 			return handler(srv, stream)
 		}
 
@@ -89,7 +100,7 @@ func StreamServerInterceptor(policy *method.Policy, log *Logger) grpc.StreamServ
 		code := status.Code(err)
 		attrs = append(attrs, logger.String(meta.CodeKey, code.String()))
 
-		log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(info.FullMethod), err), attrs...)
+		s.log.LogAttrs(ctx, CodeToLevel(code), logger.NewMessage(message(info.FullMethod), err), attrs...)
 
 		return err
 	}

--- a/transport/grpc/token/doc.go
+++ b/transport/grpc/token/doc.go
@@ -8,7 +8,8 @@
 // access interceptors enforce configured authorization policy using that subject and the transport
 // service-method.
 //
-// Start with [UnaryServerInterceptor] / [StreamServerInterceptor] for server-side verification and
-// [UnaryAccessServerInterceptor] / [StreamAccessServerInterceptor] for server-side authorization.
-// Use [UnaryClientInterceptor] / [StreamClientInterceptor] for client-side injection.
+// Use [NewServer] to construct server-side verification ([Server.UnaryInterceptor] /
+// [Server.StreamInterceptor]) and authorization ([Server.UnaryAccessInterceptor] /
+// [Server.StreamAccessInterceptor]) interceptors. Use [NewClient] to construct client-side injection
+// interceptors ([Client.UnaryInterceptor] / [Client.StreamInterceptor]).
 package token

--- a/transport/grpc/token/token.go
+++ b/transport/grpc/token/token.go
@@ -56,12 +56,24 @@ func NewVerifier(token *Token) Verifier {
 // principal) on success.
 type Verifier token.Verifier
 
-// UnaryServerInterceptor returns a gRPC unary server interceptor that verifies Authorization tokens.
+// NewServer constructs gRPC server token interceptors.
+func NewServer(policy *method.Policy, verifier Verifier, controller access.Controller) *Server {
+	return &Server{policy: policy, verifier: verifier, controller: controller}
+}
+
+// Server provides gRPC server interceptors for token verification and access control.
+type Server struct {
+	controller access.Controller
+	policy     *method.Policy
+	verifier   Verifier
+}
+
+// UnaryInterceptor returns a gRPC unary server interceptor that verifies Authorization tokens.
 //
 // Operation and unauthenticated methods bypass verification.
 //
 // The interceptor expects an Authorization value to have been extracted into the context by the metadata
-// interceptor ([github.com/alexfalkowski/go-service/v2/net/grpc/meta.UnaryServerInterceptor]). It verifies the token using verifier, scoping
+// interceptor ([github.com/alexfalkowski/go-service/v2/net/grpc/meta.NewServer]). It verifies the token using verifier, scoping
 // verification to the RPC `FullMethod`.
 //
 // Behavior:
@@ -69,16 +81,16 @@ type Verifier token.Verifier
 //   - If verification succeeds, it stores the verified subject as the user id in the context and invokes
 //     the handler.
 //
-// Callers should only install this interceptor when verifier is non-nil.
-func UnaryServerInterceptor(policy *method.Policy, verifier Verifier) grpc.UnaryServerInterceptor {
+// Callers should only install this interceptor when the server has a non-nil verifier.
+func (s *Server) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if bypassAuth(policy, info.FullMethod) {
+		if bypassAuth(s.policy, info.FullMethod) {
 			return handler(ctx, req)
 		}
 
 		auth := meta.Authorization(ctx).Value()
 
-		sub, err := verifier.Verify(strings.Bytes(auth), info.FullMethod)
+		sub, err := s.verifier.Verify(strings.Bytes(auth), info.FullMethod)
 		if err != nil {
 			return nil, status.SafeError(codes.Unauthenticated, err)
 		}
@@ -88,12 +100,12 @@ func UnaryServerInterceptor(policy *method.Policy, verifier Verifier) grpc.Unary
 	}
 }
 
-// StreamServerInterceptor returns a gRPC stream server interceptor that verifies Authorization tokens.
+// StreamInterceptor returns a gRPC stream server interceptor that verifies Authorization tokens.
 //
 // Operation and unauthenticated methods bypass verification.
 //
 // The interceptor expects an Authorization value to have been extracted into the stream context by the
-// metadata interceptor ([github.com/alexfalkowski/go-service/v2/net/grpc/meta.StreamServerInterceptor]). It verifies the token using verifier,
+// metadata interceptor ([github.com/alexfalkowski/go-service/v2/net/grpc/meta.NewServer]). It verifies the token using verifier,
 // scoping verification to the RPC `FullMethod`.
 //
 // Behavior:
@@ -101,17 +113,17 @@ func UnaryServerInterceptor(policy *method.Policy, verifier Verifier) grpc.Unary
 //   - If verification succeeds, it injects the verified subject as the user id into the stream context and
 //     invokes the handler using a wrapped stream (`go-grpc-middleware` wrapper) that carries the new context.
 //
-// Callers should only install this interceptor when verifier is non-nil.
-func StreamServerInterceptor(policy *method.Policy, verifier Verifier) grpc.StreamServerInterceptor {
+// Callers should only install this interceptor when the server has a non-nil verifier.
+func (s *Server) StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if bypassAuth(policy, info.FullMethod) {
+		if bypassAuth(s.policy, info.FullMethod) {
 			return handler(srv, stream)
 		}
 
 		ctx := stream.Context()
 		auth := meta.Authorization(ctx).Value()
 
-		sub, err := verifier.Verify(strings.Bytes(auth), info.FullMethod)
+		sub, err := s.verifier.Verify(strings.Bytes(auth), info.FullMethod)
 		if err != nil {
 			return status.SafeError(codes.Unauthenticated, err)
 		}
@@ -124,14 +136,14 @@ func StreamServerInterceptor(policy *method.Policy, verifier Verifier) grpc.Stre
 	}
 }
 
-// UnaryAccessServerInterceptor returns a gRPC unary server interceptor that enforces access policy.
+// UnaryAccessInterceptor returns a gRPC unary server interceptor that enforces access policy.
 //
 // Operation and unauthenticated methods bypass access control. For application RPCs, a missing verified user id is treated
 // as unauthenticated, a policy denial returns [codes.PermissionDenied], and policy evaluation errors return
 // [codes.Internal].
-func UnaryAccessServerInterceptor(policy *method.Policy, controller access.Controller) grpc.UnaryServerInterceptor {
+func (s *Server) UnaryAccessInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if bypassAuth(policy, info.FullMethod) {
+		if bypassAuth(s.policy, info.FullMethod) {
 			return handler(ctx, req)
 		}
 
@@ -139,7 +151,7 @@ func UnaryAccessServerInterceptor(policy *method.Policy, controller access.Contr
 			return nil, status.SafeError(codes.Unauthenticated, header.ErrInvalidAuthorization)
 		}
 
-		ok, err := controller.HasAccess(ctx)
+		ok, err := s.controller.HasAccess(ctx)
 		if err != nil {
 			return nil, status.SafeError(codes.Internal, err)
 		}
@@ -151,14 +163,14 @@ func UnaryAccessServerInterceptor(policy *method.Policy, controller access.Contr
 	}
 }
 
-// StreamAccessServerInterceptor returns a gRPC stream server interceptor that enforces access policy.
+// StreamAccessInterceptor returns a gRPC stream server interceptor that enforces access policy.
 //
 // Operation and unauthenticated methods bypass access control. For application RPCs, a missing verified user id is treated
 // as unauthenticated, a policy denial returns [codes.PermissionDenied], and policy evaluation errors return
 // [codes.Internal].
-func StreamAccessServerInterceptor(policy *method.Policy, controller access.Controller) grpc.StreamServerInterceptor {
+func (s *Server) StreamAccessInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if bypassAuth(policy, info.FullMethod) {
+		if bypassAuth(s.policy, info.FullMethod) {
 			return handler(srv, stream)
 		}
 
@@ -167,7 +179,7 @@ func StreamAccessServerInterceptor(policy *method.Policy, controller access.Cont
 			return status.SafeError(codes.Unauthenticated, header.ErrInvalidAuthorization)
 		}
 
-		ok, err := controller.HasAccess(ctx)
+		ok, err := s.controller.HasAccess(ctx)
 		if err != nil {
 			return status.SafeError(codes.Internal, err)
 		}
@@ -200,7 +212,18 @@ func NewGenerator(token *Token) Generator {
 // and a caller identity (user id).
 type Generator token.Generator
 
-// UnaryClientInterceptor returns a gRPC unary client interceptor that injects an Authorization token.
+// NewClient constructs gRPC client token interceptors.
+func NewClient(id env.UserID, generator Generator) *Client {
+	return &Client{id: id, generator: generator}
+}
+
+// Client provides gRPC client interceptors that inject Authorization tokens.
+type Client struct {
+	generator Generator
+	id        env.UserID
+}
+
+// UnaryInterceptor returns a gRPC unary client interceptor that injects an Authorization token.
 //
 // For each outbound unary RPC, it generates a token scoped to `fullMethod` and the provided user id and
 // stores it in outgoing metadata under the "authorization" key using the `Bearer` scheme.
@@ -214,10 +237,10 @@ type Generator token.Generator
 //   - If token generation returns an empty token, it returns [codes.Unauthenticated] with
 //     [header.ErrInvalidAuthorization].
 //
-// Callers should only install this interceptor when generator is non-nil.
-func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClientInterceptor {
+// Callers should only install this interceptor when the client has a non-nil generator.
+func (c *Client) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, fullMethod string, req, resp any, conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		token, err := generator.Generate(fullMethod, id.String())
+		token, err := c.generator.Generate(fullMethod, c.id.String())
 		if err != nil {
 			return status.SafeError(codes.Unauthenticated, err)
 		}
@@ -238,7 +261,7 @@ func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClient
 	}
 }
 
-// StreamClientInterceptor returns a gRPC stream client interceptor that injects an Authorization token.
+// StreamInterceptor returns a gRPC stream client interceptor that injects an Authorization token.
 //
 // For each outbound streaming RPC, it generates a token scoped to `fullMethod` and the provided user id and
 // stores it in outgoing metadata under the "authorization" key using the `Bearer` scheme.
@@ -252,10 +275,10 @@ func UnaryClientInterceptor(id env.UserID, generator Generator) grpc.UnaryClient
 //   - If token generation returns an empty token, it returns [codes.Unauthenticated] with
 //     [header.ErrInvalidAuthorization].
 //
-// Callers should only install this interceptor when generator is non-nil.
-func StreamClientInterceptor(id env.UserID, generator Generator) grpc.StreamClientInterceptor {
+// Callers should only install this interceptor when the client has a non-nil generator.
+func (c *Client) StreamInterceptor() grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		token, err := generator.Generate(fullMethod, id.String())
+		token, err := c.generator.Generate(fullMethod, c.id.String())
 		if err != nil {
 			return nil, status.SafeError(codes.Unauthenticated, err)
 		}

--- a/transport/grpc/token/token_test.go
+++ b/transport/grpc/token/token_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnaryClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
+func TestClientUnaryInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 	ctx := meta.NewOutgoingContext(context.Background(), meta.Pairs("authorization", "Bearer stale-token"))
-	interceptor := token.UnaryClientInterceptor(env.UserID("service-user"), staticTokenGenerator("fresh-token"))
+	interceptor := token.NewClient(env.UserID("service-user"), staticTokenGenerator("fresh-token")).UnaryInterceptor()
 
 	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		md, ok := meta.FromOutgoingContext(ctx)
@@ -31,9 +31,9 @@ func TestUnaryClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStreamClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
+func TestClientStreamInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 	ctx := meta.NewOutgoingContext(context.Background(), meta.Pairs("authorization", "Bearer stale-token"))
-	interceptor := token.StreamClientInterceptor(env.UserID("service-user"), staticTokenGenerator("fresh-token"))
+	interceptor := token.NewClient(env.UserID("service-user"), staticTokenGenerator("fresh-token")).StreamInterceptor()
 	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		md, ok := meta.FromOutgoingContext(ctx)
 		require.True(t, ok)
@@ -49,10 +49,10 @@ func TestStreamClientInterceptorReplacesOutgoingAuthorization(t *testing.T) {
 	require.Nil(t, stream)
 }
 
-func TestUnaryServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
+func TestServerUnaryInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 	policy := method.NewPolicy()
 	policy.AllowUnauthenticated("/events.v1.EventsService/Receive")
-	interceptor := token.UnaryServerInterceptor(policy, &test.Verifier{})
+	interceptor := token.NewServer(policy, &test.Verifier{}, nil).UnaryInterceptor()
 	called := false
 
 	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{FullMethod: "/events.v1.EventsService/Receive"}, func(context.Context, any) (any, error) {
@@ -64,10 +64,10 @@ func TestUnaryServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 	require.True(t, called)
 }
 
-func TestStreamServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
+func TestServerStreamInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 	policy := method.NewPolicy()
 	policy.AllowUnauthenticated("/events.v1.EventsService/Subscribe")
-	interceptor := token.StreamServerInterceptor(policy, &test.Verifier{})
+	interceptor := token.NewServer(policy, &test.Verifier{}, nil).StreamInterceptor()
 	stream := &test.MetaServerStream{Ctx: t.Context()}
 	called := false
 
@@ -80,7 +80,7 @@ func TestStreamServerInterceptorBypassesUnauthenticatedMethod(t *testing.T) {
 	require.True(t, called)
 }
 
-func TestUnaryAccessServerInterceptor(t *testing.T) {
+func TestServerUnaryAccessInterceptor(t *testing.T) {
 	for _, tt := range accessServerTests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
@@ -94,7 +94,7 @@ func TestUnaryAccessServerInterceptor(t *testing.T) {
 			if tt.unauthenticated {
 				policy.AllowUnauthenticated(tt.method)
 			}
-			interceptor := token.UnaryAccessServerInterceptor(policy, tt.controller)
+			interceptor := token.NewServer(policy, nil, tt.controller).UnaryAccessInterceptor()
 			called := false
 
 			_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: tt.method}, func(context.Context, any) (any, error) {
@@ -108,7 +108,7 @@ func TestUnaryAccessServerInterceptor(t *testing.T) {
 	}
 }
 
-func TestStreamAccessServerInterceptor(t *testing.T) {
+func TestServerStreamAccessInterceptor(t *testing.T) {
 	for _, tt := range accessServerTests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
@@ -122,7 +122,7 @@ func TestStreamAccessServerInterceptor(t *testing.T) {
 			if tt.unauthenticated {
 				policy.AllowUnauthenticated(tt.method)
 			}
-			interceptor := token.StreamAccessServerInterceptor(policy, tt.controller)
+			interceptor := token.NewServer(policy, nil, tt.controller).StreamAccessInterceptor()
 			stream := &test.MetaServerStream{Ctx: ctx}
 			called := false
 

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -170,9 +170,19 @@ func TestReceiveCanReportProcessingFailure(t *testing.T) {
 
 func TestReceiveLogsPanickingProcessor(t *testing.T) {
 	capture := &test.CaptureHandler{}
+	original := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+	log, err := logger.NewLogger(logger.LoggerParams{
+		Config: &logger.Config{Kind: "json"},
+		Limit:  1024,
+	})
+	require.NoError(t, err)
+	log.Logger = slog.New(capture)
 	world := test.NewWorld(t,
 		test.WithWorldHTTP(),
-		test.WithWorldLogger(&logger.Logger{Logger: slog.New(capture)}),
+		test.WithWorldLogger(log),
 	)
 	world.Receiver.Register(t.Context(), "/events", func(context.Context, events.Event) events.Result {
 		panic("processor exploded")

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -8,11 +8,12 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/config"
-	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	httpmeta "github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
 	httpserver "github.com/alexfalkowski/go-service/v2/net/http/server"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
@@ -42,6 +43,15 @@ type ServerParams struct {
 	// Shutdowner is used by the underlying *[server.Service] to coordinate shutdown.
 	Shutdowner di.Shutdowner
 
+	// ID generates request IDs when one is not already present.
+	ID id.Generator
+
+	// Verifier enables server-side token verification middleware when non-nil.
+	Verifier token.Verifier
+
+	// Access enables server-side access control middleware when non-nil.
+	Access access.Controller
+
 	// Mux is the HTTP request multiplexer that holds registered routes/handlers.
 	Mux *http.ServeMux
 
@@ -54,31 +64,25 @@ type ServerParams struct {
 	// Logger enables HTTP server logging middleware when non-nil.
 	Logger *logger.Logger
 
-	// UserAgent is the service user agent used by metadata middleware.
-	UserAgent env.UserAgent
-
-	// Version is the service version reported via response headers and/or request context metadata.
-	Version env.Version
-
-	// ID generates request IDs when one is not already present.
-	ID id.Generator
-
 	// RoutePolicy stores route policy used by transport middleware.
 	RoutePolicy *http.RoutePolicy
 
 	// Limiter enables server-side rate limiting middleware when non-nil.
 	Limiter *limiter.Server
 
-	// Verifier enables server-side token verification middleware when non-nil.
-	Verifier token.Verifier
+	// UserAgent is the service user agent used by metadata middleware.
+	UserAgent env.UserAgent
 
-	// Access enables server-side access control middleware when non-nil.
-	Access access.Controller
+	// Version is the service version reported via response headers and/or request context metadata.
+	Version env.Version
 
 	// Handlers are additional chained handlers to insert into the middleware chain.
 	//
 	// These handlers are applied in the order provided.
 	Handlers []ChainedHandler `optional:"true"`
+
+	// Limit bounds metadata values attached to server spans.
+	Limit meta.Limit
 }
 
 // NewServer constructs an HTTP transport [Server] when the transport is enabled.
@@ -137,7 +141,7 @@ func NewServer(params ServerParams) (*Server, error) {
 	}
 
 	neg := NewChainedHandlers()
-	neg.Use(meta.NewHandler(params.UserAgent, params.Version, params.ID, params.Mux))
+	neg.Use(httpmeta.NewHandler(params.UserAgent, params.Version, params.ID, params.Mux, params.Limit))
 
 	if params.Logger != nil {
 		neg.Use(logger.NewHandler(params.RoutePolicy, params.Logger))

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -107,7 +107,17 @@ func TestServerMaxReceiveSizeWithUnknownLength(t *testing.T) {
 
 func TestServerRecoversPanic(t *testing.T) {
 	capture := &test.CaptureHandler{}
-	world := test.NewWorld(t, test.WithWorldHTTP(), test.WithWorldLogger(&logger.Logger{Logger: slog.New(capture)}))
+	original := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+	log, err := logger.NewLogger(logger.LoggerParams{
+		Config: &logger.Config{Kind: "json"},
+		Limit:  1024,
+	})
+	require.NoError(t, err)
+	log.Logger = slog.New(capture)
+	world := test.NewWorld(t, test.WithWorldHTTP(), test.WithWorldLogger(log))
 	world.HandleRoute("GET /panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("test panic")
 	}))


### PR DESCRIPTION
## What

- Add configurable telemetry metadata value limits, with a 1,024-byte default and UTF-8-safe truncation across logs and traces.
- Standardize gRPC interceptor construction around client and server providers, including recovery, metadata, retries, limiting, tokens, breakers, and telemetry logging.
- Intentionally change the exported lower-level APIs; downstream callers must migrate from standalone interceptor builders to the matching `NewClient` or `NewServer` provider methods.
- Update HTTP panic-log fixtures to use the supported logger constructor and retain request metadata assertions.

## Why

- Bound metadata prevents individual request values from dominating log records and telemetry payloads while keeping full context available to request handling.
- Provider-based interceptor construction makes shared client and server dependencies explicit and keeps transport composition consistent.
- The intentional source-incompatible change establishes the new lower-level transport API shape.
- Supported logger construction keeps the CI fixture aligned with the configured metadata-limit contract.

## Testing

- `make specs` - passed.
- `make specs package=transport/http/events` - passed.
- `make lint`, `git diff --check`, and `make sec` - passed.
- Fuzz and benchmark runs remain CI coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
