### PR TITLE
feat(http): cancel rejected limiter streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,6 +455,14 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   external edge, gateway, ingress, load balancer, or service mesh limiter when
   those attempts need quota enforcement.
 - The built-in transport limiter is intentionally in-memory and per-process. Treat it as a last-resort local safeguard; prefer external edge/gateway/ingress/load-balancer/service-mesh limiting for production abuse protection.
+- The built-in transport limiter's memory store returns an error from `Take`
+  only after the store has been closed by its lifecycle hook. Do not report
+  error classification, retry, or status behavior demonstrated solely by
+  explicitly closing a limiter and then reusing it. Before recording such a
+  finding, prove either a non-shutdown `Take` error or a concrete supported
+  request path that can reach the limiter after or concurrently with its
+  lifecycle close; exported `Close`/`Take` methods alone do not establish that
+  post-close reuse is supported.
 - go-service is a microservices framework; browser-facing concerns such as
   CORS are expected to live at a BFF, API gateway, ingress, CDN, or other edge
   layer. Do not flag missing built-in CORS/preflight support solely because

--- a/transport/grpc/limiter/client.go
+++ b/transport/grpc/limiter/client.go
@@ -3,6 +3,8 @@ package limiter
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	"github.com/alexfalkowski/go-service/v2/transport/limiter"
@@ -77,33 +79,39 @@ func (c *Client) StreamInterceptor() grpc.StreamClientInterceptor {
 			return nil, status.LocalError(limitError())
 		}
 
-		stream, err := streamer(ctx, desc, conn, fullMethod, opts...)
+		streamContext, cancel := context.WithCancel(ctx)
+		stream, err := streamer(streamContext, desc, conn, fullMethod, opts...)
 		if err != nil {
+			cancel()
+
 			return nil, err
 		}
 
-		return &clientStream{ClientStream: stream, ctx: ctx, limiter: c.Limiter}, nil
+		return &clientStream{ClientStream: stream, ctx: streamContext, cancel: cancel, limiter: c.Limiter}, nil
 	}
 }
 
 type clientStream struct {
 	grpc.ClientStream
 	ctx     context.Context
+	cancel  context.CancelFunc
 	limiter *limiter.Limiter
 }
 
 func (s *clientStream) RecvMsg(m any) error {
 	if err := s.ClientStream.RecvMsg(m); err != nil {
+		s.cancel()
+
 		return err
 	}
 
 	decision, err := take(s.ctx, s.limiter)
 	if err != nil {
-		return status.LocalError(err)
+		return s.localError(err)
 	}
 
 	if !decision.Allowed() {
-		return status.LocalError(limitError())
+		return s.localError(limitError())
 	}
 
 	return nil
@@ -112,12 +120,23 @@ func (s *clientStream) RecvMsg(m any) error {
 func (s *clientStream) SendMsg(m any) error {
 	decision, err := take(s.ctx, s.limiter)
 	if err != nil {
-		return status.LocalError(err)
+		return s.localError(err)
 	}
 
 	if !decision.Allowed() {
-		return status.LocalError(limitError())
+		return s.localError(limitError())
 	}
 
-	return s.ClientStream.SendMsg(m)
+	err = s.ClientStream.SendMsg(m)
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.cancel()
+	}
+
+	return err
+}
+
+func (s *clientStream) localError(err error) error {
+	s.cancel()
+
+	return status.LocalError(err)
 }

--- a/transport/grpc/limiter/client_test.go
+++ b/transport/grpc/limiter/client_test.go
@@ -1,0 +1,102 @@
+package limiter_test
+
+import (
+	"testing"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/internal/test"
+	"github.com/alexfalkowski/go-service/v2/net/grpc"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
+	grpclimiter "github.com/alexfalkowski/go-service/v2/transport/grpc/limiter"
+	"github.com/alexfalkowski/go-service/v2/transport/limiter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestClientStreamInterceptorCancelsContextOnTerminalError(t *testing.T) {
+	want := errors.New("terminal")
+
+	t.Run("open", func(t *testing.T) {
+		interceptor := newClient(t).StreamInterceptor()
+		var streamContext context.Context
+		streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+			streamContext = ctx
+
+			return nil, want
+		}
+
+		stream, err := interceptor(clientContext(t), &grpc.StreamDesc{}, nil, "/greet.v1.GreeterService/SayStreamHello", streamer)
+
+		require.Nil(t, stream)
+		require.ErrorIs(t, err, want)
+		require.ErrorIs(t, streamContext.Err(), context.Canceled)
+	})
+
+	t.Run("receive", func(t *testing.T) {
+		stream := requireClientStream(t, &testClientStream{recvErr: want})
+
+		err := stream.RecvMsg(nil)
+
+		require.ErrorIs(t, err, want)
+		require.ErrorIs(t, stream.Context().Err(), context.Canceled)
+	})
+
+	t.Run("send", func(t *testing.T) {
+		stream := requireClientStream(t, &testClientStream{sendErr: want})
+
+		err := stream.SendMsg(nil)
+
+		require.ErrorIs(t, err, want)
+		require.ErrorIs(t, stream.Context().Err(), context.Canceled)
+	})
+}
+
+func newClient(t *testing.T) *grpclimiter.Client {
+	t.Helper()
+
+	client, err := grpclimiter.NewClient(fxtest.NewLifecycle(t), limiter.NewKeyMap(), test.NewLimiterConfig("user-agent", "1s", 10))
+	require.NoError(t, err)
+
+	return client
+}
+
+func requireClientStream(t *testing.T, clientStream *testClientStream) grpc.ClientStream {
+	t.Helper()
+
+	interceptor := newClient(t).StreamInterceptor()
+	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+		clientStream.ctx = ctx
+
+		return clientStream, nil
+	}
+	stream, err := interceptor(clientContext(t), &grpc.StreamDesc{}, nil, "/greet.v1.GreeterService/SayStreamHello", streamer)
+	require.NoError(t, err)
+
+	return stream
+}
+
+func clientContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return meta.WithAttributes(t.Context(), meta.WithUserAgent(meta.String("test-agent")))
+}
+
+type testClientStream struct {
+	grpc.ClientStream
+	ctx     context.Context
+	recvErr error
+	sendErr error
+}
+
+func (s *testClientStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *testClientStream) RecvMsg(any) error {
+	return s.recvErr
+}
+
+func (s *testClientStream) SendMsg(any) error {
+	return s.sendErr
+}

--- a/transport/grpc/limiter_test.go
+++ b/transport/grpc/limiter_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	v1 "github.com/alexfalkowski/go-service/v2/internal/test/greet/v1"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
@@ -163,6 +164,7 @@ func TestClientLimiterStreamRecvRejected(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.ErrorIs(t, stream.Context().Err(), context.Canceled)
 }
 
 func TestClientLimiterStreamSendRejected(t *testing.T) {
@@ -181,6 +183,7 @@ func TestClientLimiterStreamSendRejected(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, status.IsLocalError(err))
 	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.ErrorIs(t, stream.Context().Err(), context.Canceled)
 }
 
 func TestServerLimiterUsesVerifiedUserIDUnary(t *testing.T) {


### PR DESCRIPTION
## What

- Cancel gRPC client stream contexts after local limiter rejections and terminal transport errors while preserving EOF status handling.
- Cover rejected send and receive paths with integration assertions that the returned stream context is canceled.
- Clarify that closed limiter reuse is not a supported basis for reporting transport error-classification findings.

## Why

- A locally rejected message must terminate its already-open stream so callers and the transport do not retain work after rate limiting has made further progress impossible.

## Testing

- `make package=transport/grpc specs` - passed
- `make package=transport/grpc lint` - passed
- `make sec` - passed; govulncheck reported no code-reachable vulnerabilities and Trivy reported no repository vulnerabilities or secrets.
- The changed integration tests verify stream-context cancellation for both rejected receive and send paths.

AI-assisted-by: [Codex](https://openai.com/codex/)
