### PR TITLE
test(feature): clarify table-driven scenario descriptions

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -158,14 +158,17 @@ func TestApplicationClientShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) 
 }
 
 func TestApplicationClientInvalidConfig(t *testing.T) {
-	configs := []string{
-		test.FilePath("configs/invalid_http.config.yaml"),
-		test.FilePath("configs/invalid_grpc.config.yaml"),
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{name: "rejects invalid HTTP configuration", config: test.FilePath("configs/invalid_http.config.yaml")},
+		{name: "rejects invalid gRPC configuration", config: test.FilePath("configs/invalid_grpc.config.yaml")},
 	}
 
-	for _, config := range configs {
-		t.Run(config, func(t *testing.T) {
-			test.SetupCLI("client", "-config", config)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetupCLI("client", "-config", tt.config)
 
 			app := cli.NewApplication(
 				func(c cli.Commander) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -124,15 +124,18 @@ func TestApplicationServerDrainsStreamingRoute(t *testing.T) {
 }
 
 func TestApplicationServerInvalidConfig(t *testing.T) {
-	configs := []string{
-		test.FilePath("configs/invalid_http.config.yaml"),
-		test.FilePath("configs/invalid_grpc.config.yaml"),
-		test.FilePath("configs/invalid_debug.config.yaml"),
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{name: "rejects invalid HTTP configuration", config: test.FilePath("configs/invalid_http.config.yaml")},
+		{name: "rejects invalid gRPC configuration", config: test.FilePath("configs/invalid_grpc.config.yaml")},
+		{name: "rejects invalid debug configuration", config: test.FilePath("configs/invalid_debug.config.yaml")},
 	}
 
-	for _, config := range configs {
-		t.Run(config, func(t *testing.T) {
-			test.SetupCLI("server", "-config", config)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetupCLI("server", "-config", tt.config)
 
 			app := cli.NewApplication(
 				func(c cli.Commander) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,16 +16,19 @@ import (
 )
 
 func TestValidFileConfig(t *testing.T) {
-	files := []string{
-		test.FilePath("configs/config.hjson"),
-		test.FilePath("configs/config.toml"),
-		test.FilePath("configs/config.yaml"),
+	tests := []struct {
+		name string
+		file string
+	}{
+		{name: "loads HJSON configuration", file: test.FilePath("configs/config.hjson")},
+		{name: "loads TOML configuration", file: test.FilePath("configs/config.toml")},
+		{name: "loads YAML configuration", file: test.FilePath("configs/config.yaml")},
 	}
 
-	for _, file := range files {
-		t.Run(file, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			set := flag.NewFlagSet("test")
-			set.AddConfig(file)
+			set.AddConfig(tt.file)
 
 			decoder := test.NewDecoder(set)
 
@@ -55,26 +58,29 @@ func TestValidHomeFileConfig(t *testing.T) {
 }
 
 func TestInvalidFileConfig(t *testing.T) {
-	files := []string{
-		test.FilePath("configs/invalid.yaml"),
-		test.FilePath("configs/invalid_logger_kind.yaml"),
-		test.FilePath("configs/invalid_metrics_kind.yaml"),
-		test.FilePath("configs/invalid_telemetry.config.yaml"),
-		test.FilePath("configs/invalid_telemetry_batch.yaml"),
-		test.FilePath("configs/invalid_telemetry_cadence.yaml"),
-		test.FilePath("configs/invalid_trace.yaml"),
-		test.FilePath("configs/invalid_tracer_kind.yaml"),
-		test.FilePath("configs/missing.yml"),
-		test.FilePath("configs/script.sh"),
-		test.FilePath("config.go"),
-		strings.Empty,
-		"env:BOB",
+	tests := []struct {
+		name string
+		file string
+	}{
+		{name: "rejects invalid configuration", file: test.FilePath("configs/invalid.yaml")},
+		{name: "rejects invalid logger kind", file: test.FilePath("configs/invalid_logger_kind.yaml")},
+		{name: "rejects invalid metrics kind", file: test.FilePath("configs/invalid_metrics_kind.yaml")},
+		{name: "rejects invalid telemetry configuration", file: test.FilePath("configs/invalid_telemetry.config.yaml")},
+		{name: "rejects invalid telemetry batch", file: test.FilePath("configs/invalid_telemetry_batch.yaml")},
+		{name: "rejects invalid telemetry cadence", file: test.FilePath("configs/invalid_telemetry_cadence.yaml")},
+		{name: "rejects invalid trace configuration", file: test.FilePath("configs/invalid_trace.yaml")},
+		{name: "rejects invalid tracer kind", file: test.FilePath("configs/invalid_tracer_kind.yaml")},
+		{name: "rejects missing configuration file", file: test.FilePath("configs/missing.yml")},
+		{name: "rejects shell script", file: test.FilePath("configs/script.sh")},
+		{name: "rejects Go source file", file: test.FilePath("config.go")},
+		{name: "rejects empty configuration source", file: strings.Empty},
+		{name: "rejects missing environment variable", file: "env:BOB"},
 	}
 
-	for _, file := range files {
-		t.Run(file, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			set := flag.NewFlagSet("test")
-			set.AddConfig(file)
+			set.AddConfig(tt.file)
 
 			decoder := test.NewDecoder(set)
 
@@ -85,15 +91,18 @@ func TestInvalidFileConfig(t *testing.T) {
 }
 
 func TestValidTelemetryConfig(t *testing.T) {
-	files := []string{
-		test.FilePath("configs/valid_telemetry_batch.yaml"),
-		test.FilePath("configs/valid_ignored_telemetry_tuning.yaml"),
+	tests := []struct {
+		name string
+		file string
+	}{
+		{name: "accepts batch configuration", file: test.FilePath("configs/valid_telemetry_batch.yaml")},
+		{name: "accepts ignored telemetry tuning", file: test.FilePath("configs/valid_ignored_telemetry_tuning.yaml")},
 	}
 
-	for _, file := range files {
-		t.Run(file, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			set := flag.NewFlagSet("test")
-			set.AddConfig(file)
+			set.AddConfig(tt.file)
 
 			decoder := test.NewDecoder(set)
 
@@ -119,9 +128,9 @@ func TestValidEnvConfig(t *testing.T) {
 		kind string
 		path string
 	}{
-		{name: "yaml", kind: "yaml", path: "configs/config.yaml"},
-		{name: "hjson", kind: "hjson", path: "configs/config.hjson"},
-		{name: "toml", kind: "toml", path: "configs/config.toml"},
+		{name: "loads YAML configuration from environment", kind: "yaml", path: "configs/config.yaml"},
+		{name: "loads HJSON configuration from environment", kind: "hjson", path: "configs/config.hjson"},
+		{name: "loads TOML configuration from environment", kind: "toml", path: "configs/config.toml"},
 	}
 
 	for _, tt := range tests {
@@ -201,9 +210,9 @@ func TestValidCommonConfig(t *testing.T) {
 		path string
 		ext  string
 	}{
-		{name: "yaml", path: "configs/config.yaml", ext: ".yaml"},
-		{name: "hjson", path: "configs/config.hjson", ext: ".hjson"},
-		{name: "toml", path: "configs/config.toml", ext: ".toml"},
+		{name: "loads YAML configuration from default location", path: "configs/config.yaml", ext: ".yaml"},
+		{name: "loads HJSON configuration from default location", path: "configs/config.hjson", ext: ".hjson"},
+		{name: "loads TOML configuration from default location", path: "configs/config.toml", ext: ".toml"},
 	}
 
 	for _, tt := range tests {

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -16,12 +16,15 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-var debugPaths = []string{
-	"debug/statsviz",
-	"debug/pprof/",
-	"debug/pprof/cmdline",
-	"debug/pprof/symbol",
-	"debug/pprof/trace",
+var debugPaths = []struct {
+	name string
+	path string
+}{
+	{name: "serves statsviz", path: "debug/statsviz"},
+	{name: "serves pprof index", path: "debug/pprof/"},
+	{name: "serves pprof command line", path: "debug/pprof/cmdline"},
+	{name: "serves pprof symbol lookup", path: "debug/pprof/symbol"},
+	{name: "serves pprof trace", path: "debug/pprof/trace"},
 }
 
 func TestDebugEndpoints(t *testing.T) {
@@ -115,12 +118,12 @@ func requireDebugEndpoints(t *testing.T, scheme string, options ...test.WorldOpt
 
 	options = append([]test.WorldOption{test.WithWorldTelemetry("otlp")}, options...)
 
-	for _, path := range debugPaths {
-		t.Run(path, func(t *testing.T) {
+	for _, endpoint := range debugPaths {
+		t.Run(endpoint.name, func(t *testing.T) {
 			world := test.NewStartedWorld(t, options...)
 
 			header := http.Header{}
-			url := world.NamedDebugURL(scheme, path)
+			url := world.NamedDebugURL(scheme, endpoint.path)
 
 			res, err := world.ResponseWithNoBody(t.Context(), url, http.MethodGet, header)
 			require.NoError(t, err)

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -69,17 +69,22 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 func TestDecodeRejectsTrailingData(t *testing.T) {
 	t.Parallel()
 
-	for _, input := range []string{
-		`{"test":"test"} garbage`,
-		`{"test":"test"}{"test":"other"}`,
-	} {
-		t.Run(input, func(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "rejects trailing non-JSON data", input: `{"test":"test"} garbage`},
+		{name: "rejects second JSON value", input: `{"test":"test"}{"test":"other"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			encoder := json.NewEncoder()
 			var msg map[string]string
 
-			err := encoder.Decode(bytes.NewBufferString(input), &msg)
+			err := encoder.Decode(bytes.NewBufferString(tt.input), &msg)
 
 			require.ErrorIs(t, err, errors.ErrTrailingData)
 		})

--- a/encoding/stream/yaml/yaml_test.go
+++ b/encoding/stream/yaml/yaml_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/yaml"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/stretchr/testify/require"
@@ -42,13 +43,10 @@ func TestEncodeOrCloseReturnsError(t *testing.T) {
 
 	encoder := yaml.NewEncoder(test.ErrWriter{})
 
-	err := encoder.Encode(map[string]string{"test": "test"})
-	if err != nil {
-		require.Error(t, err)
-		return
-	}
-
-	require.Error(t, encoder.Close())
+	require.Error(t, errors.Join(
+		encoder.Encode(map[string]string{"test": "test"}),
+		encoder.Close(),
+	))
 }
 
 func TestDecodeReturnsError(t *testing.T) {

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -79,17 +79,22 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 func TestDecodeRejectsTrailingDocument(t *testing.T) {
 	t.Parallel()
 
-	for _, input := range []string{
-		"test: test\n---\ntest: other",
-		"test: test\n---\n: invalid",
-	} {
-		t.Run(input, func(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "rejects second YAML document", input: "test: test\n---\ntest: other"},
+		{name: "rejects invalid trailing YAML document", input: "test: test\n---\n: invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			encoder := yaml.NewEncoder()
 			var msg map[string]string
 
-			err := encoder.Decode(bytes.NewBufferString(input), &msg)
+			err := encoder.Decode(bytes.NewBufferString(tt.input), &msg)
 
 			require.ErrorIs(t, err, errors.ErrTrailingData)
 		})

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -20,9 +20,18 @@ func TestReadFile(t *testing.T) {
 }
 
 func TestPathExtension(t *testing.T) {
-	for _, path := range []string{"file.yaml", "file.test.yaml", "test/.config/existing.client.yaml"} {
-		t.Run(path, func(t *testing.T) {
-			require.Equal(t, "yaml", test.FS.PathExtension(path))
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "extracts single extension", path: "file.yaml"},
+		{name: "extracts extension after multiple periods", path: "file.test.yaml"},
+		{name: "extracts extension from nested path", path: "test/.config/existing.client.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, "yaml", test.FS.PathExtension(tt.path))
 		})
 	}
 

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -55,26 +55,36 @@ func TestValidateEndpointInvalidURL(t *testing.T) {
 }
 
 func TestValidateEndpointRejectsInvalidEndpoint(t *testing.T) {
-	for _, rawURL := range []string{
-		"htps://collector.example.com/v1/traces",
-		"https:///v1/traces",
-	} {
-		t.Run(rawURL, func(t *testing.T) {
-			err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: rawURL})
+	httpTests := []struct {
+		name    string
+		address string
+	}{
+		{name: "rejects unsupported URL scheme", address: "htps://collector.example.com/v1/traces"},
+		{name: "rejects URL without host", address: "https:///v1/traces"},
+	}
+
+	for _, tt := range httpTests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "http", Address: tt.address})
 
 			require.ErrorIs(t, err, otlp.ErrInvalidEndpoint)
 		})
 	}
 
-	for _, address := range []string{
-		"https://collector.example.com:4317",
-		"collector.example.com",
-		"collector.example.com:",
-		"collector.example.com:0",
-		"collector.example.com:4317/v1/traces",
-	} {
-		t.Run(address, func(t *testing.T) {
-			err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: address})
+	grpcTests := []struct {
+		name    string
+		address string
+	}{
+		{name: "rejects URL address", address: "https://collector.example.com:4317"},
+		{name: "rejects missing port", address: "collector.example.com"},
+		{name: "rejects empty port", address: "collector.example.com:"},
+		{name: "rejects zero port", address: "collector.example.com:0"},
+		{name: "rejects path", address: "collector.example.com:4317/v1/traces"},
+	}
+
+	for _, tt := range grpcTests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := otlp.ValidateEndpoint(otlp.Endpoint{Protocol: "grpc", Address: tt.address})
 
 			require.ErrorIs(t, err, otlp.ErrInvalidEndpoint)
 		})

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -18,13 +18,20 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	checks := []string{"healthz", "livez", "readyz"}
+	checks := []struct {
+		name string
+		path string
+	}{
+		{name: "serves health endpoint", path: "healthz"},
+		{name: "serves liveness endpoint", path: "livez"},
+		{name: "serves readiness endpoint", path: "readyz"},
+	}
 
 	for _, check := range checks {
-		t.Run(check, func(t *testing.T) {
+		t.Run(check.name, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),
-				test.WithWorldHTTPHealth(test.Name.String(), test.StatusURL("200"), test.HealthObserve(check, "http")),
+				test.WithWorldHTTPHealth(test.Name.String(), test.StatusURL("200"), test.HealthObserve(check.path, "http")),
 			)
 
 			ctx := meta.WithAttributes(t.Context(),
@@ -33,7 +40,7 @@ func TestHealth(t *testing.T) {
 			)
 
 			header := http.Header{}
-			url := world.NamedServerURL("http", check)
+			url := world.NamedServerURL("http", check.path)
 
 			res, body, err := world.ResponseWithBody(ctx, url, http.MethodGet, header, http.NoBody)
 			require.NoError(t, err)
@@ -129,10 +136,17 @@ func TestInvalidHealth(t *testing.T) {
 }
 
 func TestMissingHealth(t *testing.T) {
-	checks := []string{"healthz", "livez", "readyz"}
+	checks := []struct {
+		name string
+		path string
+	}{
+		{name: "rejects unobserved health endpoint", path: "healthz"},
+		{name: "rejects unobserved liveness endpoint", path: "livez"},
+		{name: "rejects unobserved readiness endpoint", path: "readyz"},
+	}
 
 	for _, check := range checks {
-		t.Run(check, func(t *testing.T) {
+		t.Run(check.name, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),
 				test.WithWorldHTTPHealth(test.Name.String(), test.StatusURL("200")),
@@ -146,7 +160,7 @@ func TestMissingHealth(t *testing.T) {
 			header := http.Header{}
 			header.Set(http.ContentTypeKey, media.JSON)
 
-			url := world.NamedServerURL("http", check)
+			url := world.NamedServerURL("http", check.path)
 
 			res, err := world.ResponseWithNoBody(ctx, url, http.MethodGet, header)
 			require.NoError(t, err)

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -32,11 +32,21 @@ func TestUnlimited(t *testing.T) {
 }
 
 func TestServerLimiter(t *testing.T) {
-	for _, f := range []string{"user-agent", "ip", "service-method", "transport-service-method"} {
-		t.Run(f, func(t *testing.T) {
+	keys := []struct {
+		name string
+		kind string
+	}{
+		{name: "limits by user agent", kind: "user-agent"},
+		{name: "limits by IP address", kind: "ip"},
+		{name: "limits by service method", kind: "service-method"},
+		{name: "limits by transport service method", kind: "transport-service-method"},
+	}
+
+	for _, key := range keys {
+		t.Run(key.name, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),
-				test.WithWorldServerLimiter(test.NewLimiterConfig(f, "1s", 0)),
+				test.WithWorldServerLimiter(test.NewLimiterConfig(key.kind, "1s", 0)),
 				test.WithWorldHTTP(),
 				test.WithWorldHello(),
 			)
@@ -103,11 +113,21 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 }
 
 func TestClientLimiter(t *testing.T) {
-	for _, f := range []string{"user-agent", "ip", "service-method", "transport-service-method"} {
-		t.Run(f, func(t *testing.T) {
+	keys := []struct {
+		name string
+		kind string
+	}{
+		{name: "limits by user agent", kind: "user-agent"},
+		{name: "limits by IP address", kind: "ip"},
+		{name: "limits by service method", kind: "service-method"},
+		{name: "limits by transport service method", kind: "transport-service-method"},
+	}
+
+	for _, key := range keys {
+		t.Run(key.name, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
 				test.WithWorldTelemetry("otlp"),
-				test.WithWorldClientLimiter(test.NewLimiterConfig(f, "1s", 0)),
+				test.WithWorldClientLimiter(test.NewLimiterConfig(key.kind, "1s", 0)),
 				test.WithWorldHTTP(),
 				test.WithWorldHello(),
 			)


### PR DESCRIPTION
## What

- Improves named scenarios across CLI, configuration, encoding, filesystem, telemetry, debug, health, and HTTP limiter coverage so failure output states the expected behavior.
- Verifies the YAML stream encoding case reports a failure from either encoding or closing the writer.

## Why

- Descriptive subtest names make CI failures immediately actionable without relying on fixture paths or opaque input values.

## Testing

- `make specs package=cli` through `make specs package=transport/http` - passed across all ten changed packages.
- `make lint` - passed.
- Updated scenarios preserve the existing behavioral coverage while making their intent explicit.

AI-assisted-by: [Codex](https://openai.com/codex/)
