### PR TITLE
docs(agents): remove obsolete webhook exception guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -675,12 +675,6 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 - HTTP webhook signing intentionally ignores the Standard Webhooks `Sign` error
   because the current vendored implementation always returns nil. Do not flag
   this unless the dependency behavior changes.
-- Standard Webhooks currently accepts a `whsec_` secret whose decoded HMAC key
-  is empty. Treat this as an upstream library defect: do not duplicate its
-  private prefix/Base64 parsing in `hooks` as a local workaround. Pursue an
-  upstream fix and update the dependency when one is available; add local
-  validation only if this repository explicitly takes ownership of that
-  validation contract.
 - HTTP CloudEvents receiver registration intentionally ignores the current
   CloudEvents constructor errors because supported wiring passes no protocol
   options and uses the typed `ReceiverFunc`, which matches the SDK receive


### PR DESCRIPTION
## What

- Remove obsolete review guidance that treated empty Standard Webhooks secrets as an upstream-only concern.
- Preserve the repository-owned validation that rejects empty resolved webhook secrets before constructing the downstream handler.

## Why

- Keep agent guidance aligned with the current ownership boundary so future reviews recognize the local empty-secret safeguard.

## Testing

- `git diff --check` - passed
- `make lint` - passed
- No executable test is needed for this documentation-only update.

AI-assisted-by: [Codex](https://openai.com/codex/)
