### PR TITLE
feat(http): record drain errors on a clean committed end

### DIFF
--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -256,6 +256,11 @@ func drainResponse[Res any](ctx context.Context, res http.ResponseWriter, s *Str
 
 	if isUnrelatedDrainError(ctx, err) {
 		abortResponse(ctx, err)
+		return
+	}
+
+	if err != nil {
+		status.RecordError(ctx, err)
 	}
 }
 

--- a/net/http/content/stream/handler_test.go
+++ b/net/http/content/stream/handler_test.go
@@ -363,7 +363,8 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 			return ctx.Err()
 		})
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	ctx := status.WithRequestError(t.Context())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
@@ -373,6 +374,7 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrain(t *testing.T) {
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
 	require.False(t, scanner.Scan())
+	require.ErrorIs(t, status.RequestError(ctx), context.Canceled)
 }
 
 func TestNewHandlerAbortsAfterCommitOnDrainForUnrelatedError(t *testing.T) {
@@ -425,7 +427,8 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError(t *testing.T) {
 			return errors.Join(test.ErrFailed, ctx.Err())
 		})
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	ctx := status.WithRequestError(t.Context())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/hello", http.NoBody)
 	req.Header.Set(http.AcceptKey, media.NDJSON)
 	res := httptest.NewRecorder()
 
@@ -435,6 +438,8 @@ func TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError(t *testing.T) {
 	scanner := bufio.NewScanner(res.Body)
 	require.Equal(t, "Hello Bob", decodeNDJSONGreeting(t, scanner))
 	require.False(t, scanner.Scan())
+	require.ErrorIs(t, status.RequestError(ctx), test.ErrFailed)
+	require.ErrorIs(t, status.RequestError(ctx), context.Canceled)
 }
 
 func TestNewHandlerDoesNotSendAfterDrain(t *testing.T) {


### PR DESCRIPTION
## What

- In `net/http/content/stream.NewHandler`/`NewRequestHandler`, a handler that ends cleanly after the response is committed and returns the drain-related cancellation error (directly, or joined with another error) now has that error captured via `status.RecordError` for operator/access-log diagnostics — matching the diagnostic capture the pre-commit and unrelated-error drain paths already got in #3190. The client-visible outcome is unchanged: the response still ends cleanly with its already-committed status.
- Extended the two clean-end drain tests to assert `status.RequestError` now surfaces the recorded drain-related error, including the `errors.Join` combined-error case.

## Why

- Before this change, a handler that observed `ctx.Done()` after drain started and returned that cancellation cause once the response was already committed had its error silently dropped — operators had no diagnostic signal for what the handler actually returned during a clean, drain-triggered end, unlike the pre-commit and unrelated-error drain paths, which already record for diagnostics.

## Testing

- `make specs package=net/http/content/stream` - passed (123 tests)
- `make golangci-lint package=net/http/content/stream` - 0 issues
- Extended `TestNewHandlerEndsCleanlyAfterCommitOnDrain` and `TestNewHandlerEndsCleanlyAfterCommitOnDrainForCombinedError` to assert `status.RequestError` captures the drain-related error (plain `context.Canceled`, and joined with `test.ErrFailed`).
- Independent code-review pass found no blocking issues.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
