### PR TITLE
feat(http): record drain failures and expose protocol tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,7 @@ transport:
 > - HTTP socket deadlines and streaming read/write inactivity budgets are controlled by `transport.http.options.read_timeout`, `write_timeout`, `idle_timeout`, and `read_header_timeout`, each of which defaults independently to `30s`. gRPC connection and keepalive lifetimes are controlled by `transport.grpc.options` and retain their documented lower-level defaults when unset.
 > - For gRPC keepalives, `keepalive_ping_time` is the interval between heartbeats and `keepalive_ping_timeout` is the maximum wait for a heartbeat acknowledgement.
 > - gRPC limits each client connection to 64 concurrent streams by default. Set `transport.grpc.options.max_concurrent_streams` to a positive base-10 integer to override it, or to `"0"` to explicitly retain upstream's unbounded behavior.
+> - HTTP/2 tuning is opt-in through `transport.http.options`: `http2_max_concurrent_streams` is a base-10 `uint32` count (with `"0"` retaining the Go default), while `http2_max_receive_buffer_per_connection` and `http2_max_receive_buffer_per_stream` are size strings. The connection buffer must be at least `65536B` and less than `4194304B`; the stream buffer must be less than `4194304B`. Zero or out-of-range buffer values retain Go's HTTP/2 defaults.
 > - `max_receive_size` limits inbound payload size. A zero value uses the default `4MB`.
 > - For HTTP, `max_receive_size` applies per request body, except for bidirectional streaming routes (see [HTTP streaming (NDJSON)](#http-streaming-ndjson)), where it applies per decoded value instead, with no cumulative total. For gRPC, it applies per inbound unary request and per inbound stream message.
 > - MVC does not enforce its own body-size caps; supported HTTP server wiring applies `max_receive_size` before MVC handlers run, and go-service HTTP clients apply their configured response-size cap when reading responses.
@@ -1324,6 +1325,9 @@ transport:
       write_timeout: 10s
       idle_timeout: 10s
       read_header_timeout: 10s
+      http2_max_concurrent_streams: "128"
+      http2_max_receive_buffer_per_connection: 1MB
+      http2_max_receive_buffer_per_stream: 512KB
   grpc:
     address: tcp://localhost:9000
     timeout: 10s

--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -246,13 +246,21 @@ func handleResponse[Res any](ctx context.Context, res http.ResponseWriter, s *St
 
 func drainResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Stream[Res], err error) {
 	if !s.committed() {
+		if isUnrelatedDrainError(ctx, err) {
+			status.RecordError(ctx, err)
+		}
+
 		_ = status.WriteError(ctx, res, status.SafeError(http.StatusServiceUnavailable, ErrDraining))
 		return
 	}
 
-	if err != nil && !errors.Is(err, ErrDraining) && !errors.Is(err, ctx.Err()) {
+	if isUnrelatedDrainError(ctx, err) {
 		abortResponse(ctx, err)
 	}
+}
+
+func isUnrelatedDrainError(ctx context.Context, err error) bool {
+	return err != nil && !errors.Is(err, ErrDraining) && !errors.Is(err, ctx.Err())
 }
 
 func abortResponse(ctx context.Context, err error) {

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -197,6 +197,30 @@ func TestNewHandlerClosesEncoderBeforeFirstSendOnDrain(t *testing.T) {
 	require.Equal(t, 1, encoder.closes)
 }
 
+func TestNewHandlerRecordsUnrelatedErrorBeforeFirstSendOnDrain(t *testing.T) {
+	drain := make(chan struct{})
+	handler := contentstream.NewHandler(
+		test.StreamContent,
+		contentstream.Options{Drain: drain}, func(ctx context.Context, _ *contentstream.Stream[test.Response]) error {
+			close(drain)
+			<-ctx.Done()
+
+			return test.ErrFailed
+		},
+	)
+
+	ctx := status.WithRequestError(t.Context())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set(http.AcceptKey, media.NDJSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, res.Code)
+	require.ErrorIs(t, status.RequestError(ctx), test.ErrFailed)
+	require.NotErrorIs(t, status.RequestError(ctx), contentstream.ErrDraining)
+}
+
 func TestNewHandlerFirstSendEncodeFailureDoesNotCommit(t *testing.T) {
 	handler := contentstream.NewHandler(test.StreamContent, contentstream.Options{}, func(_ context.Context, stream *contentstream.Stream[test.Unencodable]) error {
 		return stream.Send(&test.Unencodable{})

--- a/net/http/doc.go
+++ b/net/http/doc.go
@@ -14,7 +14,9 @@
 //
 // Server construction reads timeout keys from options.Map (`read_timeout`, `write_timeout`,
 // `idle_timeout`, `read_header_timeout`), each defaulting independently to 30 seconds, and also
-// supports `max_header_bytes` as an SI size string.
+// supports `max_header_bytes` as an SI size string. HTTP/2 tuning is opt-in through
+// `http2_max_concurrent_streams`, `http2_max_receive_buffer_per_connection`, and
+// `http2_max_receive_buffer_per_stream`; unset options preserve the Go HTTP/2 defaults.
 //
 // Start with [NewClient] and [NewServer].
 package http

--- a/net/http/http.go
+++ b/net/http/http.go
@@ -303,13 +303,16 @@ func ParseTime(value string) (time.Time, error) {
 //
 // Additional low-level server tuning may be provided through options using:
 //   - max_header_bytes
+//   - http2_max_concurrent_streams
+//   - http2_max_receive_buffer_per_connection
+//   - http2_max_receive_buffer_per_stream
 //
 // Protocols are configured via Protocols().
 //
 // Note: [opts.NonNegativeDuration] uses MustParseDuration under the hood; invalid or negative option
 // values will panic at server construction time.
 func NewServer(options config.Map, handler Handler) *Server {
-	return &http.Server{
+	server := &http.Server{
 		Handler:           handler,
 		ReadTimeout:       options.NonNegativeDuration("read_timeout", time.DefaultTimeout).Duration(),
 		WriteTimeout:      options.NonNegativeDuration("write_timeout", time.DefaultTimeout).Duration(),
@@ -318,6 +321,17 @@ func NewServer(options config.Map, handler Handler) *Server {
 		MaxHeaderBytes:    options.IntSize("max_header_bytes", bytes.Size(DefaultMaxHeaderBytes)),
 		Protocols:         Protocols(),
 	}
+	http2 := &http.HTTP2Config{
+		MaxConcurrentStreams:          int(options.Uint32("http2_max_concurrent_streams", 0)),
+		MaxReceiveBufferPerConnection: int(options.Int32Size("http2_max_receive_buffer_per_connection", 0)),
+		MaxReceiveBufferPerStream:     int(options.Int32Size("http2_max_receive_buffer_per_stream", 0)),
+	}
+
+	if http2.MaxConcurrentStreams != 0 || http2.MaxReceiveBufferPerConnection != 0 || http2.MaxReceiveBufferPerStream != 0 {
+		server.HTTP2 = http2
+	}
+
+	return server
 }
 
 // ParseServiceMethod derives a logical "service" and "method" name from an HTTP request.

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -103,10 +103,70 @@ func TestNewServerSetsProtocols(t *testing.T) {
 
 	server := http.NewServer(options.Map{}, handler)
 
+	require.Nil(t, server.HTTP2)
 	require.NotNil(t, server.Protocols)
 	require.True(t, server.Protocols.HTTP1())
 	require.True(t, server.Protocols.HTTP2())
 	require.True(t, server.Protocols.UnencryptedHTTP2())
+}
+
+func TestNewServerSetsHTTP2Options(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                       string
+		options                    options.Map
+		maxConcurrentStreams       int
+		maxReceiveBufferConnection int
+		maxReceiveBufferStream     int
+	}{
+		{
+			name:                 "max concurrent streams",
+			options:              options.Map{"http2_max_concurrent_streams": "7"},
+			maxConcurrentStreams: 7,
+		},
+		{
+			name:                       "max receive buffer per connection",
+			options:                    options.Map{"http2_max_receive_buffer_per_connection": "3MB"},
+			maxReceiveBufferConnection: int(3 * bytes.MB.Bytes()),
+		},
+		{
+			name:                   "max receive buffer per stream",
+			options:                options.Map{"http2_max_receive_buffer_per_stream": "4MB"},
+			maxReceiveBufferStream: int(4 * bytes.MB.Bytes()),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := http.NewServer(test.options, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+			require.NotNil(t, server.HTTP2)
+			require.Equal(t, test.maxConcurrentStreams, server.HTTP2.MaxConcurrentStreams)
+			require.Equal(t, test.maxReceiveBufferConnection, server.HTTP2.MaxReceiveBufferPerConnection)
+			require.Equal(t, test.maxReceiveBufferStream, server.HTTP2.MaxReceiveBufferPerStream)
+		})
+	}
+}
+
+func TestNewServerRejectsOverflowingHTTP2Options(t *testing.T) {
+	t.Parallel()
+
+	for key, value := range map[string]string{
+		"http2_max_concurrent_streams":            "4294967296",
+		"http2_max_receive_buffer_per_connection": "3GB",
+		"http2_max_receive_buffer_per_stream":     "3GB",
+	} {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			require.Panics(t, func() {
+				http.NewServer(options.Map{key: value}, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			})
+		})
+	}
 }
 
 func TestSameOriginRedirectMatchesSchemeHostAndPort(t *testing.T) {


### PR DESCRIPTION
## What

- Preserve unrelated streaming-handler failures as request diagnostics when graceful draining starts before a response is committed.
- Expose opt-in HTTP/2 stream and receive-buffer tuning through server options, reject values that would overflow Go's HTTP/2 fields, and document the supported configuration.

## Why

- Operators retain the underlying failure signal during graceful shutdown while clients receive the intended unavailable response, and can safely tune HTTP/2 capacity without silent limit wrapping.

## Testing

- `make specs package=net/http` - passed
- `make specs package=net/http/content/stream` - passed
- `make specs package=transport/http` - passed
- `make specs package=debug` - passed
- `make lint` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
