### PR TITLE
docs(readme): clarify http route middleware behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,14 @@ router.HandleRoute(
 )
 ```
 
+> [!WARNING]
+> `http.WithRouteOperation` is for service-owned infrastructure paths, such as the health and metrics routes.
+> Operation matching is path-only, so it marks the pattern's path for **every** method — marking `GET /feed`
+> also marks a separately registered `POST /feed` — and supported middleware treats an operation route as
+> exempt from token verification, access control, and rate limiting, and omits its per-request outcome log
+> line. `http.WithRouteUnauthenticated` instead bypasses transport token verification and access control while
+> retaining rate limiting and normal outcome logging; use it only when another boundary protects the route.
+
 REST and RPC route helpers accept HTTP route options. Streaming helpers add their inherent stream direction,
 and supplied streaming options are additive. MVC accepts only `mvc.WithRouteUnauthenticated` for its view routes.
 MVC static helpers keep their `StaticOption` signature; use

--- a/docs/agents/accepted-design.md
+++ b/docs/agents/accepted-design.md
@@ -321,12 +321,14 @@ areas without accounting for the entry that covers it.
   callers stop prefixing.
 - HTTP `net/http/client.Options.ContentType` is expected to be a real encodable
   request media type. Error media types (`text/error` and other `*/error`
-  subtypes) are internal error-response media with no encoder, so `Client.Do`
-  panics if one is supplied together with a request body. This is intentional:
-  error media are not valid request content types and callers control
-  `ContentType`. Do not flag the missing nil-encoder guard in `Client.Do` as a
-  bug based on supplying an error media type as a request content type; report
-  only concrete bugs where a valid request media type panics or fails to encode.
+  subtypes) are internal error-response media with no encoder, so supplying one
+  together with a request body is rejected rather than encoded: `Client.Do`
+  returns `http: encode: unary: unsupported media` from `newRequest`'s
+  nil-encoder guard and sends no request. This is intentional: error media are
+  not valid request content types and callers control `ContentType`. Do not flag
+  that rejection, or the matching nil-encoder guard on `Client.Do`'s
+  response-decode path, as a bug based on supplying an error media type; report
+  only concrete bugs where a valid request media type fails to encode.
 - gRPC client constructor options use the package's last-wins functional option
   convention. `WithClientDialOption`, `WithClientUnaryInterceptors`, and
   `WithClientStreamInterceptors` expect all custom values for one client

--- a/net/http/body/body.go
+++ b/net/http/body/body.go
@@ -33,6 +33,11 @@ func Close(body io.ReadCloser) {
 // requests, it replaces req.Body with a fresh buffered body so downstream
 // handlers can read it normally, and closes the original body after handler
 // returns.
+//
+// Closing the original body is arranged only once buffering has been attempted, so the two rejections
+// that return before that — the Content-Length short-circuit and a buffering read error — leave it open.
+// The standard library server closes the request body itself once its handler returns, so this is
+// observable only to a non-stdlib embedder that serves this handler directly.
 func NewHandler(handler http.Handler, limit int64) http.Handler {
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.ContentLength > limit {

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -153,7 +153,9 @@ type Options struct {
 	Response any
 
 	// ContentType is the request Content-Type used for encoding and the fallback decoder selection
-	// when Accept and the response Content-Type header are not set.
+	// when the response carries no Content-Type header. Accept never selects the response decoder
+	// itself; it is only sent on the request, so it acts on decoding indirectly, through the
+	// Content-Type the server chooses to answer with.
 	ContentType string
 
 	// Accept is the response Accept media type sent on the request.

--- a/net/http/events/events.go
+++ b/net/http/events/events.go
@@ -53,6 +53,11 @@ func NewClient(httpClient http.Client) Client {
 // This wrapper supports the repository's standard receiver path: it uses the
 // default CloudEvents HTTP protocol with a typed ReceiverFunc and does not
 // expose CloudEvents constructor errors to callers.
+//
+// ctx is passed through for the upstream constructor's signature and does not
+// bound the returned handler: the CloudEvents receive handler retains no
+// construction-time context and serves every request with that request's own
+// context. Cancel the server, not this ctx, to stop receiving.
 func NewReceiveHandler(ctx context.Context, receiver ReceiverFunc) http.Handler {
 	protocol, _ := cloudevents.NewHTTP()
 

--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -12,16 +12,26 @@ type routeOptions struct {
 	responseStreaming bool
 }
 
-// WithRouteOperation marks a route as a service-owned operation path.
+// WithRouteOperation marks a route as a service-owned operation path, for infrastructure endpoints such
+// as the health and metrics routes registered by transport/http/health and transport/http/telemetry/metrics.
 //
 // Operation matching is path-only so method mismatches can reach the mux and receive normal method handling.
+// Registration therefore marks the pattern's path for every method: registering "GET /admin" as an operation
+// also marks a "POST /admin" registered by a separate HandleRoute call without this option.
+//
+// Supported middleware treats an operation route as exempt from transport token verification, access control,
+// and rate limiting, and omits its per-request outcome log line (a recovered panic is still logged).
+// WithRouteUnauthenticated instead bypasses transport token verification and access control while retaining
+// rate limiting and normal outcome logging; use it only when another boundary protects the route.
 func WithRouteOperation() RouteOption {
 	return func(options *routeOptions) {
 		options.operation = true
 	}
 }
 
-// WithRouteUnauthenticated marks a route as not requiring transport token authentication.
+// WithRouteUnauthenticated marks a route to bypass transport token verification and access control.
+//
+// It retains rate limiting and normal outcome logging, so use it only when another boundary protects the route.
 func WithRouteUnauthenticated() RouteOption {
 	return func(options *routeOptions) {
 		options.unauthenticated = true

--- a/net/http/server/server.go
+++ b/net/http/server/server.go
@@ -40,7 +40,7 @@ func NewService(name string, http *http.Server, cfg *config.Config, logger *logg
 //
 // Address parsing:
 // The cfg.Address is expected to use the go-service network address convention "<network>://<address>"
-// (for example "tcp://:8080"). It is split using [net.SplitNetworkAddress] and then passed to [net.Listen].
+// (for example "tcp://:8080"). It is resolved using [net.ListenNetworkAddress] and then passed to [net.Listen].
 //
 // Listener lifecycle:
 // NewServer creates and stores the listener immediately. The listener is used by Serve/ServeTLS. If listener

--- a/net/http/server/server_test.go
+++ b/net/http/server/server_test.go
@@ -52,10 +52,14 @@ func TestShutdownClosesUnservedListener(t *testing.T) {
 
 func TestShutdownClosesActiveConnectionsWhenContextCanceled(t *testing.T) {
 	started := make(chan struct{})
+
+	// Bind loopback rather than the wildcard address: [net/http.ProxyFromEnvironment] bypasses a configured
+	// proxy only for localhost and loopback hosts, and a proxy between this client and the server answers
+	// the severed connection with its own 502 instead of the transport error asserted below.
 	srv, err := server.NewServer(&http.Server{Handler: http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		close(started)
 		<-req.Context().Done()
-	})}, &config.Config{Address: ":0"})
+	})}, &config.Config{Address: test.RandomHost()})
 	require.NoError(t, err)
 
 	serveErr := make(chan error, 1)


### PR DESCRIPTION
## What

- Clarify HTTP route-policy effects, including operation-path matching and the protections bypassed by unauthenticated routes.
- Correct related GoDoc for client media selection, request-body cleanup, CloudEvents receiver contexts, and server address resolution.
- Make the active-connection shutdown test proxy-independent by binding its server to loopback.

## Why

- Give service authors accurate security guidance before they configure a route that needs an alternative protection boundary, while documenting the existing HTTP contracts more precisely.

## Testing

- `make package=net/http specs` - passed
- `make package=net/http/body specs` - passed
- `make package=net/http/client specs` - passed
- `make package=net/http/events specs` - passed
- `make package=net/http/server specs` - passed
- `make lint` - passed
- Updated shutdown coverage remains deterministic when an HTTP proxy is configured.

AI-assisted-by: [Codex](https://openai.com/codex/)
