### PR TITLE
docs(readme): clarify protocol documentation

### DIFF
--- a/net/http/compress/compress.go
+++ b/net/http/compress/compress.go
@@ -7,19 +7,19 @@ import (
 
 // HeaderNoCompression is an alias for [gzhttp.HeaderNoCompression].
 //
-// Setting this response header before the response is written disables gzip compression for that response.
+// Setting this response header before the response is written disables compression for that response.
 const HeaderNoCompression = gzhttp.HeaderNoCompression
 
-// GzipHandler wraps h so its response is transparently gzip-compressed for clients that advertise support.
+// GzipHandler wraps h so its response is transparently zstd- or gzip-compressed for clients that advertise support.
 //
 // This is a thin wrapper around [gzhttp.GzipHandler].
 func GzipHandler(h http.Handler) http.HandlerFunc {
 	return gzhttp.GzipHandler(h)
 }
 
-// Transport wraps rt so outbound requests advertise gzip support and gzipped responses are transparently decompressed.
+// Transport wraps rt so outbound requests advertise zstd and gzip support and matching responses are transparently decompressed.
 //
-// This is a thin wrapper around [gzhttp.Transport] with gzip compression enabled.
+// This is a thin wrapper around [gzhttp.Transport] with gzip compression enabled alongside its default zstd support.
 func Transport(rt http.RoundTripper) http.RoundTripper {
 	return gzhttp.Transport(rt, gzhttp.TransportEnableGzip(true))
 }

--- a/net/http/compress/doc.go
+++ b/net/http/compress/doc.go
@@ -1,0 +1,10 @@
+// Package compress provides zstd and gzip HTTP handler and transport wrappers.
+//
+// [GzipHandler] compresses server responses for clients that advertise zstd or gzip support, and [Transport]
+// configures an outbound RoundTripper to advertise zstd and gzip support and transparently decompress responses.
+// Set [HeaderNoCompression] on a response before it is written when an endpoint must remain uncompressed,
+// such as a streaming response.
+//
+// The exported helpers are thin wrappers around the underlying implementation so callers can keep response
+// compression integration on the go-service import path.
+package compress

--- a/net/http/content/stream/doc.go
+++ b/net/http/content/stream/doc.go
@@ -1,2 +1,23 @@
-// Package stream provides HTTP request and response streaming on top of content codecs.
+// Package stream provides NDJSON HTTP request and response streaming on top of content codecs.
+//
+// [Content] owns a streaming codec registry that is separate from the single-value registry in
+// [github.com/alexfalkowski/go-service/v2/net/http/content/unary]. Streaming media negotiation is strict:
+// an unregistered or unparseable declared media type is rejected instead of falling back to another
+// representation. With no Content-Type or Accept header, response negotiation selects NDJSON.
+//
+// # Handlers
+//
+// [NewHandler] creates a send-only streaming response handler and works over HTTP/1.x or HTTP/2.
+// [NewRequestHandler] creates a bidirectional request/response handler and requires HTTP/2 (including
+// h2c). Use one goroutine at a time with [Stream.Send]; for [RequestStream], the supported pattern is
+// one goroutine calling Send and one calling Recv. See the executable streaming examples in
+// `net/http/rest` and `net/http/client` for complete server and client calls.
+//
+// # Limits and lifecycle
+//
+// [Options.MaxReceiveSize] caps each decoded request value, not the cumulative request stream. Request
+// decoding accepts only codecs that are safe for untrusted input, matching the decoder-bounds rule in
+// the unary package documentation. [Options.ReadTimeout] and [Options.WriteTimeout] are per-message
+// inactivity budgets, while [Options.Drain] cancels handlers during server shutdown. Handlers waiting
+// on an upstream source must return after their context is canceled.
 package stream


### PR DESCRIPTION
## What

- Document the streaming HTTP content contract, including NDJSON negotiation, handler protocol requirements, per-value bounds, timeouts, and drain lifecycle.
- Add package guidance for HTTP compression and correctly describe the gzip and zstd behavior of its server and client wrappers.

## Why

- Give Go users actionable package-level guidance and prevent callers from assuming outbound compression supports only gzip.

## Testing

- `make package=net/http/content/stream specs` - passed
- `make package=net/http/compress specs` - passed
- `make lint` - passed
- No new tests: this is a documentation-only change; the existing stream suite covers the documented behavior.

AI-assisted-by: [Codex](https://openai.com/codex/)
