### PR TITLE
feat(token): redact malformed paseto parsing errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,13 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   emits material that its own matching `Config` loader rejects, or where
   documented generation behavior is wrong.
 - Access model and policy config are resolved through `os.FS.ReadSource`; use `file:` for files or `env:` for content from the environment.
+- Casbin's string policy adapter can skip malformed policy rows without failing
+  startup. This is an accepted upstream limitation; the README tells operators
+  to validate policy files before deployment. Do not flag the absence of strict
+  repository-owned row validation or startup rejection solely because malformed
+  administrator-supplied policy can be skipped. Report only concrete bugs such
+  as valid rows being altered or dropped, ignored explicit validation, or a
+  public API promise of strict policy-row validation.
 - IP metadata intentionally trusts forwarding headers; deploy behind trusted proxies that strip spoofed headers before using the `"ip"` limiter key.
 - `net/header.ForwardedIPs` is intentionally an exported mutable list, similar
   to standard-library package variables such as `os.Args`. Do not flag this

--- a/token/paseto/doc.go
+++ b/token/paseto/doc.go
@@ -58,9 +58,11 @@
 // using [Config.Leeway] as optional clock-skew tolerance and checks that the
 // signed lifetime from iat to exp does not exceed [Config.Expiration].
 //
-// On failure, parser, rule, signature, and key-construction errors may come
-// from the upstream PASETO library. Local config, subject, and signed-lifetime
-// checks return shared sentinel errors from token/errors.
+// On failure, PASETO parsing errors, including invalid signatures, return
+// [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidMatch]. Rule
+// and key-construction errors may come from the upstream PASETO library. Local
+// config, subject, and signed-lifetime checks return shared sentinel errors
+// from token/errors.
 //
 // # Configuration and enablement
 //

--- a/token/paseto/paseto.go
+++ b/token/paseto/paseto.go
@@ -3,11 +3,12 @@ package paseto
 import (
 	"aidanwoods.dev/go-paseto"
 	"github.com/alexfalkowski/go-service/v2/crypto/pem"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/os"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
-	"github.com/alexfalkowski/go-service/v2/token/errors"
+	tokenerrors "github.com/alexfalkowski/go-service/v2/token/errors"
 )
 
 // NewToken constructs a Token that issues and validates PASETO v4 public (asymmetric) tokens.
@@ -50,10 +51,11 @@ type Token struct {
 //   - footer kid: from cfg.Key
 func (t *Token) Generate(aud, sub string) (string, error) {
 	if t.generator == nil {
-		return strings.Empty, errors.ErrInvalidConfig
+		return strings.Empty, tokenerrors.ErrInvalidConfig
 	}
+
 	if strings.IsEmpty(t.cfg.Issuer) || strings.IsEmpty(t.cfg.Key) || t.cfg.Expiration <= 0 {
-		return strings.Empty, errors.ErrInvalidConfig
+		return strings.Empty, tokenerrors.ErrInvalidConfig
 	}
 
 	key, err := t.cfg.Keys.Get(t.cfg.Key).Signer(t.decoder)
@@ -96,12 +98,12 @@ func (t *Token) Generate(aud, sub string) (string, error) {
 //   - audience matches aud (aud)
 //   - the signed lifetime (exp - iat) does not exceed cfg.Expiration
 //
-// On failure, parser, rule, signature, and key-construction errors may come from
-// the upstream PASETO library. Local config, subject, and signed-lifetime checks
-// return shared sentinel errors from token/errors.
+// On failure, PASETO parsing errors, including invalid signatures, return [github.com/alexfalkowski/go-service/v2/token/errors.ErrInvalidMatch].
+// Rule and key-construction errors may come from the upstream PASETO library.
+// Local config, subject, and signed-lifetime checks return shared sentinel errors from token/errors.
 func (t *Token) Verify(token, aud string) (string, error) {
 	if strings.IsEmpty(t.cfg.Issuer) || t.cfg.Expiration <= 0 {
-		return strings.Empty, errors.ErrInvalidConfig
+		return strings.Empty, tokenerrors.ErrInvalidConfig
 	}
 
 	parser := paseto.NewParserWithoutExpiryCheck()
@@ -120,7 +122,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 
 	parsed, err := parser.ParseV4Public(s, token, nil)
 	if err != nil {
-		return strings.Empty, err
+		return strings.Empty, invalidMatch(err)
 	}
 
 	if err := validateTime(parsed, t.cfg.Expiration, t.cfg.Leeway); err != nil {
@@ -133,7 +135,7 @@ func (t *Token) Verify(token, aud string) (string, error) {
 func (t *Token) publicKey(token string, parser paseto.Parser) ([]byte, error) {
 	raw, err := parser.UnsafeParseFooter(paseto.V4Public, token)
 	if err != nil {
-		return nil, err
+		return nil, invalidMatch(err)
 	}
 
 	footer, err := parseFooter(raw)
@@ -143,7 +145,7 @@ func (t *Token) publicKey(token string, parser paseto.Parser) ([]byte, error) {
 
 	key := t.cfg.Keys.Get(footer.KeyID)
 	if key == nil {
-		return nil, errors.ErrInvalidKeyID
+		return nil, tokenerrors.ErrInvalidKeyID
 	}
 
 	verifier, err := key.Verifier(t.decoder)
@@ -154,13 +156,22 @@ func (t *Token) publicKey(token string, parser paseto.Parser) ([]byte, error) {
 	return verifier.PublicKey, nil
 }
 
+func invalidMatch(err error) error {
+	if errors.Is(err, TokenError{}) {
+		return tokenerrors.ErrInvalidMatch
+	}
+
+	return err
+}
+
 func subject(token *paseto.Token) (string, error) {
 	sub, err := token.GetSubject()
 	if err != nil {
 		return strings.Empty, err
 	}
+
 	if strings.IsEmpty(sub) {
-		return strings.Empty, errors.ErrInvalidSubject
+		return strings.Empty, tokenerrors.ErrInvalidSubject
 	}
 
 	return sub, nil
@@ -169,24 +180,27 @@ func subject(token *paseto.Token) (string, error) {
 func validateTime(token *paseto.Token, maxLifetime, leeway time.Duration) error {
 	issuedAt, err := token.GetIssuedAt()
 	if err != nil {
-		return errors.ErrInvalidTime
+		return tokenerrors.ErrInvalidTime
 	}
+
 	notBefore, err := token.GetNotBefore()
 	if err != nil {
-		return errors.ErrInvalidTime
+		return tokenerrors.ErrInvalidTime
 	}
+
 	expiresAt, err := token.GetExpiration()
 	if err != nil {
-		return errors.ErrInvalidTime
+		return tokenerrors.ErrInvalidTime
 	}
 
 	now := time.Now()
 	allowedFuture := now.Add(leeway.Duration())
 	if issuedAt.After(allowedFuture) || notBefore.After(allowedFuture) {
-		return errors.ErrInvalidTime
+		return tokenerrors.ErrInvalidTime
 	}
+
 	if !expiresAt.Add(leeway.Duration()).After(now) {
-		return errors.ErrInvalidTime
+		return tokenerrors.ErrInvalidTime
 	}
 
 	return validateLifetimeRange(issuedAt, expiresAt, maxLifetime)
@@ -194,7 +208,7 @@ func validateTime(token *paseto.Token, maxLifetime, leeway time.Duration) error 
 
 func validateLifetimeRange(issuedAt, expiresAt time.Time, maxLifetime time.Duration) error {
 	if !expiresAt.After(issuedAt) || expiresAt.Sub(issuedAt) > maxLifetime.Duration() {
-		return errors.ErrInvalidTime
+		return tokenerrors.ErrInvalidTime
 	}
 
 	return nil

--- a/token/paseto/paseto_test.go
+++ b/token/paseto/paseto_test.go
@@ -280,6 +280,17 @@ func TestRejectsInvalidMalformedToken(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRedactsMalformedToken(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	token := paseto.NewToken(cfg.Paseto, test.FS, uuid.NewGenerator())
+
+	_, err := token.Verify("secret-header.secret-claims.signature", "aud")
+
+	require.ErrorIs(t, err, errors.ErrInvalidMatch)
+	require.NotContains(t, err.Error(), "secret-header")
+	require.NotContains(t, err.Error(), "secret-claims")
+}
+
 func TestRejectsInvalidGenerateMalformedPrivateKey(t *testing.T) {
 	cfg := test.NewToken("paseto")
 	badPrivate := cloneConfig(cfg.Paseto)

--- a/token/token.go
+++ b/token/token.go
@@ -150,7 +150,8 @@ func invalidMatch(err error) error {
 }
 
 func isTokenSentinel(err error) bool {
-	return errors.Is(err, token.ErrInvalidConfig) ||
+	return errors.Is(err, token.ErrInvalidMatch) ||
+		errors.Is(err, token.ErrInvalidConfig) ||
 		errors.Is(err, token.ErrInvalidIssuer) ||
 		errors.Is(err, token.ErrInvalidAudience) ||
 		errors.Is(err, token.ErrInvalidSubject) ||

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -261,3 +261,15 @@ func TestRejectsInvalidMatchClassification(t *testing.T) {
 		require.ErrorIs(t, err, errors.ErrInvalidMatch)
 	})
 }
+
+func TestVerifyRedactsPasetoTokenError(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	tkn := token.NewToken(cfg, test.FS, uuid.NewGenerator())
+
+	sub, err := tkn.Verify([]byte("secret-header.secret-claims.signature"), "hello")
+
+	require.Equal(t, strings.Empty, sub)
+	require.ErrorIs(t, err, errors.ErrInvalidMatch)
+	require.NotContains(t, err.Error(), "secret-header")
+	require.NotContains(t, err.Error(), "secret-claims")
+}

--- a/transport/http/telemetry/logger/logger_test.go
+++ b/transport/http/telemetry/logger/logger_test.go
@@ -8,11 +8,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/id/uuid"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/telemetry/logger"
 	httplogger "github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger"
+	"github.com/alexfalkowski/go-service/v2/transport/http/token"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +67,29 @@ func TestHandlerLogsStatusError(t *testing.T) {
 	test.RequireTrimmedResponseBody(t, res, "http: bad request")
 	require.Contains(t, logs.String(), `"level":"WARN"`)
 	require.Contains(t, logs.String(), `"error":"`+test.ErrInvalid.Error()+`"`)
+}
+
+func TestHandlerLogsRedactedPasetoTokenError(t *testing.T) {
+	cfg := test.NewToken("paseto")
+	verifier := token.NewToken(cfg, test.FS, uuid.NewGenerator())
+	auth := token.NewHandler(http.NewRoutePolicy(), verifier)
+	var logs bytes.Buffer
+	slogLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{}))
+	handler := httplogger.NewHandler(http.NewRoutePolicy(), &logger.Logger{Logger: slogLogger})
+	res := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/greeter/say-hello", http.NoBody)
+	req = req.WithContext(meta.WithAttributes(req.Context(), meta.WithAuthorization(meta.String("secret-header.secret-claims.signature"))))
+
+	handler.ServeHTTP(res, req, func(res http.ResponseWriter, req *http.Request) {
+		auth.ServeHTTP(res, req, func(http.ResponseWriter, *http.Request) {
+			require.Fail(t, "unexpected authorized request")
+		})
+	})
+
+	require.Equal(t, http.StatusUnauthorized, res.Code)
+	require.Contains(t, logs.String(), `"error":"token: invalid match"`)
+	require.NotContains(t, logs.String(), "secret-header")
+	require.NotContains(t, logs.String(), "secret-claims")
 }
 
 func TestHandlerSkipsOperationPath(t *testing.T) {


### PR DESCRIPTION
## What

- Normalize malformed PASETO parser failures to the shared invalid-match error before they reach HTTP telemetry logs.
- Document the PASETO error contract and clarify review guidance for malformed Casbin policy rows.

## Why

- Prevent untrusted authorization values from appearing in logs while preserving the caller-visible invalid-match classification.
- Keep token error handling and repository review guidance aligned with their supported behavior.

## Testing

- `make specs package=token` - passed
- `make specs package=token/paseto` - passed
- `make specs package=transport/http/telemetry/logger` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- Focused package coverage verifies PASETO parser redaction through the package API, token facade, and HTTP telemetry logging path; CI provides full-suite coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
