### PR TITLE
feat(http): rename budget package to quota and align content handler naming

### DIFF
--- a/internal/test/encoding.go
+++ b/internal/test/encoding.go
@@ -92,7 +92,7 @@ func (d *OpaqueErrorDecoder) Close() error {
 
 // TripleReadDecoder is a [stream.Decoder] test double that reads R one byte at a time exactly three
 // times per Decode call, regardless of intervening errors, exercising a
-// [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]'s sticky repeat-Read guard: a Read
+// [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader]'s sticky repeat-Read guard: a Read
 // call made after the reader has already latched a size-limit error from a previous call.
 type TripleReadDecoder struct {
 	R io.Reader
@@ -120,9 +120,9 @@ func (d *TripleReadDecoder) Close() error {
 // and always reports a successful decode, regardless of how many bytes that Read actually consumed.
 // A real streaming decoder's internal buffering strategy can vary by Go toolchain (for example under
 // GOEXPERIMENT=jsonv2), which can make it read incrementally and trip a
-// [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]'s live per-Read cap check before
+// [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader]'s live per-Read cap check before
 // Decode ever returns success. SingleReadDecoder bypasses that variability so a
-// [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader] post-decode size check can be
+// [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader] post-decode size check can be
 // exercised deterministically.
 type SingleReadDecoder struct {
 	R io.Reader

--- a/net/http/client/stream.go
+++ b/net/http/client/stream.go
@@ -6,8 +6,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	contentstream "github.com/alexfalkowski/go-service/v2/net/http/content/stream"
+	"github.com/alexfalkowski/go-service/v2/net/http/quota"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/runtime"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -432,7 +432,7 @@ func (s *RequestResponseStream) finish(handlerErr error) error {
 // size-capped reader over the response body.
 type responseDecoder struct {
 	decoder encodingstream.Decoder
-	capped  *budget.Reader
+	capped  *quota.Reader
 }
 
 func newResponseDecoder(c *Client, response *http.Response, opts Options) (*responseDecoder, error) {
@@ -445,7 +445,7 @@ func newResponseDecoder(c *Client, response *http.Response, opts Options) (*resp
 		return nil, errors.Prefix("http: stream media", err)
 	}
 
-	capped := budget.NewReader(response.Body, c.maxResponseSize)
+	capped := quota.NewReader(response.Body, c.maxResponseSize)
 
 	return &responseDecoder{decoder: resMedia.NewDecoder(capped), capped: capped}, nil
 }
@@ -455,7 +455,7 @@ func newResponseDecoder(c *Client, response *http.Response, opts Options) (*resp
 // truncating capped's reads, because truncating mid-read would silently drop bytes the decoder never
 // asked to give back — those bytes belong to the underlying response body, not to this one value, and
 // dropping them would desynchronize every later value in the stream. See
-// [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader] for the read-time half of the guard,
+// [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader] for the read-time half of the guard,
 // which still bounds a single pathological value across repeated Read calls.
 //
 // A decoder is not guaranteed to return capped's Read-time error unwrapped: it may fold it into its own
@@ -464,7 +464,7 @@ func newResponseDecoder(c *Client, response *http.Response, opts Options) (*resp
 // capped's own latched error directly once Decode fails, rather than trusting Decode's returned error
 // to still be classifiable as the size-limit error.
 func (d *responseDecoder) recv(v any) error {
-	d.capped.Reset(budget.BufferedLen(d.decoder))
+	d.capped.Reset(quota.BufferedLen(d.decoder))
 
 	if err := d.decoder.Decode(v); err != nil {
 		if d.capped.Err() != nil {
@@ -474,7 +474,7 @@ func (d *responseDecoder) recv(v any) error {
 		return err
 	}
 
-	if d.capped.Exceeds(budget.BufferedLen(d.decoder)) {
+	if d.capped.Exceeds(quota.BufferedLen(d.decoder)) {
 		return status.SafeError(http.StatusRequestEntityTooLarge, nil)
 	}
 

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -471,7 +471,7 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 			decoder:  func(r io.Reader) encodingstream.Decoder { return &test.OpaqueErrorDecoder{R: r} },
 		},
 		{
-			name:     "decoder calls Read again after budget.Reader already latched an error",
+			name:     "decoder calls Read again after quota.Reader already latched an error",
 			greeting: "ab",
 			maxSize:  1,
 			decoder:  func(r io.Reader) encodingstream.Decoder { return &test.TripleReadDecoder{R: r} },

--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -4,16 +4,16 @@ import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/quota"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/telemetry/tracer"
 )
 
-// NewHandler builds a handler for a send-only streaming response using cont to resolve streaming codecs and buffer
-// the initial response.
+// NewHandler builds a handler for a send-only streaming response using content to resolve streaming codecs and
+// buffer the initial response.
 //
 // Content negotiation:
 // The response encoder is resolved from the request Accept header, falling back to Content-Type,
@@ -42,7 +42,7 @@ import (
 // allowed to open the stream), every Send charges one additional token against that same limiter — see
 // [Stream.Send]. A route reached without that middleware, or with no limiter configured, sees no
 // per-message charging.
-func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http.HandlerFunc {
+func NewHandler[Res any](content *Content, opts Options, handler Handler[Res]) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		if isDraining(opts.Drain) {
@@ -51,7 +51,7 @@ func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http
 		}
 		http.AddVary(res.Header(), http.AcceptKey, http.ContentTypeKey)
 
-		resMedia, err := cont.NewFromAccept(req)
+		resMedia, err := content.NewFromAccept(req)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
@@ -61,8 +61,8 @@ func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http
 		res.Header().Set(http.ContentTypeKey, media.MustParse(resMedia.String()).WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
-		buffer := cont.pool.Get()
-		defer cont.pool.Put(buffer)
+		buffer := content.pool.Get()
+		defer content.pool.Put(buffer)
 
 		ctx, cancel := context.WithCancelCause(ctx)
 		defer cancel(nil)
@@ -104,8 +104,8 @@ func NewHandler[Res any](cont *Content, opts Options, handler Handler[Res]) http
 // return its error so the framework can finish the response.
 type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 
-// NewRequestHandler builds a handler for a bidirectional stream using cont to resolve streaming codecs and buffer
-// the initial response.
+// NewRequestHandler builds a handler for a bidirectional stream using content to resolve streaming codecs and
+// buffer the initial response.
 //
 // HTTP/2 requirement:
 // Bidirectional streaming requires HTTP/2 (including h2c): an HTTP/1.x request body is buffered ahead
@@ -121,7 +121,7 @@ type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 //
 // Inbound size limiting:
 // opts.MaxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a
-// whole (see [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]): a request with many small
+// whole (see [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader]): a request with many small
 // values is never rejected for its cumulative size, only
 // for a single value that exceeds opts.MaxReceiveSize. A value at or under the limit is a normal terminal
 // [http.MaxBytesError] surfaced from Recv; the deviation is that no total byte ceiling exists for a
@@ -138,7 +138,7 @@ type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 // decoded, in-cap value, the same way Send does, against the same request-scoped limiter. Its drain
 // contract also applies: drain cancels the handler context and closes the request body to unblock an
 // active Recv. A client can need to reconnect if an HTTP/2 peer observes that body close as a stream reset.
-func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler RequestHandler[Req, Res]) http.HandlerFunc {
+func NewRequestHandler[Req any, Res any](content *Content, opts Options, handler RequestHandler[Req, Res]) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		if isDraining(opts.Drain) {
@@ -152,13 +152,13 @@ func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler Re
 		}
 		http.AddVary(res.Header(), http.AcceptKey, http.ContentTypeKey)
 
-		reqMedia, err := cont.NewFromContentType(req)
+		reqMedia, err := content.NewFromContentType(req)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusUnsupportedMediaType, err))
 			return
 		}
 
-		resMedia, err := cont.NewFromAccept(req)
+		resMedia, err := content.NewFromAccept(req)
 		if err != nil {
 			_ = status.WriteError(ctx, res, status.SafeError(http.StatusNotAcceptable, err))
 			return
@@ -168,8 +168,8 @@ func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler Re
 		res.Header().Set(http.ContentTypeKey, media.MustParse(resMedia.String()).WithUTF8())
 		res.Header().Set(compress.HeaderNoCompression, "1")
 
-		buffer := cont.pool.Get()
-		defer cont.pool.Put(buffer)
+		buffer := content.pool.Get()
+		defer content.pool.Put(buffer)
 
 		ctx, cancel := context.WithCancelCause(ctx)
 		defer cancel(nil)
@@ -186,7 +186,7 @@ func NewRequestHandler[Req any, Res any](cont *Content, opts Options, handler Re
 		}
 
 		writer := &commitWriter{res: res, buffer: buffer}
-		capped := budget.NewReader(req.Body, opts.MaxReceiveSize.Bytes())
+		capped := quota.NewReader(req.Body, opts.MaxReceiveSize.Bytes())
 		decoder := reqMedia.NewDecoder(capped)
 		stream := &RequestStream[Req, Res]{
 			Stream: Stream[Res]{

--- a/net/http/content/stream/options.go
+++ b/net/http/content/stream/options.go
@@ -23,7 +23,7 @@ type Options struct {
 	WriteTimeout time.Duration
 
 	// MaxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a
-	// whole (see [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]). Zero disables the
+	// whole (see [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader]). Zero disables the
 	// per-value cap. Unused by [NewHandler]'s send-only stream.
 	MaxReceiveSize bytes.Size
 }

--- a/net/http/content/stream/stream.go
+++ b/net/http/content/stream/stream.go
@@ -6,8 +6,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
-	"github.com/alexfalkowski/go-service/v2/net/http/budget"
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/quota"
 	"github.com/alexfalkowski/go-service/v2/net/http/status"
 	"github.com/alexfalkowski/go-service/v2/ptr"
 	"github.com/alexfalkowski/go-service/v2/time"
@@ -172,7 +172,7 @@ func (s *Stream[Res]) close() error {
 // streaming convention, is one goroutine calling Recv and one goroutine calling Send.
 type RequestStream[Req any, Res any] struct {
 	decoder stream.Decoder
-	capped  *budget.Reader
+	capped  *quota.Reader
 	Stream[Res]
 	maxReceiveSize int64
 }
@@ -184,7 +184,7 @@ type RequestStream[Req any, Res any] struct {
 //
 // Recv is bounded independently by the per-value cap configured on [NewRequestHandler]: the cap
 // resets before every Recv rather than accumulating across the whole request stream (see
-// [github.com/alexfalkowski/go-service/v2/net/http/budget.Reader]). A value over the cap surfaces as a
+// [github.com/alexfalkowski/go-service/v2/net/http/quota.Reader]). A value over the cap surfaces as a
 // [http.MaxBytesError], the same error type
 // [github.com/alexfalkowski/go-service/v2/net/http/body.NewHandler]'s buffered path already produces,
 // so it maps to the same 413 through [github.com/alexfalkowski/go-service/v2/net/http/status.Code].
@@ -247,7 +247,7 @@ func (s *RequestStream[Req, Res]) decode() (*Req, error) {
 		return nil, err
 	}
 
-	s.capped.Reset(budget.BufferedLen(s.decoder))
+	s.capped.Reset(quota.BufferedLen(s.decoder))
 
 	req := ptr.Zero[Req]()
 	if err := s.decoder.Decode(req); err != nil {
@@ -262,7 +262,7 @@ func (s *RequestStream[Req, Res]) decode() (*Req, error) {
 		return nil, err
 	}
 
-	if s.capped.Exceeds(budget.BufferedLen(s.decoder)) {
+	if s.capped.Exceeds(quota.BufferedLen(s.decoder)) {
 		return nil, &http.MaxBytesError{Limit: s.maxReceiveSize}
 	}
 

--- a/net/http/content/unary/handler.go
+++ b/net/http/content/unary/handler.go
@@ -43,12 +43,12 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 // NewRequestHandler does not enforce request body size caps itself. In supported wiring, inbound request bodies
 // are capped by the transport HTTP server before content handlers run. Direct users should wrap the handler with
 // an equivalent request-size limit.
-func NewRequestHandler[Req any, Res any](cont *Content, handler RequestHandler[Req, Res]) http.HandlerFunc {
-	return newHandler(cont, func(ctx context.Context) (*Res, error) {
+func NewRequestHandler[Req any, Res any](content *Content, handler RequestHandler[Req, Res]) http.HandlerFunc {
+	return newHandler(content, func(ctx context.Context) (*Res, error) {
 		req := ptr.Zero[Req]()
 
 		request := meta.Request(ctx)
-		mediaType, err := cont.NewFromRequestBody(request)
+		mediaType, err := content.NewFromRequestBody(request)
 		if err != nil {
 			return nil, status.SafeError(http.StatusUnsupportedMediaType, err)
 		}
@@ -71,18 +71,18 @@ type Handler[Res any] func(ctx context.Context) (*Res, error)
 //
 // Successful responses are encoded into a pooled in-memory buffer before being written to the live
 // response writer, so encode failures do not leak partial success bodies.
-func NewHandler[Res any](cont *Content, handler Handler[Res]) http.HandlerFunc {
-	return newHandler(cont, func(ctx context.Context) (*Res, error) {
+func NewHandler[Res any](content *Content, handler Handler[Res]) http.HandlerFunc {
+	return newHandler(content, func(ctx context.Context) (*Res, error) {
 		return handler(ctx)
 	})
 }
 
-func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res, error)) http.HandlerFunc {
+func newHandler[Res any](content *Content, handler func(ctx context.Context) (*Res, error)) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		http.AddVary(res.Header(), http.AcceptKey, http.ContentTypeKey)
 
-		mediaType := cont.NewFromAccept(req)
+		mediaType := content.NewFromAccept(req)
 		ctx = meta.WithRequestResponse(ctx, req, res)
 		res.Header().Set(http.ContentTypeKey, media.MustParse(mediaType.String()).WithUTF8())
 
@@ -99,8 +99,8 @@ func newHandler[Res any](cont *Content, handler func(ctx context.Context) (*Res,
 			return
 		}
 
-		buffer := cont.pool.Get()
-		defer cont.pool.Put(buffer)
+		buffer := content.pool.Get()
+		defer content.pool.Put(buffer)
 
 		if err := mediaType.Encoder.Encode(buffer, data); err != nil {
 			if errors.Is(err, encodingerrors.ErrInvalidType) {

--- a/net/http/quota/doc.go
+++ b/net/http/quota/doc.go
@@ -1,4 +1,4 @@
-// Package budget provides a per-value byte budget for a stream decoder, shared by the HTTP server's
+// Package quota provides a per-value byte quota for a stream decoder, shared by the HTTP server's
 // bidirectional streaming request path
 // ([github.com/alexfalkowski/go-service/v2/net/http/content/stream.RequestStream.Recv]) and the HTTP client's
 // streaming response path ([github.com/alexfalkowski/go-service/v2/net/http/client.ResponseStream.Recv]).
@@ -15,4 +15,4 @@
 // ErrExceeded, instead of asking this package to build that error itself.
 //
 // Start with [NewReader].
-package budget
+package quota

--- a/net/http/quota/quota.go
+++ b/net/http/quota/quota.go
@@ -1,4 +1,4 @@
-package budget
+package quota
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
@@ -8,27 +8,34 @@ import (
 )
 
 // ErrExceeded is the sentinel [Reader.Read] latches, and [Reader.Err] returns, once a value's bytes
-// exceed the configured budget.
+// exceed the configured quota.
 //
-// ErrExceeded carries no data of its own: the budget's limit is already known to whichever caller
+// ErrExceeded carries no data of its own: the quota's limit is already known to whichever caller
 // constructed the [Reader] with it, so that caller builds whatever concrete, contract-specific error it
 // needs to return (for example a
 // [github.com/alexfalkowski/go-service/v2/net/http.MaxBytesError] carrying the limit, or a
 // [github.com/alexfalkowski/go-service/v2/net/http/status.SafeError]) once [Reader.Err] or
-// [Reader.Exceeds] tells it the budget was spent, rather than asking Reader to build that error itself.
-var ErrExceeded = errors.New("budget: exceeded")
+// [Reader.Exceeds] tells it the quota was spent, rather than asking Reader to build that error itself.
+var ErrExceeded = errors.New("quota: exceeded")
+
+// BufferedDecoder is implemented by a [stream.Decoder] that exposes its own read-ahead buffer, matching
+// [encoding/json.Decoder.Buffered]'s shape. [BufferedLen] uses it to correct a caller's read-ahead
+// accounting; a decoder that doesn't implement it gets no correction (see [BufferedLen]).
+type BufferedDecoder interface {
+	// Buffered returns the decoder's own unread, buffered input.
+	Buffered() io.Reader
+}
 
 // BufferedLen returns the number of bytes decoder has already pulled from its underlying reader for a
 // value it has not decoded yet, so a caller can subtract them from the raw bytes a [Reader] counted for
 // the value it just decoded (see [Reader.Exceeds]).
 //
-// This only recognizes decoders whose Buffered method matches [encoding/json.Decoder.Buffered]'s shape
-// and returns a concrete [bytes.Reader]. It returns 0 for any decoder that does not match, which is
-// always safe: the correction is skipped, not a wrong non-zero answer, so the check falls back to the
-// same "bound on reads attributed to one value" behavior documented on [Reader] rather than any
-// incorrect result.
+// This only recognizes a decoder implementing [BufferedDecoder] and returning a concrete [bytes.Reader]
+// from it. It returns 0 for any decoder that does not match, which is always safe: the correction is
+// skipped, not a wrong non-zero answer, so the check falls back to the same "bound on reads attributed
+// to one value" behavior documented on [Reader] rather than any incorrect result.
 func BufferedLen(decoder stream.Decoder) int64 {
-	buffered, ok := decoder.(interface{ Buffered() io.Reader })
+	buffered, ok := decoder.(BufferedDecoder)
 	if !ok {
 		return 0
 	}
@@ -41,26 +48,26 @@ func BufferedLen(decoder stream.Decoder) int64 {
 	return int64(reader.Len())
 }
 
-// NewReader constructs a Reader wrapping r with a per-value byte budget of limit. limit <= 0 disables
-// the budget entirely.
+// NewReader constructs a Reader wrapping r with a per-value byte quota of limit. limit <= 0 disables
+// the quota entirely.
 func NewReader(r io.Reader, limit int64) *Reader {
 	return &Reader{r: r, max: limit}
 }
 
-// Reader wraps an [io.Reader] with a resettable per-value byte budget, so a stream decoder bound to it
-// for a whole body gets a per-value cap rather than a cumulative one. The caller resets the budget via
+// Reader wraps an [io.Reader] with a resettable per-value byte quota, so a stream decoder bound to it
+// for a whole body gets a per-value cap rather than a cumulative one. The caller resets the quota via
 // [Reader.Reset] at the exact point a decoded value boundary is known.
 //
 // Reader never truncates or discards a Read call's data: every byte pulled from the underlying reader is
 // always returned to the caller, so a decoder's own internal buffering can never be desynchronized by
-// this guard. Read refuses to pull more data once the budget from a previous Read within the same value
+// this guard. Read refuses to pull more data once the quota from a previous Read within the same value
 // is already exceeded — a coarse, live backstop bounding a single pathological value across repeated
 // Read calls, not the authoritative bound. The guard is strictly greater-than, not at-or-above: a value
-// landing exactly on the budget still reaches the underlying reader for its terminating read (which may
+// landing exactly on the quota still reaches the underlying reader for its terminating read (which may
 // legitimately be [io.EOF]), rather than a synthetic refusal. A caller wanting the precise, corrected
 // bound uses [Reader.Exceeds] after a successful decode; see its bufferedAhead correction.
 //
-// A budget of zero or less disables it outright: Read never refuses to read and Exceeds always reports
+// A quota of zero or less disables it outright: Read never refuses to read and Exceeds always reports
 // false.
 type Reader struct {
 	r    io.Reader
@@ -78,9 +85,9 @@ func (r *Reader) Reset(bufferedAhead int64) {
 }
 
 // Exceeds reports whether the bytes read since the last [Reader.Reset], minus bufferedAhead, exceed the
-// configured budget. bufferedAhead is the decoder's own read-ahead for a later value; subtracting it
+// configured quota. bufferedAhead is the decoder's own read-ahead for a later value; subtracting it
 // corrects for a decoder that pulled more than one value's worth of bytes out of the reader in a single
-// underlying Read. The corrected count is clamped to zero, and this always reports false when the budget
+// underlying Read. The corrected count is clamped to zero, and this always reports false when the quota
 // is disabled (max <= 0). This is the post-decode check; [Reader.Read] applies its own seed-relative,
 // live check to bound a single pathological value across repeated Read calls.
 func (r *Reader) Exceeds(bufferedAhead int64) bool {
@@ -94,9 +101,9 @@ func (r *Reader) Exceeds(bufferedAhead int64) bool {
 }
 
 // Read implements [io.Reader]. Once the bytes read since the last [Reader.Reset] already exceed the
-// configured budget, excluding decoder read-ahead that [Reader.Reset] attributed to the previous value,
+// configured quota, excluding decoder read-ahead that [Reader.Reset] attributed to the previous value,
 // Read refuses to read more and returns [ErrExceeded], and every subsequent call returns that same error
-// until Reset is called. Read never refuses to read when the budget is disabled (max <= 0).
+// until Reset is called. Read never refuses to read when the quota is disabled (max <= 0).
 func (r *Reader) Read(p []byte) (int, error) {
 	if r.exceededLive() {
 		return 0, ErrExceeded
@@ -108,7 +115,7 @@ func (r *Reader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// Err returns [ErrExceeded] if the budget is already spent — the same condition a subsequent
+// Err returns [ErrExceeded] if the quota is already spent — the same condition a subsequent
 // [Reader.Read] would refuse on — or nil otherwise.
 func (r *Reader) Err() error {
 	if r.exceededLive() {
@@ -118,10 +125,10 @@ func (r *Reader) Err() error {
 	return nil
 }
 
-// exceededLive reports the same live condition [Reader.Read] and [Reader.Err] both answer: the budget is
+// exceededLive reports the same live condition [Reader.Read] and [Reader.Err] both answer: the quota is
 // enabled and reads made after the last [Reader.Reset] exceed it. Read-ahead is already buffered by the
 // decoder before Reset, so it belongs to the previous read and cannot spend the current value's live
-// budget. This needs no cached "latched" state of its own — r.read only advances when Read actually
+// quota. This needs no cached "latched" state of its own — r.read only advances when Read actually
 // reads more from r, which it refuses to do once this already reports true, so re-evaluating it on every
 // call is exactly as sticky as caching its first result would be, without an extra field to keep in sync
 // with Reset.

--- a/net/http/quota/quota_test.go
+++ b/net/http/quota/quota_test.go
@@ -1,39 +1,39 @@
-package budget_test
+package quota_test
 
 import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	streamjson "github.com/alexfalkowski/go-service/v2/encoding/stream/json"
+	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
 	"github.com/alexfalkowski/go-service/v2/io"
-	"github.com/alexfalkowski/go-service/v2/net/http/budget"
+	"github.com/alexfalkowski/go-service/v2/net/http/quota"
 	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/stretchr/testify/require"
 )
 
-func TestReaderReadDeliversValueAtExactBudget(t *testing.T) {
+func TestReaderReadDeliversValueAtExactQuota(t *testing.T) {
 	t.Parallel()
 
-	r := budget.NewReader(strings.NewReader("ab"), 2)
+	r := quota.NewReader(strings.NewReader("ab"), 2)
 	buf := make([]byte, 2)
 
 	n, err := r.Read(buf)
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
 
-	// A second read simulates a decoder's probe past the value's last byte; at exactly the budget, it
+	// A second read simulates a decoder's probe past the value's last byte; at exactly the quota, it
 	// must still reach the real underlying EOF instead of a synthetic refusal.
 	n, err = r.Read(buf)
 	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, 0, n)
 }
 
-func TestReaderReadRefusesOnceBudgetExceeded(t *testing.T) {
+func TestReaderReadRefusesOnceQuotaExceeded(t *testing.T) {
 	t.Parallel()
 
-	// The guard is strictly greater-than (see TestReaderReadDeliversValueAtExactBudget), so one read
-	// past the budget still succeeds; a fourth byte is needed to observe an actual refusal at max=2.
-	r := budget.NewReader(strings.NewReader("abcd"), 2)
+	// The guard is strictly greater-than (see TestReaderReadDeliversValueAtExactQuota), so one read
+	// past the quota still succeeds; a fourth byte is needed to observe an actual refusal at max=2.
+	r := quota.NewReader(strings.NewReader("abcd"), 2)
 	buf := make([]byte, 1)
 
 	for range 3 {
@@ -42,19 +42,19 @@ func TestReaderReadRefusesOnceBudgetExceeded(t *testing.T) {
 	}
 
 	n, err := r.Read(buf)
-	require.ErrorIs(t, err, budget.ErrExceeded)
+	require.ErrorIs(t, err, quota.ErrExceeded)
 	require.Equal(t, 0, n)
 
 	// Sticky: a repeated call after the refusal returns the same error without consulting the
 	// underlying reader again.
 	_, err = r.Read(buf)
-	require.ErrorIs(t, err, budget.ErrExceeded)
+	require.ErrorIs(t, err, quota.ErrExceeded)
 }
 
-func TestReaderReadNeverRefusesWhenBudgetDisabled(t *testing.T) {
+func TestReaderReadNeverRefusesWhenQuotaDisabled(t *testing.T) {
 	t.Parallel()
 
-	r := budget.NewReader(strings.NewReader(strings.Repeat("a", 10)), 0)
+	r := quota.NewReader(strings.NewReader(strings.Repeat("a", 10)), 0)
 	buf := make([]byte, 10)
 
 	n, err := r.Read(buf)
@@ -66,7 +66,7 @@ func TestReaderReadNeverRefusesWhenBudgetDisabled(t *testing.T) {
 func TestReaderResetClearsLatchedError(t *testing.T) {
 	t.Parallel()
 
-	r := budget.NewReader(strings.NewReader("ab"), 1)
+	r := quota.NewReader(strings.NewReader("ab"), 1)
 	buf := make([]byte, 1)
 
 	_, err := r.Read(buf)
@@ -75,7 +75,7 @@ func TestReaderResetClearsLatchedError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = r.Read(buf)
-	require.ErrorIs(t, err, budget.ErrExceeded)
+	require.ErrorIs(t, err, quota.ErrExceeded)
 
 	r.Reset(0)
 
@@ -88,11 +88,11 @@ func TestReaderResetClearsLatchedError(t *testing.T) {
 func TestReaderResetExcludesReadAheadFromLiveCheck(t *testing.T) {
 	t.Parallel()
 
-	r := budget.NewReader(strings.NewReader("a"), 2)
+	r := quota.NewReader(strings.NewReader("a"), 2)
 	r.Reset(3)
 
 	// The decoder read these bytes for the next value while handling the previous one. They must not
-	// spend the next value's live budget before it reads anything itself.
+	// spend the next value's live quota before it reads anything itself.
 	require.NoError(t, r.Err())
 
 	n, err := r.Read(make([]byte, 1))
@@ -104,7 +104,7 @@ func TestReaderResetExcludesReadAheadFromLiveCheck(t *testing.T) {
 func TestReaderErrReturnsNilBeforeAnyRefusal(t *testing.T) {
 	t.Parallel()
 
-	r := budget.NewReader(strings.NewReader("a"), 10)
+	r := quota.NewReader(strings.NewReader("a"), 10)
 
 	require.NoError(t, r.Err())
 }
@@ -112,14 +112,14 @@ func TestReaderErrReturnsNilBeforeAnyRefusal(t *testing.T) {
 func TestReaderErrReturnsLatchedError(t *testing.T) {
 	t.Parallel()
 
-	r := budget.NewReader(strings.NewReader("ab"), 1)
+	r := quota.NewReader(strings.NewReader("ab"), 1)
 	buf := make([]byte, 1)
 
 	_, _ = r.Read(buf)
 	_, _ = r.Read(buf)
 	_, _ = r.Read(buf)
 
-	require.ErrorIs(t, r.Err(), budget.ErrExceeded)
+	require.ErrorIs(t, r.Err(), quota.ErrExceeded)
 }
 
 func TestReaderExceeds(t *testing.T) {
@@ -132,21 +132,21 @@ func TestReaderExceeds(t *testing.T) {
 		bufferedAhead int64
 		expected      bool
 	}{
-		{name: "under budget", max: 10, read: 5, bufferedAhead: 0, expected: false},
-		{name: "exactly at budget", max: 10, read: 10, bufferedAhead: 0, expected: false},
-		{name: "over budget", max: 10, read: 11, bufferedAhead: 0, expected: true},
+		{name: "under quota", max: 10, read: 5, bufferedAhead: 0, expected: false},
+		{name: "exactly at quota", max: 10, read: 10, bufferedAhead: 0, expected: false},
+		{name: "over quota", max: 10, read: 11, bufferedAhead: 0, expected: true},
 		{name: "buffered ahead correction avoids false positive", max: 10, read: 15, bufferedAhead: 5, expected: false},
 		{name: "buffered ahead correction still over", max: 10, read: 20, bufferedAhead: 5, expected: true},
 		{name: "clamped to zero when buffered ahead exceeds read", max: 10, read: 3, bufferedAhead: 5, expected: false},
-		{name: "disabled budget never exceeds", max: 0, read: 1000, bufferedAhead: 0, expected: false},
-		{name: "negative budget never exceeds", max: -1, read: 1000, bufferedAhead: 0, expected: false},
+		{name: "disabled quota never exceeds", max: 0, read: 1000, bufferedAhead: 0, expected: false},
+		{name: "negative quota never exceeds", max: -1, read: 1000, bufferedAhead: 0, expected: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			r := budget.NewReader(bytes.NewReader(make([]byte, tt.read)), tt.max)
+			r := quota.NewReader(bytes.NewReader(make([]byte, tt.read)), tt.max)
 
 			if tt.read > 0 {
 				_, err := r.Read(make([]byte, tt.read))
@@ -161,12 +161,12 @@ func TestReaderExceeds(t *testing.T) {
 func TestBufferedLenReturnsDecoderBuffered(t *testing.T) {
 	t.Parallel()
 
-	decoder := streamjson.NewDecoder(strings.NewReader("{} {}"))
+	decoder := json.NewDecoder(strings.NewReader("{} {}"))
 
 	var v struct{}
 	require.NoError(t, decoder.Decode(&v))
 
-	require.Equal(t, int64(3), budget.BufferedLen(decoder))
+	require.Equal(t, int64(3), quota.BufferedLen(decoder))
 }
 
 type noBufferedDecoder struct{}
@@ -177,7 +177,7 @@ func (noBufferedDecoder) Close() error     { return nil }
 func TestBufferedLenReturnsZeroWithoutBufferedMethod(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, int64(0), budget.BufferedLen(noBufferedDecoder{}))
+	require.Equal(t, int64(0), quota.BufferedLen(noBufferedDecoder{}))
 }
 
 type wrongBufferedDecoder struct{}
@@ -189,5 +189,5 @@ func (wrongBufferedDecoder) Buffered() io.Reader { return strings.NewReader("") 
 func TestBufferedLenReturnsZeroForWrongBufferedType(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, int64(0), budget.BufferedLen(wrongBufferedDecoder{}))
+	require.Equal(t, int64(0), quota.BufferedLen(wrongBufferedDecoder{}))
 }


### PR DESCRIPTION
## What

- Renamed `net/http/budget` to `net/http/quota` (package name, doc comments, the `ErrExceeded` message, and every caller in `net/http/client`, `net/http/content/stream`, and `internal/test`) — no behavior change.
- Extracted the previously anonymous decoder type assertion inside `BufferedLen` into a named, documented `BufferedDecoder` interface in `net/http/quota/quota.go`; behavior is unchanged since Go interface satisfaction is structural.
- Renamed the `cont` parameter to `content` for consistency across `net/http/content/unary/handler.go` and `net/http/content/stream/handler.go` (both `NewHandler` and `NewRequestHandler`), including their doc comments.
- Kept the `encoding/errors` import alias in `net/http/content/unary/handler.go` as `encodingerrors` rather than `encoding`: `content.go` and `media.go` in that same package already use unaliased `encoding` for the different top-level `encoding` package, so aliasing `encoding/errors` to `encoding` there would make the same identifier mean two different packages depending on the file.

## Why

- `budget` was a generic word already used elsewhere in the codebase for unrelated timeout/config concepts; `quota` names the per-value byte allowance precisely and removes that ambiguity from doc comments that link across packages.
- `cont` read as an unexplained abbreviation next to the `Content` type and `content` fields used elsewhere; spelling it out removes that friction for readers of the two handler constructors.
- This is a breaking change for any external importer of the exact `net/http/budget` import path. No other consumers of that path exist in this repository, and this repo's accepted stance is that justified breaking changes are fine to ship without extra migration shims.

## Testing

- `make specs package=net/http/quota` - passed
- `make specs package=net/http/client` - passed
- `make specs package=net/http/content/stream` - passed
- `make specs package=net/http/content/unary` - passed
- `make specs package=net/http/rpc` - passed
- `make specs package=net/http/rest` - passed
- `make specs package=transport/http` - passed
- `make golangci-lint` on every changed package - 0 issues
- `make field-alignment` - clean
- `go build ./net/http/... ./internal/test/...` - passed
- An independent review pass (agent) confirmed no remaining stale `budget` references and no behavior change from the `BufferedDecoder` extraction; it also caught the `encoding` alias collision noted above, which is fixed in this PR.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
