### PR TITLE
feat(transport): sanitize request-id and user-agent before writing to outgoing metadata

### DIFF
--- a/net/grpc/meta/client.go
+++ b/net/grpc/meta/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/net/header"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"google.golang.org/grpc"
@@ -74,13 +75,39 @@ func clientMetadata(ctx context.Context, userAgent env.UserAgent, generator id.G
 	md, ok := FromOutgoingContext(ctx)
 	ua := clientUserAgent(ctx, md, userAgent)
 	requestID := clientRequestID(ctx, generator, md)
+	wireUA := wireUserAgent(ua.Value(), userAgent.String())
+	wireID := wireRequestID(requestID.Value(), generator)
 	if !ok {
-		return clientOutgoingHeaders(ua.Value(), requestID.Value()), ua, requestID
+		return clientOutgoingHeaders(wireUA, wireID), ua, requestID
 	}
 
-	setClientOutgoingHeaders(md, ua.Value(), requestID.Value())
+	setClientOutgoingHeaders(md, wireUA, wireID)
 
 	return md, ua, requestID
+}
+
+// wireUserAgent returns userAgent if it satisfies gRPC's printable-ASCII metadata value contract, otherwise the
+// configured fallback, so a caller-supplied value outside that contract cannot fail the whole outgoing call. The
+// context attribute keeps the original resolved value; only the value written to outgoing metadata is
+// constrained.
+func wireUserAgent(userAgent, fallback string) string {
+	if header.ValidMetadataValue(userAgent) {
+		return userAgent
+	}
+
+	return fallback
+}
+
+// wireRequestID returns requestID if it satisfies gRPC's printable-ASCII metadata value contract, otherwise a
+// freshly generated id, so a caller-supplied value outside that contract cannot fail the whole outgoing call.
+// The context attribute keeps the original resolved value; only the value written to outgoing metadata is
+// constrained.
+func wireRequestID(requestID string, generator id.Generator) string {
+	if header.ValidMetadataValue(requestID) {
+		return requestID
+	}
+
+	return generator.Generate()
 }
 
 func clientOutgoingHeaders(userAgent, requestID string) Map {

--- a/net/grpc/meta/doc.go
+++ b/net/grpc/meta/doc.go
@@ -33,6 +33,15 @@
 // use it as the idempotency key for retryable write operations. It is not a
 // per-wire attempt id.
 //
+// Client interceptors write a fresh generated id to outgoing "request-id"
+// metadata instead of a resolved value that fails gRPC's printable-ASCII
+// metadata value contract, because gRPC rejects an entire outgoing call when
+// any metadata value contains a non-printable byte. The context attribute
+// keeps the original resolved value, so the wire value can diverge from
+// [meta.RequestID] when the resolved value was invalid. The same substitution
+// applies to outgoing "user-agent" metadata, falling back to the configured
+// default user agent instead of a generated id.
+//
 // # Forwarded IP trust boundary
 //
 // Server metadata extraction intentionally treats common forwarding metadata,

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -81,6 +81,26 @@ func TestUnaryClientInterceptorPreservesOutgoingRequestID(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnaryClientInterceptorSanitizesNonPrintableMetadata(t *testing.T) {
+	ctx := grpcmeta.WithAttributes(t.Context(),
+		grpcmeta.WithUserAgent(grpcmeta.String("aaé")),
+		grpcmeta.WithRequestID(grpcmeta.String("aaé")),
+	)
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).UnaryInterceptor()
+
+	err := interceptor(ctx, "/greet.v1.Greeter/SayHello", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{"fallback-agent"}, md.Get("user-agent"))
+		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
+		require.Equal(t, grpcmeta.String("aaé"), grpcmeta.UserAgent(ctx))
+		require.Equal(t, grpcmeta.String("aaé"), meta.RequestID(ctx))
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 	ctx := grpcmeta.WithAttributes(t.Context(),
 		grpcmeta.WithUserAgent(grpcmeta.String("current-agent")),
@@ -99,6 +119,30 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
 		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+
+		return nil, nil
+	}
+
+	stream, err := interceptor(
+		ctx, &grpc.StreamDesc{ServerStreams: true}, nil, "/greet.v1.Greeter/SayStreamHello", streamer,
+	)
+	require.NoError(t, err)
+	require.Nil(t, stream)
+}
+
+func TestStreamClientInterceptorSanitizesNonPrintableMetadata(t *testing.T) {
+	ctx := grpcmeta.WithAttributes(t.Context(),
+		grpcmeta.WithUserAgent(grpcmeta.String("aaé")),
+		grpcmeta.WithRequestID(grpcmeta.String("aaé")),
+	)
+	interceptor := grpcmeta.NewClient(env.UserAgent("fallback-agent"), test.StaticIDGenerator("generated-id")).StreamInterceptor()
+	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+		md, ok := grpcmeta.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{"fallback-agent"}, md.Get("user-agent"))
+		require.Equal(t, []string{"generated-id"}, md.Get("request-id"))
+		require.Equal(t, grpcmeta.String("aaé"), grpcmeta.UserAgent(ctx))
+		require.Equal(t, grpcmeta.String("aaé"), meta.RequestID(ctx))
 
 		return nil, nil
 	}

--- a/net/header/doc.go
+++ b/net/header/doc.go
@@ -7,5 +7,5 @@
 // extracted IPs for access logs, policy, or rate limiting should only receive traffic through trusted edge
 // infrastructure that strips or overwrites client-supplied forwarding headers.
 //
-// Start with [ParseBearer], [ValidFieldName], [ValidFieldValue], and [ForwardedIPs].
+// Start with [ParseBearer], [ValidFieldName], [ValidFieldValue], [ValidMetadataValue], and [ForwardedIPs].
 package header

--- a/net/header/header.go
+++ b/net/header/header.go
@@ -28,18 +28,16 @@ var ForwardedIPs = [...]ForwardedIP{
 	{HTTP: "X-Forwarded-For", GRPC: "x-forwarded-for"},
 }
 
-var (
-	// ErrInvalidAuthorization is returned when an Authorization header cannot be parsed.
-	//
-	// This is returned when the header does not contain a scheme and value separated by a single ASCII space
-	// (i.e. it cannot be split as "<scheme> <value>").
-	ErrInvalidAuthorization = errors.New("header: authorization is invalid")
+// ErrInvalidAuthorization is returned when an Authorization header cannot be parsed.
+//
+// This is returned when the header does not contain a scheme and value separated by a single ASCII space
+// (i.e. it cannot be split as "<scheme> <value>").
+var ErrInvalidAuthorization = errors.New("header: authorization is invalid")
 
-	// ErrNotSupportedAuthorization is returned when the Authorization scheme is not supported.
-	//
-	// This is returned when the parsed scheme is not Bearer.
-	ErrNotSupportedAuthorization = errors.New("header: authorization is not supported")
-)
+// ErrNotSupportedAuthorization is returned when the Authorization scheme is not supported.
+//
+// This is returned when the parsed scheme is not Bearer.
+var ErrNotSupportedAuthorization = errors.New("header: authorization is not supported")
 
 // ForwardedIP describes one forwarding header used to derive a client IP address.
 type ForwardedIP struct {
@@ -63,6 +61,20 @@ func ValidFieldName(name string) bool {
 // ValidFieldValue reports whether value is a valid HTTP header field value.
 func ValidFieldValue(value string) bool {
 	return httpguts.ValidHeaderFieldValue(value)
+}
+
+// ValidMetadataValue reports whether value is a valid gRPC metadata value.
+//
+// gRPC rejects the entire outgoing metadata set if any value contains a byte outside printable ASCII
+// (%x20-%x7E); see hasNotPrintable in vendor/google.golang.org/grpc/internal/metadata/metadata.go.
+func ValidMetadataValue(value string) bool {
+	for i := range len(value) {
+		if value[i] < 0x20 || value[i] > 0x7E {
+			return false
+		}
+	}
+
+	return true
 }
 
 // ParseBearer parses an HTTP Authorization header and returns its bearer token value.

--- a/net/header/header_test.go
+++ b/net/header/header_test.go
@@ -75,6 +75,32 @@ func TestFieldValueAcceptsValidValue(t *testing.T) {
 	}
 }
 
+func TestMetadataValueAcceptsValidValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "plain", value: "request-id", valid: true},
+		{name: "empty", value: strings.Empty, valid: true},
+		{name: "space", value: "current id", valid: true},
+		{name: "tab", value: "a\tb"},
+		{name: "newline", value: "a\nb"},
+		{name: "nul", value: "a\x00b"},
+		{name: "unicode", value: "aaé"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.valid, header.ValidMetadataValue(tt.value))
+		})
+	}
+}
+
 func TestParseBearerAcceptsLowercaseScheme(t *testing.T) {
 	t.Parallel()
 

--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/env"
 	"github.com/alexfalkowski/go-service/v2/id"
 	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/net/header"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/slices"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -54,17 +55,40 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if clonedReq.Header == nil {
 		clonedReq.Header = http.Header{}
 	}
-	clientSetRequestHeaders(clonedReq.Header, userAgent.Value(), requestID.Value())
+	clientSetRequestHeaders(clonedReq.Header, wireUserAgent(userAgent.Value(), r.userAgent.String()), wireRequestID(requestID.Value(), r.generator))
 
 	return r.RoundTripper.RoundTrip(clonedReq)
 }
 
-func clientSetRequestHeaders(header http.Header, userAgent, requestID string) {
+func clientSetRequestHeaders(reqHeader http.Header, userAgent, requestID string) {
 	// Clip caps each header at one element so later appends allocate instead of
 	// overwriting the neighboring value in this backing array.
 	values := [...]string{userAgent, requestID}
-	header["User-Agent"] = slices.Clip(values[0:1])
-	header["Request-Id"] = slices.Clip(values[1:2])
+	reqHeader["User-Agent"] = slices.Clip(values[0:1])
+	reqHeader["Request-Id"] = slices.Clip(values[1:2])
+}
+
+// wireRequestID returns requestID if it satisfies the HTTP header field value contract, otherwise a freshly
+// generated id, so a caller-supplied value outside that contract cannot fail the outbound call. The context
+// attribute keeps the original resolved value; only the value written to the request header is constrained.
+func wireRequestID(requestID string, generator id.Generator) string {
+	if header.ValidFieldValue(requestID) {
+		return requestID
+	}
+
+	return generator.Generate()
+}
+
+// wireUserAgent returns userAgent if it satisfies the HTTP header field value contract, otherwise the configured
+// fallback, so a caller-supplied value outside that contract does not corrupt or get silently dropped from the
+// outbound header. The context attribute keeps the original resolved value; only the value written to the
+// request header is constrained.
+func wireUserAgent(userAgent, fallback string) string {
+	if header.ValidFieldValue(userAgent) {
+		return userAgent
+	}
+
+	return fallback
 }
 
 func clientUserAgent(ctx context.Context, req *http.Request, userAgent env.UserAgent) meta.Value {

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -51,5 +51,13 @@
 // it as the idempotency key for retryable write operations. It is not a per-wire
 // attempt id.
 //
+// [RoundTripper] writes a fresh generated id to the outgoing Request-Id header
+// instead of a resolved value that fails the HTTP header field value contract,
+// so an invalid value cannot corrupt or drop the header. The context attribute
+// keeps the original resolved value, so the wire value can diverge from
+// [meta.RequestID] when the resolved value was invalid. The same substitution
+// applies to the outgoing User-Agent header, falling back to the configured
+// default user agent instead of a generated id.
+//
 // This package also provides HTTP metadata middleware via [NewHandler] and [NewRoundTripper].
 package meta

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -71,6 +71,50 @@ func TestRoundTripperAppendDoesNotOverwriteRequestID(t *testing.T) {
 	require.Empty(t, req.Header.Values("Request-Id"))
 }
 
+func TestRoundTripperSanitizesInvalidMetadata(t *testing.T) {
+	roundTripper := httpmeta.NewRoundTripper(
+		env.UserAgent("fallback-agent"),
+		test.StaticIDGenerator("generated-id"),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "fallback-agent", req.Header.Get("User-Agent"))
+			require.Equal(t, "generated-id", req.Header.Get("Request-Id"))
+			require.Equal(t, "aa\x01bb", meta.UserAgent(req.Context()).Value())
+			require.Equal(t, "aa\x01bb", meta.RequestID(req.Context()).Value())
+
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "aa\x01bb")
+	req.Header.Set("Request-Id", "aa\x01bb")
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+}
+
+func TestRoundTripperKeepsHighByteMetadata(t *testing.T) {
+	roundTripper := httpmeta.NewRoundTripper(
+		env.UserAgent("fallback-agent"),
+		test.StaticIDGenerator("generated-id"),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "aaé", req.Header.Get("User-Agent"))
+			require.Equal(t, "aaé", req.Header.Get("Request-Id"))
+
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "aaé")
+	req.Header.Set("Request-Id", "aaé")
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+}
+
 func TestRoundTripperHandlesNilRequestHeader(t *testing.T) {
 	roundTripper := httpmeta.NewRoundTripper(
 		env.UserAgent("agent"),


### PR DESCRIPTION
## What

- Add `header.ValidMetadataValue`, a printable-ASCII (%x20-%x7E) check matching gRPC's own outgoing metadata value contract.
- gRPC and HTTP client metadata injection now write a sanitized value for both `request-id`/`Request-Id` and `user-agent`/`User-Agent` to the wire: if the resolved value fails the target transport's wire-format check (`header.ValidMetadataValue` for gRPC, the existing `header.ValidFieldValue` for HTTP), a replacement is written instead - a freshly generated id for request-id, the configured default user agent for user-agent. The context-visible value (`meta.RequestID`/`meta.UserAgent`) is left untouched, so logs/tracing keep the original resolved value even when the wire value was replaced.
- Update `net/header`'s package doc "Start with" list to include `ValidMetadataValue`, and add a short note to the `net/grpc/meta` and `net/http/meta` package docs describing when the wire value can diverge from the context value.
- Reformat the two `net/header` error vars from one grouped `var (...)` block into two standalone `var` declarations (each keeping its doc comment); no behavior change.

## Why

- grpc-go rejects an entire outgoing call when any outgoing metadata value contains a non-printable-ASCII byte (`imetadata.Validate`, checked in `newClientStream` before the call is even dialed). A caller-supplied or cross-service context-propagated `request-id`/`user-agent` containing e.g. a unicode character used to fail the whole RPC, not just that one field.
- On HTTP, an invalid header value doesn't fail the request the same way, but it can be silently dropped by HTTP/2 header encoding or passed through with raw invalid bytes on HTTP/1.1 - either way the header value on the wire silently diverges from what was intended, breaking downstream correlation.
- `user-agent` travels through the exact same outgoing metadata map/header set as `request-id` and is subject to the identical wire contract, so it carried the same failure mode. This is reachable whenever a service reads an untrusted incoming user-agent value into context (a supported extraction path) and reuses that context for a downstream client call - the same pattern this package already supports for request-id propagation.

## Testing

- `make specs package=net/header` - passed; covers the new `ValidMetadataValue` table (plain/empty/space accepted, tab/newline/nul/unicode rejected).
- `make specs package=net/grpc/meta` - passed; covers unary/stream client interceptors sanitizing non-printable request-id and user-agent to the generated id / configured fallback while preserving the original context value.
- `make specs package=net/http/meta` - passed; covers the round tripper sanitizing invalid (control-byte) request-id and user-agent while keeping high-byte (non-ASCII but valid HTTP field) values as-is, matching the looser HTTP wire contract.
- `make golangci-lint package=net/header`, `package=net/grpc/meta`, `package=net/http/meta` - 0 issues each.
- `make sec` - passed; 0 vulnerabilities in code we call (one pre-existing `golang.org/x/crypto/openpgp` advisory is unrelated and not invoked by this repo).
- `go build ./...` and `go vet ./...` - passed.
- Broader CI-equivalent targets (full `make specs`, `make fuzzes`, `make benchmarks`, `make coverage`) were not run locally; scoped validation covered the changed packages only.
