### PR TITLE
feat(http): normalize stream content-type headers and vary mvc not-found responses

### DIFF
--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
+	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
@@ -57,7 +58,7 @@ func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http
 		}
 
 		ctx = meta.WithRequestResponse(ctx, req, res)
-		res.Header().Set(http.ContentTypeKey, resMedia.WithUTF8())
+		res.Header().Set(http.ContentTypeKey, media.MustParse(resMedia.String()).WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
 		buffer := cont.pool.Get()
@@ -164,7 +165,7 @@ func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler Re
 		}
 
 		ctx = meta.WithRequestResponse(ctx, req, res)
-		res.Header().Set(http.ContentTypeKey, resMedia.WithUTF8())
+		res.Header().Set(http.ContentTypeKey, media.MustParse(resMedia.String()).WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
 		buffer := cont.pool.Get()

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -51,6 +51,21 @@ func TestNewHandlerSendsValuesAndOptsOutOfGzip(t *testing.T) {
 	require.False(t, scanner.Scan())
 }
 
+func TestNewHandlerNormalizesResponseContentType(t *testing.T) {
+	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
+		return stream.Send(&test.Response{Greeting: "Hello Bob"})
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.ContentTypeKey, "Application/X-NDJSON; charset=utf-7; profile=v2")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
+}
+
 func TestNewHandlerGzipHandlerPassesThroughUncompressed(t *testing.T) {
 	inner := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Response]) error {
 		return stream.Send(&test.Response{Greeting: "Hello Bob"})

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -23,6 +23,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewRequestHandlerNormalizesResponseContentType(t *testing.T) {
+	handler := contentstream.NewRequestHandler(
+		test.StreamContent,
+		contentstream.Options{}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			return stream.Send(&test.Response{Greeting: "Hello Bob"})
+		},
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", http.NoBody)
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, "Application/X-NDJSON; charset=utf-7; profile=v2")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, media.NDJSON, res.Header().Get(http.ContentTypeKey))
+}
+
 func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T) {
 	encoder := &closeTracker{}
 	decoder := &closeTracker{}

--- a/net/http/mvc/handler.go
+++ b/net/http/mvc/handler.go
@@ -17,6 +17,8 @@ func NotFoundHandler() http.NotFoundHandler {
 			return false
 		}
 
+		http.AddVary(res.Header(), http.AcceptKey, "Hx-Request")
+
 		acceptsHTML := strings.Contains(req.Header.Get("Accept"), media.HTML)
 		isHTMX := req.Header.Get("Hx-Request") == "true"
 		if !acceptsHTML && !isHTMX {

--- a/net/http/mvc/server_test.go
+++ b/net/http/mvc/server_test.go
@@ -613,6 +613,48 @@ func TestFallbackRendersFallbackTemplate(t *testing.T) {
 	}
 }
 
+func TestNotFoundHandlerAddsVary(t *testing.T) {
+	tests := []struct {
+		name    string
+		accept  string
+		handled bool
+	}{
+		{name: "accepts html", accept: media.HTML, handled: true},
+		{name: "ignores api", accept: media.JSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mvc.Register(mvc.RegisterParams{
+				Router:      newTestRouter(mux),
+				FunctionMap: mvc.NewFunctionMap(mvc.FunctionMapParams{Logger: slog.Default()}),
+				FileSystem: fstest.MapFS{
+					"views/full.tmpl":    &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+					"views/partial.tmpl": &fstest.MapFile{Data: []byte(`{{ block "content" . }}{{ end }}`)},
+					"views/error.tmpl":   &fstest.MapFile{Data: []byte(`{{ define "content" }}{{ .Model.Code }} {{ .Model.Message }}{{ end }}`)},
+				},
+				Pool:   test.Pool,
+				Layout: mvc.NewLayout("views/full.tmpl", "views/partial.tmpl"),
+			})
+
+			require.True(t, mvc.NotFound(func(_ context.Context) (*mvc.View, *mvc.Error) {
+				return mvc.NewFullView("views/error.tmpl"), &mvc.Error{
+					Code:    http.StatusNotFound,
+					Message: http.StatusText(http.StatusNotFound),
+				}
+			}))
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/missing", http.NoBody)
+			req.Header.Set("Accept", tt.accept)
+			res := httptest.NewRecorder()
+
+			require.Equal(t, tt.handled, mvc.NotFoundHandler()(res, req))
+			require.Equal(t, []string{"Accept", "Hx-Request"}, res.Header().Values(http.VaryKey))
+		})
+	}
+}
+
 func TestNotFoundWritesRenderStatusWhenViewMissing(t *testing.T) {
 	mux := http.NewServeMux()
 	mvc.Register(mvc.RegisterParams{


### PR DESCRIPTION
## What

- Streaming response handlers (`net/http/content/stream.NewHandler` and `NewRequestHandler`) now normalize the response `Content-Type` header through `media.MustParse(resMedia.String()).WithUTF8()` instead of `resMedia.WithUTF8()`. Previously, when a client's `Accept`/`Content-Type` header carried extra parameters (e.g. `charset=utf-7; profile=v2`), those parameters were echoed back verbatim in the response header. The response now always carries the canonical media type. This mirrors the pattern already used in `net/http/content/unary.NewHandler`.
- `net/http/mvc.NotFoundHandler` now adds `Vary: Accept, Hx-Request` to every response it actually renders (HTML fallback or pass-through), since its branching depends on both headers. The early-return path where no not-found controller is registered is unchanged and still sets no `Vary`.

## Why

- The streaming Content-Type leak let a caller-supplied, unvalidated parameter string ride along in the response header for a value the server itself controls; normalizing it keeps behavior consistent with the unary handler and avoids exposing arbitrary client input back through a response header.
- Missing `Vary` on the MVC not-found handler meant caches or intermediaries could serve an HTML fallback response to an API client (or vice versa) that varies only by `Accept`/`Hx-Request`, since nothing in the response declared that dependency.

## Testing

- `package=net/http/content/stream make specs` - passed (adds `TestNewHandlerNormalizesResponseContentType` and `TestNewRequestHandlerNormalizesResponseContentType`, each sending a `Content-Type` with extra parameters and asserting the response header is the canonical `media.NDJSON` value)
- `package=net/http/mvc make specs` - passed (adds `TestNotFoundHandlerAddsVary`, covering both the HTML-accepted and API-ignored branches of the handler)
- `package=net/http/content/stream make golangci-lint` - passed
- `package=net/http/mvc make golangci-lint` - passed
- Independent code review (sub-agent) found no blocking issues; traced that `resMedia.String()` can only be a value `media.MustParse` already parses successfully at init, so the new `MustParse` call cannot panic on any currently reachable input.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
