### PR TITLE
feat(http): fix forwarded-ip trimming, accept parsing, and streaming edge cases

### DIFF
--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -334,7 +334,7 @@ func TestUnaryServerInterceptorStoresPeerIPAddr(t *testing.T) {
 
 func TestUnaryServerInterceptorPrefersForwardedIPAddr(t *testing.T) {
 	interceptor := grpcmeta.NewServer(method.NewPolicy(), env.UserAgent("fallback-agent"), env.Version("v1"), test.StaticIDGenerator("generated-id"), 0).UnaryInterceptor()
-	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("x-forwarded-for", "203.0.113.10, 10.0.0.1"))
+	ctx := grpcmeta.NewIncomingContext(t.Context(), grpcmeta.Pairs("x-forwarded-for", " 203.0.113.10 , 10.0.0.1"))
 	ctx = peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 8080}})
 
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/greet.v1.Greeter/SayHello"}, func(ctx context.Context, _ any) (any, error) {

--- a/net/grpc/meta/server.go
+++ b/net/grpc/meta/server.go
@@ -173,6 +173,7 @@ func serverIPAddr(ctx context.Context) (meta.Value, meta.Value) {
 		k := h.GRPC
 		if f := serverValue(ctx, k); !strings.IsEmpty(f) {
 			ip, _, _ := strings.Cut(f, ",")
+			ip = strings.TrimSpace(ip)
 
 			return meta.String(k), meta.String(ip)
 		}

--- a/net/http/accept.go
+++ b/net/http/accept.go
@@ -25,9 +25,26 @@ import (
 func AcceptItems(header string) []string {
 	var items []string
 
+	for start := 0; ; {
+		end := acceptItemEnd(header[start:])
+		items = append(items, strings.TrimSpace(header[start:start+end]))
+
+		if start+end == len(header) {
+			return items
+		}
+
+		start += end + 1
+	}
+}
+
+// FirstAcceptItem returns the first item of header; see [AcceptItems] for the splitting rules.
+func FirstAcceptItem(header string) string {
+	return strings.TrimSpace(header[:acceptItemEnd(header)])
+}
+
+func acceptItemEnd(header string) int {
 	quoted := false
 	escaped := false
-	start := 0
 
 	for index := range header {
 		if escaped {
@@ -50,18 +67,12 @@ func AcceptItems(header string) []string {
 
 		if header[index] == ',' && !quoted {
 			// An HTTP list comma ends an item only outside a quoted string.
-			items = append(items, strings.TrimSpace(header[start:index]))
-			start = index + 1
+			return index
 		}
 	}
 
 	// Leave a single or malformed trailing item intact so the caller can accept or reject it.
-	return append(items, strings.TrimSpace(header[start:]))
-}
-
-// FirstAcceptItem returns the first item of header; see [AcceptItems] for the splitting rules.
-func FirstAcceptItem(header string) string {
-	return AcceptItems(header)[0]
+	return len(header)
 }
 
 // IsAcceptZeroQuality reports whether item's q parameter is present and exactly zero — the RFC 9110 §12.4.2

--- a/net/http/benchmark_test.go
+++ b/net/http/benchmark_test.go
@@ -2,10 +2,12 @@ package http_test
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/stretchr/testify/require"
 )
@@ -43,4 +45,19 @@ func BenchmarkClientTelemetry(b *testing.B) {
 	bench("disabled", func(testing.TB) {})
 	bench("metrics", test.EnableMetrics)
 	bench("tracer", test.EnableTracer)
+}
+
+func BenchmarkFirstAcceptItem(b *testing.B) {
+	for _, size := range []int{1 << 10, 1 << 16, 1 << 20} {
+		b.Run("commas="+strconv.Itoa(size), func(b *testing.B) {
+			header := "application/json," + strings.Repeat(",", size)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_ = http.FirstAcceptItem(header)
+			}
+		})
+	}
 }

--- a/net/http/budget/budget.go
+++ b/net/http/budget/budget.go
@@ -66,6 +66,7 @@ type Reader struct {
 	r    io.Reader
 	max  int64
 	read int64
+	seed int64
 }
 
 // Reset rearms the byte counter for the next decoded value. bufferedAhead has already been read from the
@@ -73,14 +74,15 @@ type Reader struct {
 // accounting rather than being discarded when the counter resets.
 func (r *Reader) Reset(bufferedAhead int64) {
 	r.read = bufferedAhead
+	r.seed = bufferedAhead
 }
 
 // Exceeds reports whether the bytes read since the last [Reader.Reset], minus bufferedAhead, exceed the
 // configured budget. bufferedAhead is the decoder's own read-ahead for a later value; subtracting it
 // corrects for a decoder that pulled more than one value's worth of bytes out of the reader in a single
 // underlying Read. The corrected count is clamped to zero, and this always reports false when the budget
-// is disabled (max <= 0). This is the post-decode check; [Reader.Read] applies its own uncorrected, live
-// check to bound a single pathological value across repeated Read calls.
+// is disabled (max <= 0). This is the post-decode check; [Reader.Read] applies its own seed-relative,
+// live check to bound a single pathological value across repeated Read calls.
 func (r *Reader) Exceeds(bufferedAhead int64) bool {
 	if r.max <= 0 {
 		return false
@@ -92,9 +94,9 @@ func (r *Reader) Exceeds(bufferedAhead int64) bool {
 }
 
 // Read implements [io.Reader]. Once the bytes read since the last [Reader.Reset] already exceed the
-// configured budget, Read refuses to read more and returns [ErrExceeded], and every subsequent call
-// returns that same error until Reset is called. Read never refuses to read when the budget is disabled
-// (max <= 0).
+// configured budget, excluding decoder read-ahead that [Reader.Reset] attributed to the previous value,
+// Read refuses to read more and returns [ErrExceeded], and every subsequent call returns that same error
+// until Reset is called. Read never refuses to read when the budget is disabled (max <= 0).
 func (r *Reader) Read(p []byte) (int, error) {
 	if r.exceededLive() {
 		return 0, ErrExceeded
@@ -116,11 +118,13 @@ func (r *Reader) Err() error {
 	return nil
 }
 
-// exceededLive reports the same live, uncorrected condition [Reader.Read] and [Reader.Err] both answer:
-// the budget is enabled and the raw count since the last [Reader.Reset] already exceeds it. This needs
-// no cached "latched" state of its own — r.read only advances when Read actually reads more from r,
-// which it refuses to do once this already reports true, so re-evaluating it on every call is exactly as
-// sticky as caching its first result would be, without an extra field to keep in sync with Reset.
+// exceededLive reports the same live condition [Reader.Read] and [Reader.Err] both answer: the budget is
+// enabled and reads made after the last [Reader.Reset] exceed it. Read-ahead is already buffered by the
+// decoder before Reset, so it belongs to the previous read and cannot spend the current value's live
+// budget. This needs no cached "latched" state of its own — r.read only advances when Read actually
+// reads more from r, which it refuses to do once this already reports true, so re-evaluating it on every
+// call is exactly as sticky as caching its first result would be, without an extra field to keep in sync
+// with Reset.
 func (r *Reader) exceededLive() bool {
-	return r.max > 0 && r.read > r.max
+	return r.max > 0 && r.read-r.seed > r.max
 }

--- a/net/http/budget/budget_test.go
+++ b/net/http/budget/budget_test.go
@@ -85,6 +85,22 @@ func TestReaderResetClearsLatchedError(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+func TestReaderResetExcludesReadAheadFromLiveCheck(t *testing.T) {
+	t.Parallel()
+
+	r := budget.NewReader(strings.NewReader("a"), 2)
+	r.Reset(3)
+
+	// The decoder read these bytes for the next value while handling the previous one. They must not
+	// spend the next value's live budget before it reads anything itself.
+	require.NoError(t, r.Err())
+
+	n, err := r.Read(make([]byte, 1))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.NoError(t, r.Err())
+}
+
 func TestReaderErrReturnsNilBeforeAnyRefusal(t *testing.T) {
 	t.Parallel()
 

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -237,6 +237,7 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 //   - Otherwise, if the status code is in the 4xx/5xx range, a generic status error is returned.
 //   - Otherwise, if opts.Response is non-nil, the response body is decoded into it using the encoder
 //     selected by the response Content-Type (falling back to opts.ContentType).
+//   - An empty successful response body is not decoded, leaving opts.Response unchanged.
 //
 // Notes:
 //   - Callers may pass the zero Options value when no request/response bodies are needed.
@@ -281,6 +282,10 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 		// an inbound request body); see the decoder-bounds rule in net/http/content/unary's documentation.
 		if responseMedia.Encoder == nil {
 			return errors.Prefix("http: decode", unary.ErrUnsupportedMedia)
+		}
+
+		if responseBody.Len() == 0 {
+			return nil
 		}
 
 		if err := responseMedia.Encoder.Decode(responseBody, opts.Response); err != nil {

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -32,6 +32,22 @@ func TestDoAllowsResponseAtMaxResponseSize(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDoAllowsEmptyResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(http.ContentTypeKey, media.JSON)
+		res.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
+	response := test.Response{Greeting: "unchanged"}
+
+	err := c.Get(t.Context(), server.URL, client.Options{Response: &response})
+
+	require.NoError(t, err)
+	require.Equal(t, "unchanged", response.Greeting)
+}
+
 func TestDoUsesConfiguredTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set(http.ContentTypeKey, media.Text)

--- a/net/http/client/stream.go
+++ b/net/http/client/stream.go
@@ -403,7 +403,7 @@ func (s *RequestResponseStream) Send(v any) error {
 }
 
 // finish closes the request-side pipe according to handlerErr, then always resolves and closes the
-// response. A response status error replaces only handlerErr when it is the stream's own closed-pipe
+// response. A resolved response error replaces only handlerErr when it is the stream's own closed-pipe
 // Send failure; all other handler and encoder errors retain priority.
 func (s *RequestResponseStream) finish(handlerErr error) error {
 	if handlerErr != nil {
@@ -416,7 +416,7 @@ func (s *RequestResponseStream) finish(handlerErr error) error {
 	}
 
 	closeErr := s.close()
-	if errors.Is(handlerErr, s.sendErr) && errors.Is(s.sendErr, io.ErrClosedPipe) && status.IsError(closeErr) {
+	if errors.Is(handlerErr, s.sendErr) && errors.Is(s.sendErr, io.ErrClosedPipe) && closeErr != nil {
 		return closeErr
 	}
 

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -353,6 +353,27 @@ func TestRequestStreamReturnsEarlyRejectionAfterSendFailure(t *testing.T) {
 	}
 }
 
+func TestRequestStreamReturnsTransportErrorAfterSendFailure(t *testing.T) {
+	rt := test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if err := req.Body.Close(); err != nil {
+			return nil, err
+		}
+
+		return nil, test.ErrFailed
+	})
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(rt))
+
+	var sendErr error
+	err := c.RequestStream(t.Context(), http.MethodPost, "http://example.com", client.Options{ContentType: media.NDJSON},
+		func(_ context.Context, stream *client.RequestResponseStream) error {
+			sendErr = stream.Send(&test.Request{Name: strings.Repeat("x", int(bytes.MB))})
+			return sendErr
+		})
+
+	require.ErrorIs(t, sendErr, io.ErrClosedPipe)
+	require.ErrorIs(t, err, test.ErrFailed)
+}
+
 func TestRequestStreamSendIsSticky(t *testing.T) {
 	handler := contentstream.NewRequestHandler(
 		test.StreamContent,
@@ -559,26 +580,50 @@ func TestStreamRecvDoesNotFalsePositiveOnCoalescedReads(t *testing.T) {
 	require.Equal(t, []string{"Hello Bob", "Hello Alice"}, greetings)
 }
 
-func TestStreamRecvRejectsBufferedValueOverCap(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-		res.Header().Set(http.ContentTypeKey, media.NDJSON)
-		_, _ = res.Write([]byte("{\"Greeting\":\"A\"}\n{\"Greeting\":\"a greeting far longer than the configured cap\"}\n"))
-	}))
-	t.Cleanup(server.Close)
+func TestStreamRecvHandlesBufferedValuesAtCap(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		exceedsCap bool
+	}{
+		{
+			name:       "over cap",
+			body:       "{\"Greeting\":\"A\"}\n{\"Greeting\":\"a greeting far longer than the configured cap\"}\n",
+			exceedsCap: true,
+		},
+		{
+			name: "within cap decode error",
+			body: "{\"Greeting\":\"A\"}\n{\"Greeting\":\"B\",\"Unknown\":true}\n",
+		},
+	}
 
-	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(20))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+				res.Header().Set(http.ContentTypeKey, media.NDJSON)
+				_, _ = res.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
 
-	err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
-		func(_ context.Context, stream *client.ResponseStream) error {
-			var first test.Response
-			require.NoError(t, stream.Recv(&first))
+			c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(20))
 
-			var second test.Response
-			return stream.Recv(&second)
+			err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
+				func(_ context.Context, stream *client.ResponseStream) error {
+					var first test.Response
+					require.NoError(t, stream.Recv(&first))
+
+					var second test.Response
+					return stream.Recv(&second)
+				})
+
+			require.Error(t, err)
+			if tt.exceedsCap {
+				require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+			} else {
+				require.NotEqual(t, http.StatusRequestEntityTooLarge, status.Code(err))
+			}
 		})
-
-	require.Error(t, err)
-	require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
+	}
 }
 
 func TestStreamClosesResponseBodyOnHandlerPanic(t *testing.T) {

--- a/net/http/content/stream/media.go
+++ b/net/http/content/stream/media.go
@@ -89,8 +89,10 @@ type streamAcceptMatch struct {
 // reports as satisfied by [ndjsonType] without non-quality parameters ("text/*" does not satisfy an
 // "application/x-ndjson" route the way "*/*" or "application/*" does), else the bare "*/*" wildcard —
 // and returns satisfiable only if that one reference is not [http.IsAcceptZeroQuality]; a less specific
-// reference's own quality, zero or not, is irrelevant once a more specific reference is found. This matches
-// RFC 9110 §12.5.1's "most specific reference" rule regardless of list order. When satisfiable, it returns
+// reference's own quality, zero or not, is irrelevant once a more specific reference is found. When two
+// references tie on specificity, the zero-quality one controls, so an explicit exclusion is not masked by
+// a duplicate positive entry for the same range. This matches RFC 9110 §12.5.1's "most specific reference"
+// rule regardless of list order. When satisfiable, it returns
 // the exact match's media type if the controlling reference was one, otherwise [media.NDJSON]. An
 // unparsable item is skipped rather than rejecting the whole list, the same way an unparsable single Accept
 // value already falls through to [Content.NewFromMedia]'s own rejection when nothing else in the list matches.
@@ -99,7 +101,7 @@ func matchStreamAccept(header string) (string, bool) {
 
 	for _, item := range http.AcceptItems(header) {
 		candidate := matchStreamRange(item)
-		if candidate.specificity > best.specificity {
+		if candidate.specificity > best.specificity || (candidate.specificity == best.specificity && candidate.zeroQuality) {
 			best = candidate
 		}
 	}

--- a/net/http/content/stream/media_test.go
+++ b/net/http/content/stream/media_test.go
@@ -218,6 +218,8 @@ func TestNewFromAcceptRejectsConcreteOnlyUnsatisfiableAccept(t *testing.T) {
 		{name: "zero quality exact match overrides a co-present bare wildcard, reversed", accept: "*/*, " + media.NDJSON + ";q=0"},
 		{name: "zero quality subtype wildcard overrides a co-present bare wildcard", accept: "application/*;q=0, */*"},
 		{name: "zero quality subtype wildcard overrides a co-present bare wildcard, reversed", accept: "*/*, application/*;q=0"},
+		{name: "zero quality exact match wins equal specificity tie", accept: media.NDJSON + ", " + media.NDJSON + ";q=0"},
+		{name: "zero quality exact match wins equal specificity tie, reversed", accept: media.NDJSON + ";q=0, " + media.NDJSON},
 	}
 
 	for _, tt := range tests {

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -602,6 +602,33 @@ func TestNewRequestHandlerRecvRejectsBufferedValueOverCap(t *testing.T) {
 	require.Equal(t, int64(16), maxBytesErr.Limit)
 }
 
+func TestNewRequestHandlerRecvReturnsDecodeErrorForBufferedValueWithinCap(t *testing.T) {
+	var secondErr error
+
+	handler := contentstream.NewRequestHandler(
+		test.StreamContent,
+		contentstream.Options{MaxReceiveSize: 16}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+			_, err := stream.Recv()
+			require.NoError(t, err)
+
+			_, secondErr = stream.Recv()
+			return secondErr
+		})
+
+	body := "{\"Name\":\"A\"}\n{\"Name\":\"B\",\"Unknown\":true}\n"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(body))
+	req.ProtoMajor = 2
+	req.Header.Set(http.ContentTypeKey, media.NDJSON)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Error(t, secondErr)
+	require.NotEqual(t, http.StatusRequestEntityTooLarge, status.Code(secondErr))
+	require.NotEqual(t, http.StatusRequestEntityTooLarge, res.Code)
+}
+
 func TestNewRequestHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavior(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/net/http/content/unary/content_test.go
+++ b/net/http/content/unary/content_test.go
@@ -303,11 +303,22 @@ func TestEveryEncoderKindIsClassified(t *testing.T) {
 		"msgpack": false, "gob": false,
 	}
 
+	content := unary.NewContent(encoding.NewMap(), test.Pool)
+
 	for _, kind := range encoding.NewMap().Keys() {
 		expected, ok := classified[kind]
 		require.True(t, ok, "kind %q needs an explicit request-decode classification", kind)
-		content := unary.NewContent(encoding.NewMap(), test.Pool)
 		require.Equal(t, expected, content.NewFromMedia("application/"+kind).CanDecodeRequest(), "kind %q", kind)
+	}
+
+	for alias, kind := range map[string]string{
+		"pb": "protobuf", "pbbin": "protobuf", "proto": "protobuf", "protobin": "protobuf",
+		"pbtxt": "prototext", "prototxt": "prototext", "pbjson": "protojson",
+		"octet-stream": "bytes", "plain": "bytes",
+	} {
+		expected, ok := classified[kind]
+		require.True(t, ok, "alias %q resolves to unclassified kind %q", alias, kind)
+		require.Equal(t, expected, content.NewFromMedia("application/"+alias).CanDecodeRequest(), "alias %q", alias)
 	}
 }
 

--- a/net/http/content/unary/media.go
+++ b/net/http/content/unary/media.go
@@ -81,7 +81,7 @@ func (t Media) IsError() bool {
 // fallback therefore reports JSON's answer, because JSON is genuinely what it holds; only
 // Content.NewFromRequestBody resolves a request Content-Type strictly.
 func (t Media) CanDecodeRequest() bool {
-	return t.Encoder != nil && policy.CanDecode(t.Subtype())
+	return t.Encoder != nil && policy.CanDecode(unaryKind(t.Subtype()))
 }
 
 func knownMedia(mediaType string, enc *encoding.Map) (Media, bool) {

--- a/net/http/meta/client.go
+++ b/net/http/meta/client.go
@@ -80,15 +80,18 @@ func wireRequestID(requestID string, generator id.Generator) string {
 }
 
 // wireUserAgent returns userAgent if it satisfies the HTTP header field value contract, otherwise the configured
-// fallback, so a caller-supplied value outside that contract does not corrupt or get silently dropped from the
-// outbound header. The context attribute keeps the original resolved value; only the value written to the
-// request header is constrained.
+// fallback when it also satisfies the contract, otherwise an empty value that omits the header. The context
+// attribute keeps the original resolved value; only the value written to the request header is constrained.
 func wireUserAgent(userAgent, fallback string) string {
 	if header.ValidFieldValue(userAgent) {
 		return userAgent
 	}
 
-	return fallback
+	if header.ValidFieldValue(fallback) {
+		return fallback
+	}
+
+	return strings.Empty
 }
 
 func clientUserAgent(ctx context.Context, req *http.Request, userAgent env.UserAgent) meta.Value {

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -57,7 +57,8 @@
 // keeps the original resolved value, so the wire value can diverge from
 // [meta.RequestID] when the resolved value was invalid. The same substitution
 // applies to the outgoing User-Agent header, falling back to the configured
-// default user agent instead of a generated id.
+// default user agent only when it satisfies the same contract; otherwise the
+// header is omitted.
 //
 // This package also provides HTTP metadata middleware via [NewHandler] and [NewRoundTripper].
 package meta

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	httpmeta "github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 	"github.com/stretchr/testify/require"
 )
@@ -92,6 +93,43 @@ func TestRoundTripperSanitizesInvalidMetadata(t *testing.T) {
 	res, err := roundTripper.RoundTrip(req)
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
+}
+
+func TestRoundTripperOmitsInvalidUserAgentFallback(t *testing.T) {
+	roundTripper := httpmeta.NewRoundTripper(
+		env.UserAgent("fallback-\x01agent"),
+		test.StaticIDGenerator("generated-id"),
+		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, []string{strings.Empty}, req.Header.Values("User-Agent"))
+
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
+		}),
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "aa\x01bb")
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+}
+
+func TestRoundTripperOmitsInvalidUserAgentFallbackOnWire(t *testing.T) {
+	userAgent := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		userAgent <- req.Header.Get("User-Agent")
+		res.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	roundTripper := httpmeta.NewRoundTripper(env.UserAgent("fallback-\x01agent"), test.StaticIDGenerator("generated-id"), http.DefaultTransport)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
+	require.NoError(t, err)
+
+	res, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Empty(t, <-userAgent)
 }
 
 func TestRoundTripperKeepsHighByteMetadata(t *testing.T) {
@@ -247,6 +285,19 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 		require.Equal(t, meta.Ignored("GET /users/{id}"), meta.ServiceMethod(req.Context()))
 		require.Equal(t, "GET /users/{id}", req.Pattern)
 		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+	})
+}
+
+func TestHandlerTrimsForwardedIPAddr(t *testing.T) {
+	handler := httpmeta.NewHandler(env.UserAgent("agent"), env.Version("v1"), test.StaticIDGenerator("request-id"), nil, 1024)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("X-Forwarded-For", " 203.0.113.7 , 70.41.3.18")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
+		require.Equal(t, meta.String("x-forwarded-for"), meta.Attribute(req.Context(), meta.IPAddrKindKey))
+		require.Equal(t, meta.String("203.0.113.7"), meta.IPAddr(req.Context()))
 	})
 }
 

--- a/net/http/meta/server.go
+++ b/net/http/meta/server.go
@@ -149,6 +149,7 @@ func serverIP(req *http.Request) (meta.Value, meta.Value) {
 	for _, h := range header.ForwardedIPs {
 		if ip := req.Header.Get(h.HTTP); !strings.IsEmpty(ip) {
 			ip, _, _ := strings.Cut(ip, ",")
+			ip = strings.TrimSpace(ip)
 
 			return meta.String(h.GRPC), meta.String(ip)
 		}

--- a/telemetry/logger/logger_test.go
+++ b/telemetry/logger/logger_test.go
@@ -328,7 +328,7 @@ func TestRejectsInvalidOTLPEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestOTLPGRPCLogger(t *testing.T) {
+func TestOTLPOverGRPCLogger(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{
 		Kind:     "otlp",
@@ -350,7 +350,7 @@ func TestOTLPGRPCLogger(t *testing.T) {
 	require.NoError(t, lc.Stop(t.Context()))
 }
 
-func TestRejectsInvalidOTLPGRPCEndpoint(t *testing.T) {
+func TestRejectsInvalidOTLPOverGRPCEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{
 		Kind:     "otlp",
@@ -373,7 +373,7 @@ func TestRejectsInvalidOTLPGRPCEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestOTLPGRPCLoggerWithTLSHeaders(t *testing.T) {
+func TestOTLPOverGRPCLoggerWithTLSHeaders(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{
 		Kind:     "otlp",
@@ -424,7 +424,7 @@ func TestMissingOTLPEndpointIgnoresEnv(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrMissingEndpoint)
 }
 
-func TestOTLPGRPCLoggerWithBatchTuning(t *testing.T) {
+func TestOTLPOverGRPCLoggerWithBatchTuning(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &logger.Config{
 		Kind:               "otlp",

--- a/telemetry/metrics/reader_test.go
+++ b/telemetry/metrics/reader_test.go
@@ -158,7 +158,7 @@ func TestRejectsInvalidOTLPEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestOTLPGRPCReader(t *testing.T) {
+func TestOTLPOverGRPCReader(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{
 		Kind:     "otlp",
@@ -172,7 +172,7 @@ func TestOTLPGRPCReader(t *testing.T) {
 	require.NoError(t, reader.Shutdown(t.Context()))
 }
 
-func TestRejectsInvalidOTLPGRPCEndpoint(t *testing.T) {
+func TestRejectsInvalidOTLPOverGRPCEndpoint(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{
 		Kind:     "otlp",
@@ -187,7 +187,7 @@ func TestRejectsInvalidOTLPGRPCEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestOTLPGRPCReaderWithTLSHeaders(t *testing.T) {
+func TestOTLPOverGRPCReaderWithTLSHeaders(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &metrics.Config{
 		Kind:     "otlp",

--- a/telemetry/tracer/tracer_test.go
+++ b/telemetry/tracer/tracer_test.go
@@ -272,7 +272,7 @@ func TestRegisterInvalidOTLPEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestRegisterOTLPHTTPExporterDoesNotFollowRedirects(t *testing.T) {
+func TestRegisterOTLPOverHTTPExporterDoesNotFollowRedirects(t *testing.T) {
 	trustedHeaders := make(chan string, 1)
 	attackerHeaders := make(chan string, 1)
 	attacker := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
@@ -325,7 +325,7 @@ func TestRegisterOTLPHTTPExporterDoesNotFollowRedirects(t *testing.T) {
 	}
 }
 
-func TestRegisterOTLPGRPCExporter(t *testing.T) {
+func TestRegisterOTLPOverGRPCExporter(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})
@@ -347,7 +347,7 @@ func TestRegisterOTLPGRPCExporter(t *testing.T) {
 	require.True(t, tracer.IsEnabled())
 }
 
-func TestRegisterInvalidOTLPGRPCEndpoint(t *testing.T) {
+func TestRegisterInvalidOTLPOverGRPCEndpoint(t *testing.T) {
 	err := tracer.Register(tracer.TracerParams{
 		Lifecycle: fxtest.NewLifecycle(t),
 		Config: &tracer.Config{
@@ -363,7 +363,7 @@ func TestRegisterInvalidOTLPGRPCEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, otlp.ErrInsecureEndpoint)
 }
 
-func TestRegisterOTLPGRPCExporterWithTLSHeaders(t *testing.T) {
+func TestRegisterOTLPOverGRPCExporterWithTLSHeaders(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})
@@ -390,16 +390,16 @@ func TestRegisterOTLPGRPCExporterWithTLSHeaders(t *testing.T) {
 	require.True(t, tracer.IsEnabled())
 }
 
-func TestRegisterOTLPEndpointLoopbackIPs(t *testing.T) {
+func TestRegisterOTLPEndpointAddressSecurity(t *testing.T) {
 	headers := header.Map{"Authorization": "Bearer token"}
 	tests := []struct {
 		wantErr error
 		name    string
 		url     string
 	}{
-		{name: "IPv6 loopback", url: "http://[::1]:4318/v1/traces"},
-		{name: "private IPv4", url: "http://10.0.0.10:4318/v1/traces", wantErr: otlp.ErrInsecureEndpoint},
-		{name: "unique local IPv6", url: "http://[fd00::1]:4318/v1/traces", wantErr: otlp.ErrInsecureEndpoint},
+		{name: "IPV6 loopback", url: "http://[::1]:4318/v1/traces"},
+		{name: "private IPV4", url: "http://10.0.0.10:4318/v1/traces", wantErr: otlp.ErrInsecureEndpoint},
+		{name: "unique local IPV6", url: "http://[fd00::1]:4318/v1/traces", wantErr: otlp.ErrInsecureEndpoint},
 	}
 
 	for _, tt := range tests {
@@ -477,7 +477,7 @@ func requireSamplerRecording(t *testing.T, sampler *tracer.SamplerConfig, ctx co
 	require.Equal(t, want, span.IsRecording())
 }
 
-func TestRegisterOTLPGRPCExporterWithBatchTuning(t *testing.T) {
+func TestRegisterOTLPOverGRPCExporterWithBatchTuning(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, tracer.Register(tracer.TracerParams{Lifecycle: fxtest.NewLifecycle(t)}))
 	})


### PR DESCRIPTION
## What

- Trim surrounding whitespace from forwarded-IP header values before storing them as request metadata in both the HTTP and gRPC `meta` middleware, so a proxy-inserted space (`X-Forwarded-For: 1.2.3.4 , 5.6.7.8`) no longer leaks into the stored client IP.
- `net/http/accept.go`: `AcceptItems` and `FirstAcceptItem` now share a common `acceptItemEnd` scan instead of `FirstAcceptItem` building and discarding the full split; behavior is unchanged, only the allocation cost on this hot Accept-header path drops.
- `net/http/budget.Reader` gained a `seed` field so its live, uncorrected per-`Read` budget check excludes decoder read-ahead bytes that `Reset` already attributed to the previous decoded value, instead of double-counting them against the next value's budget.
- `client.Do` no longer attempts to decode an empty successful response body; `opts.Response` is left unchanged instead of erroring.
- `client.RequestResponseStream.finish` now surfaces a real close/transport error instead of the stream's own closed-pipe send error whenever one occurs while resolving and closing the response, rather than only when that error was specifically a status error.
- Fixed an Accept-header tie-break in `net/http/content/stream`'s streaming negotiation: when an exact zero-quality (`q=0`) entry and an equally-specific positive entry name the same media range, the zero-quality one now controls, so a client that both offers and excludes the same type is correctly rejected instead of accepted.
- `unary.Media.CanDecodeRequest` now resolves subtype aliases (`pb`, `pbjson`, `octet-stream`, etc.) through the same `unaryKind` mapping encoder lookup already uses before checking the decode-safety policy, keeping the two resolution paths consistent.
- `meta.wireUserAgent` now omits the outbound `User-Agent` header entirely, rather than writing an invalid fallback string onto the wire, when both the caller-supplied value and the configured fallback fail the HTTP header field-value contract.

## Why

These are small, independently triggerable correctness bugs surfaced while hardening the HTTP/gRPC transport layer's metadata, content-negotiation, and streaming paths. Left unfixed they produce: a malformed stored client IP, unnecessary allocation on a hot header-parsing path, mis-attributed budget accounting after decoder read-ahead, spurious decode errors on empty bodies, a misleading closed-pipe error masking a real transport failure, wrong negotiation on conflicting Accept headers, and an invalid User-Agent string written onto the wire.

## Testing

- `make specs package=net/http` - passed
- `make specs package=net/http/budget` - passed
- `make specs package=net/http/client` - passed
- `make specs package=net/http/content/stream` - passed
- `make specs package=net/http/content/unary` - passed
- `make specs package=net/http/meta` - passed
- `make specs package=net/grpc/meta` - passed
- `make golangci-lint package=<each of the 7 packages above>` - passed, 0 issues
- `make field-alignment package=<each of the 7 packages above>` - passed
- Each fix has a new or updated test that fails against the pre-fix code: forwarded-IP trimming, the budget read-ahead `seed` correction, the empty-body skip, the stream transport-error surfacing, the Accept-header tie-break, and the invalid-User-Agent-fallback omission were all independently verified this way, including an on-the-wire assertion for the User-Agent case.
- One exception: the `unary.Media.CanDecodeRequest` alias-resolution test does not currently discriminate old vs. new behavior, because none of today's aliases map to a policy-denied kind (`gob`/`msgpack`/`toml`); the fix is a consistency/future-proofing change with no observable effect yet.
- No CI run observed from this session; the standard lint/spec/security pipeline is expected as additional verification.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
