### PR TITLE
feat(http): keep preflight timeouts out of breaker health

### DIFF
--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,7 @@ The transport client wrappers include optional circuit breakers:
 - HTTP breaker (`transport/http/breaker`):
   - Scope is per `"<METHOD> <HOST>"`.
   - Default failure statuses are `>=500` and `429`.
+  - Requests with an already deadline-exceeded context bypass breaker accounting.
   - Transport errors are counted as failures.
   - Failure status responses are still returned to callers (while breaker accounting records a failure).
 

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -50,6 +50,8 @@ type Settings = breaker.Settings
 //
 // The breaker executes the underlying transport call and classifies the outcome for breaker accounting:
 //
+//   - Requests whose contexts have already deadline-exceeded bypass breaker accounting because they provide no
+//     upstream-health signal.
 //   - Transport errors (i.e., the underlying RoundTripper returns a non-nil error) are counted as failures.
 //   - HTTP responses whose `StatusCode` matches the configured failure-status predicate are also counted as failures.
 //
@@ -88,7 +90,8 @@ type RoundTripper struct {
 // the call and return an error (for example [breaker.ErrOpenState] or [breaker.ErrTooManyRequests]).
 //
 // Failure accounting:
-//   - Transport errors are counted as failures.
+//   - Transport errors are counted as failures, except when the request context has already deadline-exceeded
+//     before the underlying transport call starts.
 //   - Responses that match the configured failure-status predicate are counted as failures for breaker
 //     accounting, but the response is still returned to the caller with a nil error.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -96,6 +99,11 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool) {
+	if errors.Is(req.Context().Err(), context.DeadlineExceeded) {
+		resp, err := r.RoundTripper.RoundTrip(req)
+		return resp, err, false
+	}
+
 	cb := r.get(req)
 	result, err := cb.Execute(func() (any, error) {
 		resp, err := r.RoundTripper.RoundTrip(req)

--- a/transport/http/breaker/breaker_test.go
+++ b/transport/http/breaker/breaker_test.go
@@ -37,6 +37,63 @@ func TestRoundTripperDoesNotOpenOnCallerCancellation(t *testing.T) {
 	require.NotErrorIs(t, err, breaker.ErrOpenState)
 }
 
+func TestRoundTripperDoesNotOpenOnExpiredCallerDeadline(t *testing.T) {
+	calls := 0
+	rt := breaker.NewRoundTripper(
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if err := req.Context().Err(); err != nil {
+				return nil, err
+			}
+
+			return test.ResponseWithStatus(http.StatusOK), nil
+		}),
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+	)
+	expired, cancel := context.WithTimeout(t.Context(), 0)
+	t.Cleanup(cancel)
+	<-expired.Done()
+	expiredRequest, err := http.NewRequestWithContext(expired, http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(expiredRequest)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	liveRequest, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+	res, err = rt.RoundTrip(liveRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.NoError(t, res.Body.Close())
+	require.Equal(t, 2, calls)
+}
+
+func TestRoundTripperOpensOnDeadlineAfterTransportStarts(t *testing.T) {
+	rt := breaker.NewRoundTripper(
+		&test.ErrorRoundTripper{Err: context.DeadlineExceeded},
+		breaker.WithSettings(breaker.Settings{
+			ReadyToTrip: func(counts breaker.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	res, err = rt.RoundTrip(req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, breaker.ErrOpenState)
+}
+
 func TestRoundTripperOpensOnTransportError(t *testing.T) {
 	transportErr := errors.New("transport unavailable")
 	rt := breaker.NewRoundTripper(

--- a/transport/http/breaker/doc.go
+++ b/transport/http/breaker/doc.go
@@ -12,6 +12,8 @@
 // # Failure accounting vs caller behavior
 //
 // The wrapped [RoundTripper] classifies outcomes for breaker accounting:
+//   - Requests whose contexts have already deadline-exceeded bypass breaker accounting because they provide no
+//     upstream-health signal.
 //   - Transport errors (a non-nil error returned by the underlying [RoundTripper]) are counted as failures.
 //   - HTTP responses with status codes classified as failures (see [WithFailureStatusFunc] / [WithFailureStatuses])
 //     are also counted as failures.


### PR DESCRIPTION
## What

- Keep HTTP circuit-breaker accounting out of requests whose contexts were already deadline-exceeded before dispatch, while preserving failure accounting for deadlines returned after transport work starts.
- Document the exception in the exported package, method documentation, and client breaker overview.

## Why

- A request that cannot start due to its caller's deadline provides no upstream-health signal, so it should not open the circuit breaker and block later healthy calls.

## Testing

- `make specs package=transport/http/breaker` - passed
- `make lint package=transport/http/breaker` - passed
- Added coverage for pre-expired contexts bypassing breaker accounting and deadline failures returned after dispatch still opening the breaker.

AI-assisted-by: [Codex](https://openai.com/codex/)
