### PR TITLE
feat(sql): bound database reachability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,9 +472,10 @@ Postgres config embeds common pool + DSN config (`database/sql/config.Config`), 
 Enablement is presence-based: a nil `sql` block or a nil `sql.pg` block disables SQL wiring. When enabled, the pgx stdlib driver is registered under the name `pg`, and reader/writer DSNs are resolved using the source-string rules described above. Enabled PostgreSQL config must provide at least one non-empty `reader.dsns[].url` or `writer.dsns[].url`. Driver instrumentation is installed when tracing or metrics are enabled, OpenTelemetry `database/sql` stats metrics are registered when metrics are enabled, and the resulting pools are closed on lifecycle stop.
 
 SQL wiring creates `database/sql` pool handles and applies pool settings, but it
-does not ping PostgreSQL during construction. Call `DBs.Ping`,
-`DBs.PingWriter`, `DBs.PingReader`, or register `health/checker.NewDBChecker`
-when startup or readiness should verify database reachability.
+does not ping PostgreSQL during construction. Call `DBs.Ping`, `DBs.PingWriter`,
+or `DBs.PingReader` with an SLO-appropriate
+deadline, or register `health/checker.NewDBChecker`, when startup or readiness
+should verify database reachability.
 
 Example (with source strings for DSNs):
 

--- a/database/sql/driver/connect.go
+++ b/database/sql/driver/connect.go
@@ -22,9 +22,9 @@ import (
 // then applies each role's pool settings.
 //
 // Like [database/sql.Open], this creates pool handles but does not ping the
-// database or verify network reachability. Call [DBs.Ping], [DBs.PingWriter],
-// [DBs.PingReader], or a health checker when startup/readiness must prove
-// connectivity.
+// database or verify network reachability. Call [DBs.Ping],
+// [DBs.PingWriter], [DBs.PingReader] with a deadline, or a health
+// checker when startup/readiness must prove connectivity.
 //
 // Preconditions:
 //   - cfg must be non-nil and already treated as enabled/validated by the caller.

--- a/database/sql/driver/db.go
+++ b/database/sql/driver/db.go
@@ -36,19 +36,19 @@ func (d *DBs) Readers() []*sql.DB {
 	return d.readers
 }
 
-// Ping pings all writer and reader pools.
-func (d *DBs) Ping() error {
-	return ping(d.databases())
+// Ping pings all writer and reader pools with ctx.
+func (d *DBs) Ping(ctx context.Context) error {
+	return ping(ctx, d.databases())
 }
 
-// PingWriter pings all writer pools.
-func (d *DBs) PingWriter() error {
-	return ping(d.writers)
+// PingWriter pings all writer pools with ctx.
+func (d *DBs) PingWriter(ctx context.Context) error {
+	return ping(ctx, d.writers)
 }
 
-// PingReader pings all reader pools.
-func (d *DBs) PingReader() error {
-	return ping(d.readers)
+// PingReader pings all reader pools with ctx.
+func (d *DBs) PingReader(ctx context.Context) error {
+	return ping(ctx, d.readers)
 }
 
 // Reader returns a database pool suitable for read queries.
@@ -98,11 +98,11 @@ func pick(databases []*sql.DB) *sql.DB {
 	return databases[rand.IntN(len(databases))]
 }
 
-func ping(databases []*sql.DB) error {
+func ping(ctx context.Context, databases []*sql.DB) error {
 	errs := make([]error, len(databases))
 	for i, db := range databases {
 		if db != nil {
-			errs[i] = db.PingContext(context.Background())
+			errs[i] = db.PingContext(ctx)
 		}
 	}
 

--- a/database/sql/driver/doc.go
+++ b/database/sql/driver/doc.go
@@ -12,7 +12,7 @@
 // Pool creation follows the [database/sql.Open] contract: it may not establish a
 // network connection immediately. Use [github.com/alexfalkowski/go-service/v2/database/sql/driver.DBs.Ping],
 // [github.com/alexfalkowski/go-service/v2/database/sql/driver.DBs.PingWriter],
-// [github.com/alexfalkowski/go-service/v2/database/sql/driver.DBs.PingReader], or a
+// [github.com/alexfalkowski/go-service/v2/database/sql/driver.DBs.PingReader] with a deadline, or a
 // health checker when startup/readiness must verify database reachability.
 //
 // Most applications use this package indirectly through a driver package such as

--- a/database/sql/driver/driver_test.go
+++ b/database/sql/driver/driver_test.go
@@ -3,6 +3,7 @@ package driver_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/database/sql"
 	"github.com/alexfalkowski/go-service/v2/database/sql/config"
 	"github.com/alexfalkowski/go-service/v2/database/sql/driver"
@@ -10,6 +11,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/telemetry/attributes"
+	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -32,7 +34,7 @@ func TestOpenUnregistersDBStatsMetrics(t *testing.T) {
 	lc.RequireStop()
 
 	test.RequireNoDBStatsMetrics(t, reader)
-	require.Error(t, db.Ping())
+	require.Error(t, db.Ping(t.Context()))
 }
 
 func TestOpenReturnsConnectError(t *testing.T) {
@@ -173,6 +175,60 @@ func TestConnectWritersReadersReturnsErrors(t *testing.T) {
 
 	require.Nil(t, db)
 	require.Error(t, errors.Join(errs...))
+}
+
+func TestDBsPingReturnsDeadlineWhenWaitingForConnection(t *testing.T) {
+	tests := []struct {
+		name    string
+		writers []string
+		readers []string
+		ping    func(*sql.DBs, context.Context) error
+	}{
+		{
+			name:    "all pools",
+			writers: []string{"benchmark"},
+			ping:    func(db *sql.DBs, ctx context.Context) error { return db.Ping(ctx) },
+		},
+		{
+			name:    "writers",
+			writers: []string{"benchmark"},
+			ping:    func(db *sql.DBs, ctx context.Context) error { return db.PingWriter(ctx) },
+		},
+		{
+			name:    "readers",
+			readers: []string{"benchmark"},
+			ping:    func(db *sql.DBs, ctx context.Context) error { return db.PingReader(ctx) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driverName := test.RegisterBenchmarkSQLDriver(t, "test-sql-")
+			db, errs := sql.ConnectWritersReaders(driverName, tt.writers, tt.readers)
+			require.Empty(t, errs)
+			t.Cleanup(func() {
+				require.NoError(t, db.Destroy())
+			})
+
+			pool, err := db.Writer()
+			if len(tt.readers) > 0 {
+				pool, err = db.Reader()
+			}
+			require.NoError(t, err)
+			pool.SetMaxOpenConns(1)
+
+			conn, err := pool.Conn(t.Context())
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, conn.Close())
+			}()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+			defer cancel()
+
+			require.ErrorIs(t, tt.ping(db, ctx), context.DeadlineExceeded)
+		})
+	}
 }
 
 func newPool(maxOpenConns int) *config.Pool {

--- a/database/sql/pg/pg_test.go
+++ b/database/sql/pg/pg_test.go
@@ -122,7 +122,7 @@ func TestOpenRejectsInvalidDSNConfiguration(t *testing.T) {
 func TestConfiguredSQLConnectionRespondsToPing(t *testing.T) {
 	world := test.NewStartedWorld(t, test.WithWorldTelemetry("otlp"), test.WithWorldPGConfig(nil), test.WithWorldLoggerConfig("otlp"))
 
-	require.NoError(t, world.DB.Ping())
+	require.NoError(t, world.DB.Ping(t.Context()))
 }
 
 func TestConnectUsesPostgreSQLTelemetryOptions(t *testing.T) {
@@ -152,10 +152,10 @@ func TestOpenClosesDBsOnStop(t *testing.T) {
 	require.NotNil(t, db)
 
 	lc.RequireStart()
-	require.NoError(t, db.Ping())
+	require.NoError(t, db.Ping(t.Context()))
 
 	lc.RequireStop()
-	require.Error(t, db.Ping())
+	require.Error(t, db.Ping(t.Context()))
 }
 
 func TestDatabaseExecutesReaderQuery(t *testing.T) {
@@ -372,7 +372,7 @@ func TestRejectsInvalidSQLPort(t *testing.T) {
 	require.NoError(t, err)
 
 	lc.RequireStart()
-	require.Error(t, db.Ping())
+	require.Error(t, db.Ping(t.Context()))
 	lc.RequireStop()
 }
 


### PR DESCRIPTION
## What

- Require callers of the SQL DB collection ping helpers to supply a context so reachability checks can honor caller-owned cancellation and deadlines.
- Update SQL documentation and tests to show bounded reachability checks through `DBs.Ping(ctx)`, `DBs.PingWriter(ctx)`, and `DBs.PingReader(ctx)`.
- This is an intentional source-breaking v2 API change: downstream callers must replace no-argument ping calls with the corresponding context-aware form and use an SLO-appropriate bounded context.

## Why

- A ping that waits for a saturated or unavailable connection pool must be bounded by the caller's readiness or startup budget instead of using an unbounded background context.
- Propagating the caller context makes cancellation and deadline behavior deterministic for all writer and reader pools.

## Testing

- `make package=database/sql/driver specs` - passed
- `make package=database/sql/pg specs` - passed
- `make package=database/sql/driver lint` - passed
- `make package=database/sql/pg lint` - passed
- Targeted SQL driver and PostgreSQL package validation covers deadline propagation, lifecycle cleanup, configured connectivity, and linting; CI will run the complete suite and remaining repository checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
