### PR TITLE
feat(telemetry): prevent collector header forwarding on redirects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,14 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   projections cannot be supplied through `di.Decorate`, or the support boundary
   changes.
 - Standard module wiring is the supported path. Do not flag hypothetical failures that require hand-wiring an incomplete DI graph unless the public API explicitly promises that custom construction mode.
+- An exported constructor, setter, helper, option, or other symbol does not
+  make every direct invocation or argument a supported contract. Before
+  recording an issue that cannot occur through standard module, CLI, template,
+  or integration wiring, identify a current supported consumer or an explicit
+  contract for the exact construction and triggering input. Package-local tests
+  of nil, zero, invalid, or defensive branches do not establish supported usage
+  by themselves. If no supported path supplies the triggering input, reject the
+  candidate as unsupported misuse.
 - Recommend Fx `optional:"true"` dependency tags only with concrete evidence
   that a supported DI graph may omit that dependency. A nil check, "optional"
   prose, or guarded hook installation is a lead, not enough by itself; verify

--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ telemetry:
     level: info
     protocol: http
     url: http://localhost:4318/v1/logs
+    http_timeout: 10s
     batch_timeout: 5s
     export_timeout: 30s
     max_queue_size: 2048
@@ -684,18 +685,21 @@ telemetry:
 
 > [!NOTE]
 > - `batch_timeout`, `export_timeout`, `max_queue_size`, and `max_export_batch_size` tune the OTLP batch export pipeline and apply only when `kind` is `otlp`. When a value is unset or zero, the OpenTelemetry SDK default is used (queue `2048`, batch `512`). A nonzero `batch_timeout` must use whole-second precision. Explicit queue and batch limits may be at most `8192` and `2048`, respectively; the effective batch may not exceed the effective queue.
+> - `http_timeout` bounds one OTLP/HTTP export request. It defaults to `10s` when unset or zero and does not apply to OTLP/gRPC.
 > - `headers` values are source strings.
 > - Telemetry header maps are resolved during config projection; unset `env:` values and unreadable `file:` values fail fast (panic during startup).
 > - After resolution, go-service passes header names and values to the selected exporter without validating HTTP or gRPC syntax. Use headers valid for the selected protocol; an exporter may report invalid syntax only when it attempts an export, not during startup.
 
 > [!WARNING]
 > OTLP exporters reject non-loopback `http://` endpoints when headers are configured. Use HTTPS for remote collectors that require authorization headers; cleartext with headers is accepted only for local loopback endpoints.
+> OTLP/HTTP exporters do not follow redirects; configure the final collector URL.
 >
 > OTLP/gRPC exporters use `protocol: grpc` and a `host:port` endpoint such as `localhost:4317`. Header-bearing remote gRPC endpoints require the signal's `tls` config; loopback gRPC endpoints may still use cleartext.
 >
 > OTLP exporter endpoints must be set in go-service config fields such as `telemetry.logger.url`, `telemetry.metrics.url`, and `telemetry.tracer.url`. Standard OpenTelemetry endpoint environment variables such as `OTEL_EXPORTER_OTLP_ENDPOINT` are not used as fallback sources.
+> Configure OTLP/HTTP request timeouts and TLS material with `http_timeout` and `tls`; corresponding OpenTelemetry timeout and certificate environment variables are not projected into go-service config.
 
-Remote OTLP/gRPC exporters can use the same TLS source-string model as other go-service clients:
+OTLP exporters can use the same TLS source-string model as other go-service clients. HTTP exporters require an `https://` URL for TLS, while gRPC exporters use `protocol: grpc`:
 
 ```yaml
 telemetry:
@@ -712,7 +716,7 @@ telemetry:
       Authorization: env:OTLP_TRACES_AUTH
 ```
 
-Use the same `tls` shape under `telemetry.logger` or `telemetry.metrics` when those signals export through OTLP/gRPC.
+Use the same `tls` shape under `telemetry.logger` or `telemetry.metrics` for OTLP/HTTPS or OTLP/gRPC.
 
 ### Metrics
 
@@ -751,15 +755,17 @@ telemetry:
     kind: otlp
     protocol: http
     url: http://localhost:9009/otlp/v1/metrics
+    http_timeout: 10s
     interval: 30s
     timeout: 5s
     headers:
       Authorization: env:OTLP_METRICS_AUTH
 ```
 
-`interval` and `timeout` apply only to OTLP push metrics. When either value is
-unset or zero, the OpenTelemetry SDK default is used. A nonzero `interval` must
-use whole-second precision.
+`interval` and `timeout` apply only to OTLP push metrics. `http_timeout` bounds
+an OTLP/HTTP request. When `interval` or `timeout` is unset or zero, the
+OpenTelemetry SDK default is used; `http_timeout` defaults to `10s`. A nonzero
+`interval` must use whole-second precision.
 
 #### Histogram buckets
 
@@ -800,6 +806,7 @@ telemetry:
     kind: otlp
     protocol: http
     url: http://localhost:4318/v1/traces
+    http_timeout: 10s
     batch_timeout: 5s
     export_timeout: 30s
     max_queue_size: 2048
@@ -813,6 +820,8 @@ telemetry:
 
 > [!NOTE]
 > `batch_timeout`, `export_timeout`, `max_queue_size`, and `max_export_batch_size` tune the OTLP batch span export pipeline. When a value is unset or zero, the OpenTelemetry SDK default is used (queue `2048`, batch `512`). A nonzero `batch_timeout` must use whole-second precision. Explicit queue and batch limits may be at most `8192` and `2048`, respectively; the effective batch may not exceed the effective queue.
+>
+> `http_timeout` bounds one OTLP/HTTP export request. It defaults to `10s` when unset or zero and does not apply to OTLP/gRPC.
 >
 > OTLP exporters default to `protocol: http`. Set `protocol: grpc` and use a
 > `host:port` `url`, such as `localhost:4317`, to export through OTLP/gRPC.

--- a/telemetry/doc.go
+++ b/telemetry/doc.go
@@ -49,6 +49,10 @@
 // headers. When headers are configured, non-loopback "http://" endpoints are rejected to avoid sending
 // credential-bearing headers over cleartext transport. Use "https://" for external collectors. Local
 // development collectors on "localhost" or loopback IP addresses may use "http://".
+// HTTP exporters return redirect responses without following them, so a collector cannot forward configured
+// headers to another endpoint.
+// HTTP request timeouts and TLS material are configured with each signal's HTTPTimeout and TLS fields; the
+// corresponding OpenTelemetry timeout and certificate environment variables are not projected into config.
 // OTLP/gRPC exporters use host:port endpoints. Header-bearing remote gRPC endpoints
 // require the signal's TLS config; loopback gRPC endpoints may still use cleartext.
 //

--- a/telemetry/internal/otlp/client.go
+++ b/telemetry/internal/otlp/client.go
@@ -1,0 +1,50 @@
+package otlp
+
+import (
+	"net/http"
+
+	"github.com/alexfalkowski/go-service/v2/config/client"
+	"github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/net"
+	"github.com/alexfalkowski/go-service/v2/os"
+	"github.com/alexfalkowski/go-service/v2/time"
+)
+
+// NewHTTPClient constructs an OTLP HTTP client that returns redirect responses
+// without following them. A zero timeout uses the OpenTelemetry default of ten
+// seconds.
+func NewHTTPClient(fs *os.FS, cfg *config.Config, timeout time.Duration) (*http.Client, error) {
+	dialer := &net.Dialer{
+		Timeout:   (30 * time.Second).Duration(),
+		KeepAlive: (30 * time.Second).Duration(),
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       (90 * time.Second).Duration(),
+		TLSHandshakeTimeout:   (10 * time.Second).Duration(),
+		ExpectContinueTimeout: time.Second.Duration(),
+	}
+	if cfg.IsEnabled() {
+		tlsConfig, err := client.NewConfig(fs, cfg)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   timeout.Duration(),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	return client, nil
+}

--- a/telemetry/internal/otlp/client_test.go
+++ b/telemetry/internal/otlp/client_test.go
@@ -1,0 +1,72 @@
+package otlp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
+	"github.com/alexfalkowski/go-service/v2/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPClientUsesConfiguredTimeoutAndTLS(t *testing.T) {
+	client, err := otlp.NewHTTPClient(test.FS, &tls.Config{ServerName: "collector.example.com"}, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, time.Second.Duration(), client.Timeout)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.Equal(t, "collector.example.com", transport.TLSClientConfig.ServerName)
+}
+
+func TestNewHTTPClientRejectsInvalidTLSConfig(t *testing.T) {
+	client, err := otlp.NewHTTPClient(test.FS, &tls.Config{CA: "invalid ca"}, time.Second)
+	require.ErrorIs(t, err, tls.ErrInvalidCA)
+	require.Nil(t, client)
+}
+
+func TestNewHTTPClientReturnsRedirectWithoutFollowingIt(t *testing.T) {
+	trustedHeaders := make(chan string, 1)
+	attackerRequests := make(chan struct{}, 1)
+	attacker := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		attackerRequests <- struct{}{}
+	}))
+	t.Cleanup(attacker.Close)
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		trustedHeaders <- req.Header.Get("X-Api-Key")
+		res.Header().Set("Location", attacker.URL+"/v1/traces")
+		res.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(trusted.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, trusted.URL+"/v1/traces", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("X-Api-Key", "token")
+
+	client, err := otlp.NewHTTPClient(test.FS, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, (10 * time.Second).Duration(), client.Timeout)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+	require.NoError(t, res.Body.Close())
+
+	select {
+	case header := <-trustedHeaders:
+		require.Equal(t, "token", header)
+	default:
+		require.Fail(t, "trusted endpoint did not receive a request")
+	}
+
+	select {
+	case <-attackerRequests:
+		require.Fail(t, "redirect target received a request")
+	default:
+	}
+}

--- a/telemetry/logger/config.go
+++ b/telemetry/logger/config.go
@@ -28,10 +28,11 @@ type Config struct {
 	// prepares configuration for use by the logger/exporter.
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
 
-	// TLS configures OTLP/gRPC client transport security.
+	// TLS configures OTLP client transport security.
 	//
-	// This only applies when Kind is "otlp" and Protocol is "grpc". A non-nil
-	// config enables TLS; Cert, Key, and CA values use go-service source strings.
+	// This applies when Kind is "otlp" and Protocol is "grpc", or when Protocol
+	// is "http" with an HTTPS URL. Cert, Key, and CA values use go-service source
+	// strings.
 	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Kind selects the logger implementation.
@@ -68,6 +69,13 @@ type Config struct {
 	//
 	// Unknown values are rejected by NewLogger with ErrInvalidLevel.
 	Level string `yaml:"level,omitempty" json:"level,omitempty" toml:"level,omitempty"`
+
+	// HTTPTimeout is the maximum duration allowed for one OTLP/HTTP export request.
+	//
+	// A zero value uses the OpenTelemetry HTTP exporter default of ten seconds.
+	// Negative values are invalid. This field only applies when Kind is "otlp"
+	// and Protocol is "http".
+	HTTPTimeout time.Duration `yaml:"http_timeout,omitempty" json:"http_timeout,omitempty" toml:"http_timeout,omitempty" validate:"gte=0"`
 
 	// BatchTimeout is the maximum delay between batched log record exports.
 	//

--- a/telemetry/logger/doc.go
+++ b/telemetry/logger/doc.go
@@ -65,6 +65,8 @@
 // rejected to avoid sending credential-bearing headers over cleartext transport.
 // Use "https://" for external collectors. Local development collectors on
 // "localhost" or loopback IP addresses may use "http://".
+// [Config.HTTPTimeout] bounds OTLP/HTTP export requests. [Config.TLS] configures
+// TLS for OTLP/HTTPS and OTLP/gRPC exporters.
 // Header-bearing remote OTLP/gRPC endpoints require [Config.TLS]; loopback gRPC
 // endpoints may still use cleartext.
 //

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -52,6 +52,10 @@ func TestConfigGetProtocol(t *testing.T) {
 	require.Equal(t, otlp.ProtocolGRPC, (&logger.Config{Protocol: otlp.ProtocolGRPC}).GetProtocol())
 }
 
+func TestConfigRejectsNegativeHTTPTimeout(t *testing.T) {
+	require.Error(t, test.Validator.Struct(&logger.Config{HTTPTimeout: -time.Second}))
+}
+
 func TestConfigGetKind(t *testing.T) {
 	require.Equal(t, strings.Empty, (*logger.Config)(nil).GetKind())
 	require.Equal(t, strings.Empty, (&logger.Config{}).GetKind())

--- a/telemetry/logger/otlp.go
+++ b/telemetry/logger/otlp.go
@@ -76,7 +76,14 @@ func newOtlpExporter(params LoggerParams) (log.Exporter, error) {
 		}
 		return otlploggrpc.New(context.Background(), opts...)
 	default:
-		opts := []otlploghttp.Option{otlploghttp.WithHeaders(params.Config.Headers)}
+		httpClient, err := otlp.NewHTTPClient(params.FS, params.Config.TLS, params.Config.HTTPTimeout)
+		if err != nil {
+			return nil, err
+		}
+		opts := []otlploghttp.Option{
+			otlploghttp.WithHTTPClient(httpClient),
+			otlploghttp.WithHeaders(params.Config.Headers),
+		}
 		if !strings.IsEmpty(params.Config.URL) {
 			opts = append(opts, otlploghttp.WithEndpointURL(params.Config.URL))
 		}

--- a/telemetry/metrics/config.go
+++ b/telemetry/metrics/config.go
@@ -21,10 +21,11 @@ type Config struct {
 	// or header.Map.MustSecrets).
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
 
-	// TLS configures OTLP/gRPC client transport security.
+	// TLS configures OTLP client transport security.
 	//
-	// This only applies when Kind is "otlp" and Protocol is "grpc". A non-nil
-	// config enables TLS; Cert, Key, and CA values use go-service source strings.
+	// This applies when Kind is "otlp" and Protocol is "grpc", or when Protocol
+	// is "http" with an HTTPS URL. Cert, Key, and CA values use go-service source
+	// strings.
 	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Prometheus configures Prometheus exporter output shaping.
@@ -73,6 +74,13 @@ type Config struct {
 	// the matching instrument. A nil or empty list keeps the SDK default boundaries,
 	// so this field is a no-op unless configured.
 	Views []ViewConfig `yaml:"views,omitempty" json:"views,omitempty" toml:"views,omitempty" validate:"omitempty,dive"`
+
+	// HTTPTimeout is the maximum duration allowed for one OTLP/HTTP export request.
+	//
+	// A zero value uses the OpenTelemetry HTTP exporter default of ten seconds.
+	// Negative values are invalid. This field only applies when Kind is "otlp"
+	// and Protocol is "http".
+	HTTPTimeout time.Duration `yaml:"http_timeout,omitempty" json:"http_timeout,omitempty" toml:"http_timeout,omitempty" validate:"gte=0"`
 
 	// Interval is the OTLP periodic export interval.
 	//

--- a/telemetry/metrics/doc.go
+++ b/telemetry/metrics/doc.go
@@ -43,6 +43,8 @@
 // reader export cadence. Zero values preserve the OpenTelemetry SDK defaults.
 // [Config.Protocol] selects the OTLP transport protocol. The empty value uses
 // OTLP/HTTP. Set "grpc" to use OTLP/gRPC with a host:port endpoint.
+// [Config.HTTPTimeout] bounds OTLP/HTTP export requests, and [Config.TLS]
+// configures TLS for OTLP/HTTPS and OTLP/gRPC exporters.
 //
 // For "prometheus", [Config.Prometheus] optionally shapes exporter output by
 // dropping unit/counter suffixes, the target_info metric, or the scope-info

--- a/telemetry/metrics/reader.go
+++ b/telemetry/metrics/reader.go
@@ -136,7 +136,14 @@ func newOTLPExporter(fs *os.FS, cfg *Config) (metric.Exporter, error) {
 		}
 		return otlpmetricgrpc.New(context.Background(), opts...)
 	default:
-		opts := []otlpmetrichttp.Option{otlpmetrichttp.WithHeaders(cfg.Headers)}
+		httpClient, err := otlp.NewHTTPClient(fs, cfg.TLS, cfg.HTTPTimeout)
+		if err != nil {
+			return nil, err
+		}
+		opts := []otlpmetrichttp.Option{
+			otlpmetrichttp.WithHTTPClient(httpClient),
+			otlpmetrichttp.WithHeaders(cfg.Headers),
+		}
 		if !strings.IsEmpty(cfg.URL) {
 			opts = append(opts, otlpmetrichttp.WithEndpointURL(cfg.URL))
 		}

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/telemetry/header"
 	"github.com/alexfalkowski/go-service/v2/telemetry/internal/otlp"
 	"github.com/alexfalkowski/go-service/v2/telemetry/metrics"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
@@ -26,6 +27,10 @@ func TestConfigGetProtocol(t *testing.T) {
 	require.Equal(t, otlp.ProtocolHTTP, (*metrics.Config)(nil).GetProtocol())
 	require.Equal(t, otlp.ProtocolHTTP, (&metrics.Config{}).GetProtocol())
 	require.Equal(t, otlp.ProtocolGRPC, (&metrics.Config{Protocol: otlp.ProtocolGRPC}).GetProtocol())
+}
+
+func TestConfigRejectsNegativeHTTPTimeout(t *testing.T) {
+	require.Error(t, test.Validator.Struct(&metrics.Config{HTTPTimeout: -time.Second}))
 }
 
 func TestReaderShutdownIgnoresAlreadyShutdownReader(t *testing.T) {

--- a/telemetry/tracer/config.go
+++ b/telemetry/tracer/config.go
@@ -21,10 +21,11 @@ type Config struct {
 	// exporter (for example via header.Map.Secrets or header.Map.MustSecrets).
 	Headers header.Map `yaml:"headers,omitempty" json:"headers,omitempty" toml:"headers,omitempty"`
 
-	// TLS configures OTLP/gRPC client transport security.
+	// TLS configures OTLP client transport security.
 	//
-	// This only applies when Kind is "otlp" and Protocol is "grpc". A non-nil
-	// config enables TLS; Cert, Key, and CA values use go-service source strings.
+	// This applies when Kind is "otlp" and Protocol is "grpc", or when Protocol
+	// is "http" with an HTTPS URL. Cert, Key, and CA values use go-service source
+	// strings.
 	TLS *tls.Config `yaml:"tls,omitempty" json:"tls,omitempty" toml:"tls,omitempty"`
 
 	// Sampler configures trace head sampling.
@@ -52,6 +53,13 @@ type Config struct {
 	// Standard OpenTelemetry endpoint environment variables are not used as fallbacks;
 	// configure this value explicitly through go-service config.
 	URL string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty"`
+
+	// HTTPTimeout is the maximum duration allowed for one OTLP/HTTP export request.
+	//
+	// A zero value uses the OpenTelemetry HTTP exporter default of ten seconds.
+	// Negative values are invalid. This field only applies when Kind is "otlp"
+	// and Protocol is "http".
+	HTTPTimeout time.Duration `yaml:"http_timeout,omitempty" json:"http_timeout,omitempty" toml:"http_timeout,omitempty" validate:"gte=0"`
 
 	// BatchTimeout is the maximum delay between batched span exports.
 	//

--- a/telemetry/tracer/doc.go
+++ b/telemetry/tracer/doc.go
@@ -62,6 +62,8 @@
 // [Config.BatchTimeout], [Config.ExportTimeout], [Config.MaxQueueSize], and
 // [Config.MaxExportBatchSize] tune the batch span processor used for OTLP
 // export. Zero values preserve the OpenTelemetry SDK defaults.
+// [Config.HTTPTimeout] bounds OTLP/HTTP export requests. [Config.TLS] configures
+// TLS for OTLP/HTTPS and OTLP/gRPC exporters.
 //
 // The exporter request headers are provided by [Config.Headers]. Header values may be
 // configured as go-service "source strings" (for example "env:NAME", "file:/path", or a

--- a/telemetry/tracer/tracer.go
+++ b/telemetry/tracer/tracer.go
@@ -243,7 +243,14 @@ func newOTLPExporter(params TracerParams) (*otlptrace.Exporter, error) {
 		}
 		return otlptrace.NewUnstarted(otlptracegrpc.NewClient(opts...)), nil
 	default:
-		opts := []otlptracehttp.Option{otlptracehttp.WithHeaders(params.Config.Headers)}
+		httpClient, err := otlp.NewHTTPClient(params.FS, params.Config.TLS, params.Config.HTTPTimeout)
+		if err != nil {
+			return nil, err
+		}
+		opts := []otlptracehttp.Option{
+			otlptracehttp.WithHTTPClient(httpClient),
+			otlptracehttp.WithHeaders(params.Config.Headers),
+		}
 		if !strings.IsEmpty(params.Config.URL) {
 			opts = append(opts, otlptracehttp.WithEndpointURL(params.Config.URL))
 		}

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -1,6 +1,8 @@
 package tracer_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"unicode/utf8"
 
@@ -134,6 +136,10 @@ func TestConfigGetProtocol(t *testing.T) {
 	require.Equal(t, otlp.ProtocolGRPC, (&tracer.Config{Protocol: otlp.ProtocolGRPC}).GetProtocol())
 }
 
+func TestConfigRejectsNegativeHTTPTimeout(t *testing.T) {
+	require.Error(t, test.Validator.Struct(&tracer.Config{HTTPTimeout: -time.Second}))
+}
+
 func TestRegisterStopResetsGlobalProvider(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
@@ -264,6 +270,59 @@ func TestRegisterInvalidOTLPEndpoint(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
+}
+
+func TestRegisterOTLPHTTPExporterDoesNotFollowRedirects(t *testing.T) {
+	trustedHeaders := make(chan string, 1)
+	attackerHeaders := make(chan string, 1)
+	attacker := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		attackerHeaders <- req.Header.Get("Authorization")
+	}))
+	t.Cleanup(attacker.Close)
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		trustedHeaders <- req.Header.Get("Authorization")
+		res.Header().Set("Location", attacker.URL+"/v1/traces")
+		res.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(trusted.Close)
+
+	lifecycle := fxtest.NewLifecycle(t)
+	t.Cleanup(func() {
+		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
+	})
+	require.NoError(t, tracer.Register(tracer.TracerParams{
+		Lifecycle: lifecycle,
+		Config: &tracer.Config{
+			Kind: "otlp",
+			URL:  trusted.URL + "/v1/traces",
+			Headers: header.Map{
+				"Authorization": "Bearer token",
+			},
+		},
+		ID:          test.ID,
+		Name:        test.Name,
+		Version:     test.Version,
+		Environment: test.Environment,
+	}))
+
+	lifecycle.RequireStart()
+	_, span := tracer.GetProvider().Tracer(test.Name.String()).Start(t.Context(), "redirect")
+	span.End()
+	require.NoError(t, lifecycle.Stop(t.Context()))
+
+	select {
+	case header := <-trustedHeaders:
+		require.Equal(t, "Bearer token", header)
+	default:
+		require.Fail(t, "trusted endpoint did not receive a request")
+	}
+
+	select {
+	case <-attackerHeaders:
+		require.Fail(t, "redirect target received a request")
+	default:
+	}
 }
 
 func TestRegisterOTLPGRPCExporter(t *testing.T) {


### PR DESCRIPTION
## What

- Prevent OTLP/HTTP exporters from following collector redirects and forwarding configured headers to a different endpoint.
- Add config-owned `http_timeout` and HTTPS TLS settings for OTLP HTTP exporters across logs, metrics, and traces.
- Document the explicit OTLP HTTP configuration boundary and default timeout.

## Why

- Collector redirects can forward caller-supplied authentication or routing headers to an unintended endpoint; returning the redirect keeps credentials scoped to the configured collector.
- Keep HTTP request timing and TLS material in go-service config rather than relying on suppressed upstream environment settings.

## Testing

- `make specs package=telemetry/internal/otlp` - passed
- `make specs package=telemetry/logger` - passed
- `make specs package=telemetry/metrics` - passed
- `make specs package=telemetry/tracer` - passed
- `make lint` - passed
- `make sec` - passed (no affected vulnerabilities; Trivy clean)
- CI will additionally run full specs, generated-output freshness, fuzzes, benchmarks, and coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
