### PR TITLE
feat(http): map unary response encode type mismatches to 406 not acceptable

### DIFF
--- a/net/http/content/unary/handler.go
+++ b/net/http/content/unary/handler.go
@@ -2,6 +2,8 @@ package unary
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	encodingerrors "github.com/alexfalkowski/go-service/v2/encoding/errors"
+	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
@@ -30,6 +32,9 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 // Errors:
 // If request decoding fails, NewRequestHandler converts the decode error into a 400 Bad Request using
 // net/http/status, allowing the response to be rendered consistently by [status.WriteError].
+// If response encoding fails because the response value does not satisfy the negotiated encoder's
+// required type (see [github.com/alexfalkowski/go-service/v2/encoding/errors.ErrInvalidType]), the encode
+// error becomes a 406 Not Acceptable; any other encode failure keeps its default status.
 //
 // Successful responses are encoded into a pooled in-memory buffer before being written to the live
 // response writer, so encode failures do not leak partial success bodies.
@@ -61,7 +66,8 @@ type Handler[Res any] func(ctx context.Context) (*Res, error)
 
 // NewHandler builds a handler that encodes the response and writes errors using status helpers.
 //
-// Context population and response content negotiation are the same as NewRequestHandler (see its documentation).
+// Context population, response content negotiation, and encode-error handling are the same as
+// NewRequestHandler (see its documentation).
 //
 // Successful responses are encoded into a pooled in-memory buffer before being written to the live
 // response writer, so encode failures do not leak partial success bodies.
@@ -97,6 +103,10 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 		defer cont.pool.Put(buffer)
 
 		if err := mediaType.Encoder.Encode(buffer, data); err != nil {
+			if errors.Is(err, encodingerrors.ErrInvalidType) {
+				err = status.SafeError(http.StatusNotAcceptable, err)
+			}
+
 			_ = status.WriteError(ctx, res, err)
 
 			return

--- a/net/http/content/unary/handler_test.go
+++ b/net/http/content/unary/handler_test.go
@@ -165,6 +165,32 @@ func TestNewHandlerDoesNotLeakPartialBodyWhenEncodeFails(t *testing.T) {
 	test.RequireResponseBodyNotContains(t, res, "partial")
 }
 
+func TestNewHandlerRejectsUnencodableAcceptAsNotAcceptable(t *testing.T) {
+	for _, mediaType := range []string{
+		media.Text, "application/octet-stream", media.Protobuf, media.ProtobufText, media.ProtobufJSON,
+	} {
+		t.Run(mediaType, func(t *testing.T) {
+			called := false
+			handler := unary.NewHandler(test.UnaryContent, func(_ context.Context) (*test.Response, error) {
+				called = true
+
+				return &test.Response{Greeting: "Hello Bob"}, nil
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+			req.Header.Set(http.AcceptKey, mediaType)
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.True(t, called)
+			require.Equal(t, http.StatusNotAcceptable, res.Code)
+			require.Equal(t, "text/error; charset=utf-8", res.Header().Get(http.ContentTypeKey))
+			test.RequireTrimmedResponseBody(t, res, "http: not acceptable")
+		})
+	}
+}
+
 func TestNewHandlerRejectsUnavailableResponseCodec(t *testing.T) {
 	enc := encoding.NewMap()
 	enc.Register("json", nil)


### PR DESCRIPTION
## What

- `net/http/content/unary`'s response handler now maps an `encoding/errors.ErrInvalidType` encode failure to `406 Not Acceptable` instead of the default `500`. This happens when a response value doesn't satisfy the negotiated encoder's required type — for example, Accept: `application/protobuf`/`prototext`/`protojson` against a handler whose response isn't a `proto.Message`, or Accept: `text/plain`/`application/octet-stream` against a value that isn't `io.WriterTo`.
- Added `TestNewHandlerRejectsUnencodableAcceptAsNotAcceptable`, covering `media.Text`, `application/octet-stream`, `media.Protobuf`, `media.ProtobufText`, and `media.ProtobufJSON`.
- Documented the new encode-error status mapping in `NewRequestHandler`'s and `NewHandler`'s GoDoc, alongside the existing decode-error → 400 mapping.

## Why

- The unary handler already resolves the response media type through content negotiation, but a value that can't actually be represented in that negotiated type only failed later, at encode time — previously producing an opaque, misleading 500 instead of a 406 telling the client its Accept choice can't be satisfied for this response.
- This brings unary handlers in line with the streaming handler (`net/http/content/stream`), which already returns 406 when Accept can't be satisfied, just at negotiation time instead of encode time.
- This changes an observable status code (500 → 406) for callers hitting this specific encode-time mismatch. It's a deliberate correctness fix rather than a new capability, and is scoped narrowly to the `encodingerrors.ErrInvalidType` sentinel — other encode failures (marshal errors, write errors) keep their existing default status.

## Testing

- `package=net/http/content/unary make specs` - passed (127 tests)
- `package=net/http/content/unary make golangci-lint` - passed (0 issues)
- `package=net/http/content/unary make coverage` - `newHandler` remains at 100% statement coverage
- The new test asserts `called: true` before checking the response, confirming the 406 comes from the encode-time branch and not the pre-existing nil-encoder negotiation path (covered separately by `TestNewHandlerRejectsUnavailableResponseCodec`).
