### PR TITLE
test(feature): clarify behavioral specification names

### DIFF
--- a/bytes/bytes_test.go
+++ b/bytes/bytes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClone(t *testing.T) {
+func TestCloneReturnsEqualBytes(t *testing.T) {
 	hello := strings.Bytes("hello")
 	require.Equal(t, hello, bytes.Clone(hello))
 }

--- a/bytes/size_test.go
+++ b/bytes/size_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMustParseSize(t *testing.T) {
+func TestMustParseSizePanicsForInvalidInput(t *testing.T) {
 	t.Parallel()
 
 	require.Panics(t, func() { bytes.MustParseSize("test") })
 }
 
-func TestDefaultSize(t *testing.T) {
+func TestDefaultSizeIsFourMegabytes(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, 4*bytes.MB, bytes.DefaultSize)
@@ -77,7 +77,7 @@ func TestSizeJSONRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSizeUnmarshalTextInvalid(t *testing.T) {
+func TestSizeUnmarshalTextRejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
 	var size bytes.Size
@@ -86,7 +86,7 @@ func TestSizeUnmarshalTextInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSizeUnmarshalJSONInvalid(t *testing.T) {
+func TestSizeUnmarshalJSONRejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -113,7 +113,7 @@ func TestSizeUnmarshalJSONInvalid(t *testing.T) {
 	}
 }
 
-func TestSizeUnmarshalJSONWithWhitespace(t *testing.T) {
+func TestSizeUnmarshalJSONAcceptsWhitespace(t *testing.T) {
 	t.Parallel()
 
 	var size bytes.Size

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestValidCache(t *testing.T) {
+func TestCacheRoundTripsSupportedFormats(t *testing.T) {
 	for _, tt := range cacheRoundTripCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			test.RequireCacheRoundTrip(t, tt.config, tt.persist(), tt.get())
@@ -36,7 +36,7 @@ func TestValidCache(t *testing.T) {
 	}
 }
 
-func TestGenericValidCache(t *testing.T) {
+func TestGenericCachePersistsAndGetsValue(t *testing.T) {
 	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
@@ -50,7 +50,7 @@ func TestGenericValidCache(t *testing.T) {
 	require.NoError(t, world.Remove(t.Context(), "test"))
 }
 
-func TestGetOrPersist(t *testing.T) {
+func TestGetOrPersistLoadsOnlyOnCacheMiss(t *testing.T) {
 	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
@@ -74,7 +74,7 @@ func TestGetOrPersist(t *testing.T) {
 	require.NoError(t, world.Remove(t.Context(), "test"))
 }
 
-func TestGetOrPersistRedis(t *testing.T) {
+func TestGetOrPersistUsesRedisCache(t *testing.T) {
 	cfg := test.NewCacheConfig("redis", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 	ctx := t.Context()
@@ -420,7 +420,7 @@ func TestModuleRegistersGenericCache(t *testing.T) {
 	require.Equal(t, "hello?", *value)
 }
 
-func TestGenericDisabledCache(t *testing.T) {
+func TestGenericCacheIgnoresValuesWhenDisabled(t *testing.T) {
 	cache.Register(nil)
 
 	require.NoError(t, cache.Persist(t.Context(), "test", new("hello?"), time.Minute))
@@ -445,7 +445,7 @@ func TestGenericGetValidEmptyCache(t *testing.T) {
 	require.NoError(t, world.Remove(t.Context(), "test"))
 }
 
-func TestGenericGetMissingCache(t *testing.T) {
+func TestGenericCacheReportsMissWithoutValue(t *testing.T) {
 	cfg := test.NewCacheConfig("ttlcache", "none", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
@@ -457,7 +457,7 @@ func TestGenericGetMissingCache(t *testing.T) {
 	require.NoError(t, world.Remove(t.Context(), "missing"))
 }
 
-func TestGenericGetDisabledCache(t *testing.T) {
+func TestGenericCacheReportsMissWhenDisabled(t *testing.T) {
 	cache.Register(nil)
 	t.Cleanup(func() {
 		cache.Register(nil)
@@ -471,7 +471,7 @@ func TestGenericGetDisabledCache(t *testing.T) {
 	require.Nil(t, value)
 }
 
-func TestMaxSizeOnPersist(t *testing.T) {
+func TestCachePersistRejectsValuesOverConfiguredLimit(t *testing.T) {
 	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
 	cfg.MaxSize = 4
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
@@ -480,7 +480,7 @@ func TestMaxSizeOnPersist(t *testing.T) {
 	require.ErrorIs(t, err, compresserrors.ErrTooLarge)
 }
 
-func TestMaxSizeOnPersistCompressedValue(t *testing.T) {
+func TestCachePersistRejectsCompressedValuesOverConfiguredLimit(t *testing.T) {
 	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
 	cfg.MaxSize = 4
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
@@ -500,7 +500,7 @@ func TestMaxSizeOnPersistStopsOversizedEncodedValue(t *testing.T) {
 	require.Equal(t, cfg.MaxSize.Bytes(), value.written)
 }
 
-func TestMaxSizeOnGet(t *testing.T) {
+func TestGetRejectsValueExceedingConfiguredLimit(t *testing.T) {
 	cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
 	world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
 
@@ -596,7 +596,7 @@ func TestGetMissesAfterCacheFormatChange(t *testing.T) {
 	}
 }
 
-func TestExpiredCache(t *testing.T) {
+func TestCacheDoesNotReturnExpiredValue(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		cfg := test.NewCacheConfig("ttlcache", "snappy", "json", "redis")
 		world := test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
@@ -612,7 +612,7 @@ func TestExpiredCache(t *testing.T) {
 	})
 }
 
-func TestErroneousCache(t *testing.T) {
+func TestNewDriverRejectsInvalidCacheConfiguration(t *testing.T) {
 	tests := []struct {
 		config *config.Config
 		name   string
@@ -634,7 +634,7 @@ func TestErroneousCache(t *testing.T) {
 	}
 }
 
-func TestDisabledCache(t *testing.T) {
+func TestNewDriverAndCacheSupportDisabledConfiguration(t *testing.T) {
 	t.Run("driver", func(t *testing.T) {
 		_, err := driver.NewDriver(driver.DriverParams{
 			Lifecycle: fxtest.NewLifecycle(t),
@@ -650,7 +650,7 @@ func TestDisabledCache(t *testing.T) {
 	})
 }
 
-func TestErroneousSave(t *testing.T) {
+func TestCachePersistReportsEncodingErrors(t *testing.T) {
 	t.Run("invalid encoder", func(t *testing.T) {
 		cfg := test.NewCacheConfig("ttlcache", "snappy", "error", "redis")
 		test.NewStartedWorld(t, test.WithWorldCacheConfig(cfg), test.WithWorldRegisterCache())
@@ -670,7 +670,7 @@ func TestErroneousSave(t *testing.T) {
 	})
 }
 
-func TestErroneousGet(t *testing.T) {
+func TestGetPropagatesDriverAndDecodeErrors(t *testing.T) {
 	tests := []struct {
 		driver driver.Driver
 		config *config.Config

--- a/cache/config/config_test.go
+++ b/cache/config/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMaxSize(t *testing.T) {
+func TestGetMaxSizeReturnsConfiguredOrDefaultValue(t *testing.T) {
 	tests := []struct {
 		cfg  *config.Config
 		name string
@@ -38,7 +38,7 @@ func TestGetMaxSize(t *testing.T) {
 	}
 }
 
-func TestConfigValidation(t *testing.T) {
+func TestConfigAcceptsValidLimitsAndRejectsInvalidLimits(t *testing.T) {
 	tests := []struct {
 		cfg  *config.Config
 		name string

--- a/cache/driver/driver_test.go
+++ b/cache/driver/driver_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewDriver(t *testing.T) {
+func TestNewDriverReturnsConfiguredDriverOrError(t *testing.T) {
 	tests := []struct {
 		config  *config.Config
 		err     error

--- a/cache/driver/errors/errors_test.go
+++ b/cache/driver/errors/errors_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrorClassification(t *testing.T) {
+func TestErrorClassificationIdentifiesCacheErrorKinds(t *testing.T) {
 	tests := []struct {
 		name    string
 		err     error

--- a/cache/driver/internal/redis/redis_test.go
+++ b/cache/driver/internal/redis/redis_test.go
@@ -32,7 +32,7 @@ func TestClientClosesOnStop(t *testing.T) {
 	require.ErrorIs(t, err, redis.ErrClosed)
 }
 
-func TestDriverPings(t *testing.T) {
+func TestDriverPingsRedis(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := redisConfig("redis://localhost:6379")
 

--- a/cache/driver/internal/ttlcache/ttlcache_test.go
+++ b/cache/driver/internal/ttlcache/ttlcache_test.go
@@ -49,7 +49,7 @@ func TestDriverGetOrSave(t *testing.T) {
 	require.Equal(t, "first", value)
 }
 
-func TestDriverPings(t *testing.T) {
+func TestDriverPingsSuccessfully(t *testing.T) {
 	d := cachettl.NewDriver(config.DefaultMaxEntries)
 
 	require.NoError(t, d.Ping(t.Context()))

--- a/cli/application_test.go
+++ b/cli/application_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestApplicationDuplicateCommand(t *testing.T) {
+func TestNewApplicationRejectsDuplicateCommand(t *testing.T) {
 	var err error
 
 	func() {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -39,7 +39,7 @@ func TestApplicationClientRunWithInvalidFlag(t *testing.T) {
 	require.Error(t, app.Run(t.Context()))
 }
 
-func TestApplicationClient(t *testing.T) {
+func TestApplicationRunsClientCommand(t *testing.T) {
 	test.SetupCLI("client")
 
 	opts := []di.Option{di.NoLogger}
@@ -157,13 +157,13 @@ func TestApplicationClientShutdownExitCodeIsReturnedWhenStopFails(t *testing.T) 
 	}
 }
 
-func TestApplicationClientInvalidConfig(t *testing.T) {
+func TestApplicationClientRejectsInvalidConfiguration(t *testing.T) {
 	tests := []struct {
 		name   string
 		config string
 	}{
 		{name: "rejects invalid HTTP configuration", config: test.FilePath("configs/invalid_http.config.yaml")},
-		{name: "rejects invalid gRPC configuration", config: test.FilePath("configs/invalid_grpc.config.yaml")},
+		{name: "rejects invalid grpc configuration", config: test.FilePath("configs/invalid_grpc.config.yaml")},
 	}
 
 	for _, tt := range tests {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/fx"
 )
 
-func TestApplicationServerRun(t *testing.T) {
+func TestApplicationRunsServerCommand(t *testing.T) {
 	config := test.FilePath("configs/config.yaml")
 	test.SetupCLI("server", "-config", config)
 
@@ -123,13 +123,13 @@ func TestApplicationServerDrainsStreamingRoute(t *testing.T) {
 	requireServerExit(t, code)
 }
 
-func TestApplicationServerInvalidConfig(t *testing.T) {
+func TestApplicationServerRejectsInvalidConfiguration(t *testing.T) {
 	tests := []struct {
 		name   string
 		config string
 	}{
 		{name: "rejects invalid HTTP configuration", config: test.FilePath("configs/invalid_http.config.yaml")},
-		{name: "rejects invalid gRPC configuration", config: test.FilePath("configs/invalid_grpc.config.yaml")},
+		{name: "rejects invalid grpc configuration", config: test.FilePath("configs/invalid_grpc.config.yaml")},
 		{name: "rejects invalid debug configuration", config: test.FilePath("configs/invalid_debug.config.yaml")},
 	}
 
@@ -151,7 +151,7 @@ func TestApplicationServerInvalidConfig(t *testing.T) {
 	}
 }
 
-func TestApplicationServerDisabled(t *testing.T) {
+func TestApplicationRunsWhenServerIsDisabled(t *testing.T) {
 	test.SetupCLI("server", "-config", test.FilePath("configs/disabled.config.yaml"))
 
 	app := cli.NewApplication(

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -17,7 +17,7 @@ import (
 
 var compressorKinds = []string{"zstd", "s2", "snappy", "none"}
 
-func TestMap(t *testing.T) {
+func TestMapReturnsRegisteredCompressors(t *testing.T) {
 	for _, kind := range compressorKinds {
 		t.Run(kind, func(t *testing.T) {
 			cmp := test.Compressor.Get(kind)
@@ -33,7 +33,7 @@ func TestMap(t *testing.T) {
 	}
 
 	for _, key := range []string{"test", "bob"} {
-		t.Run(key, func(t *testing.T) {
+		t.Run("returns nil for "+key, func(t *testing.T) {
 			cmp := test.Compressor.Get(key)
 			require.Nil(t, cmp)
 		})
@@ -57,7 +57,7 @@ func TestNewMapRegistersDefaultCompressors(t *testing.T) {
 	}
 }
 
-func TestMapRegister(t *testing.T) {
+func TestMapRegisterReplacesExistingCompressor(t *testing.T) {
 	compressors := compress.NewMap()
 	custom := test.NewCompressor(test.ErrFailed)
 	replacement := none.NewCompressor()

--- a/compress/s2/s2_test.go
+++ b/compress/s2/s2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompressor(t *testing.T) {
+func TestCompressorRoundTripsData(t *testing.T) {
 	t.Parallel()
 
 	cmp := s2.NewCompressor()

--- a/compress/snappy/snappy_test.go
+++ b/compress/snappy/snappy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompressor(t *testing.T) {
+func TestCompressorRoundTripsData(t *testing.T) {
 	t.Parallel()
 
 	cmp := snappy.NewCompressor()

--- a/compress/zstd/zstd_test.go
+++ b/compress/zstd/zstd_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompressor(t *testing.T) {
+func TestCompressorRoundTripsData(t *testing.T) {
 	t.Parallel()
 
 	cmp := zstd.NewCompressor()

--- a/config/client/config_test.go
+++ b/config/client/config_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig(t *testing.T) {
+func TestConfigIsEnabledUnlessNil(t *testing.T) {
 	require.False(t, (*client.Config)(nil).IsEnabled())
 	require.True(t, (&client.Config{}).IsEnabled())
 }
@@ -34,7 +34,7 @@ func TestConfigRejectsNegativeBreakerDurations(t *testing.T) {
 	require.Error(t, test.Validator.Struct(cfg))
 }
 
-func TestNewConfig(t *testing.T) {
+func TestNewConfigLoadsMutuallyAuthenticatedTLS(t *testing.T) {
 	tlsConfig, err := client.NewConfig(test.FS, test.NewTLSClientConfig())
 	require.NoError(t, err)
 	require.NotNil(t, tlsConfig)
@@ -56,7 +56,7 @@ func TestNewConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewConfigWithOptionalTLSMaterial(t *testing.T) {
+func TestNewConfigAcceptsOptionalTLSMaterial(t *testing.T) {
 	tests := []struct {
 		config       *config.Config
 		name         string
@@ -103,7 +103,7 @@ func TestNewConfigWithOptionalTLSMaterial(t *testing.T) {
 	}
 }
 
-func TestNewConfigInvalidKeyPair(t *testing.T) {
+func TestNewConfigRejectsInvalidKeyPair(t *testing.T) {
 	_, err := client.NewConfig(test.FS, &config.Config{
 		Cert: test.FilePath("certs/client-cert.pem"),
 		Key:  test.FilePath("secrets/none"),
@@ -111,7 +111,7 @@ func TestNewConfigInvalidKeyPair(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNewConfigInvalidCA(t *testing.T) {
+func TestNewConfigRejectsInvalidCA(t *testing.T) {
 	_, err := client.NewConfig(test.FS, &config.Config{CA: "invalid ca"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, config.ErrInvalidCA)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidFileConfig(t *testing.T) {
+func TestConfigLoadsValidFileSources(t *testing.T) {
 	tests := []struct {
 		name string
 		file string
@@ -39,7 +39,7 @@ func TestValidFileConfig(t *testing.T) {
 	}
 }
 
-func TestValidHomeFileConfig(t *testing.T) {
+func TestConfigExpandsHomeDirectoryInFileSource(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -57,7 +57,7 @@ func TestValidHomeFileConfig(t *testing.T) {
 	verifyConfig(t, cfg)
 }
 
-func TestInvalidFileConfig(t *testing.T) {
+func TestConfigRejectsInvalidFileSources(t *testing.T) {
 	tests := []struct {
 		name string
 		file string
@@ -90,7 +90,7 @@ func TestInvalidFileConfig(t *testing.T) {
 	}
 }
 
-func TestValidTelemetryConfig(t *testing.T) {
+func TestConfigAcceptsValidTelemetrySettings(t *testing.T) {
 	tests := []struct {
 		name string
 		file string
@@ -112,7 +112,7 @@ func TestValidTelemetryConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidTimeTimeoutConfig(t *testing.T) {
+func TestConfigRejectsInvalidTimeout(t *testing.T) {
 	set := flag.NewFlagSet("test")
 	set.AddConfig(test.FilePath("configs/invalid_time.config.yaml"))
 
@@ -122,7 +122,7 @@ func TestInvalidTimeTimeoutConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestValidEnvConfig(t *testing.T) {
+func TestConfigLoadsValidEnvironmentSources(t *testing.T) {
 	tests := []struct {
 		name string
 		kind string
@@ -152,7 +152,7 @@ func TestValidEnvConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidEnvMissingConfig(t *testing.T) {
+func TestConfigReportsMissingEnvironmentSource(t *testing.T) {
 	set := flag.NewFlagSet("test")
 	set.AddConfig("env:CONFIG")
 
@@ -163,7 +163,7 @@ func TestInvalidEnvMissingConfig(t *testing.T) {
 	require.ErrorContains(t, err, "env CONFIG")
 }
 
-func TestInvalidEnvKindConfig(t *testing.T) {
+func TestConfigRejectsUnknownEnvironmentSourceKind(t *testing.T) {
 	d, err := test.FS.ReadFile(test.Path("configs/config.yaml"))
 	require.NoError(t, err)
 
@@ -180,7 +180,7 @@ func TestInvalidEnvKindConfig(t *testing.T) {
 	require.ErrorContains(t, err, "kind what")
 }
 
-func TestInvalidFileKindConfig(t *testing.T) {
+func TestConfigRejectsUnknownFileSourceKind(t *testing.T) {
 	set := flag.NewFlagSet("test")
 	set.AddConfig("file:config.go")
 
@@ -192,7 +192,7 @@ func TestInvalidFileKindConfig(t *testing.T) {
 	require.ErrorContains(t, err, "extension go")
 }
 
-func TestInvalidEnvDataConfig(t *testing.T) {
+func TestConfigRejectsInvalidEnvironmentSourceData(t *testing.T) {
 	t.Setenv("CONFIG", "yaml:not_good")
 
 	set := flag.NewFlagSet("test")
@@ -204,7 +204,7 @@ func TestInvalidEnvDataConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestValidCommonConfig(t *testing.T) {
+func TestConfigLoadsValidDefaultLocationSources(t *testing.T) {
 	tests := []struct {
 		name string
 		path string
@@ -245,7 +245,7 @@ func TestValidCommonConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidCommonConfig(t *testing.T) {
+func TestConfigReportsMissingDefaultLocationSource(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", test.FS.Join(home, ".config"))
@@ -261,7 +261,7 @@ func TestInvalidCommonConfig(t *testing.T) {
 	require.ErrorContains(t, err, "/etc/"+test.Name.String()+"/"+test.Name.String()+".yaml")
 }
 
-func TestInvalidKindConfig(t *testing.T) {
+func TestConfigRejectsUnknownDefaultLocationSourceKind(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", test.FS.Join(home, ".config"))

--- a/config/options/options_test.go
+++ b/config/options/options_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDuration(t *testing.T) {
+func TestDurationReturnsConfiguredOrDefaultValue(t *testing.T) {
 	require.Equal(t, 10*time.Minute, test.ConfigOptions.Duration("read_timeout", 5*time.Second))
 	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("timeout", 5*time.Second))
 	require.Equal(t, 5*time.Second, test.ConfigOptions.Duration("missing", 5*time.Second))
 }
 
-func TestNonNegativeDuration(t *testing.T) {
+func TestNonNegativeDurationRejectsNegativeAndInvalidValues(t *testing.T) {
 	opts := options.Map{"timeout": "10s"}
 
 	require.Equal(t, 10*time.Second, opts.NonNegativeDuration("timeout", time.Second))
@@ -25,7 +25,7 @@ func TestNonNegativeDuration(t *testing.T) {
 	require.Panics(t, func() { options.Map{"timeout": "invalid"}.NonNegativeDuration("timeout", time.Second) })
 }
 
-func TestUint32(t *testing.T) {
+func TestUint32RejectsInvalidAndOutOfRangeValues(t *testing.T) {
 	opts := options.Map{"count": "12"}
 
 	require.EqualValues(t, 12, opts.Uint32("count", 5))
@@ -35,7 +35,7 @@ func TestUint32(t *testing.T) {
 	require.Panics(t, func() { options.Map{"overflow": "4294967296"}.Uint32("overflow", 5) })
 }
 
-func TestSize(t *testing.T) {
+func TestSizeRejectsInvalidValues(t *testing.T) {
 	opts := options.Map{"limit": "16MB"}
 
 	require.Equal(t, 16*bytes.MB, opts.Size("limit", bytes.MB))
@@ -43,14 +43,14 @@ func TestSize(t *testing.T) {
 	require.Panics(t, func() { options.Map{"invalid": "abc"}.Size("invalid", bytes.MB) })
 }
 
-func TestIntSize(t *testing.T) {
+func TestIntSizeReturnsConfiguredOrDefaultValue(t *testing.T) {
 	opts := options.Map{"limit": "16MB"}
 
 	require.Equal(t, int(16*bytes.MB), opts.IntSize("limit", bytes.MB))
 	require.Equal(t, int(bytes.MB), opts.IntSize("missing", bytes.MB))
 }
 
-func TestInt32Size(t *testing.T) {
+func TestInt32SizeRejectsOverflow(t *testing.T) {
 	opts := options.Map{"limit": "16MB"}
 
 	require.EqualValues(t, 16*bytes.MB, opts.Int32Size("limit", bytes.MB))
@@ -58,7 +58,7 @@ func TestInt32Size(t *testing.T) {
 	require.Panics(t, func() { options.Map{"overflow": "3GB"}.Int32Size("overflow", 0) })
 }
 
-func TestUint32Size(t *testing.T) {
+func TestUint32SizeRejectsOverflow(t *testing.T) {
 	opts := options.Map{"limit": "16MB"}
 
 	require.EqualValues(t, 16*bytes.MB, opts.Uint32Size("limit", bytes.MB))

--- a/config/server/config_test.go
+++ b/config/server/config_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMaxReceiveSize(t *testing.T) {
+func TestGetMaxReceiveSizeReturnsConfiguredOrDefaultValue(t *testing.T) {
 	tests := []struct {
 		cfg  *server.Config
 		name string
@@ -33,7 +33,7 @@ func TestGetMaxReceiveSize(t *testing.T) {
 	}
 }
 
-func TestGetTimeout(t *testing.T) {
+func TestGetTimeoutReturnsConfiguredOrDefaultValue(t *testing.T) {
 	tests := []struct {
 		cfg  *server.Config
 		name string
@@ -52,7 +52,7 @@ func TestGetTimeout(t *testing.T) {
 	}
 }
 
-func TestGetReadAndWriteTimeout(t *testing.T) {
+func TestGetReadAndWriteTimeoutUsesDirectionSpecificOptions(t *testing.T) {
 	getters := []struct {
 		get   func(*server.Config) time.Duration
 		key   string
@@ -96,12 +96,12 @@ func TestConfigRejectsNegativeTimeout(t *testing.T) {
 	require.Error(t, test.Validator.Struct(cfg))
 }
 
-func TestConfig(t *testing.T) {
+func TestConfigIsEnabledUnlessNil(t *testing.T) {
 	require.False(t, (*server.Config)(nil).IsEnabled())
 	require.True(t, (&server.Config{}).IsEnabled())
 }
 
-func TestNewConfig(t *testing.T) {
+func TestNewConfigLoadsMutuallyAuthenticatedTLS(t *testing.T) {
 	tlsConfig, err := server.NewConfig(test.FS, test.NewTLSServerConfig())
 	require.NoError(t, err)
 	require.NotNil(t, tlsConfig)
@@ -123,7 +123,7 @@ func TestNewConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewConfigWithOptionalTLSMaterial(t *testing.T) {
+func TestNewConfigAcceptsOptionalTLSMaterial(t *testing.T) {
 	tests := []struct {
 		config       *config.Config
 		name         string
@@ -176,7 +176,7 @@ func TestNewConfigRejectsIncompleteKeyPair(t *testing.T) {
 	}
 }
 
-func TestNewConfigInvalidKeyPair(t *testing.T) {
+func TestNewConfigRejectsInvalidKeyPair(t *testing.T) {
 	_, err := server.NewConfig(test.FS, &config.Config{
 		Cert: test.FilePath("certs/cert.pem"),
 		Key:  test.FilePath("secrets/none"),
@@ -184,7 +184,7 @@ func TestNewConfigInvalidKeyPair(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNewConfigInvalidCA(t *testing.T) {
+func TestNewConfigRejectsInvalidCA(t *testing.T) {
 	_, err := server.NewConfig(test.FS, &config.Config{
 		Cert: test.FilePath("certs/cert.pem"),
 		Key:  test.FilePath("certs/key.pem"),

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBackground(t *testing.T) {
+func TestBackgroundHasNoCancellationOrDeadline(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -22,7 +22,7 @@ func TestBackground(t *testing.T) {
 	require.NoError(t, context.Cause(ctx))
 }
 
-func TestCauseBeforeCancellation(t *testing.T) {
+func TestCauseIsNilBeforeCancellation(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -31,7 +31,7 @@ func TestCauseBeforeCancellation(t *testing.T) {
 	require.NoError(t, context.Cause(ctx))
 }
 
-func TestWithCancel(t *testing.T) {
+func TestWithCancelReportsCancellationAsCause(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -43,7 +43,7 @@ func TestWithCancel(t *testing.T) {
 	require.ErrorIs(t, context.Cause(ctx), context.Canceled)
 }
 
-func TestWithCancelCause(t *testing.T) {
+func TestWithCancelCausePreservesProvidedOrDefaultCause(t *testing.T) {
 	t.Parallel()
 
 	t.Run("records provided cause", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestWithCancelCause(t *testing.T) {
 	})
 }
 
-func TestWithTimeoutCause(t *testing.T) {
+func TestWithTimeoutCauseReportsTimeoutOrCancellationCause(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns configured cause when timeout expires", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestWithTimeoutCause(t *testing.T) {
 	})
 }
 
-func TestWithDeadline(t *testing.T) {
+func TestWithDeadlineReportsDeadlineOrCancellationCause(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns deadline exceeded when deadline passes", func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestWithDeadline(t *testing.T) {
 	})
 }
 
-func TestWithDeadlineCause(t *testing.T) {
+func TestWithDeadlineCauseReportsConfiguredCause(t *testing.T) {
 	t.Parallel()
 
 	cause := errors.New("deadline cause")
@@ -140,7 +140,7 @@ func TestWithDeadlineCause(t *testing.T) {
 	require.ErrorIs(t, context.Cause(ctx), cause)
 }
 
-func TestWithTimeout(t *testing.T) {
+func TestWithTimeoutReportsDeadlineOrCancellationCause(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns deadline exceeded when timeout expires", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestCausePropagatesFromParent(t *testing.T) {
 	require.ErrorIs(t, context.Cause(child), cause)
 }
 
-func TestWithoutCancel(t *testing.T) {
+func TestWithoutCancelPreservesValuesWithoutCancellation(t *testing.T) {
 	t.Parallel()
 
 	key := context.Key("key")
@@ -202,7 +202,7 @@ func TestWithoutCancel(t *testing.T) {
 	require.Equal(t, "value", child.Value(key))
 }
 
-func TestWithValue(t *testing.T) {
+func TestWithValueStoresValueByKey(t *testing.T) {
 	t.Parallel()
 
 	key := context.Key("key")

--- a/crypto/aes/aes_test.go
+++ b/crypto/aes/aes_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerator(t *testing.T) {
+func TestGeneratorGeneratesKeyOrReturnsEntropyError(t *testing.T) {
 	gen := aes.NewGenerator(rand.NewGenerator(rand.NewReader()))
 	key, err := gen.Generate()
 	require.NoError(t, err)
@@ -26,7 +26,7 @@ func TestGenerator(t *testing.T) {
 	require.Empty(t, key)
 }
 
-func TestValidCipher(t *testing.T) {
+func TestNewCipherEncryptsAndDecryptsOrDisablesWhenUnconfigured(t *testing.T) {
 	gen := rand.NewGenerator(rand.NewReader())
 
 	cipher, err := aes.NewCipher(gen, test.FS, test.NewAES())
@@ -45,7 +45,7 @@ func TestValidCipher(t *testing.T) {
 	require.Nil(t, cipher)
 }
 
-func TestInvalidCipherConfig(t *testing.T) {
+func TestNewCipherRejectsInvalidKeyConfiguration(t *testing.T) {
 	t.Setenv("AES_EMPTY", "")
 
 	tests := []struct {
@@ -73,7 +73,7 @@ func TestInvalidCipherConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidCipher(t *testing.T) {
+func TestCipherRejectsInvalidCiphertext(t *testing.T) {
 	t.Run("nonce generation error", func(t *testing.T) {
 		gen := rand.NewGenerator(&test.ErrReaderCloser{})
 

--- a/crypto/bcrypt/bcrypt_test.go
+++ b/crypto/bcrypt/bcrypt_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSigner(t *testing.T) {
+func TestSignerAuthenticatesCorrectPasswordOnly(t *testing.T) {
 	signer := bcrypt.NewSigner()
 
 	t.Run("sign and verify", func(t *testing.T) {

--- a/crypto/config_test.go
+++ b/crypto/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsEnabled(t *testing.T) {
+func TestConfigIsEnabledUnlessNil(t *testing.T) {
 	require.False(t, (*crypto.Config)(nil).IsEnabled())
 	require.True(t, (&crypto.Config{}).IsEnabled())
 }

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerator(t *testing.T) {
+func TestGeneratorProducesUsableKeyPairOrReturnsEntropyError(t *testing.T) {
 	gen := ed25519.NewGenerator(rand.NewGenerator(rand.NewReader()))
 	pub, pri, err := gen.Generate()
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestGenerator(t *testing.T) {
 	require.Empty(t, pri)
 }
 
-func TestValid(t *testing.T) {
+func TestSignerAndVerifierSignAndVerifyOrDisableWhenUnconfigured(t *testing.T) {
 	cfg := test.NewEd25519()
 
 	signer, err := ed25519.NewSigner(test.PEM, cfg)
@@ -64,7 +64,7 @@ func TestValid(t *testing.T) {
 	require.Nil(t, verifier)
 }
 
-func TestInvalidConfig(t *testing.T) {
+func TestSignerAndVerifierRejectInvalidKeyConfiguration(t *testing.T) {
 	signerTests := []struct {
 		config *ed25519.Config
 		name   string
@@ -108,7 +108,7 @@ func TestInvalidConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidSignature(t *testing.T) {
+func TestVerifierRejectsAlteredSignatureAndMessage(t *testing.T) {
 	cfg := test.NewEd25519()
 
 	signer, err := ed25519.NewSigner(test.PEM, cfg)
@@ -128,7 +128,7 @@ func TestInvalidSignature(t *testing.T) {
 	require.ErrorIs(t, verifier.Verify(sig, strings.Bytes("bob")), errors.ErrInvalidMatch)
 }
 
-func TestInvalidSignerPrivateKey(t *testing.T) {
+func TestRejectsInvalidSignerPrivateKey(t *testing.T) {
 	tests := []struct {
 		signer *ed25519.Signer
 		name   string
@@ -153,7 +153,7 @@ func TestInvalidSignerPrivateKey(t *testing.T) {
 	}
 }
 
-func TestInvalidVerifierPublicKey(t *testing.T) {
+func TestRejectsInvalidVerifierPublicKey(t *testing.T) {
 	tests := []struct {
 		verifier *ed25519.Verifier
 		name     string
@@ -174,7 +174,7 @@ func TestInvalidVerifierPublicKey(t *testing.T) {
 	}
 }
 
-func TestInvalidKeyType(t *testing.T) {
+func TestSignerAndVerifierRejectUnsupportedKeyType(t *testing.T) {
 	public, private, err := rsa.NewGenerator(rand.NewGenerator(rand.NewReader())).Generate()
 	require.NoError(t, err)
 

--- a/crypto/hmac/hmac_test.go
+++ b/crypto/hmac/hmac_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerator(t *testing.T) {
+func TestGeneratorGeneratesKeyOrReturnsEntropyError(t *testing.T) {
 	gen := hmac.NewGenerator(rand.NewGenerator(rand.NewReader()))
 	key, err := gen.Generate()
 	require.NoError(t, err)
@@ -25,13 +25,13 @@ func TestGenerator(t *testing.T) {
 	require.Empty(t, key)
 }
 
-func TestIsEnabled(t *testing.T) {
+func TestConfigIsEnabledUnlessNil(t *testing.T) {
 	require.False(t, (*hmac.Config)(nil).IsEnabled())
 	require.True(t, (&hmac.Config{}).IsEnabled())
 	require.True(t, test.NewHMAC().IsEnabled())
 }
 
-func TestValidSigner(t *testing.T) {
+func TestNewSignerSignsAndVerifiesOrDisablesWhenUnconfigured(t *testing.T) {
 	signer, err := hmac.NewSigner(test.FS, test.NewHMAC())
 	require.NoError(t, err)
 	require.NotNil(t, signer)
@@ -49,7 +49,7 @@ func TestValidSigner(t *testing.T) {
 	require.Nil(t, signer)
 }
 
-func TestSignerMissingKey(t *testing.T) {
+func TestNewSignerRejectsMissingKey(t *testing.T) {
 	t.Setenv("HMAC_EMPTY", "")
 
 	tests := []struct {
@@ -76,7 +76,7 @@ func TestSignerMissingKey(t *testing.T) {
 	}
 }
 
-func TestInvalidSigner(t *testing.T) {
+func TestSignerRejectsInvalidSignature(t *testing.T) {
 	t.Run("tampered signature", func(t *testing.T) {
 		signer, err := hmac.NewSigner(test.FS, test.NewHMAC())
 		require.NoError(t, err)

--- a/crypto/pem/pem_test.go
+++ b/crypto/pem/pem_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecode(t *testing.T) {
+func TestDecodeReturnsMatchingBlockOrValidationError(t *testing.T) {
 	t.Setenv("PEM_EMPTY", "")
 
 	t.Run("valid block", func(t *testing.T) {

--- a/crypto/rand/rand_test.go
+++ b/crypto/rand/rand_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidRand(t *testing.T) {
+func TestGeneratorGeneratesRequestedBytesAndText(t *testing.T) {
 	gen := rand.NewGenerator(rand.NewReader())
 
 	c, err := gen.GenerateBytes(5)
@@ -48,7 +48,7 @@ func TestGenerateBytesReadsShortChunksFully(t *testing.T) {
 	require.Equal(t, []byte{0x00, 0x01, 0x7f, 0x80, 0xff}, data)
 }
 
-func TestInvalidRand(t *testing.T) {
+func TestGeneratorPropagatesEntropyErrors(t *testing.T) {
 	t.Run("bytes", func(t *testing.T) {
 		gen := rand.NewGenerator(&test.ErrReaderCloser{})
 
@@ -64,7 +64,7 @@ func TestInvalidRand(t *testing.T) {
 	})
 }
 
-func TestInvalidSize(t *testing.T) {
+func TestGeneratorRejectsNegativeSize(t *testing.T) {
 	t.Run("bytes", func(t *testing.T) {
 		gen := rand.NewGenerator(rand.NewReader())
 

--- a/crypto/rsa/rsa_test.go
+++ b/crypto/rsa/rsa_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerator(t *testing.T) {
+func TestGeneratorProducesConfiguredSizeKeyPair(t *testing.T) {
 	gen := rsa.NewGenerator(rand.NewGenerator(rand.NewReader()))
 	pub, pri, err := gen.Generate()
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestGenerator(t *testing.T) {
 	require.Equal(t, rsa.KeySize, privateKey.N.BitLen())
 }
 
-func TestValid(t *testing.T) {
+func TestEncryptorAndDecryptorEncryptAndDecryptOrDisableWhenUnconfigured(t *testing.T) {
 	gen := rand.NewGenerator(rand.NewReader())
 
 	enc, err := rsa.NewEncryptor(gen, test.PEM, test.NewRSA())
@@ -83,7 +83,7 @@ func TestValid(t *testing.T) {
 	require.Nil(t, dec)
 }
 
-func TestInvalidConfig(t *testing.T) {
+func TestEncryptorAndDecryptorRejectMissingKeyConfiguration(t *testing.T) {
 	t.Setenv("RSA_EMPTY", "")
 
 	t.Run("missing public key", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestInvalidConfig(t *testing.T) {
 	})
 }
 
-func TestInvalid(t *testing.T) {
+func TestDecryptorRejectsInvalidCiphertext(t *testing.T) {
 	t.Run("tampered ciphertext", func(t *testing.T) {
 		gen := rand.NewGenerator(rand.NewReader())
 		cfg := test.NewRSA()
@@ -179,7 +179,7 @@ func TestEncryptorAuthenticatesMetadata(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidKey(t *testing.T) {
+func TestEncryptorAndDecryptorRejectInvalidOrUndersizedKeys(t *testing.T) {
 	t.Run("invalid public key", func(t *testing.T) {
 		gen := rand.NewGenerator(rand.NewReader())
 
@@ -223,7 +223,7 @@ func TestInvalidKey(t *testing.T) {
 	})
 }
 
-func TestInvalidConfigParse(t *testing.T) {
+func TestConfigRejectsUnparseableKeys(t *testing.T) {
 	t.Run("public key", func(t *testing.T) {
 		_, err := (&rsa.Config{Public: test.FilePath("secrets/rsa_public_invalid")}).PublicKey(test.PEM)
 		require.Error(t, err)

--- a/crypto/ssh/ssh_test.go
+++ b/crypto/ssh/ssh_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerator(t *testing.T) {
+func TestGeneratorProducesUsableKeyPairOrReturnsEntropyError(t *testing.T) {
 	gen := ssh.NewGenerator(rand.NewGenerator(rand.NewReader()))
 	pub, pri, err := gen.Generate()
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestGenerator(t *testing.T) {
 	require.Empty(t, pri)
 }
 
-func TestValid(t *testing.T) {
+func TestSignerAndVerifierSignAndVerifyOrDisableWhenUnconfigured(t *testing.T) {
 	cfg := test.NewSSH("secrets/ssh_public", "secrets/ssh_private")
 
 	signer, err := ssh.NewSigner(test.FS, cfg)
@@ -60,7 +60,7 @@ func TestValid(t *testing.T) {
 	require.Nil(t, verifier)
 }
 
-func TestInvalidConfig(t *testing.T) {
+func TestSignerAndVerifierRejectMissingKeyConfiguration(t *testing.T) {
 	t.Setenv("SSH_EMPTY", "")
 
 	newSigner := func(config *ssh.Config) error {
@@ -92,7 +92,7 @@ func TestInvalidConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidPublicKeyConfig(t *testing.T) {
+func TestRejectsInvalidPublicKeyConfig(t *testing.T) {
 	data, err := test.FS.ReadSource(test.FilePath("secrets/ssh_public"))
 	require.NoError(t, err)
 	public := bytes.String(data)
@@ -125,7 +125,7 @@ func TestInvalidPublicKeyConfig(t *testing.T) {
 	})
 }
 
-func TestInvalidPrivateKeyConfig(t *testing.T) {
+func TestNewSignerRejectsInvalidPrivateKeyConfiguration(t *testing.T) {
 	t.Run("invalid signer private key", func(t *testing.T) {
 		_, err := ssh.NewSigner(test.FS, &ssh.Config{Private: test.FilePath("secrets/redis")})
 		require.Error(t, err)
@@ -143,7 +143,7 @@ func TestInvalidPrivateKeyConfig(t *testing.T) {
 	})
 }
 
-func TestInvalidSignature(t *testing.T) {
+func TestVerifierRejectsAlteredSignatureAndMessage(t *testing.T) {
 	cfg := test.NewSSH("secrets/ssh_public", "secrets/ssh_private")
 
 	signer, err := ssh.NewSigner(test.FS, cfg)
@@ -163,7 +163,7 @@ func TestInvalidSignature(t *testing.T) {
 	require.ErrorIs(t, verifier.Verify(sig, strings.Bytes("bob")), errors.ErrInvalidMatch)
 }
 
-func TestInvalidSignerPrivateKey(t *testing.T) {
+func TestRejectsInvalidSignerPrivateKey(t *testing.T) {
 	tests := []struct {
 		signer *ssh.Signer
 		name   string
@@ -188,7 +188,7 @@ func TestInvalidSignerPrivateKey(t *testing.T) {
 	}
 }
 
-func TestInvalidVerifierPublicKey(t *testing.T) {
+func TestRejectsInvalidVerifierPublicKey(t *testing.T) {
 	tests := []struct {
 		verifier *ssh.Verifier
 		name     string
@@ -209,7 +209,7 @@ func TestInvalidVerifierPublicKey(t *testing.T) {
 	}
 }
 
-func TestInvalidKeyType(t *testing.T) {
+func TestSignerAndVerifierRejectUnsupportedKeyType(t *testing.T) {
 	var verifierErr error
 	require.NotPanics(t, func() {
 		_, verifierErr = ssh.NewVerifier(test.FS, &ssh.Config{

--- a/crypto/tls/config/certificate_test.go
+++ b/crypto/tls/config/certificate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewKeyPair(t *testing.T) {
+func TestNewKeyPairLoadsCompletePairAndRejectsInvalidInput(t *testing.T) {
 	validTests := []struct {
 		config *tls.Config
 		name   string

--- a/crypto/tls/config/config_test.go
+++ b/crypto/tls/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHasKeyMaterial(t *testing.T) {
+func TestHasKeyMaterialRequiresCertificateOrKey(t *testing.T) {
 	tests := []struct {
 		config *tls.Config
 		name   string
@@ -29,7 +29,7 @@ func TestHasKeyMaterial(t *testing.T) {
 	}
 }
 
-func TestIsEnabled(t *testing.T) {
+func TestIsEnabledRequiresAnyTLSSetting(t *testing.T) {
 	tests := []struct {
 		config *tls.Config
 		name   string

--- a/crypto/tls/config/pool_test.go
+++ b/crypto/tls/config/pool_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCertPool(t *testing.T) {
+func TestNewCertPoolLoadsTrustedCertificateAuthority(t *testing.T) {
 	pool, err := tls.NewCertPool(test.FS, test.NewTLSServerConfig())
 	require.NoError(t, err)
 	require.NotNil(t, pool)
@@ -28,7 +28,7 @@ func TestNewCertPool(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewCertPoolInvalid(t *testing.T) {
+func TestNewCertPoolRejectsMissingOrInvalidAuthority(t *testing.T) {
 	tests := []struct {
 		config *tls.Config
 		name   string
@@ -46,7 +46,7 @@ func TestNewCertPoolInvalid(t *testing.T) {
 	}
 }
 
-func TestNewCertPoolSourceError(t *testing.T) {
+func TestNewCertPoolPropagatesAuthoritySourceError(t *testing.T) {
 	_, err := tls.NewCertPool(test.FS, &tls.Config{CA: test.FilePath("certs/missing.pem")})
 	require.Error(t, err)
 	require.NotErrorIs(t, err, tls.ErrInvalidCA)

--- a/database/sql/config/config_test.go
+++ b/database/sql/config/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigValidation(t *testing.T) {
+func TestConfigRejectsInvalidPoolSettings(t *testing.T) {
 	tests := []struct {
 		cfg  *config.Config
 		name string

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestConnect(t *testing.T) {
+func TestDriverConnectRejectsUnknownDriver(t *testing.T) {
 	cfg := test.NewPGConfig()
 
 	_, err := driver.Connect("missing", test.FS, cfg.Config)
@@ -38,7 +38,7 @@ func TestConfigIsEnabled(t *testing.T) {
 	}
 }
 
-func TestDisabledConfig(t *testing.T) {
+func TestConfigIsDisabledWhenNilOrEmpty(t *testing.T) {
 	tests := []struct {
 		config *pg.Config
 		name   string
@@ -62,7 +62,7 @@ func TestDisabledConfig(t *testing.T) {
 	}
 }
 
-func TestInvalidOpen(t *testing.T) {
+func TestOpenRejectsInvalidDSNConfiguration(t *testing.T) {
 	tests := []struct {
 		wantErr error
 		config  *pg.Config
@@ -119,7 +119,7 @@ func TestInvalidOpen(t *testing.T) {
 	}
 }
 
-func TestConfiguredSQLPings(t *testing.T) {
+func TestConfiguredSQLConnectionRespondsToPing(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil), test.WithWorldLoggerConfig("otlp"))
 
 	require.NoError(t, world.DB.Ping())
@@ -158,7 +158,7 @@ func TestOpenClosesDBsOnStop(t *testing.T) {
 	require.Error(t, db.Ping())
 }
 
-func TestDBQuery(t *testing.T) {
+func TestDatabaseExecutesReaderQuery(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -179,7 +179,7 @@ func TestDBQuery(t *testing.T) {
 	require.NoError(t, rows.Close())
 }
 
-func TestDBExec(t *testing.T) {
+func TestDatabaseExecutesWriterStatement(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -196,7 +196,7 @@ func TestDBExec(t *testing.T) {
 	require.Positive(t, num)
 }
 
-func TestDBCommitTransExec(t *testing.T) {
+func TestCommittedTransactionReportsAffectedRows(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -225,7 +225,7 @@ func TestDBCommitTransExec(t *testing.T) {
 	require.Positive(t, num)
 }
 
-func TestDBRollbackTransExec(t *testing.T) {
+func TestRolledBackTransactionReportsAffectedRows(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -251,7 +251,7 @@ func TestDBRollbackTransExec(t *testing.T) {
 	require.Positive(t, num)
 }
 
-func TestStatementQuery(t *testing.T) {
+func TestPreparedReaderStatementReturnsRows(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -277,7 +277,7 @@ func TestStatementQuery(t *testing.T) {
 	require.NoError(t, rows.Close())
 }
 
-func TestStatementExec(t *testing.T) {
+func TestPreparedWriterStatementReportsAffectedRows(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -302,7 +302,7 @@ func TestStatementExec(t *testing.T) {
 	require.Positive(t, num)
 }
 
-func TestTransStatementExec(t *testing.T) {
+func TestPreparedTransactionStatementCommitsAndReportsAffectedRows(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -336,7 +336,7 @@ func TestTransStatementExec(t *testing.T) {
 	require.Positive(t, num)
 }
 
-func TestInvalidStatementQuery(t *testing.T) {
+func TestRejectsInvalidStatementQuery(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil), test.WithWorldLoggerConfig("tint"))
 
 	ctx, cleanup := test.SetupAccounts(t, world.DB)
@@ -354,7 +354,7 @@ func TestInvalidStatementQuery(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidSQLPort(t *testing.T) {
+func TestRejectsInvalidSQLPort(t *testing.T) {
 	cfg := &pg.Config{Config: &config.Config{
 		Reader: newPool(test.FilePath("secrets/pg_invalid")),
 		Writer: newPool(test.FilePath("secrets/pg_invalid")),

--- a/database/sql/telemetry/telemetry_test.go
+++ b/database/sql/telemetry/telemetry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOpen(t *testing.T) {
+func TestOpenReportsUnknownDriver(t *testing.T) {
 	db, err := telemetry.Open("missing", "dsn")
 	require.Nil(t, db)
 	require.Error(t, err)

--- a/debug/server_test.go
+++ b/debug/server_test.go
@@ -27,7 +27,7 @@ var debugPaths = []struct {
 	{name: "serves pprof trace", path: "debug/pprof/trace"},
 }
 
-func TestDebugEndpoints(t *testing.T) {
+func TestDebugServerExposesRegisteredEndpoints(t *testing.T) {
 	tests := []struct {
 		name    string
 		scheme  string
@@ -44,7 +44,7 @@ func TestDebugEndpoints(t *testing.T) {
 	}
 }
 
-func TestInvalidServer(t *testing.T) {
+func TestNewServerRejectsInvalidTLSConfiguration(t *testing.T) {
 	cfg := &debug.Config{
 		Config: &server.Config{
 			Timeout: 5 * time.Second,
@@ -61,7 +61,7 @@ func TestInvalidServer(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMaxReceiveSize(t *testing.T) {
+func TestDebugServerRejectsBodiesOverMaxReceiveSize(t *testing.T) {
 	mux := debughttp.NewServeMux()
 	cfg := &debug.Config{
 		Config: &server.Config{

--- a/encoding/bytes/bytes_test.go
+++ b/encoding/bytes/bytes_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncoder(t *testing.T) {
+func TestEncoderEncodesAndDecodesByteBuffers(t *testing.T) {
 	t.Parallel()
 
 	encoder := encoding.NewEncoder()
@@ -49,7 +49,7 @@ func TestDecodeResetsDestination(t *testing.T) {
 	require.Equal(t, "fresh", buffer.String())
 }
 
-func TestInvalidTypedNilEncode(t *testing.T) {
+func TestEncodeRejectsTypedNilValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := encoding.NewEncoder()
@@ -74,7 +74,7 @@ func TestDecodeReturnsReadFromError(t *testing.T) {
 	require.ErrorIs(t, encoder.Decode(bytes.NewBufferString("test"), errReaderFrom{}), test.ErrFailed)
 }
 
-func TestInvalidTypedNilDecode(t *testing.T) {
+func TestDecodeRejectsTypedNilDestination(t *testing.T) {
 	t.Parallel()
 
 	encoder := encoding.NewEncoder()

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/fx"
 )
 
-func TestEncoder(t *testing.T) {
+func TestMapReturnsRegisteredEncoders(t *testing.T) {
 	for _, k := range test.Encoder.Keys() {
 		t.Run(k, func(t *testing.T) {
 			require.NotNil(t, test.Encoder.Get(k))
@@ -18,7 +18,7 @@ func TestEncoder(t *testing.T) {
 	}
 
 	for _, k := range []string{"test", "bob"} {
-		t.Run(k, func(t *testing.T) {
+		t.Run("returns nil for "+k, func(t *testing.T) {
 			require.Nil(t, test.Encoder.Get(k))
 		})
 	}

--- a/encoding/errors/errors_test.go
+++ b/encoding/errors/errors_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTrailingData(t *testing.T) {
+func TestTrailingDataAcceptsEOFAndRejectsExtraOrInvalidData(t *testing.T) {
 	parseErr := errors.New("parse failed")
 
 	t.Run("eof", func(t *testing.T) {

--- a/encoding/gob/gob_test.go
+++ b/encoding/gob/gob_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := gob.NewEncoder()
@@ -24,7 +24,7 @@ func TestEncodeDecode(t *testing.T) {
 	require.Equal(t, map[string]string{"test": "test"}, msg)
 }
 
-func TestMarshalUnmarshal(t *testing.T) {
+func TestMarshalAndUnmarshalRoundTripValue(t *testing.T) {
 	t.Parallel()
 
 	msg := map[string]string{"test": "test"}

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncode(t *testing.T) {
+func TestEncoderWritesEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := hjson.NewEncoder()
@@ -20,7 +20,7 @@ func TestEncode(t *testing.T) {
 	require.Contains(t, buf.String(), "test")
 }
 
-func TestMarshalUnmarshal(t *testing.T) {
+func TestMarshalAndUnmarshalRoundTripValue(t *testing.T) {
 	t.Parallel()
 
 	data, err := hjson.Marshal(&message{Test: "test"})
@@ -57,7 +57,7 @@ func TestEncodeReturnsWriteError(t *testing.T) {
 	require.ErrorIs(t, encoder.Encode(test.ErrWriter{}, &message{Test: "test"}), test.ErrFailed)
 }
 
-func TestDecode(t *testing.T) {
+func TestDecoderReadsEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := hjson.NewEncoder()

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncode(t *testing.T) {
+func TestEncoderWritesEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()
@@ -34,7 +34,7 @@ func TestEncodeReturnsError(t *testing.T) {
 	require.Error(t, encoder.Encode(buffer, func() {}))
 }
 
-func TestDecode(t *testing.T) {
+func TestDecoderReadsEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := json.NewEncoder()
@@ -91,7 +91,7 @@ func TestDecodeRejectsTrailingData(t *testing.T) {
 	}
 }
 
-func TestMarshal(t *testing.T) {
+func TestMarshalProducesEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	msg := map[string]string{"test": "test"}
@@ -110,7 +110,7 @@ func TestMarshalReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestUnmarshal(t *testing.T) {
+func TestUnmarshalRestoresValue(t *testing.T) {
 	t.Parallel()
 
 	var msg map[string]string

--- a/encoding/map_test.go
+++ b/encoding/map_test.go
@@ -39,7 +39,7 @@ func TestNewMapRegistersDefaultEncoders(t *testing.T) {
 	}
 }
 
-func TestMapRegister(t *testing.T) {
+func TestMapRegisterReplacesExistingEncoder(t *testing.T) {
 	encoders := encoding.NewMap()
 	custom := test.NewEncoder(test.ErrFailed)
 	replacement := bytes.NewEncoder()

--- a/encoding/msgpack/msgpack_test.go
+++ b/encoding/msgpack/msgpack_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()
@@ -45,7 +45,7 @@ func TestDecodeReturnsError(t *testing.T) {
 	require.Error(t, encoder.Decode(&test.ErrReaderCloser{}, &actual))
 }
 
-func TestMarshalUnmarshal(t *testing.T) {
+func TestMarshalAndUnmarshalRoundTripValue(t *testing.T) {
 	t.Parallel()
 
 	msg := map[string]string{"test": "test"}

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	for _, tt := range protoEncoders() {
 		t.Run(tt.name, func(t *testing.T) {
 			buffer := test.Pool.Get()
@@ -144,7 +144,7 @@ func TestDecodeReturnsReadError(t *testing.T) {
 	}
 }
 
-func TestInvalidTypedNilEncode(t *testing.T) {
+func TestEncodeRejectsTypedNilValue(t *testing.T) {
 	for _, tt := range protoEncoders() {
 		t.Run(tt.name, func(t *testing.T) {
 			var msg *health.Response

--- a/encoding/stream/gob/gob_test.go
+++ b/encoding/stream/gob/gob_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()

--- a/encoding/stream/json/json_test.go
+++ b/encoding/stream/json/json_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()

--- a/encoding/stream/map_test.go
+++ b/encoding/stream/map_test.go
@@ -79,7 +79,7 @@ func TestMapKeysIncludesPartiallyRegisteredKinds(t *testing.T) {
 	require.ElementsMatch(t, []string{"json", "msgpack", "gob", "yaml", "encode-only", "decode-only"}, m.Keys())
 }
 
-func TestMapRegister(t *testing.T) {
+func TestMapRegisterReplacesExistingCodec(t *testing.T) {
 	t.Parallel()
 
 	m := stream.NewMap()

--- a/encoding/stream/msgpack/msgpack_test.go
+++ b/encoding/stream/msgpack/msgpack_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()

--- a/encoding/stream/yaml/yaml_test.go
+++ b/encoding/stream/yaml/yaml_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecode(t *testing.T) {
+func TestEncoderRoundTripsValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncode(t *testing.T) {
+func TestEncoderWritesEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()
@@ -23,7 +23,7 @@ func TestEncode(t *testing.T) {
 	require.Equal(t, `test = "test"`, strings.TrimSpace(buffer.String()))
 }
 
-func TestMarshalUnmarshal(t *testing.T) {
+func TestMarshalAndUnmarshalRoundTripValue(t *testing.T) {
 	t.Parallel()
 
 	msg := map[string]string{"test": "test"}
@@ -56,7 +56,7 @@ func TestEncodeReturnsError(t *testing.T) {
 	require.Error(t, encoder.Encode(buffer, func() {}))
 }
 
-func TestDecode(t *testing.T) {
+func TestDecoderReadsEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := toml.NewEncoder()

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncode(t *testing.T) {
+func TestEncoderWritesEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	buffer := test.Pool.Get()
@@ -24,7 +24,7 @@ func TestEncode(t *testing.T) {
 	require.Equal(t, "test: test", strings.TrimSpace(buffer.String()))
 }
 
-func TestMarshalUnmarshal(t *testing.T) {
+func TestMarshalAndUnmarshalRoundTripValue(t *testing.T) {
 	t.Parallel()
 
 	msg := map[string]string{"test": "test"}
@@ -54,7 +54,7 @@ func TestEncodeReturnsError(t *testing.T) {
 	require.Error(t, encoder.Encode(test.ErrWriter{}, map[string]string{"test": "test"}))
 }
 
-func TestDecode(t *testing.T) {
+func TestDecoderReadsEncodedValue(t *testing.T) {
 	t.Parallel()
 
 	encoder := yaml.NewEncoder()

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -9,19 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestName(t *testing.T) {
+func TestNewNameUsesEnvironmentOverrideOrDefault(t *testing.T) {
 	require.Equal(t, "env.test", env.NewName(test.FS).String())
 
 	t.Setenv("SERVICE_NAME", test.Name.String())
 	require.Equal(t, "test", env.NewName(test.FS).String())
 }
 
-func TestUserAgent(t *testing.T) {
+func TestNewUserAgentCombinesNameAndVersion(t *testing.T) {
 	require.Equal(t, "test/1.0.0", env.NewUserAgent(env.Name("test"), env.Version("v1.0.0")).String())
 	require.Equal(t, "test/test", env.NewUserAgent(env.Name("test"), env.Version("test")).String())
 }
 
-func TestID(t *testing.T) {
+func TestNewIDUsesEnvironmentOverrideOrGenerator(t *testing.T) {
 	t.Run("generated default", func(t *testing.T) {
 		generator := uuid.NewGenerator()
 

--- a/env/version_test.go
+++ b/env/version_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVersion(t *testing.T) {
+func TestNewVersionUsesEnvironmentOverrideOrDevelopmentDefault(t *testing.T) {
 	require.Equal(t, "(devel)", env.NewVersion().String())
 
 	t.Setenv("SERVICE_VERSION", test.Version.String())
 	require.Equal(t, "1.0.0", env.NewVersion().String())
 }
 
-func TestVersionString(t *testing.T) {
+func TestVersionStringNormalizesVersionValue(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		version  env.Version

--- a/errors/safe_test.go
+++ b/errors/safe_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSafeMessage(t *testing.T) {
+func TestSafeMessageReturnsSafeMessageOrFallback(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error

--- a/feature/feature_test.go
+++ b/feature/feature_test.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestRegister(t *testing.T) {
+func TestRegisterInitializesClientWithOptionalProvider(t *testing.T) {
 	for _, tt := range []struct {
 		provider openfeature.FeatureProvider
 		name     string

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -13,7 +13,7 @@ func TestGetConfigWithoutAddConfig(t *testing.T) {
 	require.Empty(t, set.GetConfig())
 }
 
-func TestAddConfig(t *testing.T) {
+func TestAddConfigParsesLongAndShortConfigFlags(t *testing.T) {
 	cases := []struct {
 		name string
 		want string

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerator(t *testing.T) {
+func TestGeneratorGeneratesNonEmptyWebhookSecret(t *testing.T) {
 	gen := hooks.NewGenerator(rand.NewGenerator(rand.NewReader()))
 
 	secret, err := gen.Generate()

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidID(t *testing.T) {
+func TestNewGeneratorReturnsGeneratorForSupportedKinds(t *testing.T) {
 	kinds := []string{
 		"uuid",
 		"ksuid",
@@ -27,14 +27,14 @@ func TestValidID(t *testing.T) {
 	}
 }
 
-func TestDefaultID(t *testing.T) {
+func TestNewGeneratorReturnsDefaultGeneratorWithoutConfig(t *testing.T) {
 	gen, err := id.NewGenerator(nil, test.Generators)
 	require.NoError(t, err)
 	require.NotNil(t, gen)
 	require.NotEmpty(t, gen.Generate())
 }
 
-func TestInvalidID(t *testing.T) {
+func TestNewGeneratorRejectsUnsupportedKind(t *testing.T) {
 	_, err := id.NewGenerator(&id.Config{Kind: "invalid"}, test.Generators)
 	require.ErrorIs(t, err, id.ErrNotFound)
 }

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWriteString(t *testing.T) {
+func TestWriteStringWritesCompleteString(t *testing.T) {
 	buffer := test.Pool.Get()
 	defer test.Pool.Put(buffer)
 

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStrings(t *testing.T) {
+func TestStringsFormatsVisibleAttributesWithCaseAndPrefix(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
 		meta.NewPair("testId", meta.String("1")),
 		meta.NewPair("see", meta.Ignored("secret")),
@@ -57,7 +57,7 @@ func TestWithAttributesDoesNotCollideWithStringContextKey(t *testing.T) {
 	require.Equal(t, meta.String("request-id"), meta.Attribute(ctx, meta.RequestIDKey))
 }
 
-func TestPairHelpers(t *testing.T) {
+func TestPairHelpersCreatePairsWithExpectedKeys(t *testing.T) {
 	for _, test := range []struct {
 		pair  func(meta.Value) meta.Pair
 		name  string
@@ -116,7 +116,7 @@ func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
 	require.Equal(t, meta.String("user"), meta.Attribute(child, "userId"))
 }
 
-func TestAccessors(t *testing.T) {
+func TestAccessorsReturnStoredAttributes(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
 		meta.WithRequestID(meta.String("request-id")),
 		meta.WithTransport(meta.String("transport")),

--- a/meta/value_test.go
+++ b/meta/value_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValue(t *testing.T) {
+func TestValueFormatsVisibleIgnoredAndRedactedValues(t *testing.T) {
 	tests := []struct {
 		name       string
 		wantValue  string
@@ -33,7 +33,7 @@ func TestValue(t *testing.T) {
 	}
 }
 
-func TestError(t *testing.T) {
+func TestErrorReturnsVisibleErrorMessage(t *testing.T) {
 	value := meta.Error(&test.MessageError{Message: "boom"})
 
 	require.Equal(t, "boom", value.Value())
@@ -41,7 +41,7 @@ func TestError(t *testing.T) {
 	require.False(t, value.IsEmpty())
 }
 
-func TestErrorWithNil(t *testing.T) {
+func TestErrorReturnsBlankValueForNilErrors(t *testing.T) {
 	var typedNil error = (*test.MessageError)(nil)
 
 	for _, test := range []struct {
@@ -57,7 +57,7 @@ func TestErrorWithNil(t *testing.T) {
 	}
 }
 
-func TestStringerConversions(t *testing.T) {
+func TestValueConversionsUseConfiguredStringers(t *testing.T) {
 	tests := []struct {
 		name       string
 		wantValue  string
@@ -78,7 +78,7 @@ func TestStringerConversions(t *testing.T) {
 	}
 }
 
-func TestStringerConversionsWithNil(t *testing.T) {
+func TestValueConversionsHandleNilStringers(t *testing.T) {
 	var stringer fmt.Stringer = (*test.Stringer)(nil)
 
 	tests := []struct {
@@ -99,7 +99,7 @@ func TestStringerConversionsWithNil(t *testing.T) {
 	}
 }
 
-func TestRedactedWithMultiByteValue(t *testing.T) {
+func TestRedactedValuePreservesMultiByteCharacters(t *testing.T) {
 	tests := []struct {
 		name  string
 		value string

--- a/net/grpc/codes/codes_test.go
+++ b/net/grpc/codes/codes_test.go
@@ -7,6 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatusText(t *testing.T) {
+func TestStatusTextMapsCodeToMessage(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated.String(), codes.StatusText(codes.Unauthenticated))
 }

--- a/net/grpc/errors/errors_test.go
+++ b/net/grpc/errors/errors_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServerError(t *testing.T) {
+func TestServerErrorIgnoresExpectedShutdown(t *testing.T) {
 	t.Parallel()
 
 	require.NoError(t, errors.ServerError(fmt.Errorf("server stopped: %w", grpc.ErrServerStopped)))

--- a/net/grpc/grpc_test.go
+++ b/net/grpc/grpc_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatusText(t *testing.T) {
+func TestStatusTextMapsCodeToMessage(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, codes.Unauthenticated.String(), grpc.StatusText(codes.Unauthenticated))
@@ -42,7 +42,7 @@ func TestParseServiceMethod(t *testing.T) {
 	}
 }
 
-func TestSetTrailer(t *testing.T) {
+func TestSetTrailerAcceptsEmptyMetadata(t *testing.T) {
 	t.Parallel()
 
 	require.NoError(t, grpc.SetTrailer(t.Context(), nil))

--- a/net/grpc/status/status_test.go
+++ b/net/grpc/status/status_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFromError(t *testing.T) {
+func TestFromErrorConvertsStatusError(t *testing.T) {
 	err := status.Error(codes.NotFound, "missing")
 
 	s, ok := status.FromError(err)
@@ -20,7 +20,7 @@ func TestFromError(t *testing.T) {
 	require.Equal(t, "missing", s.Message())
 }
 
-func TestFromErrorWrapped(t *testing.T) {
+func TestFromErrorConvertsWrappedError(t *testing.T) {
 	err := fmt.Errorf("wrapped: %w", status.Error(codes.InvalidArgument, "invalid"))
 
 	s, ok := status.FromError(err)
@@ -29,7 +29,7 @@ func TestFromErrorWrapped(t *testing.T) {
 	require.Contains(t, s.Message(), "wrapped:")
 }
 
-func TestFromErrorUnknown(t *testing.T) {
+func TestFromErrorConvertsUnknownError(t *testing.T) {
 	s, ok := status.FromError(errors.New("plain error"))
 	require.False(t, ok)
 	require.Equal(t, codes.Unknown, s.Code())
@@ -49,7 +49,7 @@ func TestNewWithRetryInfo(t *testing.T) {
 	require.Equal(t, time.Second.Duration(), retryInfo.GetRetryDelay().AsDuration())
 }
 
-func TestErrorf(t *testing.T) {
+func TestErrorfFormatsStatusMessage(t *testing.T) {
 	err := status.Errorf(codes.InvalidArgument, "invalid %s", "name")
 
 	s, ok := status.FromError(err)
@@ -58,7 +58,7 @@ func TestErrorf(t *testing.T) {
 	require.Equal(t, "invalid name", s.Message())
 }
 
-func TestSafeError(t *testing.T) {
+func TestSafeErrorHidesCauseFromClient(t *testing.T) {
 	cause := errors.New("secret database failure")
 	err := status.SafeError(codes.Internal, cause)
 
@@ -85,7 +85,7 @@ func TestSafeErrorSurfacesCauseInErrorString(t *testing.T) {
 	require.Contains(t, plain.Error(), "widget missing")
 }
 
-func TestLocalError(t *testing.T) {
+func TestLocalErrorMarksStatusAsLocal(t *testing.T) {
 	cause := errors.New("local limiter rejection")
 	err := status.LocalError(status.SafeError(codes.ResourceExhausted, cause))
 
@@ -115,13 +115,13 @@ func TestLocalErrorAllowsNil(t *testing.T) {
 	require.NoError(t, status.LocalError(nil))
 }
 
-func TestSafeErrorOK(t *testing.T) {
+func TestSafeErrorPreservesOKStatus(t *testing.T) {
 	err := status.SafeError(codes.OK, errors.New("ignored"))
 
 	require.NoError(t, err)
 }
 
-func TestSafeErrorf(t *testing.T) {
+func TestSafeErrorfHidesFormattedCauseFromClient(t *testing.T) {
 	cause := errors.New("secret database failure")
 	err := status.SafeErrorf(codes.Internal, cause, "load tenant %s", "tenant-1")
 
@@ -166,7 +166,7 @@ func TestSafeErrorfWithoutFormat(t *testing.T) {
 	require.Same(t, cause, unwrapper.Unwrap())
 }
 
-func TestSafeErrorfOK(t *testing.T) {
+func TestSafeErrorfPreservesOKStatus(t *testing.T) {
 	err := status.SafeErrorf(codes.OK, errors.New("ignored"), "ignored")
 
 	require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestSafeErrorWrapped(t *testing.T) {
 	require.Contains(t, s.Message(), "secret database failure")
 }
 
-func TestErrorIs(t *testing.T) {
+func TestErrorIsMatchesEquivalentStatusError(t *testing.T) {
 	err := status.Error(codes.NotFound, "missing")
 	target := status.Error(codes.NotFound, "missing")
 

--- a/net/header/header_test.go
+++ b/net/header/header_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidParseBearer(t *testing.T) {
+func TestParseBearerAcceptsValidHeader(t *testing.T) {
 	t.Parallel()
 
 	value, err := header.ParseBearer("Bearer token")
@@ -16,7 +16,7 @@ func TestValidParseBearer(t *testing.T) {
 	require.Equal(t, "token", value)
 }
 
-func TestForwardedIPs(t *testing.T) {
+func TestForwardedIPsExtractsForwardedAddresses(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, [...]header.ForwardedIP{
@@ -27,7 +27,7 @@ func TestForwardedIPs(t *testing.T) {
 	}, header.ForwardedIPs)
 }
 
-func TestValidFieldName(t *testing.T) {
+func TestFieldNameAcceptsValidValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -51,7 +51,7 @@ func TestValidFieldName(t *testing.T) {
 	}
 }
 
-func TestValidFieldValue(t *testing.T) {
+func TestFieldValueAcceptsValidValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -75,7 +75,7 @@ func TestValidFieldValue(t *testing.T) {
 	}
 }
 
-func TestValidParseBearerWithLowercaseScheme(t *testing.T) {
+func TestParseBearerAcceptsLowercaseScheme(t *testing.T) {
 	t.Parallel()
 
 	value, err := header.ParseBearer("bearer token")
@@ -83,7 +83,7 @@ func TestValidParseBearerWithLowercaseScheme(t *testing.T) {
 	require.Equal(t, "token", value)
 }
 
-func TestMissingParseBearer(t *testing.T) {
+func TestParseBearerRejectsMissingHeader(t *testing.T) {
 	t.Parallel()
 
 	_, err := header.ParseBearer(strings.Empty)

--- a/net/http/accept_test.go
+++ b/net/http/accept_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAcceptItems(t *testing.T) {
+func TestAcceptItemsParsesAndOrdersMediaRanges(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/net/http/budget/budget_test.go
+++ b/net/http/budget/budget_test.go
@@ -158,7 +158,7 @@ type noBufferedDecoder struct{}
 func (noBufferedDecoder) Decode(any) error { return nil }
 func (noBufferedDecoder) Close() error     { return nil }
 
-func TestBufferedLenNoBufferedMethod(t *testing.T) {
+func TestBufferedLenReturnsZeroWithoutBufferedMethod(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, int64(0), budget.BufferedLen(noBufferedDecoder{}))
@@ -170,7 +170,7 @@ func (wrongBufferedDecoder) Decode(any) error    { return nil }
 func (wrongBufferedDecoder) Close() error        { return nil }
 func (wrongBufferedDecoder) Buffered() io.Reader { return strings.NewReader("") }
 
-func TestBufferedLenWrongBufferedType(t *testing.T) {
+func TestBufferedLenReturnsZeroForWrongBufferedType(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, int64(0), budget.BufferedLen(wrongBufferedDecoder{}))

--- a/net/http/content/policy/policy_test.go
+++ b/net/http/content/policy/policy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCanDecode(t *testing.T) {
+func TestCanDecodeMatchesSupportedContentKind(t *testing.T) {
 	tests := []struct {
 		kind string
 		want bool

--- a/net/http/content/unary/content_test.go
+++ b/net/http/content/unary/content_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewFromMedia(t *testing.T) {
+func TestNewFromMediaSelectsUsableCodec(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
 			media := test.UnaryContent.NewFromMedia(tc.mediaType)
@@ -23,7 +23,7 @@ func TestNewFromMedia(t *testing.T) {
 	}
 }
 
-func TestNewFromRequest(t *testing.T) {
+func TestContentSelectionUsesRequestMediaType(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
@@ -135,7 +135,7 @@ func TestNewFromRequestFallsBackFromInternalErrorMedia(t *testing.T) {
 	require.Same(t, test.Encoder.Get("bytes"), media.Encoder)
 }
 
-func TestNewFromContentType(t *testing.T) {
+func TestContentSelectionUsesContentType(t *testing.T) {
 	for _, tc := range mediaTests() {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), "POST", "/hello", nil)
@@ -311,7 +311,7 @@ func TestEveryEncoderKindIsClassified(t *testing.T) {
 	}
 }
 
-func TestNewFromMediaWithParameters(t *testing.T) {
+func TestContentSelectionParsesParameterizedMediaType(t *testing.T) {
 	tests := []struct {
 		name      string
 		mediaType string

--- a/net/http/errors/errors_test.go
+++ b/net/http/errors/errors_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServerClose(t *testing.T) {
+func TestServerCloseClassifiesExpectedShutdown(t *testing.T) {
 	require.NoError(t, errors.ServerError(http.ErrServerClosed))
 	require.Error(t, errors.ServerError(test.ErrFailed))
 }

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -51,7 +51,7 @@ func TestNewServerRejectsNegativeTimeoutOption(t *testing.T) {
 	}
 }
 
-func TestProtocols(t *testing.T) {
+func TestProtocolsReturnsSupportedHTTPVersions(t *testing.T) {
 	t.Parallel()
 
 	protocols := http.Protocols()
@@ -61,7 +61,7 @@ func TestProtocols(t *testing.T) {
 	require.True(t, protocols.UnencryptedHTTP2())
 }
 
-func TestParseTime(t *testing.T) {
+func TestParseTimeParsesHTTPHeaderTime(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC()
@@ -73,7 +73,7 @@ func TestParseTime(t *testing.T) {
 	require.Equal(t, now.Truncate(time.Second.Duration()), parsed)
 }
 
-func TestTransport(t *testing.T) {
+func TestTransportReturnsConfiguredRoundTripper(t *testing.T) {
 	t.Parallel()
 
 	cfg := &tls.Config{}
@@ -109,7 +109,7 @@ func TestNewServerSetsProtocols(t *testing.T) {
 	require.True(t, server.Protocols.UnencryptedHTTP2())
 }
 
-func TestSameOriginRedirect(t *testing.T) {
+func TestSameOriginRedirectMatchesSchemeHostAndPort(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -170,7 +170,7 @@ func TestSameOriginRedirectStopsAfterTenRedirects(t *testing.T) {
 	require.ErrorIs(t, http.SameOriginRedirect(crossOrigin, via), http.ErrUseLastResponse)
 }
 
-func TestSameOrigin(t *testing.T) {
+func TestSameOriginComparesSchemeHostAndPort(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/net/http/media/media_test.go
+++ b/net/http/media/media_test.go
@@ -47,7 +47,7 @@ func TestParseStripsVendorSubtypePrefix(t *testing.T) {
 	require.Equal(t, "msgpack", mediaType.Subtype())
 }
 
-func TestTypeMajor(t *testing.T) {
+func TestTypeMajorReturnsMediaTypeMajorPart(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -71,7 +71,7 @@ func TestTypeMajor(t *testing.T) {
 	}
 }
 
-func TestTypeWithUTF8(t *testing.T) {
+func TestTypeWithUTF8AddsUTF8Charset(t *testing.T) {
 	t.Parallel()
 
 	mediaType, err := media.Parse("TEXT/PLAIN; Charset=utf-8")
@@ -80,13 +80,13 @@ func TestTypeWithUTF8(t *testing.T) {
 	require.Equal(t, "TEXT/PLAIN; Charset=utf-8", mediaType.WithUTF8())
 }
 
-func TestTypeByExtension(t *testing.T) {
+func TestTypeByExtensionMapsKnownExtension(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, "image/svg+xml", media.TypeByExtension(".svg"))
 }
 
-func TestTypeWithUTF8Values(t *testing.T) {
+func TestTypeWithUTF8AddsCharsetWhenNeeded(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithRequestResponse(t *testing.T) {
+func TestWithRequestResponseStoresPairedValues(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
 	require.NoError(t, err)
 	res := httptest.NewRecorder()

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -348,7 +348,7 @@ func TestNewViewUsesLayoutPathWhenBasenameCollides(t *testing.T) {
 	}
 }
 
-func TestLayoutNames(t *testing.T) {
+func TestLayoutNamesFindsConfiguredLayouts(t *testing.T) {
 	layout := mvc.NewLayout("views/full.tmpl", "views/partial.tmpl")
 
 	require.Equal(t, "full.tmpl", layout.FullName())
@@ -562,7 +562,7 @@ func TestNotFoundUsesDefaultWhenControllerMissing(t *testing.T) {
 	test.RequireResponseBodyContains(t, res, "404 page not found")
 }
 
-func TestFallback(t *testing.T) {
+func TestFallbackRendersFallbackTemplate(t *testing.T) {
 	tests := []struct {
 		name    string
 		accept  string

--- a/net/http/status/status_test.go
+++ b/net/http/status/status_test.go
@@ -75,7 +75,7 @@ func TestNotFoundHandlerWritesStatusError(t *testing.T) {
 	test.RequireTrimmedResponseBody(t, res, "http: not found")
 }
 
-func TestDefaultMessage(t *testing.T) {
+func TestStatusErrorUsesDefaultMessage(t *testing.T) {
 	require.Equal(t, "http: bad request", httpstatus.DefaultMessage(http.StatusBadRequest))
 	require.Equal(t, "http: client closed request", httpstatus.DefaultMessage(http.StatusClientClosedRequest))
 	require.Equal(t, "http: internal server error", httpstatus.DefaultMessage(999))
@@ -94,7 +94,7 @@ func TestSafeErrorKeepsWrappedCoder(t *testing.T) {
 	require.Same(t, err, httpstatus.SafeError(http.StatusBadRequest, err))
 }
 
-func TestSafeErrorf(t *testing.T) {
+func TestSafeErrorfFormatsSafeHTTPMessage(t *testing.T) {
 	err := httpstatus.SafeErrorf(http.StatusUnauthorized, test.ErrInvalid, "load tenant %s", "tenant-1")
 
 	require.ErrorIs(t, err, test.ErrInvalid)
@@ -128,7 +128,7 @@ func TestSafeErrorfWithoutFormat(t *testing.T) {
 	test.RequireTrimmedResponseBody(t, res, "http: unauthorized")
 }
 
-func TestLocalError(t *testing.T) {
+func TestLocalErrorCreatesLocalHTTPError(t *testing.T) {
 	err := httpstatus.LocalError(httpstatus.SafeError(http.StatusTooManyRequests, test.ErrInvalid))
 
 	require.True(t, httpstatus.IsLocalError(err))

--- a/net/http/vary_test.go
+++ b/net/http/vary_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddVary(t *testing.T) {
+func TestAddVaryAddsResponseVaryHeader(t *testing.T) {
 	tests := []struct {
 		name     string
 		existing []string

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultAddress(t *testing.T) {
+func TestDefaultAddressBindsAllInterfaces(t *testing.T) {
 	require.Equal(t, "tcp://:9000", net.DefaultAddress("9000"))
 }
 
@@ -15,7 +15,7 @@ func TestNetworkAddressValue(t *testing.T) {
 	require.Equal(t, "tcp://localhost:9000", net.NetworkAddress("tcp", "localhost:9000"))
 }
 
-func TestHost(t *testing.T) {
+func TestHostExtractsHostFromAddress(t *testing.T) {
 	tests := []struct {
 		name string
 		addr string
@@ -40,7 +40,7 @@ func TestSplitAndJoinHostPort(t *testing.T) {
 	require.Equal(t, "localhost:9000", net.JoinHostPort(host, port))
 }
 
-func TestLookupPort(t *testing.T) {
+func TestLookupPortResolvesKnownService(t *testing.T) {
 	port, err := net.LookupPort(t.Context(), "tcp", "9000")
 	require.NoError(t, err)
 	require.Equal(t, 9000, port)

--- a/net/server/service_test.go
+++ b/net/server/service_test.go
@@ -76,7 +76,7 @@ func TestStartReturnsWhileServeIsRunning(t *testing.T) {
 	})
 }
 
-func TestInvalidStop(t *testing.T) {
+func TestStopReturnsShutdownFailure(t *testing.T) {
 	sh := test.NewShutdowner()
 	srv := test.NewObservableServer(nil, test.ErrFailed)
 	svc := server.NewService("test", srv, nil, sh)

--- a/net/url/url_test.go
+++ b/net/url/url_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSplitPath(t *testing.T) {
+func TestSplitPathSeparatesBaseAndTail(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadFile(t *testing.T) {
+func TestReadFileClassifiesMissingFile(t *testing.T) {
 	path := "none"
 
 	_, err := test.FS.ReadFile(path)
@@ -19,7 +19,7 @@ func TestReadFile(t *testing.T) {
 	require.False(t, test.FS.PathExists(path))
 }
 
-func TestPathExtension(t *testing.T) {
+func TestPathExtensionExtractsFinalExtension(t *testing.T) {
 	tests := []struct {
 		name string
 		path string
@@ -38,7 +38,7 @@ func TestPathExtension(t *testing.T) {
 	require.Empty(t, test.FS.PathExtension("file"))
 }
 
-func TestExpandPath(t *testing.T) {
+func TestExpandPathExpandsHomeDirectory(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -54,7 +54,7 @@ func TestCleanPathExpandsBeforeCleaning(t *testing.T) {
 	require.Equal(t, test.FS.Join(home, "..", "path.txt"), test.FS.CleanPath("~/../path.txt"))
 }
 
-func TestReadSource(t *testing.T) {
+func TestReadSourceResolvesEnvironmentFileAndLiteralSources(t *testing.T) {
 	t.Setenv("DUMMY", "yes")
 	t.Setenv("EMPTY", "")
 

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 //nolint:usetesting
-func TestEnv(t *testing.T) {
+func TestEnvironmentExposesSetAndUnsetVariables(t *testing.T) {
 	key := "__ENV_KEY"
 
 	require.NoError(t, os.Setenv(key, "test"))
@@ -23,7 +23,7 @@ func TestEnv(t *testing.T) {
 	require.Empty(t, value)
 }
 
-func TestSanitizeArgs(t *testing.T) {
+func TestSanitizeArgsRemovesGoTestArguments(t *testing.T) {
 	args := []string{"service", "-test.v", "server", "-config", "config.yml", "-test.run=TestName", "-test-mode"}
 	sanitized := os.SanitizeArgs(args)
 

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsNil(t *testing.T) {
+func TestIsNilRecognizesNilAndTypedNil(t *testing.T) {
 	var err error = (*test.NilError)(nil)
 
 	tests := []struct {
@@ -29,7 +29,7 @@ func TestIsNil(t *testing.T) {
 	}
 }
 
-func TestIsZero(t *testing.T) {
+func TestIsZeroRecognizesZeroAndTypedNil(t *testing.T) {
 	var err error = (*test.NilError)(nil)
 
 	tests := []struct {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -19,7 +19,7 @@ func TestCallerPreservesSkipSemantics(t *testing.T) {
 	require.Contains(t, file, "runtime_test.go")
 }
 
-func TestRecover(t *testing.T) {
+func TestConvertRecoverConvertsRecoveredValuesToErrors(t *testing.T) {
 	tests := []struct {
 		value   any
 		name    string

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAppendEmpty(t *testing.T) {
+func TestAppendNotZeroExcludesZeroValues(t *testing.T) {
 	t.Parallel()
 
 	var writer *test.ErrWriter
@@ -36,7 +36,7 @@ func TestAppendEmpty(t *testing.T) {
 	}
 }
 
-func TestAppendNotZero(t *testing.T) {
+func TestAppendNotZeroIncludesNonZeroValues(t *testing.T) {
 	t.Parallel()
 
 	integer := 2
@@ -61,7 +61,7 @@ func TestAppendNotZero(t *testing.T) {
 	}
 }
 
-func TestBackward(t *testing.T) {
+func TestBackwardIteratesValuesInReverseOrder(t *testing.T) {
 	t.Parallel()
 
 	values := []string{}
@@ -72,7 +72,7 @@ func TestBackward(t *testing.T) {
 	require.Equal(t, []string{"second", "first"}, values)
 }
 
-func TestElemFunc(t *testing.T) {
+func TestElemFuncReturnsMatchingElementOrNil(t *testing.T) {
 	t.Parallel()
 
 	elems := []*string{new("test")}
@@ -104,7 +104,7 @@ func TestElemFunc(t *testing.T) {
 	}
 }
 
-func TestClip(t *testing.T) {
+func TestClipPreventsAppendFromMutatingOriginalArray(t *testing.T) {
 	t.Parallel()
 
 	values := [...]string{"first", "second"}
@@ -117,7 +117,7 @@ func TestClip(t *testing.T) {
 	require.Equal(t, []string{"second"}, second)
 }
 
-func TestContains(t *testing.T) {
+func TestContainsRecognizesPresentValue(t *testing.T) {
 	t.Parallel()
 
 	type names []string

--- a/strings/strcase_test.go
+++ b/strings/strcase_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCaseConversion(t *testing.T) {
+func TestCaseConversionUsesRequestedStyle(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -11,7 +11,7 @@ import (
 // testBytesSink keeps conversion results observable for allocation assertions.
 var testBytesSink []byte
 
-func TestBytes(t *testing.T) {
+func TestBytesConvertsStringsToEqualBytes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -47,7 +47,7 @@ func TestBytesDoesNotAllocate(t *testing.T) {
 	require.Zero(t, allocs)
 }
 
-func TestIsEmpty(t *testing.T) {
+func TestIsEmptyRecognizesOnlyEmptyStrings(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -69,7 +69,7 @@ func TestIsEmpty(t *testing.T) {
 	}
 }
 
-func TestIsAnyEmpty(t *testing.T) {
+func TestIsAnyEmptyRecognizesAnyEmptyString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -92,7 +92,7 @@ func TestIsAnyEmpty(t *testing.T) {
 	}
 }
 
-func TestJoin(t *testing.T) {
+func TestJoinJoinsStringsWithSeparator(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -115,7 +115,7 @@ func TestJoin(t *testing.T) {
 	}
 }
 
-func TestConcat(t *testing.T) {
+func TestConcatJoinsStringsWithoutSeparator(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -137,7 +137,7 @@ func TestConcat(t *testing.T) {
 	}
 }
 
-func TestCutColon(t *testing.T) {
+func TestCutColonSplitsAtFirstColon(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -167,7 +167,7 @@ func TestCutColon(t *testing.T) {
 	}
 }
 
-func TestCutAfter(t *testing.T) {
+func TestCutAfterReturnsSuffixAfterFirstSeparator(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -190,13 +190,13 @@ func TestCutAfter(t *testing.T) {
 	}
 }
 
-func TestSplitSeq(t *testing.T) {
+func TestSplitSeqSplitsStringIntoSequence(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, []string{"accept", "content-type"}, slices.Collect(strings.SplitSeq("accept,content-type", ",")))
 }
 
-func TestLastIndex(t *testing.T) {
+func TestLastIndexReturnsFinalSubstringPosition(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -219,7 +219,7 @@ func TestLastIndex(t *testing.T) {
 	}
 }
 
-func TestCount(t *testing.T) {
+func TestCountReturnsSubstringOccurrences(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -242,7 +242,7 @@ func TestCount(t *testing.T) {
 	}
 }
 
-func TestReplaceAll(t *testing.T) {
+func TestReplaceAllReplacesEveryMatch(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -266,7 +266,7 @@ func TestReplaceAll(t *testing.T) {
 	}
 }
 
-func TestTrim(t *testing.T) {
+func TestTrimRemovesLeadingAndTrailingCutset(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/telemetry/attributes/attributes_test.go
+++ b/telemetry/attributes/attributes_test.go
@@ -55,7 +55,7 @@ func TestResourceIncludesServiceInstanceIDWithoutConfiguredDuplicate(t *testing.
 	require.Equal(t, "host-id", attrs["service.instance.id"])
 }
 
-func TestDeploymentEnvironmentName(t *testing.T) {
+func TestDeploymentEnvironmentNameNormalizesAliases(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/telemetry/header/header_test.go
+++ b/telemetry/header/header_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSecrets(t *testing.T) {
+func TestSecretsResolvesSourcesOrReturnsError(t *testing.T) {
 	headers := header.Map{
 		"file":    test.FilePath("secrets/hooks"),
 		"literal": "literal-token",
@@ -26,7 +26,7 @@ func TestSecrets(t *testing.T) {
 	require.Error(t, header.Map{"test": test.FilePath("none")}.Secrets(test.ErrFS))
 }
 
-func TestMustSecrets(t *testing.T) {
+func TestMustSecretsPanicsWhenSourceCannotBeResolved(t *testing.T) {
 	headers := header.Map{"test": test.FilePath("secrets/hooks")}
 
 	require.NotPanics(t, func() {

--- a/telemetry/internal/otlp/endpoint_test.go
+++ b/telemetry/internal/otlp/endpoint_test.go
@@ -22,12 +22,12 @@ func TestValidateEndpoint(t *testing.T) {
 		{name: "uppercase localhost HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://LOCALHOST:4318/v1/traces", Headers: headers}},
 		{name: "loopback IP HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://127.0.0.1:4318/v1/traces", Headers: headers}},
 		{name: "headerless HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces"}},
-		{name: "loopback gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "localhost:4317", Headers: headers}},
-		{name: "mixed case localhost gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "Localhost:4317", Headers: headers}},
-		{name: "headerless gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317"}},
-		{name: "TLS gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers, TLS: &tls.Config{}}},
+		{name: "loopback grpc", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "localhost:4317", Headers: headers}},
+		{name: "mixed case localhost grpc", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "Localhost:4317", Headers: headers}},
+		{name: "headerless grpc", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317"}},
+		{name: "TLS grpc", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers, TLS: &tls.Config{}}},
 		{name: "insecure HTTP", endpoint: otlp.Endpoint{Protocol: "http", Address: "http://collector.example.com/v1/traces", Headers: headers}, wantErr: otlp.ErrInsecureEndpoint},
-		{name: "insecure gRPC", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers}, wantErr: otlp.ErrInsecureEndpoint},
+		{name: "insecure grpc", endpoint: otlp.Endpoint{Protocol: "grpc", Address: "collector.example.com:4317", Headers: headers}, wantErr: otlp.ErrInsecureEndpoint},
 	}
 
 	for _, tt := range tests {

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestLogger(t *testing.T) {
+func TestLoggerEmitsRecordsWithoutPanic(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	log, err := test.NewLogger(lc, test.NewTextLoggerConfig())
 	require.NoError(t, err)
@@ -215,7 +215,7 @@ func TestStdoutLoggerLogsUnderSpan(t *testing.T) {
 	})
 }
 
-func TestInvalidLogger(t *testing.T) {
+func TestRejectsInvalidLogger(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{Kind: "wrong", Level: "debug"}
 	params := logger.LoggerParams{
@@ -241,7 +241,7 @@ func TestInvalidLogger(t *testing.T) {
 	})
 }
 
-func TestDisabledLogger(t *testing.T) {
+func TestNewLoggerDisablesLoggingWhenUnconfigured(t *testing.T) {
 	original := slog.Default()
 	t.Cleanup(func() {
 		slog.SetDefault(original)
@@ -286,7 +286,7 @@ func TestLogAddsMetadataAndError(t *testing.T) {
 	require.Equal(t, context.Canceled, handler.Records[1].Attrs["error"].Any())
 }
 
-func TestInvalidLevel(t *testing.T) {
+func TestNewLoggerRejectsInvalidLevel(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{Kind: "text", Level: "bob"}
 	params := logger.LoggerParams{
@@ -302,7 +302,7 @@ func TestInvalidLevel(t *testing.T) {
 	require.ErrorIs(t, err, logger.ErrInvalidLevel)
 }
 
-func TestInvalidOTLPEndpoint(t *testing.T) {
+func TestRejectsInvalidOTLPEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{
 		Kind: "otlp",
@@ -346,7 +346,7 @@ func TestOTLPGRPCLogger(t *testing.T) {
 	require.NoError(t, lc.Stop(t.Context()))
 }
 
-func TestInvalidOTLPGRPCEndpoint(t *testing.T) {
+func TestRejectsInvalidOTLPGRPCEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{
 		Kind:     "otlp",

--- a/telemetry/metrics/provider_test.go
+++ b/telemetry/metrics/provider_test.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestIsEnabled(t *testing.T) {
+func TestIsEnabledReflectsInstalledMeterProvider(t *testing.T) {
 	t.Cleanup(func() {
 		metrics.NewMeterProvider(metrics.MeterProviderParams{Lifecycle: fxtest.NewLifecycle(t)})
 	})

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestInvalidReader(t *testing.T) {
+func TestRejectsInvalidReader(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{Kind: "wrong"}
 
@@ -139,7 +139,7 @@ func gatherFamilyNames(t *testing.T) []string {
 	return names
 }
 
-func TestInvalidOTLPEndpoint(t *testing.T) {
+func TestRejectsInvalidOTLPEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{
 		Kind: "otlp",
@@ -167,7 +167,7 @@ func TestOTLPGRPCReader(t *testing.T) {
 	require.NoError(t, reader.Shutdown(t.Context()))
 }
 
-func TestInvalidOTLPGRPCEndpoint(t *testing.T) {
+func TestRejectsInvalidOTLPGRPCEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{
 		Kind:     "otlp",

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestMeta(t *testing.T) {
+func TestMetaConvertsContextAttributesToTraceAttributes(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
 		meta.WithRequestID(meta.String("request-id")),
 		meta.WithUserID(meta.String("user-id")),
@@ -80,7 +80,7 @@ func TestMetaSpanProcessorStampsChildSpans(t *testing.T) {
 	require.Equal(t, "request-id", values[meta.RequestIDKey])
 }
 
-func TestIsEnabled(t *testing.T) {
+func TestIsEnabledReflectsInstalledTracerProvider(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})

--- a/time/duration_test.go
+++ b/time/duration_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMustParseDuration(t *testing.T) {
+func TestMustParseDurationPanicsForInvalidInput(t *testing.T) {
 	t.Parallel()
 
 	require.Panics(t, func() { time.MustParseDuration("test") })
 }
 
-func TestDefaultTimeout(t *testing.T) {
+func TestDefaultTimeoutIsThirtySeconds(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, 30*time.Second, time.DefaultTimeout)
@@ -48,7 +48,7 @@ func TestDurationJSONRoundTrip(t *testing.T) {
 	require.Equal(t, duration, decoded)
 }
 
-func TestDurationUnmarshalTextInvalid(t *testing.T) {
+func TestDurationTextRejectsInvalidValue(t *testing.T) {
 	t.Parallel()
 
 	var duration time.Duration
@@ -57,7 +57,7 @@ func TestDurationUnmarshalTextInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestDurationUnmarshalJSONInvalid(t *testing.T) {
+func TestDurationJSONRejectsInvalidValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -83,7 +83,7 @@ func TestDurationUnmarshalJSONInvalid(t *testing.T) {
 	}
 }
 
-func TestDurationZeroValueEncoding(t *testing.T) {
+func TestDurationZeroValueEncodesAsZero(t *testing.T) {
 	t.Parallel()
 
 	var duration time.Duration

--- a/time/net_test.go
+++ b/time/net_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewNetworkNilConfig(t *testing.T) {
+func TestNewNetworkAcceptsNilConfig(t *testing.T) {
 	net, err := time.NewNetwork(nil)
 	require.NoError(t, err)
 	require.Nil(t, net)
 }
 
-func TestNewNetworkInvalidKind(t *testing.T) {
+func TestNewNetworkRejectsInvalidKind(t *testing.T) {
 	_, err := time.NewNetwork(&time.Config{Kind: "invalid"})
 	require.Error(t, err)
 }

--- a/time/ntp_test.go
+++ b/time/ntp_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-func TestValidNTP(t *testing.T) {
+func TestNetworkNowReturnsTimeFromReachableNTPServer(t *testing.T) {
 	requireAnyNetworkNow(t,
 		&time.Config{Kind: "ntp", Address: "0.beevik-ntp.pool.ntp.org", Timeout: 2 * time.Second},
 		&time.Config{Kind: "ntp", Address: "1.beevik-ntp.pool.ntp.org", Timeout: 2 * time.Second},
@@ -14,6 +14,6 @@ func TestValidNTP(t *testing.T) {
 	)
 }
 
-func TestInvalidNTP(t *testing.T) {
+func TestNetworkNowReturnsErrorForIncompleteNTPConfig(t *testing.T) {
 	requireNetworkNowError(t, &time.Config{Kind: "ntp"})
 }

--- a/time/nts_test.go
+++ b/time/nts_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/alexfalkowski/go-service/v2/time"
 )
 
-func TestValidNTS(t *testing.T) {
+func TestNetworkNowReturnsTimeFromReachableNTSServer(t *testing.T) {
 	requireAnyNetworkNow(t,
 		&time.Config{Kind: "nts", Address: "time.cloudflare.com", Timeout: 2 * time.Second},
 		&time.Config{Kind: "nts", Address: "nts.netnod.se", Timeout: 2 * time.Second},
 	)
 }
 
-func TestInvalidNTS(t *testing.T) {
+func TestNetworkNowReturnsErrorForIncompleteNTSConfig(t *testing.T) {
 	requireNetworkNowError(t, &time.Config{Kind: "nts"})
 }

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewTimer(t *testing.T) {
+func TestNewTimerDeliversConfiguredDeadline(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		timer := time.NewTimer(time.Nanosecond)
 		require.NotNil(t, timer)
@@ -21,7 +21,7 @@ func TestNewTimer(t *testing.T) {
 	})
 }
 
-func TestUntil(t *testing.T) {
+func TestUntilReturnsDurationUntilFutureTime(t *testing.T) {
 	future := time.Now().Add(time.Hour.Duration())
 
 	duration := time.Until(future)

--- a/token/access/access_test.go
+++ b/token/access/access_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewController(t *testing.T) {
+func TestNewControllerLoadsConfiguredModelsAndPolicies(t *testing.T) {
 	_, err := access.NewController(&access.Config{
 		Model:  test.FilePath("configs/rbac.conf"),
 		Policy: test.FilePath("configs/bob"),
@@ -22,7 +22,7 @@ func TestNewController(t *testing.T) {
 	require.Nil(t, controller)
 }
 
-func TestHasAccess(t *testing.T) {
+func TestHasAccessAllowsConfiguredPrincipalAndOperationOnly(t *testing.T) {
 	config := test.NewAccessConfig()
 
 	controller, err := access.NewController(config, test.FS)
@@ -75,7 +75,7 @@ func TestHasAccessUsesTransportServiceMethod(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestNewControllerErrors(t *testing.T) {
+func TestNewControllerRejectsInvalidModelOrPolicySources(t *testing.T) {
 	tests := []struct {
 		err    error
 		config *access.Config

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -65,7 +65,7 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 	require.NoError(t, test.Validator.Struct(valid))
 }
 
-func TestValid(t *testing.T) {
+func TestTokenGeneratesAndVerifiesValidToken(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	token := jwt.NewToken(cfg.JWT, test.FS, uuid.NewGenerator())
 
@@ -139,7 +139,7 @@ func TestVerifyWithLeeway(t *testing.T) {
 	})
 }
 
-func TestInvalid(t *testing.T) {
+func TestTokenRejectsInvalidToken(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
 	token := jwt.NewToken(cfg.JWT, test.FS, gen)
@@ -195,7 +195,7 @@ func TestInvalid(t *testing.T) {
 	})
 }
 
-func TestInvalidSignature(t *testing.T) {
+func TestTokenRejectsInvalidSignature(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	token := jwt.NewToken(cfg.JWT, test.FS, uuid.NewGenerator())
 
@@ -221,7 +221,7 @@ func TestInvalidSignature(t *testing.T) {
 	require.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
 }
 
-func TestInvalidKeyID(t *testing.T) {
+func TestTokenRejectsInvalidKeyID(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
 	token := jwt.NewToken(cfg.JWT, test.FS, gen)
@@ -274,7 +274,7 @@ func TestInvalidKeyID(t *testing.T) {
 	})
 }
 
-func TestInvalidRequiredClaims(t *testing.T) {
+func TestRejectsInvalidRequiredClaims(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	token := jwt.NewToken(cfg.JWT, test.FS, uuid.NewGenerator())
 
@@ -313,7 +313,7 @@ func TestInvalidRequiredClaims(t *testing.T) {
 	}
 }
 
-func TestInvalidLifetimeExceedsConfig(t *testing.T) {
+func TestRejectsInvalidLifetimeExceedsConfig(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
 	generatorCfg := cloneConfig(cfg.JWT)
@@ -331,7 +331,7 @@ func TestInvalidLifetimeExceedsConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
-func TestInvalidVerifyExpirationConfig(t *testing.T) {
+func TestRejectsInvalidVerifyExpirationConfig(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
 	generator := jwt.NewToken(cfg.JWT, test.FS, gen)

--- a/token/keys/keys_test.go
+++ b/token/keys/keys_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMapGet(t *testing.T) {
+func TestMapGetReturnsConfiguredKeyOrNil(t *testing.T) {
 	key := &keys.Config{Config: test.NewEd25519()}
 
 	tests := []struct {

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -67,7 +67,7 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 	require.NoError(t, test.Validator.Struct(valid))
 }
 
-func TestValid(t *testing.T) {
+func TestTokenGeneratesAndVerifiesValidToken(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
 
@@ -125,7 +125,7 @@ func TestVerifyWithLeeway(t *testing.T) {
 	})
 }
 
-func TestInvalidEmptySubject(t *testing.T) {
+func TestRejectsInvalidEmptySubject(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
 
@@ -138,7 +138,7 @@ func TestInvalidEmptySubject(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidSubject)
 }
 
-func TestInvalidKeyID(t *testing.T) {
+func TestTokenRejectsInvalidKeyID(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
 	token := paseto.NewToken(cfg.Paseto, test.FS, gen)
@@ -158,7 +158,7 @@ func TestInvalidKeyID(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidKeyID)
 }
 
-func TestInvalidLifetimeExceedsConfig(t *testing.T) {
+func TestRejectsInvalidLifetimeExceedsConfig(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
 	generatorCfg := cloneConfig(cfg.Paseto)
@@ -176,7 +176,7 @@ func TestInvalidLifetimeExceedsConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
-func TestInvalidIssuer(t *testing.T) {
+func TestRejectsInvalidIssuer(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
 	generatorCfg := cloneConfig(cfg.Paseto)
@@ -192,7 +192,7 @@ func TestInvalidIssuer(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidVerifyExpirationConfig(t *testing.T) {
+func TestRejectsInvalidVerifyExpirationConfig(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
 	generator := paseto.NewToken(cfg.Paseto, test.FS, gen)
@@ -208,7 +208,7 @@ func TestInvalidVerifyExpirationConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
-func TestInvalidGenerateExpirationConfig(t *testing.T) {
+func TestRejectsInvalidGenerateExpirationConfig(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	generateCfg := cloneConfig(cfg.Paseto)
 	generateCfg.Expiration = 0
@@ -219,7 +219,7 @@ func TestInvalidGenerateExpirationConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
-func TestInvalidGenerateIssuerConfig(t *testing.T) {
+func TestRejectsInvalidGenerateIssuerConfig(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	generateCfg := cloneConfig(cfg.Paseto)
 	generateCfg.Issuer = strings.Empty
@@ -230,7 +230,7 @@ func TestInvalidGenerateIssuerConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
-func TestInvalidVerifyIssuerConfig(t *testing.T) {
+func TestRejectsInvalidVerifyIssuerConfig(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	gen := uuid.NewGenerator()
 	generator := paseto.NewToken(cfg.Paseto, test.FS, gen)
@@ -246,7 +246,7 @@ func TestInvalidVerifyIssuerConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
-func TestInvalidAudience(t *testing.T) {
+func TestRejectsInvalidAudience(t *testing.T) {
 	gen := uuid.NewGenerator()
 	cfg := test.NewToken("paseto")
 	token := paseto.NewToken(cfg.Paseto, test.FS, gen)
@@ -259,7 +259,7 @@ func TestInvalidAudience(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestValidMatchingIssuerAndAudience(t *testing.T) {
+func TestTokenAcceptsMatchingIssuerAndAudience(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	cfg.Paseto.Issuer = "test"
 	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
@@ -272,7 +272,7 @@ func TestValidMatchingIssuerAndAudience(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInvalidMalformedToken(t *testing.T) {
+func TestRejectsInvalidMalformedToken(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
 
@@ -280,7 +280,7 @@ func TestInvalidMalformedToken(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidGenerateMalformedPrivateKey(t *testing.T) {
+func TestRejectsInvalidGenerateMalformedPrivateKey(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	badPrivate := cloneConfig(cfg.Paseto)
 	badPrivate.Keys = keys.Map{
@@ -295,7 +295,7 @@ func TestInvalidGenerateMalformedPrivateKey(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidVerifyMalformedPublicKey(t *testing.T) {
+func TestRejectsInvalidVerifyMalformedPublicKey(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
 
@@ -303,7 +303,7 @@ func TestInvalidVerifyMalformedPublicKey(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidNilConfig(t *testing.T) {
+func TestRejectsInvalidNilConfig(t *testing.T) {
 	token := paseto.NewToken(nil, test.FS, uuid.NewGenerator())
 	require.Nil(t, token)
 }

--- a/token/ssh/ssh_test.go
+++ b/token/ssh/ssh_test.go
@@ -64,7 +64,7 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 	require.NoError(t, test.Validator.Struct(valid))
 }
 
-func TestValid(t *testing.T) {
+func TestTokenGeneratesAndVerifiesValidToken(t *testing.T) {
 	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 
 	tkn, err := token.Generate(strings.Empty, strings.Empty)
@@ -79,7 +79,7 @@ func TestValid(t *testing.T) {
 	require.Nil(t, ssh)
 }
 
-func TestValidForAudience(t *testing.T) {
+func TestTokenAcceptsValidAudience(t *testing.T) {
 	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 
 	tkn, err := token.Generate("/service.Method", strings.Empty)
@@ -143,7 +143,7 @@ func TestVerifyWithLeeway(t *testing.T) {
 	}
 }
 
-func TestInvalidAudience(t *testing.T) {
+func TestRejectsInvalidAudience(t *testing.T) {
 	token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 
 	tkn, err := token.Generate("/service.Method", strings.Empty)
@@ -155,7 +155,7 @@ func TestInvalidAudience(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidAudience)
 }
 
-func TestInvalidExpired(t *testing.T) {
+func TestRejectsInvalidExpired(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		cfg := test.NewToken("ssh").SSH
 		cfg.Expiration = time.Nanosecond
@@ -173,7 +173,7 @@ func TestInvalidExpired(t *testing.T) {
 	})
 }
 
-func TestInvalidLifetimeExceedsConfig(t *testing.T) {
+func TestRejectsInvalidLifetimeExceedsConfig(t *testing.T) {
 	genCfg := test.NewToken("ssh").SSH
 	genCfg.Expiration = time.Hour
 	generator := ssh.NewToken(genCfg, test.FS)
@@ -190,7 +190,7 @@ func TestInvalidLifetimeExceedsConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
-func TestInvalidMissingIssuedAt(t *testing.T) {
+func TestRejectsInvalidMissingIssuedAt(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
 	claims := map[string]any{
 		"ver": "v1",
@@ -208,7 +208,7 @@ func TestInvalidMissingIssuedAt(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidTime)
 }
 
-func TestInvalidSignedClaims(t *testing.T) {
+func TestRejectsInvalidSignedClaims(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
 	token := ssh.NewToken(cfg, test.FS)
 	now := time.Now()
@@ -267,7 +267,7 @@ func TestInvalidSignedClaims(t *testing.T) {
 	}
 }
 
-func TestInvalidSubjectDiffersFromKeyID(t *testing.T) {
+func TestRejectsInvalidSubjectDiffersFromKeyID(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
 	token := ssh.NewToken(cfg, test.FS)
 	now := time.Now()
@@ -287,7 +287,7 @@ func TestInvalidSubjectDiffersFromKeyID(t *testing.T) {
 	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
 }
 
-func TestInvalidMalformedTokens(t *testing.T) {
+func TestRejectsInvalidMalformedTokens(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
 	token := ssh.NewToken(cfg, test.FS)
 	now := time.Now()
@@ -343,7 +343,7 @@ func TestInvalidMalformedTokens(t *testing.T) {
 	}
 }
 
-func TestValidNameWithDash(t *testing.T) {
+func TestTokenAcceptsKeyNameWithDash(t *testing.T) {
 	cfg := test.NewToken("ssh").SSH
 	cfg.Keys["test-user"] = cfg.Keys.Get(cfg.Key)
 	cfg.Key = "test-user"
@@ -359,7 +359,7 @@ func TestValidNameWithDash(t *testing.T) {
 	require.Equal(t, "test-user", sub)
 }
 
-func TestInvalidPrivateKey(t *testing.T) {
+func TestRejectsInvalidPrivateKey(t *testing.T) {
 	token := ssh.NewToken(&ssh.Config{
 		Expiration: time.Hour,
 		Key:        "test",
@@ -374,19 +374,29 @@ func TestInvalidPrivateKey(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestInvalidTokenShapes(t *testing.T) {
-	for _, tkn := range []string{strings.Empty, "none-", "test-", "test-bob"} {
-		t.Run(tkn, func(t *testing.T) {
+func TestRejectsInvalidTokenShapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{name: "empty token", token: strings.Empty},
+		{name: "malformed none dash", token: "none-"},
+		{name: "malformed test dash", token: "test-"},
+		{name: "malformed test dash bob", token: "test-bob"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			token := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 
-			sub, err := token.Verify(tkn, strings.Empty)
+			sub, err := token.Verify(tt.token, strings.Empty)
 			require.Error(t, err)
 			require.Empty(t, sub)
 		})
 	}
 }
 
-func TestInvalidPublicKey(t *testing.T) {
+func TestRejectsInvalidPublicKey(t *testing.T) {
 	valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 	tkn, err := valid.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
@@ -405,7 +415,7 @@ func TestInvalidPublicKey(t *testing.T) {
 	require.Empty(t, sub)
 }
 
-func TestInvalidUnknownKey(t *testing.T) {
+func TestRejectsInvalidUnknownKey(t *testing.T) {
 	valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 	tkn, err := valid.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
@@ -424,7 +434,7 @@ func TestInvalidUnknownKey(t *testing.T) {
 	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
 }
 
-func TestInvalidSignature(t *testing.T) {
+func TestTokenRejectsInvalidSignature(t *testing.T) {
 	valid := ssh.NewToken(test.NewToken("ssh").SSH, test.FS)
 	tkn, err := valid.Generate(strings.Empty, strings.Empty)
 	require.NoError(t, err)
@@ -437,7 +447,7 @@ func TestInvalidSignature(t *testing.T) {
 	require.ErrorIs(t, err, crypto.ErrInvalidMatch)
 }
 
-func TestInvalidConfig(t *testing.T) {
+func TestRejectsInvalidConfig(t *testing.T) {
 	token := ssh.NewToken(nil, test.FS)
 	require.Nil(t, token)
 }
@@ -553,7 +563,7 @@ func TestInvalidVerifyConfigDoesNotPanic(t *testing.T) {
 	})
 }
 
-func TestKeysGet(t *testing.T) {
+func TestKeysGetReturnsConfiguredKeyOrNil(t *testing.T) {
 	keys := ssh.Keys{
 		"other": nil,
 		"test":  &ssh.Key{Config: test.NewSSH("secrets/ssh_public", "secrets/ssh_private")},
@@ -567,7 +577,7 @@ func TestKeysGet(t *testing.T) {
 	require.Nil(t, ssh.Keys(nil).Get("missing"))
 }
 
-func TestKeyLoaders(t *testing.T) {
+func TestKeyLoadersCacheUsableSignerAndVerifier(t *testing.T) {
 	loaders := []struct {
 		load func(*ssh.Key, *os.FS) (any, error)
 		name string

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerate(t *testing.T) {
+func TestGenerateCreatesSupportedTokenKinds(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
@@ -28,7 +28,7 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
-func TestVerify(t *testing.T) {
+func TestVerifyReturnsSubjectForMatchingAudience(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
@@ -190,7 +190,7 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 	}
 }
 
-func TestUnknownKindConfig(t *testing.T) {
+func TestNewTokenRejectsUnknownKindConfiguration(t *testing.T) {
 	cfg := test.NewToken("none")
 	tkn := token.NewToken(cfg, test.FS, nil)
 
@@ -203,12 +203,12 @@ func TestUnknownKindConfig(t *testing.T) {
 	require.ErrorIs(t, err, errors.ErrInvalidConfig)
 }
 
-func TestNewTokenWithNilConfig(t *testing.T) {
+func TestNewTokenReturnsNilForNilConfig(t *testing.T) {
 	tkn := token.NewToken(nil, test.FS, nil)
 	require.Nil(t, tkn)
 }
 
-func TestInvalidKindConfig(t *testing.T) {
+func TestRejectsInvalidKindConfig(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto", "ssh"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := &token.Config{Kind: kind}
@@ -238,7 +238,7 @@ func TestInvalidDependenciesDoNotPanic(t *testing.T) {
 	}
 }
 
-func TestInvalidMatchClassification(t *testing.T) {
+func TestRejectsInvalidMatchClassification(t *testing.T) {
 	gen := uuid.NewGenerator()
 
 	for _, kind := range []string{"jwt", "paseto"} {

--- a/transport/access_test.go
+++ b/transport/access_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewAccessController(t *testing.T) {
+func TestNewAccessControllerBuildsConfiguredController(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
 		config         *access.Config

--- a/transport/breaker/breaker_test.go
+++ b/transport/breaker/breaker_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultSettings(t *testing.T) {
+func TestCircuitBreakerUsesDefaultSettings(t *testing.T) {
 	settings := breaker.DefaultSettings
 
 	require.Equal(t, uint32(3), settings.MaxRequests)
@@ -49,7 +49,7 @@ func TestDefaultSettings(t *testing.T) {
 	}
 }
 
-func TestConfig(t *testing.T) {
+func TestConfigIsEnabledUnlessNil(t *testing.T) {
 	require.False(t, (*breaker.Config)(nil).IsEnabled())
 	require.True(t, (&breaker.Config{}).IsEnabled())
 }
@@ -133,7 +133,7 @@ func TestConfigSettingsDefaults(t *testing.T) {
 	require.True(t, settings.ReadyToTrip(breaker.Counts{ConsecutiveFailures: 5}))
 }
 
-func TestNewCircuitBreaker(t *testing.T) {
+func TestNewCircuitBreakerAppliesConfiguredSettings(t *testing.T) {
 	errFailed := errors.New("failed")
 	cb := breaker.NewCircuitBreaker(breaker.Settings{
 		ReadyToTrip: func(counts breaker.Counts) bool {

--- a/transport/grpc/auth_test.go
+++ b/transport/grpc/auth_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTokenErrorAuthUnary(t *testing.T) {
+func TestUnaryHandlerPropagatesTokenError(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator("bob", test.ErrGenerate), test.NewVerifier("test")),
@@ -35,7 +35,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
-func TestEmptyAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsEmptyAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator(strings.Empty, nil), test.NewVerifier("test")),
@@ -54,7 +54,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
-func TestMissingClientAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsMissingClientAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
@@ -69,7 +69,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
-func TestInvalidAuthUnary(t *testing.T) {
+func TestRejectsInvalidAuthUnary(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator("bob", nil), test.NewVerifier("test")),
@@ -130,7 +130,7 @@ func TestAuthStreamWithAppend(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
-func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
+func TestUnaryHandlerAcceptsLowercaseBearerScheme(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldGRPC())
 
 	ctx := t.Context()
@@ -149,7 +149,7 @@ func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestValidAuthUnary(t *testing.T) {
+func TestUnaryHandlerAcceptsValidAuthentication(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto", "ssh"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
@@ -173,7 +173,7 @@ func TestValidAuthUnary(t *testing.T) {
 	}
 }
 
-func TestAccessDeniedUnary(t *testing.T) {
+func TestUnaryHandlerRejectsDeniedAccess(t *testing.T) {
 	controller, err := access.NewController(&access.Config{
 		Model:  test.FilePath("configs/rbac.conf"),
 		Policy: "p, " + test.UserID.String() + ", grpc:/greet.v1.GreeterService/Other, invoke",
@@ -199,7 +199,7 @@ func TestAccessDeniedUnary(t *testing.T) {
 	require.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
-func TestUnknownTokenKindAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsUnknownTokenKind(t *testing.T) {
 	cfg := test.NewToken("none")
 	tkn := token.NewToken(cfg, test.FS, nil)
 
@@ -218,7 +218,7 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	require.Contains(t, err.Error(), grpc.StatusText(codes.Unauthenticated))
 }
 
-func TestValidAuthStream(t *testing.T) {
+func TestStreamHandlerAcceptsValidAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator("test", nil), test.NewVerifier("test")),
@@ -241,7 +241,7 @@ func TestValidAuthStream(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestInvalidAuthStream(t *testing.T) {
+func TestRejectsInvalidAuthStream(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator("bob", nil), test.NewVerifier("test")),
@@ -280,7 +280,7 @@ func TestEmptyAuthStream(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
-func TestMissingClientAuthStream(t *testing.T) {
+func TestStreamHandlerRejectsMissingClientAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(nil, test.NewVerifier("test")),

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient(t *testing.T) {
+func TestNewClientValidatesTLSConfig(t *testing.T) {
 	transportgrpc.Register(test.FS)
 
 	_, err := transportgrpc.NewClient("none", transportgrpc.WithClientTLS(&tls.Config{Cert: "bob", Key: "bob"}))

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInsecureUnary(t *testing.T) {
+func TestUnaryCallSucceedsWithoutTLS(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC())
 
 	ctx := meta.WithAttributes(t.Context(),
@@ -43,7 +43,7 @@ func TestInsecureUnary(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestCompressionUnary(t *testing.T) {
+func TestUnaryCallUsesConfiguredCompression(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldGRPC(), test.WithWorldCompression())
 
 	conn := test.RequireGRPCConn(t, world)
@@ -59,7 +59,7 @@ func TestCompressionUnary(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestSecureUnary(t *testing.T) {
+func TestGRPCUnaryServesSecureRequest(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC(), test.WithWorldSecure())
 
 	ctx := meta.WithAttributes(t.Context(), meta.NewPair("ip", meta.ToIgnored(net.ParseIP("192.168.8.0"))))
@@ -77,7 +77,7 @@ func TestSecureUnary(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestStream(t *testing.T) {
+func TestGRPCStreamSendsAndReceivesMessages(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldGRPC())
 
 	ctx := meta.WithAttributes(t.Context(), test.WithTest(meta.Redacted("test")))
@@ -119,7 +119,7 @@ func TestServerRecoversUnaryPanic(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestBreakerUnary(t *testing.T) {
+func TestGRPCUnaryOpensCircuitBreakerAfterFailure(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldGRPC(), test.WithWorldBreaker(test.NewBreaker(1)))
 
 	conn := test.RequireGRPCConn(t, world)
@@ -161,7 +161,7 @@ func TestServerRecoversStreamPanic(t *testing.T) {
 	require.Equal(t, "Hello test", resp.GetMessage())
 }
 
-func TestUnaryMaxReceiveSize(t *testing.T) {
+func TestUnaryServerRejectsOversizedRequest(t *testing.T) {
 	world := newStartedGRPCWorld(t, 64)
 	conn := test.RequireGRPCConn(t, world)
 	t.Cleanup(func() {

--- a/transport/grpc/health/health_test.go
+++ b/transport/grpc/health/health_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheck(t *testing.T) {
+func TestCheckReturnsServingStatus(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)),
@@ -69,7 +69,7 @@ func TestCheckBypassesServerLimiter(t *testing.T) {
 	require.Equal(t, health.Serving, resp.GetStatus())
 }
 
-func TestInvalidCheck(t *testing.T) {
+func TestCheckRejectsInvalidRequest(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
@@ -91,7 +91,7 @@ func TestInvalidCheck(t *testing.T) {
 	require.Equal(t, health.NotServing, resp.GetStatus())
 }
 
-func TestCheckDrains(t *testing.T) {
+func TestCheckReportsDrainingService(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -109,7 +109,7 @@ func TestCheckDrains(t *testing.T) {
 	require.Equal(t, health.NotServing, resp.GetStatus())
 }
 
-func TestOverallCheck(t *testing.T) {
+func TestOverallCheckReturnsAggregateServingStatus(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -126,7 +126,7 @@ func TestOverallCheck(t *testing.T) {
 	require.Equal(t, health.Serving, resp.GetStatus())
 }
 
-func TestInvalidOverallCheck(t *testing.T) {
+func TestRejectsInvalidOverallCheck(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
@@ -144,7 +144,7 @@ func TestInvalidOverallCheck(t *testing.T) {
 	require.Equal(t, health.NotServing, resp.GetStatus())
 }
 
-func TestInvalidOverallList(t *testing.T) {
+func TestRejectsInvalidOverallList(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
@@ -161,7 +161,7 @@ func TestInvalidOverallList(t *testing.T) {
 	require.Equal(t, health.NotServing, resp.GetStatuses()[""].GetStatus())
 }
 
-func TestUnknownOverallCheck(t *testing.T) {
+func TestCheckRejectsUnknownOverallService(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldGRPCHealth(test.Name.String(), test.StatusURL("200")),
 		test.WithWorldTelemetry("otlp"),
@@ -180,7 +180,7 @@ func TestUnknownOverallCheck(t *testing.T) {
 	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
-func TestNotFoundCheck(t *testing.T) {
+func TestCheckReportsServiceNotFound(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -221,7 +221,7 @@ func TestIgnoreAuthCheck(t *testing.T) {
 	require.Equal(t, health.Serving, resp.GetStatus())
 }
 
-func TestList(t *testing.T) {
+func TestListReturnsRegisteredServices(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)),
@@ -251,7 +251,7 @@ func TestList(t *testing.T) {
 	require.Equal(t, expected, resp.GetStatuses())
 }
 
-func TestListDrains(t *testing.T) {
+func TestListReportsDrainingServices(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -271,7 +271,7 @@ func TestListDrains(t *testing.T) {
 	require.Equal(t, health.NotServing, resp.GetStatuses()[test.Name.String()].GetStatus())
 }
 
-func TestWatch(t *testing.T) {
+func TestWatchStreamsServiceStatus(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"),
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 10)),
@@ -455,7 +455,7 @@ func TestWatchServerLimiterStatusSend(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
-func TestInvalidWatch(t *testing.T) {
+func TestWatchRejectsInvalidRequest(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
@@ -481,7 +481,7 @@ func TestInvalidWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
-func TestOverallWatch(t *testing.T) {
+func TestOverallWatchStreamsAggregateStatus(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -504,7 +504,7 @@ func TestOverallWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
-func TestInvalidOverallWatch(t *testing.T) {
+func TestRejectsInvalidOverallWatch(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 	requireUnhealthyObservedHealth(t, world.GRPCHealth, test.Name.String())
@@ -528,7 +528,7 @@ func TestInvalidOverallWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
-func TestUnknownOverallWatch(t *testing.T) {
+func TestWatchRejectsUnknownOverallService(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldGRPCHealth(test.Name.String(), test.StatusURL("200")),
 		test.WithWorldTelemetry("otlp"),
@@ -553,7 +553,7 @@ func TestUnknownOverallWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
-func TestNotFoundWatch(t *testing.T) {
+func TestWatchReportsServiceNotFound(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("500"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -577,7 +577,7 @@ func TestNotFoundWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
-func TestNotFoundWatchDrains(t *testing.T) {
+func TestWatchReportsServiceNotFoundWhenDraining(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 
@@ -636,7 +636,7 @@ func TestIgnoreAuthWatch(t *testing.T) {
 	requireWatchStaysOpenUntilCancel(t, cancel, wc)
 }
 
-func TestWatchStatusChanges(t *testing.T) {
+func TestWatchStreamsStatusChanges(t *testing.T) {
 	var unhealthy sync.Bool
 	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if unhealthy.Load() {
@@ -685,7 +685,7 @@ func TestWatchStatusChanges(t *testing.T) {
 	}
 }
 
-func TestWatchDrains(t *testing.T) {
+func TestWatchReportsDrainingService(t *testing.T) {
 	world := newGRPCHealthWorld(t, test.StatusURL("200"), test.WithWorldTelemetry("otlp"))
 	requireGRPCReady(t, world)
 

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -111,7 +111,7 @@ func TestServerLimiterStreamHeaderNotDuplicated(t *testing.T) {
 	require.Len(t, header.Get("ratelimit-policy"), 1)
 }
 
-func TestClientLimiterUnary(t *testing.T) {
+func TestClientLimiterRejectsExcessUnaryRequests(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldClientLimiter(test.NewLimiterConfig("user-agent", "1s", 0)), test.WithWorldGRPC())
 
 	conn := test.RequireGRPCConn(t, world)
@@ -228,7 +228,7 @@ func TestServerLimiterUsesVerifiedUserIDStream(t *testing.T) {
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
 
-func TestLimiterUnlimitedUnary(t *testing.T) {
+func TestLimiterAllowsUnlimitedUnaryRequests(t *testing.T) {
 	cfg := test.NewLimiterConfig("user-agent", "1s", 10)
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
@@ -249,7 +249,7 @@ func TestLimiterUnlimitedUnary(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestLimiterAuthUnary(t *testing.T) {
+func TestLimiterUsesAuthenticatedPrincipal(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 10)),

--- a/transport/grpc/retry/retry_test.go
+++ b/transport/grpc/retry/retry_test.go
@@ -399,7 +399,7 @@ func TestClientUnaryInterceptorRetriesWhenPolicyAllowsReadMethod(t *testing.T) {
 	}
 }
 
-func TestClientUnaryInterceptorComposesMultiplePolicies(t *testing.T) {
+func TestClientUnaryInterceptorCombinesMultiplePolicies(t *testing.T) {
 	allow := retry.Policy(func(context.Context, string, any) bool { return true })
 	deny := retry.Policy(func(context.Context, string, any) bool { return false })
 

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -26,7 +26,7 @@ func init() {
 	grpc.Register(test.FS)
 }
 
-func TestServer(t *testing.T) {
+func TestServerRegistersAndRunsConfiguredServices(t *testing.T) {
 	mux := http.NewServeMux()
 	lc := fxtest.NewLifecycle(t)
 	logger, err := test.NewLogger(lc, test.NewTextLoggerConfig())
@@ -40,21 +40,21 @@ func TestServer(t *testing.T) {
 	lc.RequireStop()
 }
 
-func TestDisabledServer(t *testing.T) {
+func TestServerSkipsStartupWhenDisabled(t *testing.T) {
 	srv, err := grpc.NewServer(grpc.ServerParams{Config: nil})
 
 	require.NoError(t, err)
 	require.Nil(t, srv)
 }
 
-func TestNilServer(t *testing.T) {
+func TestNilServerReturnsNilRegistrars(t *testing.T) {
 	var srv *grpc.Server
 
 	require.Nil(t, srv.ServiceRegistrar())
 	require.Nil(t, srv.GetService())
 }
 
-func TestInvalidServer(t *testing.T) {
+func TestRejectsInvalidServer(t *testing.T) {
 	cfg := &grpc.Config{
 		Config: &server.Config{
 			Timeout: 5 * time.Second,

--- a/transport/grpc/telemetry/logger/logger_test.go
+++ b/transport/grpc/telemetry/logger/logger_test.go
@@ -96,7 +96,7 @@ func TestServerStreamInterceptorLogs(t *testing.T) {
 	require.Contains(t, logs.String(), `"error":"rpc error: code = NotFound desc = missing"`)
 }
 
-func TestClientUnaryInterceptorLogs(t *testing.T) {
+func TestClientUnaryInterceptorLogsRequests(t *testing.T) {
 	var logs bytes.Buffer
 	interceptor := grpclogger.NewClient(newLogger(&logs)).UnaryInterceptor()
 	conn, err := grpc.NewClient("passthrough:///backend", grpc.WithTransportCredentials(grpc.NewInsecureCredentials()))
@@ -198,7 +198,7 @@ func TestClientStreamInterceptorDoesNotLogRecvMsgEOF(t *testing.T) {
 	require.NotContains(t, logs.String(), `"error"`)
 }
 
-func TestCodeToLevel(t *testing.T) {
+func TestCodeToLevelMapsStatusCodeToLogLevel(t *testing.T) {
 	tests := []struct {
 		name  string
 		level logger.Level

--- a/transport/grpc/token_test.go
+++ b/transport/grpc/token_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewTokenWithoutTokenConfig(t *testing.T) {
+func TestNewTokenUsesDefaultConfiguration(t *testing.T) {
 	tkn := grpc.NewToken(test.NewGRPCTransportConfig(), nil, nil)
 	require.Nil(t, tkn)
 }

--- a/transport/http/auth_test.go
+++ b/transport/http/auth_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTokenAuthUnary(t *testing.T) {
+func TestUnaryHandlerAuthenticatesSupportedToken(t *testing.T) {
 	for _, kind := range []string{"jwt", "paseto", "ssh"} {
 		t.Run(kind, func(t *testing.T) {
 			cfg := test.NewToken(kind)
@@ -43,7 +43,7 @@ func TestTokenAuthUnary(t *testing.T) {
 	}
 }
 
-func TestUnknownTokenKindAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsUnknownTokenKind(t *testing.T) {
 	cfg := test.NewToken("none")
 	tkn := token.NewToken(cfg, test.FS, nil)
 
@@ -63,7 +63,7 @@ func TestUnknownTokenKindAuthUnary(t *testing.T) {
 	require.Equal(t, "http: unauthorized", body)
 }
 
-func TestValidAuthUnary(t *testing.T) {
+func TestUnaryHandlerAcceptsValidAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(test.NewGenerator("test", nil), test.NewVerifier("test")), test.WithWorldHTTP())
 
 	rpc.Route("/hello", test.SuccessSayHello)
@@ -81,7 +81,7 @@ func TestValidAuthUnary(t *testing.T) {
 	require.NotEmpty(t, body)
 }
 
-func TestAccessDeniedUnary(t *testing.T) {
+func TestUnaryHandlerRejectsDeniedAccess(t *testing.T) {
 	controller, err := access.NewController(&access.Config{
 		Model:  test.FilePath("configs/rbac.conf"),
 		Policy: "p, " + test.UserID.String() + ", http:POST /other, invoke",
@@ -122,7 +122,7 @@ func TestAuthDoesNotBypassApplicationMetricsPath(t *testing.T) {
 	require.Equal(t, "http: unauthorized", body)
 }
 
-func TestInvalidAuthUnary(t *testing.T) {
+func TestRejectsInvalidAuthUnary(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(test.NewGenerator("bob", nil), test.NewVerifier("test")), test.WithWorldHTTP())
 
 	rpc.Route("/hello", test.SuccessSayHello)
@@ -157,7 +157,7 @@ func TestAuthUnaryWithAppend(t *testing.T) {
 	require.NotEmpty(t, body)
 }
 
-func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
+func TestUnaryHandlerAcceptsLowercaseBearerScheme(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldHTTP())
 
 	rpc.Route("/hello", test.SuccessSayHello)
@@ -175,7 +175,7 @@ func TestAuthUnaryWithLowercaseBearer(t *testing.T) {
 	require.NotEmpty(t, body)
 }
 
-func TestMissingAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsMissingAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldHTTP())
 
 	rpc.Route("/hello", test.SuccessSayHello)
@@ -192,7 +192,7 @@ func TestMissingAuthUnary(t *testing.T) {
 	require.Equal(t, "http: unauthorized", body)
 }
 
-func TestEmptyAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsEmptyAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(test.NewGenerator(strings.Empty, nil), test.NewVerifier("test")), test.WithWorldHTTP())
 
 	rpc.Route("/hello", test.SuccessSayHello)
@@ -208,7 +208,7 @@ func TestEmptyAuthUnary(t *testing.T) {
 	require.Contains(t, err.Error(), "authorization is invalid")
 }
 
-func TestMissingClientAuthUnary(t *testing.T) {
+func TestUnaryHandlerRejectsMissingClientAuthentication(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldToken(nil, test.NewVerifier("test")), test.WithWorldHTTP())
 
 	rpc.Route("/hello", test.SuccessSayHello)
@@ -225,7 +225,7 @@ func TestMissingClientAuthUnary(t *testing.T) {
 	require.Equal(t, "http: unauthorized", body)
 }
 
-func TestTokenErrorAuthUnary(t *testing.T) {
+func TestUnaryHandlerPropagatesTokenError(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator(strings.Empty, test.ErrGenerate), test.NewVerifier("test")),
@@ -244,7 +244,7 @@ func TestTokenErrorAuthUnary(t *testing.T) {
 	require.Contains(t, err.Error(), "token: generation issue")
 }
 
-func TestBreakerAuthUnary(t *testing.T) {
+func TestUnaryHandlerReturnsBreakerError(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldToken(test.NewGenerator(strings.Empty, test.ErrGenerate), test.NewVerifier("test")),

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient(t *testing.T) {
+func TestNewClientValidatesTLSConfig(t *testing.T) {
 	transporthttp.Register(test.FS)
 
 	_, err := transporthttp.NewClient(transporthttp.WithClientTLS(&tls.Config{Cert: "bob", Key: "bob"}))

--- a/transport/http/health/health_test.go
+++ b/transport/http/health/health_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHealth(t *testing.T) {
+func TestHealthRegistersHealthLivenessAndReadinessEndpoints(t *testing.T) {
 	checks := []struct {
 		name string
 		path string
@@ -118,7 +118,7 @@ func TestReadinessDrains(t *testing.T) {
 	require.Equal(t, http.StatusOK, healthStatus(mux, "livez"))
 }
 
-func TestInvalidHealth(t *testing.T) {
+func TestRejectsInvalidHealth(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
 		test.WithWorldHTTPHealth(test.Name.String(), test.StatusURL("500"), test.HealthObserve("healthz", "http")),
@@ -135,7 +135,7 @@ func TestInvalidHealth(t *testing.T) {
 	require.Equal(t, "text/error; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
-func TestMissingHealth(t *testing.T) {
+func TestHealthEndpointReportsMissingCheck(t *testing.T) {
 	checks := []struct {
 		name string
 		path string

--- a/transport/http/hooks/hooks_test.go
+++ b/transport/http/hooks/hooks_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVerify(t *testing.T) {
+func TestWebhookVerifiesWhenNoHookIsConfigured(t *testing.T) {
 	hook := httphooks.NewWebhook(nil, nil)
 	req := &http.Request{Body: &test.ErrReaderCloser{}}
 
 	require.NoError(t, hook.Verify(req))
 }
 
-func TestSign(t *testing.T) {
+func TestWebhookSignsWhenNoHookIsConfigured(t *testing.T) {
 	hook := httphooks.NewWebhook(nil, nil)
 	req := &http.Request{Body: &test.ErrReaderCloser{}}
 
@@ -84,7 +84,7 @@ func TestSignHandlesNilRequestHeader(t *testing.T) {
 	require.NoError(t, hook.Verify(req))
 }
 
-func TestRoundTripper(t *testing.T) {
+func TestRoundTripperDelegatesRequestWhenNoHookIsConfigured(t *testing.T) {
 	hook := httphooks.NewWebhook(nil, nil)
 	rt := httphooks.NewRoundTripper(hook, test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
@@ -192,7 +192,7 @@ func TestRoundTripperClosesBodyOnSignError(t *testing.T) {
 	require.True(t, body.Closed)
 }
 
-func TestHandler(t *testing.T) {
+func TestHandlerDelegatesRequestWhenNoHookIsConfigured(t *testing.T) {
 	handler := httphooks.NewHandler(nil)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com", http.NoBody)
 	res := httptest.NewRecorder()

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSecure(t *testing.T) {
+func TestHTTPTransportServesSecureRequest(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldSecure(), test.WithWorldTelemetry("prometheus"), test.WithWorldHTTP(), test.WithWorldHello())
 
 	client, err := world.NewHTTP()

--- a/transport/http/limiter_test.go
+++ b/transport/http/limiter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnlimited(t *testing.T) {
+func TestLimiterAllowsRequestsWithinConfiguredQuota(t *testing.T) {
 	cfg := test.NewLimiterConfig("user-agent", "1s", 100)
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("otlp"),
@@ -112,7 +112,7 @@ func TestServerLimiterDoesNotBypassApplicationMetricsPath(t *testing.T) {
 	require.Equal(t, `"default";q=1;w=1`, res.Header.Get("Ratelimit-Policy"))
 }
 
-func TestClientLimiter(t *testing.T) {
+func TestClientLimiterRejectsExcessRequests(t *testing.T) {
 	keys := []struct {
 		name string
 		kind string

--- a/transport/http/metrics_test.go
+++ b/transport/http/metrics_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrometheusHTTP(t *testing.T) {
+func TestPrometheusEndpointExportsMetrics(t *testing.T) {
 	world := test.NewStartedWorld(t,
 		test.WithWorldTelemetry("prometheus"),
 		test.WithWorldPGConfig(nil),
@@ -37,7 +37,7 @@ func TestPrometheusHTTP(t *testing.T) {
 	require.Contains(t, body, "runtime")
 }
 
-func TestPrometheusAuthHTTP(t *testing.T) {
+func TestPrometheusEndpointRequiresAuthentication(t *testing.T) {
 	cfg := test.NewToken("jwt")
 	gen := uuid.NewGenerator()
 	tkn := token.NewToken(cfg, test.FS, gen)

--- a/transport/http/mvc_test.go
+++ b/transport/http/mvc_test.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/net/html"
 )
 
-func TestRouteSuccess(t *testing.T) {
+func TestRouteRendersSuccessfulView(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldCompression(), test.WithWorldHTTP())
 
 	full, _ := mvc.NewViewPair("views/hello.tmpl")
@@ -69,7 +69,7 @@ func TestRoutePartialViewSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRouteError(t *testing.T) {
+func TestRouteRendersErrorView(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRoundTripper(http.DefaultTransport), test.WithWorldHTTP())
 
 	view := mvc.NewFullView("views/error.tmpl")
@@ -92,7 +92,7 @@ func TestRouteError(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNotFound(t *testing.T) {
+func TestRouteRendersNotFoundView(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	view := mvc.NewFullView("views/error.tmpl")
@@ -161,7 +161,7 @@ func TestNotFoundHandlesHTMXRequest(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStaticFileSuccess(t *testing.T) {
+func TestStaticFileRouteServesExistingFile(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	mvc.StaticFile("/robots.txt", "static/robots.txt")
@@ -178,7 +178,7 @@ func TestStaticFileSuccess(t *testing.T) {
 	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
-func TestStaticFileError(t *testing.T) {
+func TestStaticFileRouteReportsMissingFile(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	mvc.StaticFile("/robots.txt", "static/bob.txt")
@@ -191,7 +191,7 @@ func TestStaticFileError(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
-func TestStaticPathValueSuccess(t *testing.T) {
+func TestStaticPathRouteServesExistingFile(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	mvc.StaticPathValue("/{file}", "file", "static")
@@ -208,7 +208,7 @@ func TestStaticPathValueSuccess(t *testing.T) {
 	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get(http.ContentTypeKey))
 }
 
-func TestStaticPathValueError(t *testing.T) {
+func TestStaticPathRouteReportsMissingFile(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	mvc.StaticPathValue("/{file}", "file", "static")
@@ -221,7 +221,7 @@ func TestStaticPathValueError(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
-func TestMissingViews(t *testing.T) {
+func TestNewServerRejectsMissingViews(t *testing.T) {
 	mvc.Register(mvc.RegisterParams{
 		Router:      newTestRouter(),
 		FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),

--- a/transport/http/rest_test.go
+++ b/transport/http/rest_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRestNoContent(t *testing.T) {
+func TestRESTResponseWritesNoContent(t *testing.T) {
 	for _, method := range []string{http.MethodDelete, http.MethodGet} {
 		t.Run(method, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
@@ -29,7 +29,7 @@ func TestRestNoContent(t *testing.T) {
 	}
 }
 
-func TestRestRequestNoContent(t *testing.T) {
+func TestRESTRequestWritesNoContent(t *testing.T) {
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
 		t.Run(method, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
@@ -48,7 +48,7 @@ func TestRestRequestNoContent(t *testing.T) {
 	}
 }
 
-func TestRestError(t *testing.T) {
+func TestRESTReturnsStatusError(t *testing.T) {
 	for _, method := range []string{http.MethodDelete, http.MethodGet} {
 		t.Run(method, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP(), test.WithWorldLoggerConfig("tint"))
@@ -62,7 +62,7 @@ func TestRestError(t *testing.T) {
 	}
 }
 
-func TestRestNotFound(t *testing.T) {
+func TestRESTReturnsNotFound(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
 
 	header := http.Header{}
@@ -75,7 +75,7 @@ func TestRestNotFound(t *testing.T) {
 	require.Equal(t, "http: not found", body)
 }
 
-func TestRestRequestError(t *testing.T) {
+func TestRESTRequestWritesError(t *testing.T) {
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
 		t.Run(method, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldRest(), test.WithWorldHTTP())
@@ -94,7 +94,7 @@ func TestRestRequestError(t *testing.T) {
 	}
 }
 
-func TestRestWithContent(t *testing.T) {
+func TestRESTResponseWritesContent(t *testing.T) {
 	for _, method := range []string{http.MethodDelete, http.MethodGet} {
 		t.Run(method, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
@@ -113,7 +113,7 @@ func TestRestWithContent(t *testing.T) {
 	}
 }
 
-func TestRestRequestWithContent(t *testing.T) {
+func TestRESTRequestWritesContent(t *testing.T) {
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
 		t.Run(method, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
@@ -162,7 +162,7 @@ func TestRestRequestUsesAcceptForResponse(t *testing.T) {
 	require.Equal(t, "Hello Bob", response.Greeting)
 }
 
-func TestRestInvalidStatusCode(t *testing.T) {
+func TestRESTResponseRejectsInvalidStatusCode(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	test.RegisterHandlers("/hello", test.RestInvalidStatusCode)

--- a/transport/http/rpc_test.go
+++ b/transport/http/rpc_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRPCNoContent(t *testing.T) {
+func TestRPCReturnsNoContent(t *testing.T) {
 	for _, mt := range test.MessageMediaTypes() {
 		t.Run(mt.Name, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
@@ -41,7 +41,7 @@ func TestRPCNoContent(t *testing.T) {
 	}
 }
 
-func TestRPCWithContent(t *testing.T) {
+func TestRPCWritesContentResponse(t *testing.T) {
 	for _, mt := range test.MessageMediaTypes() {
 		t.Run(mt.Name, func(t *testing.T) {
 			requireSuccessfulRPCPost(t, mt.ContentType)
@@ -49,7 +49,7 @@ func TestRPCWithContent(t *testing.T) {
 	}
 }
 
-func TestSuccessProtobufRPC(t *testing.T) {
+func TestRPCWritesProtobufResponse(t *testing.T) {
 	for _, mt := range []string{"proto", "protobuf", "prototext", "protojson"} {
 		t.Run(mt, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
@@ -67,7 +67,7 @@ func TestSuccessProtobufRPC(t *testing.T) {
 	}
 }
 
-func TestErroneousProtobufRPC(t *testing.T) {
+func TestRPCPropagatesProtobufErrors(t *testing.T) {
 	handlers := []struct {
 		handler unary.RequestHandler[v1.SayHelloRequest, v1.SayHelloResponse]
 		name    string
@@ -99,7 +99,7 @@ func TestErroneousProtobufRPC(t *testing.T) {
 	}
 }
 
-func TestErroneousUnmarshalRPC(t *testing.T) {
+func TestRPCReportsUnmarshalErrors(t *testing.T) {
 	for _, mt := range test.MessageMediaTypes() {
 		t.Run(mt.Name, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
@@ -119,7 +119,7 @@ func TestErroneousUnmarshalRPC(t *testing.T) {
 	}
 }
 
-func TestErrorRPC(t *testing.T) {
+func TestRPCReturnsStatusError(t *testing.T) {
 	handlers := []struct {
 		handler unary.RequestHandler[test.Request, test.Response]
 		name    string
@@ -163,7 +163,7 @@ func TestErrorRPC(t *testing.T) {
 	}
 }
 
-func TestRPCNotFound(t *testing.T) {
+func TestRPCReturnsNotFound(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldHTTP())
 
 	header := http.Header{}
@@ -176,7 +176,7 @@ func TestRPCNotFound(t *testing.T) {
 	require.Equal(t, "http: not found", body)
 }
 
-func TestAllowedRPC(t *testing.T) {
+func TestRPCAllowsConfiguredOperation(t *testing.T) {
 	for _, mt := range test.MessageMediaTypes() {
 		t.Run(mt.Name, func(t *testing.T) {
 			requireSuccessfulRPCPost(t, mt.ContentType)
@@ -184,7 +184,7 @@ func TestAllowedRPC(t *testing.T) {
 	}
 }
 
-func TestDisallowedRPC(t *testing.T) {
+func TestRPCRejectsDisallowedMediaType(t *testing.T) {
 	for _, mt := range []string{media.JSON, media.HumanJSON, media.YAML, media.TOML, "application/gob", media.MessagePack, "test"} {
 		t.Run(mt, func(t *testing.T) {
 			world := test.NewStartedWorld(t,
@@ -211,7 +211,7 @@ func TestDisallowedRPC(t *testing.T) {
 	}
 }
 
-func TestInvalidRPCRequest(t *testing.T) {
+func TestRejectsInvalidRPCRequest(t *testing.T) {
 	for _, mt := range []string{"gob", "toml", "yml"} {
 		t.Run(mt, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())
@@ -228,7 +228,7 @@ func TestInvalidRPCRequest(t *testing.T) {
 	}
 }
 
-func TestInvalidRPCResponse(t *testing.T) {
+func TestRejectsInvalidRPCResponse(t *testing.T) {
 	for _, mt := range []string{"json"} {
 		t.Run(mt, func(t *testing.T) {
 			world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldServerLimiter(test.NewLimiterConfig("user-agent", "1s", 100)), test.WithWorldHTTP())

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInvalidServer(t *testing.T) {
+func TestRejectsInvalidServer(t *testing.T) {
 	transporthttp.Register(test.FS)
 
 	cfg := &transporthttp.Config{

--- a/transport/http/token_test.go
+++ b/transport/http/token_test.go
@@ -12,12 +12,12 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func TestNewTokenWithoutTokenConfig(t *testing.T) {
+func TestNewTokenUsesDefaultConfiguration(t *testing.T) {
 	tkn := http.NewToken(test.NewHTTPTransportConfig(), nil, nil)
 	require.Nil(t, tkn)
 }
 
-func TestNewTokenWithTokenConfig(t *testing.T) {
+func TestNewTokenUsesConfiguredTokenSettings(t *testing.T) {
 	cfg := test.NewHTTPTransportConfig()
 	cfg.Token = test.NewToken("jwt")
 	gen := uuid.NewGenerator()

--- a/transport/limiter/limiter_test.go
+++ b/transport/limiter/limiter_test.go
@@ -39,7 +39,7 @@ func TestConfigGetMaxKeys(t *testing.T) {
 	}
 }
 
-func TestValidLimiter(t *testing.T) {
+func TestLimiterAllowsRequestsWithinQuota(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
 	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
@@ -61,7 +61,7 @@ func TestNewLimiterRejectsTooLargeInterval(t *testing.T) {
 	require.ErrorIs(t, err, limiter.ErrIntervalTooLarge)
 }
 
-func TestTake(t *testing.T) {
+func TestTakeRejectsRequestsBeyondQuota(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
 	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: time.Second}
@@ -93,7 +93,7 @@ func TestTake(t *testing.T) {
 	require.Equal(t, `"default";r=0;t=1`, header)
 }
 
-func TestTakeDecisionHeaders(t *testing.T) {
+func TestTakeDecisionIncludesRateLimitHeaders(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
 	config := &limiter.Config{Kind: "user-agent", Tokens: 2, Interval: 1500 * time.Millisecond}
@@ -197,7 +197,7 @@ func TestTakeSupportsCustomKeyKind(t *testing.T) {
 	})
 }
 
-func TestTakeRefillsAfterConfiguredInterval(t *testing.T) {
+func TestTakeRefillsBucketAfterConfiguredInterval(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
 	config := &limiter.Config{Kind: "user-agent", Tokens: 1, Interval: 25 * time.Millisecond}
@@ -323,7 +323,7 @@ func TestTakeDoesNotCollideOversizedKeysWithRawHashKeys(t *testing.T) {
 	require.Equal(t, `"default";r=0;t=1`, header)
 }
 
-func TestNewKeyMap(t *testing.T) {
+func TestNewKeyMapReturnsIndependentLimiters(t *testing.T) {
 	tests := []struct {
 		name string
 		ctx  context.Context
@@ -384,7 +384,7 @@ func TestLifecycleStopsLimiter(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMissingLimiter(t *testing.T) {
+func TestLimiterHandlesMissingConfiguration(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{}
 	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
@@ -393,7 +393,7 @@ func TestMissingLimiter(t *testing.T) {
 	require.ErrorIs(t, err, limiter.ErrMissingKey)
 }
 
-func TestNilKeyFuncLimiter(t *testing.T) {
+func TestNewLimiterRejectsNilKeyFunction(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": nil}
 	config := &limiter.Config{Kind: "user-agent", Tokens: 0, Interval: time.Second}
@@ -402,7 +402,7 @@ func TestNilKeyFuncLimiter(t *testing.T) {
 	require.ErrorIs(t, err, limiter.ErrMissingKey)
 }
 
-func TestDisabledLimiter(t *testing.T) {
+func TestLimiterAllowsRequestsWhenDisabled(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	m := limiter.KeyMap{"user-agent": meta.UserAgent}
 

--- a/transport/retry/config_test.go
+++ b/transport/retry/config_test.go
@@ -119,7 +119,7 @@ func TestConfigGetStrategy(t *testing.T) {
 	}
 }
 
-func TestConfigAttempts(t *testing.T) {
+func TestConfigAttemptsReturnsConfiguredOrDefaultValue(t *testing.T) {
 	tests := []struct {
 		cfg          *retry.Config
 		name         string

--- a/transport/server_test.go
+++ b/transport/server_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewServers(t *testing.T) {
+func TestNewServersReturnsConfiguredServicesInOrder(t *testing.T) {
 	httpService := newService("http")
 	grpcService := newService("grpc")
 	debugService := newService("debug")


### PR DESCRIPTION
## What

- Rename Go test and subtest labels across library packages to state the behavior each scenario exercises.
- Preserve test bodies and coverage; no production or public API behavior changes.

## Why

- Descriptive test output makes local and CI failures easier to identify and diagnose across the framework's broad package surface.

## Testing

- `make lint` - passed
- `make specs` - passed (2,781 race-enabled tests)
- CI will additionally run generated-output, security, fuzz, benchmark, and coverage checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
