### PR TITLE
feat(http): preserve generated error response headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,6 +380,12 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   deduplicate by request id when duplicate processing would be unsafe. Do not
   flag the default HTTP/gRPC retry policy merely because metadata injects
   request ids before retry.
+- gRPC user-agent is intentionally a connection-level protocol header managed
+  by grpc-go and configured with `grpc.WithUserAgent`. Do not introduce a
+  request-scoped or logical user-agent metadata header, or otherwise propagate
+  context/outgoing user-agent values across gRPC calls. Do not flag the
+  resulting difference between local client metadata and downstream gRPC
+  user-agent attribution as a code issue unless the supported contract changes.
 - HTTP retry intentionally does not apply `transport/retry.Config.Timeout` as a
   per-attempt timeout. HTTP response bodies are caller-owned after `RoundTrip`
   returns, and tying retry-owned attempt contexts to returned bodies requires

--- a/net/http/client/doc.go
+++ b/net/http/client/doc.go
@@ -11,7 +11,7 @@
 //
 // [NewClient] accepts optional ClientOption values to configure:
 //   - the underlying RoundTripper (e.g. to add retries, breakers, auth, etc.)
-//   - the overall client timeout ([http.Client.Timeout])
+//   - the unary [Client.Do] timeout, applied through the request context
 //   - the maximum response body size buffered in memory
 //   - redirect behavior (optionally return redirects instead of following them)
 //

--- a/net/http/handler.go
+++ b/net/http/handler.go
@@ -37,7 +37,7 @@ func (h *notFoundHandler) ServeHTTP(res ResponseWriter, req *Request) {
 	}
 
 	response := &bufferedWriter{
-		header:   Header{},
+		header:   res.Header().Clone(),
 		response: res,
 		buffer:   h.pool.Get(),
 		pool:     h.pool,

--- a/net/http/handler_test.go
+++ b/net/http/handler_test.go
@@ -1,6 +1,7 @@
 package http_test
 
 import (
+	"maps"
 	"net/http/httptest"
 	"testing"
 
@@ -35,6 +36,19 @@ func TestNewNotFoundHandler(t *testing.T) {
 			handle:        true,
 			code:          http.StatusMethodNotAllowed,
 		},
+		{
+			name:          "flushes method not allowed headers",
+			method:        http.MethodPost,
+			path:          "/hello",
+			registerRoute: true,
+			code:          http.StatusMethodNotAllowed,
+			header: http.Header{
+				"Content-Type":   {"application/problem+json"},
+				"Content-Length": {"999"},
+			},
+			contentType:        "text/plain; charset=utf-8",
+			checkContentLength: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -45,14 +59,18 @@ func TestNewNotFoundHandler(t *testing.T) {
 }
 
 type notFoundHandlerTest struct {
-	name          string
-	method        string
-	path          string
-	body          string
-	contains      string
-	registerRoute bool
-	handle        bool
-	code          int
+	name               string
+	method             string
+	path               string
+	body               string
+	contains           string
+	header             http.Header
+	registerRoute      bool
+	handle             bool
+	contentType        string
+	contentLength      string
+	checkContentLength bool
+	code               int
 }
 
 func testNotFoundHandler(t *testing.T, tt notFoundHandlerTest) {
@@ -78,6 +96,7 @@ func testNotFoundHandler(t *testing.T, tt notFoundHandlerTest) {
 
 	req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, http.NoBody)
 	res := httptest.NewRecorder()
+	maps.Copy(res.Header(), tt.header)
 
 	handler.ServeHTTP(res, req)
 
@@ -87,5 +106,11 @@ func testNotFoundHandler(t *testing.T, tt notFoundHandlerTest) {
 	}
 	if !strings.IsEmpty(tt.contains) {
 		test.RequireResponseBodyContains(t, res, tt.contains)
+	}
+	if !strings.IsEmpty(tt.contentType) {
+		require.Equal(t, tt.contentType, res.Header().Get("Content-Type"))
+	}
+	if tt.checkContentLength {
+		require.Equal(t, tt.contentLength, res.Header().Get("Content-Length"))
 	}
 }

--- a/net/http/writer.go
+++ b/net/http/writer.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"maps"
+
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-sync"
 )
@@ -40,17 +42,10 @@ func (w *bufferedWriter) WriteHeader(code int) {
 
 func (w *bufferedWriter) Flush() {
 	header := w.response.Header()
-	for key, values := range w.header {
-		if len(values) == 0 {
-			header.Del(key)
-			continue
-		}
-
-		header.Set(key, values[0])
-		for _, value := range values[1:] {
-			header.Add(key, value)
-		}
+	for key := range header {
+		header.Del(key)
 	}
+	maps.Copy(header, w.header)
 
 	if w.code != 0 {
 		w.response.WriteHeader(w.code)


### PR DESCRIPTION
## What

- Preserve the headers generated by ServeMux method-mismatch responses when the not-found handler buffers and replays them, including removals such as stale Content-Length values.
- Clarify that the client timeout applies only to unary calls through their request context, and record the gRPC user-agent ownership boundary for reviews.

## Why

- A buffered 405 response could previously leave pre-existing response headers in place, producing a response that did not match the mux-generated result.
- The regression test protects the header replacement behavior while the documentation prevents callers from assuming stream lifetimes use http.Client.Timeout.

## Testing

- `make specs package=net/http` - passed
- `make lint` - passed
- `git diff --check` - passed
- Added a 405 method-mismatch regression case that verifies the generated Content-Type replaces a stale value and Content-Length is cleared.

AI-assisted-by: [Codex](https://openai.com/codex/)
