### PR TITLE
feat(encoding): support forward-compatible decode options

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/encoding/base64"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/proto"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -282,7 +283,7 @@ func (c *Cache) compressorKind() string {
 	return "none"
 }
 
-func (c *Cache) readEncoder(value any) encoding.Encoder {
+func (c *Cache) readEncoder(value any) codec.Encoder {
 	switch value.(type) {
 	case io.ReaderFrom:
 		return c.encoding.Get("bytes")
@@ -293,7 +294,7 @@ func (c *Cache) readEncoder(value any) encoding.Encoder {
 	}
 }
 
-func (c *Cache) writeEncoder(value any) encoding.Encoder {
+func (c *Cache) writeEncoder(value any) codec.Encoder {
 	switch value.(type) {
 	case io.WriterTo:
 		return c.encoding.Get("bytes")
@@ -304,7 +305,7 @@ func (c *Cache) writeEncoder(value any) encoding.Encoder {
 	}
 }
 
-func (c *Cache) configuredEncoder() encoding.Encoder {
+func (c *Cache) configuredEncoder() codec.Encoder {
 	return c.encoding.Get(c.encoderKind())
 }
 

--- a/encoding/bytes/bytes.go
+++ b/encoding/bytes/bytes.go
@@ -1,6 +1,7 @@
 package bytes
 
 import (
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/reflect"
@@ -16,7 +17,7 @@ import (
 //   - [io.ReaderFrom] for Decode
 //
 // It is useful when you want to treat a value as its own codec (for example when caching or transporting
-// pre-serialized payloads) while still satisfying the go-service [encoding.Encoder] interface.
+// pre-serialized payloads) while still satisfying the go-service [codec.Encoder] interface.
 func NewEncoder() *Encoder {
 	return &Encoder{}
 }
@@ -47,7 +48,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // If v also implements [io.Resetter], Decode resets it before reading so the
 // destination is repopulated rather than appended to.
 // Any error returned by ReadFrom is returned.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+func (e *Encoder) Decode(r io.Reader, v any, _ ...codec.Option) error {
 	from, err := readerFrom(v)
 	if err != nil {
 		return err

--- a/encoding/codec/encoder.go
+++ b/encoding/codec/encoder.go
@@ -1,4 +1,5 @@
-package encoding
+// Package codec defines the common contract implemented by supported encodings.
+package codec
 
 import "github.com/alexfalkowski/go-service/v2/io"
 
@@ -33,6 +34,8 @@ type Encoder interface {
 	// Encode writes a serialized representation of v to w.
 	Encode(w io.Writer, v any) error
 
-	// Decode reads from r and decodes into v.
-	Decode(r io.Reader, v any) error
+	// Decode reads from r and decodes into v. WithDiscardUnknown makes codecs
+	// ignore source members that do not map to v; without it, codecs reject
+	// unknown members when their format supports that distinction.
+	Decode(r io.Reader, v any, opts ...Option) error
 }

--- a/encoding/codec/options.go
+++ b/encoding/codec/options.go
@@ -1,0 +1,45 @@
+package codec
+
+// Option configures one [Encoder.Decode] operation.
+type Option interface {
+	apply(opts *options)
+}
+
+// Options reports settings resolved for one [Encoder.Decode] operation.
+type Options interface {
+	// DiscardUnknown reports whether unknown source members are discarded.
+	DiscardUnknown() bool
+}
+
+type options struct {
+	discardUnknown bool
+}
+
+type optionFunc func(*options)
+
+func (f optionFunc) apply(o *options) {
+	f(o)
+}
+
+func (o options) DiscardUnknown() bool {
+	return o.discardUnknown
+}
+
+// Apply resolves opts for one [Encoder.Decode] operation.
+func Apply(opts ...Option) Options {
+	resolved := options{}
+	for _, opt := range opts {
+		opt.apply(&resolved)
+	}
+
+	return resolved
+}
+
+// WithDiscardUnknown configures decoding to ignore source members that do not
+// map to the destination. It preserves all other format validation, including
+// unary trailing-data checks.
+func WithDiscardUnknown() Option {
+	return optionFunc(func(options *options) {
+		options.discardUnknown = true
+	})
+}

--- a/encoding/doc.go
+++ b/encoding/doc.go
@@ -1,11 +1,11 @@
 // Package encoding provides value encoding/decoding helpers and DI wiring used by go-service.
 //
-// This package defines a small [Encoder] interface (encode to an [io.Writer], decode from an [io.Reader])
-// and a registry ([Map]) used to select an encoder by kind at runtime.
+// This package provides a registry ([Map]) that selects
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder] implementations by kind at runtime.
 //
 // # Registry
 //
-// Map is a kind-to-Encoder lookup. It is commonly used by configuration loading and transport layers to
+// Map is a kind-to-[github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder] lookup. It is commonly used by configuration loading and transport layers to
 // choose a decoder/encoder based on either:
 //   - a file extension (for example "yaml", "toml", "json"), or
 //   - a content kind / media subtype (for example "protobuf", "bytes").
@@ -16,6 +16,14 @@
 //
 // Callers typically obtain a *[Map] via DI and then use [Map.Get] to select an encoder, often
 // falling back to a default when the requested kind is not registered.
+//
+// # Decode options
+//
+// Decoding rejects unknown members by default where the format supports that distinction. Callers at
+// a forward-compatible API boundary can pass
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] to
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder.Decode]; framing,
+// syntax, and type validation remain unchanged.
 //
 // # Wiring
 //
@@ -28,5 +36,6 @@
 //
 // Module provides the default *[Map] for Fx applications.
 //
-// Start with [Encoder], [Map], [NewMap], and [Module].
+// Start with [Map], [NewMap], [Module], and
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 package encoding

--- a/encoding/gob/gob.go
+++ b/encoding/gob/gob.go
@@ -4,6 +4,7 @@ import (
 	"encoding/gob"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
@@ -13,7 +14,7 @@ var defaultEncoder = &Encoder{}
 // NewEncoder constructs a gob encoder.
 //
 // This encoder is a thin adapter around the standard library [encoding/gob] package that satisfies
-// [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewEncoder() *Encoder {
 	return defaultEncoder
 }
@@ -34,7 +35,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
 // Decode reads one gob value and rejects additional values in the same stream.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+func (e *Encoder) Decode(r io.Reader, v any, _ ...codec.Option) error {
 	decoder := gob.NewDecoder(r)
 	if err := decoder.Decode(v); err != nil {
 		return err

--- a/encoding/hjson/doc.go
+++ b/encoding/hjson/doc.go
@@ -1,7 +1,9 @@
 // Package hjson provides HJSON encoding helpers and adapters used by go-service.
 //
 // This package integrates HJSON encoding/decoding behind the go-service encoding abstraction.
-// Decode rejects duplicate object keys and unknown destination fields.
+// Decode rejects duplicate object keys and unknown destination fields by default; callers can use
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] for forward-compatible API
+// payloads.
 //
 // Start with the package-level constructors.
 package hjson

--- a/encoding/hjson/hjson.go
+++ b/encoding/hjson/hjson.go
@@ -2,6 +2,7 @@ package hjson
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 	hjson "github.com/hjson/hjson-go/v4"
 )
@@ -11,7 +12,7 @@ var defaultEncoder = &Encoder{}
 // NewEncoder constructs an HJSON encoder.
 //
 // This encoder is a thin adapter around [github.com/hjson/hjson-go] that satisfies
-// [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewEncoder() *Encoder {
 	return defaultEncoder
 }
@@ -33,10 +34,12 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads HJSON from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
-// Decode rejects duplicate object keys and unknown destination fields.
+// Decode rejects duplicate object keys and unknown destination fields unless
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] is
+// supplied.
 // Decode buffers all remaining input from r before decoding; callers should bound
 // untrusted or potentially large readers before calling it.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+func (e *Encoder) Decode(r io.Reader, v any, opts ...codec.Option) error {
 	data, _, err := io.ReadAll(r)
 	if err != nil {
 		return err
@@ -44,7 +47,7 @@ func (e *Encoder) Decode(r io.Reader, v any) error {
 
 	options := hjson.DefaultDecoderOptions()
 	options.DisallowDuplicateKeys = true
-	options.DisallowUnknownFields = true
+	options.DisallowUnknownFields = !codec.Apply(opts...).DiscardUnknown()
 
 	return hjson.UnmarshalWithOptions(data, v, options)
 }

--- a/encoding/hjson/hjson_test.go
+++ b/encoding/hjson/hjson_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -77,6 +78,16 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeDiscardsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	encoder := hjson.NewEncoder()
+	msg := &message{}
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("{\n  test: test\n  extra: ignored\n}\n"), msg, codec.WithDiscardUnknown()))
+	require.Equal(t, "test", msg.Test)
 }
 
 func TestDecodeReturnsReadError(t *testing.T) {

--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -10,7 +10,8 @@
 //     path instead of importing encoding/json directly
 //
 // Marshal and Valid preserve the standard library's encoding/json semantics.
-// Encoder and Unmarshal use the standard decoder with unknown fields and
-// trailing values rejected. Duplicate object keys keep the standard library's
-// last-wins behavior.
+// Encoder and Unmarshal reject unknown fields and trailing values by default.
+// [Encoder.Decode] accepts [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown]
+// for forward-compatible API payloads. Duplicate object keys keep the standard
+// library's last-wins behavior.
 package json

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -38,7 +39,7 @@ var defaultEncoder = &Encoder{}
 // NewEncoder constructs a JSON encoder.
 //
 // NewEncoder returns an [Encoder] that satisfies
-// [github.com/alexfalkowski/go-service/v2/encoding.Encoder] while delegating to
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder] while delegating to
 // the standard library's [encoding/json] implementation with readable indented
 // encoding and strict decoding.
 func NewEncoder() *Encoder {
@@ -67,13 +68,16 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value, such as
 // `*MyStruct` or `*map[string]any`. Decode is equivalent to calling
-// `json.NewDecoder(r).Decode(v)` with unknown fields rejected, then requiring
-// the stream to contain no additional JSON values.
+// `json.NewDecoder(r).Decode(v)` with unknown fields rejected unless
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] is
+// supplied, then requiring the stream to contain no additional JSON values.
 //
 // Duplicate JSON object keys keep the standard library's last-wins behavior.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+func (e *Encoder) Decode(r io.Reader, v any, opts ...codec.Option) error {
 	decoder := json.NewDecoder(r)
-	decoder.DisallowUnknownFields()
+	if !codec.Apply(opts...).DiscardUnknown() {
+		decoder.DisallowUnknownFields()
+	}
 	if err := decoder.Decode(v); err != nil {
 		return err
 	}

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -64,6 +65,16 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeDiscardsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	encoder := json.NewEncoder()
+	msg := &message{}
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString(`{"test":"test","extra":"ignored"}`), msg, codec.WithDiscardUnknown()))
+	require.Equal(t, "test", msg.Test)
 }
 
 func TestDecodeRejectsTrailingData(t *testing.T) {

--- a/encoding/map.go
+++ b/encoding/map.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 
 	"github.com/alexfalkowski/go-service/v2/encoding/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/gob"
 	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
@@ -27,7 +28,7 @@ import (
 // Callers can add additional kinds or override existing kinds via [Map.Register].
 func NewMap() *Map {
 	return &Map{
-		encoders: map[string]Encoder{
+		encoders: map[string]codec.Encoder{
 			"json":      json.NewEncoder(),
 			"hjson":     hjson.NewEncoder(),
 			"yaml":      yaml.NewEncoder(),
@@ -49,13 +50,13 @@ func NewMap() *Map {
 //
 // Map is not concurrency-safe. If you mutate it via Register, do so during initialization.
 type Map struct {
-	encoders map[string]Encoder
+	encoders map[string]codec.Encoder
 }
 
 // Register associates kind with enc, overwriting any existing encoder.
 //
 // If kind already exists, the previous encoder is replaced.
-func (f *Map) Register(kind string, enc Encoder) {
+func (f *Map) Register(kind string, enc codec.Encoder) {
 	f.encoders[kind] = enc
 }
 
@@ -63,7 +64,7 @@ func (f *Map) Register(kind string, enc Encoder) {
 //
 // If no encoder is registered for kind, or if kind was registered with a nil encoder, Get returns nil.
 // Callers typically treat nil as "unknown or unavailable kind" and fall back to a default encoder elsewhere.
-func (f *Map) Get(kind string) Encoder {
+func (f *Map) Get(kind string) codec.Encoder {
 	return f.encoders[kind]
 }
 

--- a/encoding/map_test.go
+++ b/encoding/map_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/encoding"
 	"github.com/alexfalkowski/go-service/v2/encoding/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/gob"
 	"github.com/alexfalkowski/go-service/v2/encoding/hjson"
 	"github.com/alexfalkowski/go-service/v2/encoding/json"
@@ -19,7 +20,7 @@ import (
 func TestNewMapRegistersDefaultEncoders(t *testing.T) {
 	encoders := encoding.NewMap()
 
-	expected := map[string]encoding.Encoder{
+	expected := map[string]codec.Encoder{
 		"json":      json.NewEncoder(),
 		"hjson":     hjson.NewEncoder(),
 		"yaml":      yaml.NewEncoder(),

--- a/encoding/msgpack/msgpack.go
+++ b/encoding/msgpack/msgpack.go
@@ -3,6 +3,7 @@ package msgpack
 import (
 	"github.com/Basekick-Labs/msgpack/v6"
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
@@ -25,7 +26,7 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads one MessagePack value from r and decodes it into v.
 //
 // It rejects trailing encoded values or malformed trailing data.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+func (e *Encoder) Decode(r io.Reader, v any, _ ...codec.Option) error {
 	decoder := msgpack.NewDecoder(r)
 	if err := decoder.Decode(v); err != nil {
 		return err

--- a/encoding/proto/binary.go
+++ b/encoding/proto/binary.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"google.golang.org/protobuf/proto"
 )
@@ -8,7 +9,7 @@ import (
 // NewBinary constructs a protobuf binary encoder.
 //
 // This encoder is a thin adapter around google.golang.org/protobuf/proto Marshal/Unmarshal that satisfies
-// [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewBinary() *Binary {
 	return &Binary{}
 }
@@ -48,13 +49,8 @@ func (e *Binary) Encode(w io.Writer, v any) error {
 // unmarshaling.
 //
 // Any read error from [io.ReadAll] and any unmarshal error from [proto.Unmarshal] is returned.
-func (e *Binary) Decode(r io.Reader, v any) error {
-	msg, err := message(v)
-	if err != nil {
-		return err
-	}
-
-	bytes, _, err := io.ReadAll(r)
+func (e *Binary) Decode(r io.Reader, v any, _ ...codec.Option) error {
+	msg, bytes, err := readMessage(r, v)
 	if err != nil {
 		return err
 	}

--- a/encoding/proto/json.go
+++ b/encoding/proto/json.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -8,7 +9,7 @@ import (
 // NewJSON constructs a protobuf JSON encoder.
 //
 // This encoder is a thin adapter around google.golang.org/protobuf/encoding/protojson Marshal/Unmarshal that
-// satisfies [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// satisfies [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewJSON() *JSON {
 	return &JSON{}
 }
@@ -45,19 +46,16 @@ func (e *JSON) Encode(w io.Writer, v any) error {
 // [github.com/alexfalkowski/go-service/v2/encoding/errors.ErrInvalidType] without reading from r.
 //
 // Decode otherwise reads all remaining bytes from r (via [io.ReadAll]) before
-// unmarshaling. Unknown protobuf JSON fields are discarded during unmarshal.
+// unmarshaling. Unknown protobuf JSON fields are rejected unless
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] is
+// supplied.
 //
 // Any read error from [io.ReadAll] and any unmarshal error from [protojson.UnmarshalOptions.Unmarshal] is returned.
-func (e *JSON) Decode(r io.Reader, v any) error {
-	msg, err := message(v)
+func (e *JSON) Decode(r io.Reader, v any, opts ...codec.Option) error {
+	msg, bytes, err := readMessage(r, v)
 	if err != nil {
 		return err
 	}
 
-	bytes, _, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
-	return protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(bytes, msg)
+	return protojson.UnmarshalOptions{DiscardUnknown: codec.Apply(opts...).DiscardUnknown()}.Unmarshal(bytes, msg)
 }

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
+	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/reflect"
 	"google.golang.org/protobuf/proto"
 )
@@ -16,4 +17,18 @@ func message(v any) (Message, error) {
 	}
 
 	return msg, nil
+}
+
+func readMessage(r io.Reader, v any) (Message, []byte, error) {
+	msg, err := message(v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bytes, _, err := io.ReadAll(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return msg, bytes, nil
 }

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
-	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/proto"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -109,12 +109,28 @@ func TestEncodersUseExpectedWireFormats(t *testing.T) {
 	})
 }
 
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		encoder := proto.NewJSON()
+
+		var decode health.Response
+		require.Error(t, encoder.Decode(bytes.NewBufferString(`{"status":"SERVING","futureField":"ignored"}`), &decode))
+	})
+
+	t.Run("text", func(t *testing.T) {
+		encoder := proto.NewText()
+
+		var decode health.Response
+		require.Error(t, encoder.Decode(bytes.NewBufferString("status: SERVING\nfuture_field: \"ignored\""), &decode))
+	})
+}
+
 func TestDecodeDiscardsUnknownFields(t *testing.T) {
 	t.Run("json", func(t *testing.T) {
 		encoder := proto.NewJSON()
 
 		var decode health.Response
-		require.NoError(t, encoder.Decode(bytes.NewBufferString(`{"status":"SERVING","futureField":"ignored"}`), &decode))
+		require.NoError(t, encoder.Decode(bytes.NewBufferString(`{"status":"SERVING","futureField":"ignored"}`), &decode, codec.WithDiscardUnknown()))
 		require.Equal(t, health.Serving, decode.GetStatus())
 	})
 
@@ -122,7 +138,7 @@ func TestDecodeDiscardsUnknownFields(t *testing.T) {
 		encoder := proto.NewText()
 
 		var decode health.Response
-		require.NoError(t, encoder.Decode(bytes.NewBufferString("status: SERVING\nfuture_field: \"ignored\""), &decode))
+		require.NoError(t, encoder.Decode(bytes.NewBufferString("status: SERVING\nfuture_field: \"ignored\""), &decode, codec.WithDiscardUnknown()))
 		require.Equal(t, health.Serving, decode.GetStatus())
 	})
 }
@@ -169,11 +185,11 @@ func TestInvalidTypedNilDecodeDoesNotRead(t *testing.T) {
 }
 
 func protoEncoders() []struct {
-	encoder encoding.Encoder
+	encoder codec.Encoder
 	name    string
 } {
 	return []struct {
-		encoder encoding.Encoder
+		encoder codec.Encoder
 		name    string
 	}{
 		{encoder: proto.NewBinary(), name: "binary"},

--- a/encoding/proto/text.go
+++ b/encoding/proto/text.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"google.golang.org/protobuf/encoding/prototext"
 )
@@ -8,7 +9,7 @@ import (
 // NewText constructs a protobuf text encoder.
 //
 // This encoder is a thin adapter around google.golang.org/protobuf/encoding/prototext Marshal/Unmarshal that
-// satisfies [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// satisfies [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewText() *Text {
 	return &Text{}
 }
@@ -45,19 +46,16 @@ func (e *Text) Encode(w io.Writer, v any) error {
 // [github.com/alexfalkowski/go-service/v2/encoding/errors.ErrInvalidType] without reading from r.
 //
 // Decode otherwise reads all remaining bytes from r (via [io.ReadAll]) before
-// unmarshaling. Unknown protobuf text fields are discarded during unmarshal.
+// unmarshaling. Unknown protobuf text fields are rejected unless
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] is
+// supplied.
 //
 // Any read error from [io.ReadAll] and any unmarshal error from [prototext.UnmarshalOptions.Unmarshal] is returned.
-func (e *Text) Decode(r io.Reader, v any) error {
-	msg, err := message(v)
+func (e *Text) Decode(r io.Reader, v any, opts ...codec.Option) error {
+	msg, bytes, err := readMessage(r, v)
 	if err != nil {
 		return err
 	}
 
-	bytes, _, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
-	return prototext.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(bytes, msg)
+	return prototext.UnmarshalOptions{DiscardUnknown: codec.Apply(opts...).DiscardUnknown()}.Unmarshal(bytes, msg)
 }

--- a/encoding/stream/doc.go
+++ b/encoding/stream/doc.go
@@ -12,8 +12,9 @@
 // exporting NewEncoder(io.Writer) [Encoder] and NewDecoder(io.Reader) [Decoder]. They wrap the same
 // underlying libraries as the sibling encoding/<kind> packages, carrying over the same policy with two
 // exceptions needed for multi-value streams: no output indentation (which would break newline-delimited
-// framing) and no trailing-data rejection (a stream is expected to contain many values). Strict/unknown-
-// field decoding is preserved.
+// framing) and no trailing-data rejection (a stream is expected to contain many values). Unknown
+// fields are rejected by default and can be discarded at construction with
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown].
 //
 // Start with [Encoder] and [Decoder].
 package stream

--- a/encoding/stream/gob/gob.go
+++ b/encoding/stream/gob/gob.go
@@ -3,6 +3,7 @@ package gob
 import (
 	"encoding/gob"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -48,7 +49,7 @@ type Decoder struct {
 // Unlike [github.com/alexfalkowski/go-service/v2/encoding/gob.Encoder]'s Decode, the returned decoder
 // allows additional gob values after the first: it does not enforce single-value trailing-data
 // rejection, since a stream is expected to carry many values.
-func NewDecoder(r io.Reader) *Decoder {
+func NewDecoder(r io.Reader, _ ...codec.Option) *Decoder {
 	return &Decoder{Decoder: gob.NewDecoder(r)}
 }
 

--- a/encoding/stream/json/doc.go
+++ b/encoding/stream/json/doc.go
@@ -2,10 +2,10 @@
 // [github.com/alexfalkowski/go-service/v2/encoding/stream.Decoder] pair used by go-service.
 //
 // It wraps the standard library [encoding/json] package's own NewEncoder/NewDecoder types, which are
-// each bound to one writer/reader for many Encode/Decode calls. It carries over the strict decoding
-// policy of [github.com/alexfalkowski/go-service/v2/encoding/json] (unknown fields rejected), but
-// drops that package's indentation (which would break newline-delimited framing) and trailing-data
-// rejection (a stream is expected to contain many values).
+// each bound to one writer/reader for many Encode/Decode calls. It rejects unknown fields by default
+// and accepts [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] for
+// forward-compatible API streams. It drops the sibling package's indentation (which would break
+// newline-delimited framing) and trailing-data rejection (a stream is expected to contain many values).
 //
 // Start with the package-level constructors.
 package json

--- a/encoding/stream/json/json.go
+++ b/encoding/stream/json/json.go
@@ -3,6 +3,7 @@ package json
 import (
 	"encoding/json"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -46,11 +47,13 @@ type Decoder struct {
 //
 // Unlike [github.com/alexfalkowski/go-service/v2/encoding/json.Encoder]'s Decode, the returned
 // decoder allows additional JSON values after the first: it does not enforce single-value
-// trailing-data rejection, since a stream is expected to carry many values. Unknown fields remain
-// rejected.
-func NewDecoder(r io.Reader) *Decoder {
+// trailing-data rejection, since a stream is expected to carry many values. Unknown fields are
+// rejected unless [codec.WithDiscardUnknown] is supplied.
+func NewDecoder(r io.Reader, opts ...codec.Option) *Decoder {
 	decoder := json.NewDecoder(r)
-	decoder.DisallowUnknownFields()
+	if !codec.Apply(opts...).DiscardUnknown() {
+		decoder.DisallowUnknownFields()
+	}
 
 	return &Decoder{Decoder: decoder}
 }

--- a/encoding/stream/json/json_test.go
+++ b/encoding/stream/json/json_test.go
@@ -3,6 +3,7 @@ package json_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
@@ -70,6 +71,22 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeDiscardsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	_, err := buffer.WriteString(`{"test":"test","extra":"ignored"}`)
+	require.NoError(t, err)
+
+	decoder := json.NewDecoder(buffer, codec.WithDiscardUnknown())
+	msg := &message{}
+
+	require.NoError(t, decoder.Decode(msg))
+	require.Equal(t, "test", msg.Test)
 }
 
 func TestDecodeAllowsTrailingValues(t *testing.T) {

--- a/encoding/stream/map.go
+++ b/encoding/stream/map.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"maps"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/gob"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/msgpack"
@@ -27,10 +28,22 @@ import (
 func NewMap() *Map {
 	return &Map{
 		codecs: map[string]Codec{
-			"json":    {Encoder: func(w io.Writer) Encoder { return json.NewEncoder(w) }, Decoder: func(r io.Reader) Decoder { return json.NewDecoder(r) }},
-			"msgpack": {Encoder: func(w io.Writer) Encoder { return msgpack.NewEncoder(w) }, Decoder: func(r io.Reader) Decoder { return msgpack.NewDecoder(r) }},
-			"gob":     {Encoder: func(w io.Writer) Encoder { return gob.NewEncoder(w) }, Decoder: func(r io.Reader) Decoder { return gob.NewDecoder(r) }},
-			"yaml":    {Encoder: func(w io.Writer) Encoder { return yaml.NewEncoder(w) }, Decoder: func(r io.Reader) Decoder { return yaml.NewDecoder(r) }},
+			"json": {
+				Encoder: func(w io.Writer) Encoder { return json.NewEncoder(w) },
+				Decoder: func(r io.Reader, opts ...codec.Option) Decoder { return json.NewDecoder(r, opts...) },
+			},
+			"msgpack": {
+				Encoder: func(w io.Writer) Encoder { return msgpack.NewEncoder(w) },
+				Decoder: func(r io.Reader, opts ...codec.Option) Decoder { return msgpack.NewDecoder(r, opts...) },
+			},
+			"gob": {
+				Encoder: func(w io.Writer) Encoder { return gob.NewEncoder(w) },
+				Decoder: func(r io.Reader, opts ...codec.Option) Decoder { return gob.NewDecoder(r, opts...) },
+			},
+			"yaml": {
+				Encoder: func(w io.Writer) Encoder { return yaml.NewEncoder(w) },
+				Decoder: func(r io.Reader, opts ...codec.Option) Decoder { return yaml.NewDecoder(r, opts...) },
+			},
 		},
 	}
 }

--- a/encoding/stream/map_test.go
+++ b/encoding/stream/map_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	encodingcodec "github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/gob"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/json"
@@ -74,7 +75,7 @@ func TestMapKeysIncludesPartiallyRegisteredKinds(t *testing.T) {
 
 	m := stream.NewMap()
 	m.Register("encode-only", stream.Codec{Encoder: func(w io.Writer) stream.Encoder { return json.NewEncoder(w) }})
-	m.Register("decode-only", stream.Codec{Decoder: func(r io.Reader) stream.Decoder { return json.NewDecoder(r) }})
+	m.Register("decode-only", stream.Codec{Decoder: func(r io.Reader, _ ...encodingcodec.Option) stream.Decoder { return json.NewDecoder(r) }})
 
 	require.ElementsMatch(t, []string{"json", "msgpack", "gob", "yaml", "encode-only", "decode-only"}, m.Keys())
 }
@@ -84,7 +85,7 @@ func TestMapRegisterReplacesExistingCodec(t *testing.T) {
 
 	m := stream.NewMap()
 	encoder := func(w io.Writer) stream.Encoder { return json.NewEncoder(w) }
-	decoder := func(r io.Reader) stream.Decoder { return json.NewDecoder(r) }
+	decoder := func(r io.Reader, _ ...encodingcodec.Option) stream.Decoder { return json.NewDecoder(r) }
 
 	m.Register("custom", stream.Codec{Encoder: encoder, Decoder: decoder})
 	codec := m.Get("custom")
@@ -92,7 +93,7 @@ func TestMapRegisterReplacesExistingCodec(t *testing.T) {
 	require.Equal(t, reflect.ValueOf(decoder).Pointer(), reflect.ValueOf(codec.Decoder).Pointer())
 
 	replacementEncoder := func(w io.Writer) stream.Encoder { return msgpack.NewEncoder(w) }
-	replacementDecoder := func(r io.Reader) stream.Decoder { return yaml.NewDecoder(r) }
+	replacementDecoder := func(r io.Reader, _ ...encodingcodec.Option) stream.Decoder { return yaml.NewDecoder(r) }
 
 	m.Register("custom", stream.Codec{Encoder: replacementEncoder, Decoder: replacementDecoder})
 	codec = m.Get("custom")

--- a/encoding/stream/msgpack/msgpack.go
+++ b/encoding/stream/msgpack/msgpack.go
@@ -2,6 +2,7 @@ package msgpack
 
 import (
 	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -42,7 +43,7 @@ type Decoder struct {
 // Unlike [github.com/alexfalkowski/go-service/v2/encoding/msgpack.Encoder]'s Decode, the returned
 // decoder allows additional MessagePack values after the first: it does not enforce single-value
 // trailing-data rejection, since a stream is expected to carry many values.
-func NewDecoder(r io.Reader) *Decoder {
+func NewDecoder(r io.Reader, _ ...codec.Option) *Decoder {
 	return &Decoder{Decoder: msgpack.NewDecoder(r)}
 }
 

--- a/encoding/stream/stream.go
+++ b/encoding/stream/stream.go
@@ -1,10 +1,13 @@
 package stream
 
-import "github.com/alexfalkowski/go-service/v2/io"
+import (
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
+	"github.com/alexfalkowski/go-service/v2/io"
+)
 
 // Encoder encodes a sequence of values to a writer bound at construction.
 //
-// Encoder differs from [github.com/alexfalkowski/go-service/v2/encoding.Encoder] in two ways: it is
+// Encoder differs from [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder] in two ways: it is
 // bound to one writer for its entire lifetime (constructed with the writer rather than given one per
 // call), and it is expected to serve many Encode calls rather than exactly one.
 //
@@ -32,7 +35,7 @@ type Encoder interface {
 
 // Decoder decodes a sequence of values from a reader bound at construction.
 //
-// Decoder differs from [github.com/alexfalkowski/go-service/v2/encoding.Encoder]'s Decode in two
+// Decoder differs from [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder]'s Decode in two
 // ways: it is bound to one reader for its entire lifetime (constructed with the reader rather than
 // given one per call), and it is expected to serve many Decode calls rather than exactly one.
 //
@@ -64,4 +67,7 @@ type EncoderFunc func(w io.Writer) Encoder
 
 // DecoderFunc constructs a [Decoder] bound to r. Registered in a [Map] by kind as part of a [Codec]
 // via [Map.Register], and returned by [Map.Get].
-type DecoderFunc func(r io.Reader) Decoder
+//
+// With [codec.WithDiscardUnknown], the decoder ignores source members that
+// do not map to its destination.
+type DecoderFunc func(r io.Reader, opts ...codec.Option) Decoder

--- a/encoding/stream/yaml/yaml.go
+++ b/encoding/stream/yaml/yaml.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 	yaml "go.yaml.in/yaml/v3"
 )
@@ -37,11 +38,11 @@ type Decoder struct {
 //
 // Unlike [github.com/alexfalkowski/go-service/v2/encoding/yaml.Encoder]'s Decode, the returned
 // decoder allows additional YAML documents after the first: it does not enforce single-value
-// trailing-data rejection, since a stream is expected to carry many documents. Unknown fields remain
-// rejected.
-func NewDecoder(r io.Reader) *Decoder {
+// trailing-data rejection, since a stream is expected to carry many documents. Unknown fields are
+// rejected unless [codec.WithDiscardUnknown] is supplied.
+func NewDecoder(r io.Reader, opts ...codec.Option) *Decoder {
 	decoder := yaml.NewDecoder(r)
-	decoder.KnownFields(true)
+	decoder.KnownFields(!codec.Apply(opts...).DiscardUnknown())
 
 	return &Decoder{Decoder: decoder}
 }

--- a/encoding/stream/yaml/yaml_test.go
+++ b/encoding/stream/yaml/yaml_test.go
@@ -3,6 +3,7 @@ package yaml_test
 import (
 	"testing"
 
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/stream/yaml"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -74,6 +75,22 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeDiscardsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	buffer := test.Pool.Get()
+	defer test.Pool.Put(buffer)
+
+	_, err := buffer.WriteString("test: test\nextra: ignored")
+	require.NoError(t, err)
+
+	decoder := yaml.NewDecoder(buffer, codec.WithDiscardUnknown())
+	msg := &message{}
+
+	require.NoError(t, decoder.Decode(msg))
+	require.Equal(t, "test", msg.Test)
 }
 
 func TestDecodeAllowsTrailingDocuments(t *testing.T) {

--- a/encoding/toml/toml.go
+++ b/encoding/toml/toml.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/io"
 )
 
@@ -13,7 +14,7 @@ var defaultEncoder = &Encoder{}
 // NewEncoder constructs a TOML encoder.
 //
 // This encoder is a thin adapter around [github.com/BurntSushi/toml] that satisfies
-// [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewEncoder() *Encoder {
 	return defaultEncoder
 }
@@ -34,14 +35,16 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
 //
-// This method rejects keys that do not decode into v.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+// This method rejects keys that do not decode into v unless
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] is
+// supplied.
+func (e *Encoder) Decode(r io.Reader, v any, opts ...codec.Option) error {
 	meta, err := toml.NewDecoder(r).Decode(v)
 	if err != nil {
 		return err
 	}
 
-	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+	if undecoded := meta.Undecoded(); !codec.Apply(opts...).DiscardUnknown() && len(undecoded) > 0 {
 		return fmt.Errorf("toml: undecoded key %s", undecoded[0])
 	}
 

--- a/encoding/toml/toml_test.go
+++ b/encoding/toml/toml_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/toml"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/strings"
@@ -76,6 +77,16 @@ func TestDecodeRejectsUndecodedMetadata(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeDiscardsUndecodedMetadata(t *testing.T) {
+	t.Parallel()
+
+	encoder := toml.NewEncoder()
+	msg := &message{}
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("test = \"test\"\nextra = \"ignored\""), msg, codec.WithDiscardUnknown()))
+	require.Equal(t, "test", msg.Test)
 }
 
 type message struct {

--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	yaml "go.yaml.in/yaml/v3"
@@ -12,7 +13,7 @@ var defaultEncoder = &Encoder{}
 // NewEncoder constructs a YAML encoder.
 //
 // This encoder is a thin adapter around go-yaml v3 (imported as [go.yaml.in/yaml/v3]) that satisfies
-// [github.com/alexfalkowski/go-service/v2/encoding.Encoder].
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.Encoder].
 func NewEncoder() *Encoder {
 	return defaultEncoder
 }
@@ -38,11 +39,12 @@ func (e *Encoder) Encode(w io.Writer, v any) error {
 // Decode reads YAML from r and decodes it into v.
 //
 // In most cases v should be a pointer to the destination value (for example *MyStruct).
-// Decode reads one YAML document and rejects unknown fields and additional
-// documents in the same stream.
-func (e *Encoder) Decode(r io.Reader, v any) error {
+// Decode reads one YAML document and rejects unknown fields unless
+// [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown] is
+// supplied. It always rejects additional documents in the same stream.
+func (e *Encoder) Decode(r io.Reader, v any, opts ...codec.Option) error {
 	decoder := yaml.NewDecoder(r)
-	decoder.KnownFields(true)
+	decoder.KnownFields(!codec.Apply(opts...).DiscardUnknown())
 	if err := decoder.Decode(v); err != nil {
 		return err
 	}

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/encoding/yaml"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -74,6 +75,16 @@ func TestDecodeRejectsUnknownFields(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extra")
+}
+
+func TestDecodeDiscardsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	encoder := yaml.NewEncoder()
+	msg := &message{}
+
+	require.NoError(t, encoder.Decode(bytes.NewBufferString("test: test\nextra: ignored"), msg, codec.WithDiscardUnknown()))
+	require.Equal(t, "test", msg.Test)
 }
 
 func TestDecodeRejectsTrailingDocument(t *testing.T) {

--- a/internal/test/cache.go
+++ b/internal/test/cache.go
@@ -151,7 +151,7 @@ func redisCache(lc di.Lifecycle) (*cache.Cache, cache.Pinger, error) {
 	return cache.NewCache(params), cache.NewPinger(drv), nil
 }
 
-func newWorldCache(tb testing.TB, lc di.Lifecycle, opts *worldOpts) (*cache.Cache, cache.Pinger) {
+func newWorldCache(tb testing.TB, lc di.Lifecycle, opts *options) (*cache.Cache, cache.Pinger) {
 	tb.Helper()
 
 	var kind *cache.Cache
@@ -174,7 +174,7 @@ func newWorldCache(tb testing.TB, lc di.Lifecycle, opts *worldOpts) (*cache.Cach
 	return kind, pinger
 }
 
-func createWorldCache(tb testing.TB, lc di.Lifecycle, opts *worldCacheOpts) (*cache.Cache, cache.Pinger) {
+func createWorldCache(tb testing.TB, lc di.Lifecycle, opts *worldCacheOptions) (*cache.Cache, cache.Pinger) {
 	tb.Helper()
 
 	drv := opts.driver

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -3,7 +3,7 @@ package test
 import (
 	cache "github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/config"
-	"github.com/alexfalkowski/go-service/v2/config/options"
+	configoptions "github.com/alexfalkowski/go-service/v2/config/options"
 	"github.com/alexfalkowski/go-service/v2/config/server"
 	"github.com/alexfalkowski/go-service/v2/crypto/aes"
 	"github.com/alexfalkowski/go-service/v2/crypto/ed25519"
@@ -54,7 +54,7 @@ var FastRetryConfig = &retry.Config{
 
 // ConfigOptions contains long-lived server timeout defaults used in tests that
 // decode server configs from option maps.
-var ConfigOptions = options.Map{
+var ConfigOptions = configoptions.Map{
 	"read_timeout":        "10m",
 	"write_timeout":       "10m",
 	"idle_timeout":        "10m",

--- a/internal/test/encoding.go
+++ b/internal/test/encoding.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
@@ -23,7 +24,7 @@ var UnaryContent = unary.NewContent(Encoder, Pool)
 var StreamContent = contentstream.NewContent(StreamEncoder, Pool)
 
 // NewEncoder returns an encoder test double whose Encode and Decode methods fail with the supplied error.
-func NewEncoder(err error) encoding.Encoder {
+func NewEncoder(err error) codec.Encoder {
 	return &enc{err: err}
 }
 
@@ -31,13 +32,13 @@ type enc struct {
 	err error
 }
 
-// Encode implements [encoding.Encoder] and returns the configured error.
+// Encode implements [codec.Encoder] and returns the configured error.
 func (e *enc) Encode(_ io.Writer, _ any) error {
 	return e.err
 }
 
-// Decode implements [encoding.Encoder] and returns the configured error.
-func (e *enc) Decode(_ io.Reader, _ any) error {
+// Decode implements [codec.Encoder] and returns the configured error.
+func (e *enc) Decode(_ io.Reader, _ any, _ ...codec.Option) error {
 	return e.err
 }
 
@@ -50,8 +51,8 @@ func (PartialEncoder) Encode(w io.Writer, _ any) error {
 	return ErrFailed
 }
 
-// Decode implements [encoding.Encoder] and always succeeds.
-func (PartialEncoder) Decode(io.Reader, any) error {
+// Decode implements [codec.Encoder] and always succeeds.
+func (PartialEncoder) Decode(io.Reader, any, ...codec.Option) error {
 	return nil
 }
 

--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -76,7 +76,7 @@ func (w *World) registerTelemetry() {
 	errors.Register(errors.NewHandler(nil))
 }
 
-func createLogger(lc di.Lifecycle, os *worldOpts) (*logger.Logger, error) {
+func createLogger(lc di.Lifecycle, os *options) (*logger.Logger, error) {
 	if os.logger != nil {
 		return os.logger, nil
 	}

--- a/internal/test/metrics.go
+++ b/internal/test/metrics.go
@@ -166,7 +166,7 @@ func EnableMetricsReader(tb testing.TB) metrics.Reader {
 	return reader
 }
 
-func meter(lc di.Lifecycle, router *http.Router, os *worldOpts) (metrics.Meter, error) {
+func meter(lc di.Lifecycle, router *http.Router, os *options) (metrics.Meter, error) {
 	if os.telemetry == "otlp" {
 		return NewMeter(lc, NewOTLPMetricsConfig())
 	}

--- a/internal/test/options.go
+++ b/internal/test/options.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	cacheconfig "github.com/alexfalkowski/go-service/v2/cache/config"
+	cache "github.com/alexfalkowski/go-service/v2/cache/config"
 	"github.com/alexfalkowski/go-service/v2/cache/driver"
 	tls "github.com/alexfalkowski/go-service/v2/crypto/tls/config"
 	"github.com/alexfalkowski/go-service/v2/database/sql/pg"
@@ -17,10 +17,10 @@ import (
 
 // WorldOption configures optional features on a World before it is created.
 type WorldOption interface {
-	apply(opts *worldOpts)
+	apply(opts *options)
 }
 
-type worldOpts struct {
+type options struct {
 	verifier      token.Verifier
 	access        access.Controller
 	rt            http.RoundTripper
@@ -30,9 +30,9 @@ type worldOpts struct {
 	clientLimiter *limiter.Config
 	serverLimiter *limiter.Config
 	pg            *pg.Config
-	cache         *worldCacheOpts
-	httpHealth    *worldHealthOpts
-	grpcHealth    *worldHealthOpts
+	cache         *worldCacheOptions
+	httpHealth    *worldHealthOptions
+	grpcHealth    *worldHealthOptions
 	transport     *transport.Config
 	telemetry     string
 	loggerConfig  string
@@ -46,26 +46,26 @@ type worldOpts struct {
 	registerCache bool
 }
 
-type worldOptionFunc func(*worldOpts)
+type worldOptionFunc func(*options)
 
-func (f worldOptionFunc) apply(o *worldOpts) {
+func (f worldOptionFunc) apply(o *options) {
 	f(o)
 }
 
-type worldCacheOpts struct {
-	config *cacheconfig.Config
+type worldCacheOptions struct {
+	config *cache.Config
 	driver driver.Driver
 }
 
-func (o *worldOpts) cacheOptions() *worldCacheOpts {
+func (o *options) cacheOptions() *worldCacheOptions {
 	if o.cache == nil {
-		o.cache = &worldCacheOpts{}
+		o.cache = &worldCacheOptions{}
 	}
 
 	return o.cache
 }
 
-type worldHealthOpts struct {
+type worldHealthOptions struct {
 	name         string
 	url          string
 	observations []HealthObservation
@@ -87,7 +87,7 @@ func HealthObserve(kind string, names ...string) HealthObservation {
 
 // WithWorldSecure enables TLS for the transport and debug servers in the test world.
 func WithWorldSecure() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.secure = true
 	})
 }
@@ -97,35 +97,35 @@ func WithWorldSecure() WorldOption {
 // The current helpers recognize "otlp" for OTLP metrics and fall back to the
 // Prometheus test setup for any other value.
 func WithWorldTelemetry(kind string) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.telemetry = kind
 	})
 }
 
 // WithWorldClientLimiter installs the provided client-side rate limiter config.
 func WithWorldClientLimiter(config *limiter.Config) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.clientLimiter = config
 	})
 }
 
 // WithWorldBreaker installs the provided client-side circuit breaker config.
 func WithWorldBreaker(config *breaker.Config) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.breaker = config
 	})
 }
 
 // WithWorldServerLimiter installs the provided server-side rate limiter config.
 func WithWorldServerLimiter(config *limiter.Config) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.serverLimiter = config
 	})
 }
 
 // WithWorldCompression enables transport compression for clients created by the world.
 func WithWorldCompression() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.compression = true
 	})
 }
@@ -135,30 +135,30 @@ func WithWorldCompression() WorldOption {
 // Pair this with [WithWorldHTTP] or [WithWorldGRPC] when the test needs the corresponding transport
 // server registered.
 func WithWorldTransportConfig(config *transport.Config) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.transport = config
 	})
 }
 
 // WithWorldRoundTripper overrides the HTTP round tripper used by world clients and event senders.
 func WithWorldRoundTripper(rt http.RoundTripper) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.rt = rt
 	})
 }
 
 // WithWorldHTTP enables registration of the HTTP transport server.
 func WithWorldHTTP() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.http = true
 	})
 }
 
 // WithWorldHTTPHealth registers the HTTP health routes on the world before it starts.
 func WithWorldHTTPHealth(name, url string, observations ...HealthObservation) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.http = true
-		o.httpHealth = &worldHealthOpts{
+		o.httpHealth = &worldHealthOptions{
 			name:         name,
 			url:          url,
 			observations: append([]HealthObservation(nil), observations...),
@@ -168,16 +168,16 @@ func WithWorldHTTPHealth(name, url string, observations ...HealthObservation) Wo
 
 // WithWorldGRPC enables registration of the gRPC transport server.
 func WithWorldGRPC() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.grpc = true
 	})
 }
 
 // WithWorldGRPCHealth registers the gRPC health service on the world before it starts.
 func WithWorldGRPCHealth(name, url string, observations ...HealthObservation) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.grpc = true
-		o.grpcHealth = &worldHealthOpts{
+		o.grpcHealth = &worldHealthOptions{
 			name:         name,
 			url:          url,
 			observations: append([]HealthObservation(nil), observations...),
@@ -187,14 +187,14 @@ func WithWorldGRPCHealth(name, url string, observations ...HealthObservation) Wo
 
 // WithWorldDebug enables registration of the debug server.
 func WithWorldDebug() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.debug = true
 	})
 }
 
 // WithWorldHello registers the default GET /hello test handler on the world's mux.
 func WithWorldHello() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.hello = true
 	})
 }
@@ -203,8 +203,8 @@ func WithWorldHello() WorldOption {
 //
 // When config is nil, the world cache is disabled instead of using the default
 // Redis-backed test cache.
-func WithWorldCacheConfig(config *cacheconfig.Config) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+func WithWorldCacheConfig(config *cache.Config) WorldOption {
+	return worldOptionFunc(func(o *options) {
 		o.cacheOptions().config = config
 	})
 }
@@ -214,7 +214,7 @@ func WithWorldCacheConfig(config *cacheconfig.Config) WorldOption {
 // If no custom cache driver is provided, the driver is built from the selected
 // cache config.
 func WithWorldCacheDriver(driver driver.Driver) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.cacheOptions().driver = driver
 	})
 }
@@ -226,7 +226,7 @@ func WithWorldCacheDriver(driver driver.Driver) WorldOption {
 // option is intended for tests that specifically exercise the generic cache
 // helpers.
 func WithWorldRegisterCache() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.registerCache = true
 	})
 }
@@ -234,7 +234,7 @@ func WithWorldRegisterCache() WorldOption {
 // WithWorldPGConfig enables Postgres for the world using config or the default
 // test config when config is nil.
 func WithWorldPGConfig(config *pg.Config) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		if config != nil {
 			o.pg = config
 		} else {
@@ -245,7 +245,7 @@ func WithWorldPGConfig(config *pg.Config) WorldOption {
 
 // WithWorldLogger injects a prebuilt logger into the world instead of constructing one from config.
 func WithWorldLogger(logger *logger.Logger) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.logger = logger
 	})
 }
@@ -255,21 +255,21 @@ func WithWorldLogger(logger *logger.Logger) WorldOption {
 // Recognized values are "json", "text", "tint", and "otlp". Empty or
 // unrecognized values use the OTLP logger config.
 func WithWorldLoggerConfig(config string) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.loggerConfig = config
 	})
 }
 
 // WithWorldRest configures NewWorld to create a REST client backed by the world's HTTP transport.
 func WithWorldRest() WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.rest = true
 	})
 }
 
 // WithWorldToken overrides the token generator and verifier used by world clients and servers.
 func WithWorldToken(generator token.Generator, verifier token.Verifier) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.generator = generator
 		o.verifier = verifier
 	})
@@ -277,13 +277,13 @@ func WithWorldToken(generator token.Generator, verifier token.Verifier) WorldOpt
 
 // WithWorldAccessController overrides the access controller used by world servers.
 func WithWorldAccessController(controller access.Controller) WorldOption {
-	return worldOptionFunc(func(o *worldOpts) {
+	return worldOptionFunc(func(o *options) {
 		o.access = controller
 	})
 }
 
-func worldOptions(opts ...WorldOption) *worldOpts {
-	os := &worldOpts{}
+func worldOptions(opts ...WorldOption) *options {
+	os := &options{}
 	for _, o := range opts {
 		o.apply(os)
 	}
@@ -291,7 +291,7 @@ func worldOptions(opts ...WorldOption) *worldOpts {
 	return os
 }
 
-func (w *World) registerOptions(opts *worldOpts) {
+func (w *World) registerOptions(opts *options) {
 	if opts.hello {
 		w.HandleHello()
 	}
@@ -303,7 +303,7 @@ func (w *World) registerOptions(opts *worldOpts) {
 	}
 }
 
-func transportConfig(opts *worldOpts) *transport.Config {
+func transportConfig(opts *options) *transport.Config {
 	if opts.transport != nil {
 		return opts.transport
 	}
@@ -315,7 +315,7 @@ func transportConfig(opts *worldOpts) *transport.Config {
 	return NewInsecureTransportConfig()
 }
 
-func debugConfig(opts *worldOpts) *debug.Config {
+func debugConfig(opts *options) *debug.Config {
 	if opts.secure {
 		return NewSecureDebugConfig()
 	}
@@ -323,7 +323,7 @@ func debugConfig(opts *worldOpts) *debug.Config {
 	return NewInsecureDebugConfig()
 }
 
-func tlsConfig(opts *worldOpts) *tls.Config {
+func tlsConfig(opts *options) *tls.Config {
 	if opts.secure {
 		return NewTLSClientConfig()
 	}

--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -91,7 +91,7 @@ func registerRest(router *http.Router) {
 	rest.Register(router, UnaryContent, StreamContent, Pool, stream.Options{})
 }
 
-func restClient(client *http.Client, os *worldOpts) *rest.Client {
+func restClient(client *http.Client, os *options) *rest.Client {
 	if os.rest {
 		return rest.NewClient(
 			rest.WithClientRoundTripper(client.Transport),

--- a/net/http/client/client.go
+++ b/net/http/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -19,7 +20,7 @@ import (
 // Options are applied in the order provided to NewClient. If multiple options configure the same
 // field, the last one wins.
 type ClientOption interface {
-	apply(opts *clientOpts)
+	apply(opts *clientOptions)
 }
 
 // Redirect configures how Client handles HTTP redirects.
@@ -36,16 +37,16 @@ const (
 	RedirectSameOrigin
 )
 
-type clientOpts struct {
+type clientOptions struct {
 	roundTripper    http.RoundTripper
 	timeout         time.Duration
 	maxResponseSize bytes.Size
 	redirect        Redirect
 }
 
-type clientOptionFunc func(*clientOpts)
+type clientOptionFunc func(*clientOptions)
 
-func (f clientOptionFunc) apply(o *clientOpts) {
+func (f clientOptionFunc) apply(o *clientOptions) {
 	f(o)
 }
 
@@ -56,7 +57,7 @@ func (f clientOptionFunc) apply(o *clientOpts) {
 //
 // If not provided, NewClient uses [http.Transport](nil) (go-service's tuned default transport).
 func WithRoundTripper(rt http.RoundTripper) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.roundTripper = rt
 	})
 }
@@ -69,7 +70,7 @@ func WithRoundTripper(rt http.RoundTripper) ClientOption {
 //
 // If not provided, NewClient defaults to [time.DefaultTimeout].
 func WithTimeout(timeout time.Duration) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.timeout = timeout
 	})
 }
@@ -85,7 +86,7 @@ func WithTimeout(timeout time.Duration) ClientOption {
 //
 // If not provided, NewClient defaults to [bytes.DefaultSize].
 func WithMaxResponseSize(size bytes.Size) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.maxResponseSize = size
 	})
 }
@@ -97,7 +98,7 @@ func WithMaxResponseSize(size bytes.Size) ClientOption {
 // origin by an upstream redirect. Use RedirectFollow to opt into standard
 // library cross-origin redirect behavior.
 func WithRedirect(redirect Redirect) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.redirect = redirect
 	})
 }
@@ -237,6 +238,7 @@ func (c *Client) Patch(ctx context.Context, url string, opts Options) error {
 //   - Otherwise, if the status code is in the 4xx/5xx range, a generic status error is returned.
 //   - Otherwise, if opts.Response is non-nil, the response body is decoded into it using the encoder
 //     selected by the response Content-Type (falling back to opts.ContentType).
+//     Unknown response members are discarded so newer servers remain compatible with older clients.
 //   - An empty successful response body is not decoded, leaving opts.Response unchanged.
 //
 // Notes:
@@ -288,7 +290,7 @@ func (c *Client) Do(ctx context.Context, method, url string, opts Options) error
 			return nil
 		}
 
-		if err := responseMedia.Encoder.Decode(responseBody, opts.Response); err != nil {
+		if err := responseMedia.Encoder.Decode(responseBody, opts.Response, codec.WithDiscardUnknown()); err != nil {
 			return errors.Prefix("http: decode", err)
 		}
 	}
@@ -417,8 +419,8 @@ func responseContentType(header http.Header, opts Options) string {
 	return opts.ContentType
 }
 
-func options(opts ...ClientOption) *clientOpts {
-	clientOptions := &clientOpts{redirect: RedirectSameOrigin}
+func options(opts ...ClientOption) *clientOptions {
+	clientOptions := &clientOptions{redirect: RedirectSameOrigin}
 	for _, o := range opts {
 		o.apply(clientOptions)
 	}

--- a/net/http/client/client_test.go
+++ b/net/http/client/client_test.go
@@ -217,6 +217,22 @@ func TestDoSendsAccept(t *testing.T) {
 	require.Equal(t, "Hello Bob", response.Greeting)
 }
 
+func TestDoDiscardsUnknownResponseFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		res.Header().Set(http.ContentTypeKey, media.JSON)
+		_, _ = io.WriteString(res, `{"greeting":"Hello Bob","future":"ignored"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	var response test.Response
+	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool)
+
+	err := c.Get(t.Context(), server.URL, client.Options{Response: &response})
+
+	require.NoError(t, err)
+	require.Equal(t, "Hello Bob", response.Greeting)
+}
+
 func TestDoDetachesRequestBodyFromResponseBuffer(t *testing.T) {
 	var body io.ReadCloser
 	c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithRoundTripper(test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/net/http/client/stream.go
+++ b/net/http/client/stream.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/io"
@@ -447,7 +448,7 @@ func newResponseDecoder(c *Client, response *http.Response, opts Options) (*resp
 
 	capped := quota.NewReader(response.Body, c.maxResponseSize)
 
-	return &responseDecoder{decoder: resMedia.NewDecoder(capped), capped: capped}, nil
+	return &responseDecoder{decoder: resMedia.NewDecoder(capped, codec.WithDiscardUnknown()), capped: capped}, nil
 }
 
 // recv decodes the next value into v and, on success, checks it against the per-value cap. The check

--- a/net/http/client/stream_test.go
+++ b/net/http/client/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	encodingcodec "github.com/alexfalkowski/go-service/v2/encoding/codec"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
@@ -441,7 +442,9 @@ func TestStreamRejectsValueOverCapWhenDecodeSucceedsInOneRead(t *testing.T) {
 
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
-	codec.Decoder = func(r io.Reader) encodingstream.Decoder { return &test.SingleReadDecoder{R: r} }
+	codec.Decoder = func(r io.Reader, _ ...encodingcodec.Option) encodingstream.Decoder {
+		return &test.SingleReadDecoder{R: r}
+	}
 	sm.Register("json", codec)
 	unaryContent := unary.NewContent(test.Encoder, test.Pool)
 
@@ -462,19 +465,23 @@ func TestStreamRecvRecoversCapReaderErrorDespiteDecoder(t *testing.T) {
 		name     string
 		greeting string
 		maxSize  bytes.Size
-		decoder  func(io.Reader) encodingstream.Decoder
+		decoder  func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder
 	}{
 		{
 			name:     "decoder discards the error's type",
 			greeting: "a greeting far longer than the configured cap",
 			maxSize:  8,
-			decoder:  func(r io.Reader) encodingstream.Decoder { return &test.OpaqueErrorDecoder{R: r} },
+			decoder: func(r io.Reader, _ ...encodingcodec.Option) encodingstream.Decoder {
+				return &test.OpaqueErrorDecoder{R: r}
+			},
 		},
 		{
 			name:     "decoder calls Read again after quota.Reader already latched an error",
 			greeting: "ab",
 			maxSize:  1,
-			decoder:  func(r io.Reader) encodingstream.Decoder { return &test.TripleReadDecoder{R: r} },
+			decoder: func(r io.Reader, _ ...encodingcodec.Option) encodingstream.Decoder {
+				return &test.TripleReadDecoder{R: r}
+			},
 		},
 	}
 
@@ -585,15 +592,18 @@ func TestStreamRecvHandlesBufferedValuesAtCap(t *testing.T) {
 		name       string
 		body       string
 		exceedsCap bool
+		maxSize    bytes.Size
 	}{
 		{
 			name:       "over cap",
 			body:       "{\"Greeting\":\"A\"}\n{\"Greeting\":\"a greeting far longer than the configured cap\"}\n",
 			exceedsCap: true,
+			maxSize:    20,
 		},
 		{
-			name: "within cap decode error",
-			body: "{\"Greeting\":\"A\"}\n{\"Greeting\":\"B\",\"Unknown\":true}\n",
+			name:    "within cap discards unknown fields",
+			body:    "{\"Greeting\":\"A\"}\n{\"Greeting\":\"B\",\"Unknown\":true}\n",
+			maxSize: 64,
 		},
 	}
 
@@ -605,7 +615,7 @@ func TestStreamRecvHandlesBufferedValuesAtCap(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(20))
+			c := client.NewClient(test.UnaryContent, test.StreamContent, test.Pool, client.WithMaxResponseSize(tt.maxSize))
 
 			err := c.Stream(t.Context(), http.MethodGet, server.URL, client.Options{Accept: media.NDJSON},
 				func(_ context.Context, stream *client.ResponseStream) error {
@@ -616,11 +626,11 @@ func TestStreamRecvHandlesBufferedValuesAtCap(t *testing.T) {
 					return stream.Recv(&second)
 				})
 
-			require.Error(t, err)
 			if tt.exceedsCap {
+				require.Error(t, err)
 				require.Equal(t, http.StatusRequestEntityTooLarge, status.Code(err))
 			} else {
-				require.NotEqual(t, http.StatusRequestEntityTooLarge, status.Code(err))
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -837,7 +847,7 @@ func TestStreamRecvBufferedLenFallback(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sm := encodingstream.NewMap()
 			codec := sm.Get("json")
-			codec.Decoder = func(io.Reader) encodingstream.Decoder { return tt.decoder }
+			codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder { return tt.decoder }
 			sm.Register("json", codec)
 			unaryContent := unary.NewContent(test.Encoder, test.Pool)
 

--- a/net/http/content/stream/handler.go
+++ b/net/http/content/stream/handler.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
 	"github.com/alexfalkowski/go-service/v2/net/http/compress"
@@ -117,7 +118,8 @@ type Handler[Res any] func(ctx context.Context, stream *Stream[Res]) error
 // an unregistered or unparseable media type with 415. The response encoder is resolved from Accept
 // (falling back to Content-Type) via [Content.NewFromAccept], rejecting an Accept that cannot be
 // satisfied with 406 instead: Accept negotiates the response representation, not the request payload,
-// so a failure there is answered as RFC 9110 §15.5.7 rather than §15.5.16.
+// so a failure there is answered as RFC 9110 §15.5.7 rather than §15.5.16. Each request value discards
+// unknown members so a new field does not break an older stream consumer.
 //
 // Inbound size limiting:
 // opts.MaxReceiveSize bounds each value decoded by [RequestStream.Recv], not the request stream as a
@@ -187,7 +189,7 @@ func NewRequestHandler[Req any, Res any](content *Content, opts Options, handler
 
 		writer := &commitWriter{res: res, buffer: buffer}
 		capped := quota.NewReader(req.Body, opts.MaxReceiveSize.Bytes())
-		decoder := reqMedia.NewDecoder(capped)
+		decoder := reqMedia.NewDecoder(capped, codec.WithDiscardUnknown())
 		stream := &RequestStream[Req, Res]{
 			Stream: Stream[Res]{
 				ctx:          ctx,

--- a/net/http/content/stream/request_handler_test.go
+++ b/net/http/content/stream/request_handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
+	encodingcodec "github.com/alexfalkowski/go-service/v2/encoding/codec"
 	encodingstream "github.com/alexfalkowski/go-service/v2/encoding/stream"
 	"github.com/alexfalkowski/go-service/v2/internal/test"
 	"github.com/alexfalkowski/go-service/v2/io"
@@ -48,7 +49,9 @@ func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommitOnDrain(t *testing.T
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
-	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder {
+		return &trackedDecoder{tracker: decoder}
+	}
 	sm.Register("json", codec)
 	drain := make(chan struct{})
 	handler := contentstream.NewRequestHandler(
@@ -85,7 +88,9 @@ func TestNewRequestHandlerClosesCodecsBeforeAbortAfterCommit(t *testing.T) {
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
-	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder {
+		return &trackedDecoder{tracker: decoder}
+	}
 	sm.Register("json", codec)
 	handler := contentstream.NewRequestHandler(
 		contentstream.NewContent(sm, test.Pool),
@@ -118,7 +123,9 @@ func TestNewRequestHandlerClosesCodecsAfterCommitPanic(t *testing.T) {
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
-	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder {
+		return &trackedDecoder{tracker: decoder}
+	}
 	sm.Register("json", codec)
 	handler := contentstream.NewRequestHandler(
 		contentstream.NewContent(sm, test.Pool),
@@ -151,7 +158,9 @@ func TestNewRequestHandlerClosesCodecsAfterReceiveOnlyHandler(t *testing.T) {
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return &trackedEncoder{tracker: encoder} }
-	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder {
+		return &trackedDecoder{tracker: decoder}
+	}
 	sm.Register("json", codec)
 	handler := contentstream.NewRequestHandler(
 		contentstream.NewContent(sm, test.Pool),
@@ -183,7 +192,9 @@ func TestNewRequestHandlerIgnoresCodecCloseErrors(t *testing.T) {
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
 	codec.Encoder = func(io.Writer) encodingstream.Encoder { return test.CloseErrEncoder{} }
-	codec.Decoder = func(io.Reader) encodingstream.Decoder { return &trackedDecoder{tracker: decoder} }
+	codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder {
+		return &trackedDecoder{tracker: decoder}
+	}
 	sm.Register("json", codec)
 	handler := contentstream.NewRequestHandler(
 		contentstream.NewContent(sm, test.Pool),
@@ -287,7 +298,7 @@ func TestNewRequestHandlerRecvRejectsValueWhenDrainStartsAfterDecode(t *testing.
 	body := &drainBody{closed: make(chan struct{})}
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
-	codec.Decoder = func(io.Reader) encodingstream.Decoder {
+	codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder {
 		return &drainAfterDecode{drain: drain, closed: body.closed}
 	}
 	sm.Register("json", codec)
@@ -602,17 +613,17 @@ func TestNewRequestHandlerRecvRejectsBufferedValueOverCap(t *testing.T) {
 	require.Equal(t, int64(16), maxBytesErr.Limit)
 }
 
-func TestNewRequestHandlerRecvReturnsDecodeErrorForBufferedValueWithinCap(t *testing.T) {
-	var secondErr error
+func TestNewRequestHandlerRecvDiscardsUnknownFieldsWithinCap(t *testing.T) {
+	var second *test.Request
 
 	handler := contentstream.NewRequestHandler(
 		test.StreamContent,
-		contentstream.Options{MaxReceiveSize: 16}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
+		contentstream.Options{MaxReceiveSize: 64}, func(_ context.Context, stream *contentstream.RequestStream[test.Request, test.Response]) error {
 			_, err := stream.Recv()
 			require.NoError(t, err)
 
-			_, secondErr = stream.Recv()
-			return secondErr
+			second, err = stream.Recv()
+			return err
 		})
 
 	body := "{\"Name\":\"A\"}\n{\"Name\":\"B\",\"Unknown\":true}\n"
@@ -624,9 +635,8 @@ func TestNewRequestHandlerRecvReturnsDecodeErrorForBufferedValueWithinCap(t *tes
 
 	handler.ServeHTTP(res, req)
 
-	require.Error(t, secondErr)
-	require.NotEqual(t, http.StatusRequestEntityTooLarge, status.Code(secondErr))
-	require.NotEqual(t, http.StatusRequestEntityTooLarge, res.Code)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, "B", second.Name)
 }
 
 func TestNewRequestHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavior(t *testing.T) {
@@ -634,19 +644,23 @@ func TestNewRequestHandlerRecvRejectsValueOverCapRegardlessOfDecoderBehavior(t *
 		name    string
 		body    string
 		maxSize bytes.Size
-		decoder func(io.Reader) encodingstream.Decoder
+		decoder func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder
 	}{
 		{
 			name:    "decode succeeds in one read",
 			body:    "a value with far more than eight bytes",
 			maxSize: 8,
-			decoder: func(r io.Reader) encodingstream.Decoder { return &test.SingleReadDecoder{R: r} },
+			decoder: func(r io.Reader, _ ...encodingcodec.Option) encodingstream.Decoder {
+				return &test.SingleReadDecoder{R: r}
+			},
 		},
 		{
 			name:    "decoder discards the error's type",
 			body:    "{\"Name\":\"a value with a name far longer than the configured cap\"}\n",
 			maxSize: 16,
-			decoder: func(r io.Reader) encodingstream.Decoder { return &test.OpaqueErrorDecoder{R: r} },
+			decoder: func(r io.Reader, _ ...encodingcodec.Option) encodingstream.Decoder {
+				return &test.OpaqueErrorDecoder{R: r}
+			},
 		},
 	}
 
@@ -1010,7 +1024,7 @@ func TestNewRequestHandlerRecvBufferedLenFallback(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sm := encodingstream.NewMap()
 			codec := sm.Get("json")
-			codec.Decoder = func(io.Reader) encodingstream.Decoder { return tt.decoder }
+			codec.Decoder = func(io.Reader, ...encodingcodec.Option) encodingstream.Decoder { return tt.decoder }
 			sm.Register("json", codec)
 			handler := contentstream.NewRequestHandler(
 				contentstream.NewContent(sm, test.Pool),
@@ -1037,7 +1051,9 @@ func TestNewRequestHandlerRecvBufferedLenFallback(t *testing.T) {
 func TestNewRequestHandlerRecvRecoversStickyCapReaderError(t *testing.T) {
 	sm := encodingstream.NewMap()
 	codec := sm.Get("json")
-	codec.Decoder = func(r io.Reader) encodingstream.Decoder { return &test.TripleReadDecoder{R: r} }
+	codec.Decoder = func(r io.Reader, _ ...encodingcodec.Option) encodingstream.Decoder {
+		return &test.TripleReadDecoder{R: r}
+	}
 	sm.Register("json", codec)
 	opts := contentstream.Options{MaxReceiveSize: bytes.Size(1)}
 	content := contentstream.NewContent(sm, test.Pool)

--- a/net/http/content/unary/doc.go
+++ b/net/http/content/unary/doc.go
@@ -33,6 +33,12 @@
 // since the caller asserted nothing, but an unparseable or unregistered Content-Type is rejected
 // instead of silently decoded as a different format the caller did not send.
 //
+// # Forward-compatible payloads
+//
+// HTTP request handlers decode with [github.com/alexfalkowski/go-service/v2/encoding/codec.WithDiscardUnknown],
+// so a newly added field does not break an older service during a rolling deployment. Message framing,
+// syntax, types, and request-size limits remain enforced.
+//
 // # The decoder-bounds rule
 //
 // A wire format is admissible for decoding untrusted input — a server request body, or a streaming

--- a/net/http/content/unary/handler.go
+++ b/net/http/content/unary/handler.go
@@ -2,6 +2,7 @@ package unary
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	encodingerrors "github.com/alexfalkowski/go-service/v2/encoding/errors"
 	"github.com/alexfalkowski/go-service/v2/errors"
 	"github.com/alexfalkowski/go-service/v2/net/http"
@@ -25,7 +26,8 @@ type RequestHandler[Req any, Res any] func(ctx context.Context, req *Req) (*Res,
 // Request-body decoding uses the request Content-Type, falling back to JSON when Content-Type is absent.
 // An unparseable, unregistered, or intentionally undecodable Content-Type (see the decoder-bounds rule in
 // the package documentation) is rejected with [ErrUnsupportedRequestMedia] rather than falling back to
-// JSON; see [Content.NewFromRequestBody]. Response encoding uses the request Accept header, falling back
+// JSON; see [Content.NewFromRequestBody]. Unknown request members are discarded so API additions remain
+// forward-compatible. Response encoding uses the request Accept header, falling back
 // to Content-Type when Accept is absent. The response Content-Type header is set to the negotiated
 // response media type. The selected response encoder remains internal to the handler.
 //
@@ -53,7 +55,7 @@ func NewRequestHandler[Req any, Res any](content *Content, handler RequestHandle
 			return nil, status.SafeError(http.StatusUnsupportedMediaType, err)
 		}
 
-		if err := mediaType.Encoder.Decode(request.Body, req); err != nil {
+		if err := mediaType.Encoder.Decode(request.Body, req, codec.WithDiscardUnknown()); err != nil {
 			return nil, status.BadRequestError(err)
 		}
 

--- a/net/http/content/unary/handler_test.go
+++ b/net/http/content/unary/handler_test.go
@@ -46,6 +46,23 @@ func TestNewRequestHandlerUsesAcceptForResponse(t *testing.T) {
 	}
 }
 
+func TestNewRequestHandlerDiscardsUnknownRequestFields(t *testing.T) {
+	handler := unary.NewRequestHandler(test.UnaryContent, func(_ context.Context, req *test.Request) (*test.Response, error) {
+		return &test.Response{Greeting: "Hello " + req.Name}, nil
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/hello", strings.NewReader(`{"name":"Bob","future":"ignored"}`))
+	req.Header.Set(http.ContentTypeKey, media.JSON)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	var response test.Response
+	require.NoError(t, test.Encoder.Get("json").Decode(res.Body, &response))
+	require.Equal(t, "Hello Bob", response.Greeting)
+}
+
 func TestNewRequestHandlerRejectsUnsafeRequestBody(t *testing.T) {
 	for _, tc := range []struct {
 		mediaType string

--- a/net/http/content/unary/media.go
+++ b/net/http/content/unary/media.go
@@ -2,6 +2,7 @@ package unary
 
 import (
 	"github.com/alexfalkowski/go-service/v2/encoding"
+	"github.com/alexfalkowski/go-service/v2/encoding/codec"
 	"github.com/alexfalkowski/go-service/v2/net/http/content/policy"
 	"github.com/alexfalkowski/go-service/v2/net/http/media"
 )
@@ -61,7 +62,7 @@ func unaryKind(subtype string) string {
 // Type is the parsed media type. Encoder may be nil when Subtype is "error".
 type Media struct {
 	// Encoder is the encoder/decoder associated with the media subtype.
-	Encoder encoding.Encoder
+	Encoder codec.Encoder
 
 	// Type is the parsed media type.
 	media.Type

--- a/net/http/mvc/options.go
+++ b/net/http/mvc/options.go
@@ -3,39 +3,55 @@ package mvc
 import "github.com/alexfalkowski/go-service/v2/net/http"
 
 // RouteOption configures MVC route registration.
-type RouteOption func(*routeOptions)
+type RouteOption interface {
+	apply(opts *routeOptions)
+}
 
 type routeOptions struct {
 	unauthenticated bool
 }
 
 // StaticOption configures static file response behavior.
-type StaticOption func(*staticOptions)
+type StaticOption interface {
+	apply(opts *staticOptions)
+}
 
 type staticOptions struct {
 	cacheControl string
 	routeOptions
 }
 
+type routeOptionFunc func(*routeOptions)
+
+func (f routeOptionFunc) apply(o *routeOptions) {
+	f(o)
+}
+
+type staticOptionFunc func(*staticOptions)
+
+func (f staticOptionFunc) apply(o *staticOptions) {
+	f(o)
+}
+
 // WithRouteUnauthenticated marks an MVC route as not requiring transport token authentication.
 func WithRouteUnauthenticated() RouteOption {
-	return func(options *routeOptions) {
+	return routeOptionFunc(func(options *routeOptions) {
 		options.unauthenticated = true
-	}
+	})
 }
 
 // WithCacheControl sets the Cache-Control response header for a static route.
 func WithCacheControl(value string) StaticOption {
-	return func(options *staticOptions) {
+	return staticOptionFunc(func(options *staticOptions) {
 		options.cacheControl = value
-	}
+	})
 }
 
 // WithStaticUnauthenticated marks a static route as not requiring transport token authentication.
 func WithStaticUnauthenticated() StaticOption {
-	return func(options *staticOptions) {
+	return staticOptionFunc(func(options *staticOptions) {
 		options.unauthenticated = true
-	}
+	})
 }
 
 func (options *routeOptions) httpOptions() []http.RouteOption {
@@ -49,7 +65,7 @@ func (options *routeOptions) httpOptions() []http.RouteOption {
 func options(opts ...StaticOption) *staticOptions {
 	options := &staticOptions{}
 	for _, opt := range opts {
-		opt(options)
+		opt.apply(options)
 	}
 
 	return options

--- a/net/http/mvc/server.go
+++ b/net/http/mvc/server.go
@@ -75,7 +75,7 @@ func Route[Model any](pattern string, controller Controller[Model], options ...R
 
 	routeOptions := &routeOptions{}
 	for _, option := range options {
-		option(routeOptions)
+		option.apply(routeOptions)
 	}
 
 	handler := func(res http.ResponseWriter, req *http.Request) {

--- a/net/http/rest/client.go
+++ b/net/http/rest/client.go
@@ -14,17 +14,17 @@ type Options = client.Options
 // Options are applied in the order provided to NewClient. If multiple options configure the same
 // field, the last one wins.
 type ClientOption interface {
-	apply(opts *clientOpts)
+	apply(opts *clientOptions)
 }
 
-type clientOpts struct {
+type clientOptions struct {
 	roundTripper http.RoundTripper
 	timeout      time.Duration
 }
 
-type clientOptionFunc func(*clientOpts)
+type clientOptionFunc func(*clientOptions)
 
-func (f clientOptionFunc) apply(o *clientOpts) {
+func (f clientOptionFunc) apply(o *clientOptions) {
 	f(o)
 }
 
@@ -33,7 +33,7 @@ func (f clientOptionFunc) apply(o *clientOpts) {
 // This is typically used to inject a transport that includes middleware such as retries, circuit
 // breakers, authentication, or custom TLS.
 func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.roundTripper = rt
 	})
 }
@@ -44,7 +44,7 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 // The duration string is parsed using [time.MustParseDuration] and panics if it cannot be parsed.
 // Streaming calls remain bounded by their caller-provided contexts.
 func WithClientTimeout(timeout string) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.timeout = time.MustParseDuration(timeout)
 	})
 }
@@ -74,8 +74,8 @@ type Client struct {
 	*client.Client
 }
 
-func options(opts ...ClientOption) *clientOpts {
-	os := &clientOpts{}
+func options(opts ...ClientOption) *clientOptions {
+	os := &clientOptions{}
 	for _, o := range opts {
 		o.apply(os)
 	}

--- a/net/http/routes.go
+++ b/net/http/routes.go
@@ -3,13 +3,21 @@ package http
 import "github.com/alexfalkowski/go-service/v2/strings"
 
 // RouteOption configures an HTTP route.
-type RouteOption func(*routeOptions)
+type RouteOption interface {
+	apply(opts *routeOptions)
+}
 
 type routeOptions struct {
 	operation         bool
 	unauthenticated   bool
 	requestStreaming  bool
 	responseStreaming bool
+}
+
+type routeOptionFunc func(*routeOptions)
+
+func (f routeOptionFunc) apply(o *routeOptions) {
+	f(o)
 }
 
 // WithRouteOperation marks a route as a service-owned operation path, for infrastructure endpoints such
@@ -24,46 +32,46 @@ type routeOptions struct {
 // WithRouteUnauthenticated instead bypasses transport token verification and access control while retaining
 // rate limiting and normal outcome logging; use it only when another boundary protects the route.
 func WithRouteOperation() RouteOption {
-	return func(options *routeOptions) {
+	return routeOptionFunc(func(options *routeOptions) {
 		options.operation = true
-	}
+	})
 }
 
 // WithRouteUnauthenticated marks a route to bypass transport token verification and access control.
 //
 // It retains rate limiting and normal outcome logging, so use it only when another boundary protects the route.
 func WithRouteUnauthenticated() RouteOption {
-	return func(options *routeOptions) {
+	return routeOptionFunc(func(options *routeOptions) {
 		options.unauthenticated = true
-	}
+	})
 }
 
 // WithRouteRequestStreaming marks a route whose request body is streamed incrementally rather than buffered whole.
 func WithRouteRequestStreaming() RouteOption {
-	return func(options *routeOptions) {
+	return routeOptionFunc(func(options *routeOptions) {
 		options.requestStreaming = true
-	}
+	})
 }
 
 // WithRouteResponseStreaming marks a route whose response body is streamed incrementally rather than buffered whole.
 func WithRouteResponseStreaming() RouteOption {
-	return func(options *routeOptions) {
+	return routeOptionFunc(func(options *routeOptions) {
 		options.responseStreaming = true
-	}
+	})
 }
 
 // WithRouteStreaming marks a route whose request and response bodies are streamed incrementally rather than buffered whole.
 func WithRouteStreaming() RouteOption {
-	return func(options *routeOptions) {
+	return routeOptionFunc(func(options *routeOptions) {
 		options.requestStreaming = true
 		options.responseStreaming = true
-	}
+	})
 }
 
 func options(opts ...RouteOption) *routeOptions {
 	options := &routeOptions{}
 	for _, opt := range opts {
-		opt(options)
+		opt.apply(options)
 	}
 
 	return options

--- a/net/http/rpc/client.go
+++ b/net/http/rpc/client.go
@@ -22,19 +22,19 @@ var (
 // Options are applied in the order provided to NewClient. If multiple options configure the same
 // field, the last one wins.
 type ClientOption interface {
-	apply(opts *clientOpts)
+	apply(opts *clientOptions)
 }
 
-type clientOpts struct {
+type clientOptions struct {
 	roundTripper http.RoundTripper
 	contentType  string
 	accept       string
 	timeout      time.Duration
 }
 
-type clientOptionFunc func(*clientOpts)
+type clientOptionFunc func(*clientOptions)
 
-func (f clientOptionFunc) apply(o *clientOpts) {
+func (f clientOptionFunc) apply(o *clientOptions) {
 	f(o)
 }
 
@@ -43,7 +43,7 @@ func (f clientOptionFunc) apply(o *clientOpts) {
 // This is typically used to inject a transport that includes middleware such as retries, circuit
 // breakers, authentication, or custom TLS.
 func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.roundTripper = rt
 	})
 }
@@ -54,7 +54,7 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 // request encoder. Typical values include "application/json", "application/hjson", or go-service
 // protobuf media types.
 func WithClientContentType(ct string) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.contentType = ct
 	})
 }
@@ -64,7 +64,7 @@ func WithClientContentType(ct string) ClientOption {
 // This value is passed through to the underlying content-aware HTTP client and sent as the request
 // Accept header.
 func WithClientAccept(accept string) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.accept = accept
 	})
 }
@@ -74,7 +74,7 @@ func WithClientAccept(accept string) ClientOption {
 //
 // The duration string is parsed using [time.MustParseDuration] and panics if it cannot be parsed.
 func WithClientTimeout(timeout string) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.timeout = time.MustParseDuration(timeout)
 	})
 }
@@ -130,8 +130,8 @@ func (c *Client) Post(ctx context.Context, path string, req, res any) error {
 	return c.client.Post(ctx, c.url+path, opts)
 }
 
-func options(opts ...ClientOption) *clientOpts {
-	os := &clientOpts{}
+func options(opts ...ClientOption) *clientOptions {
+	os := &clientOptions{}
 	for _, o := range opts {
 		o.apply(os)
 	}

--- a/transport/grpc/breaker/breaker.go
+++ b/transport/grpc/breaker/breaker.go
@@ -18,12 +18,12 @@ type Settings = breaker.Settings
 
 // NewClient returns a gRPC client guarded by circuit breakers.
 func NewClient(options ...Option) *Client {
-	o := defaultOpts()
+	o := defaultOptions()
 	for _, option := range options {
 		option.apply(o)
 	}
 
-	return &Client{registry: &registry{opts: o, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}}
+	return &Client{registry: &registry{options: o, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}}
 }
 
 // Client provides gRPC client circuit-breaking interceptors.
@@ -45,7 +45,7 @@ type Client struct {
 // # Failure classification
 //
 // The interceptor counts failures based on gRPC status codes. By default it treats a subset of transient/server
-// codes as failures (see [WithFailureCodes] and the defaults in `defaultOpts`). Calls that return other codes
+// codes as failures (see [WithFailureCodes] and the defaults in `defaultOptions`). Calls that return other codes
 // do not contribute to opening the breaker. A context that is already deadline-exceeded before the invocation
 // bypasses breaker accounting, because it provides no downstream-health signal.
 //

--- a/transport/grpc/breaker/options.go
+++ b/transport/grpc/breaker/options.go
@@ -10,17 +10,17 @@ import (
 // Options are applied in the order provided to [NewClient]. If multiple options configure
 // the same field, the last one wins.
 type Option interface {
-	apply(opts *opts)
+	apply(options *options)
 }
 
-type opts struct {
+type options struct {
 	settings     Settings
 	failureCodes map[codes.Code]struct{}
 }
 
-type optionFunc func(*opts)
+type optionFunc func(*options)
 
-func (f optionFunc) apply(o *opts) {
+func (f optionFunc) apply(o *options) {
 	f(o)
 }
 
@@ -34,7 +34,7 @@ func (f optionFunc) apply(o *opts) {
 // Note: because settings are copied, if your [Settings] contains function fields that close over
 // mutable state, ensure that state is safe for concurrent use.
 func WithSettings(s Settings) Option {
-	return optionFunc(func(o *opts) {
+	return optionFunc(func(o *options) {
 		o.settings = s
 	})
 }
@@ -47,7 +47,7 @@ func WithSettings(s Settings) Option {
 // breaker: a caller aborting an in-flight call should not trip the breaker against a healthy upstream. An
 // already-expired caller deadline bypasses breaker accounting before invocation for the same reason.
 func WithFailureCodes(cs ...codes.Code) Option {
-	return optionFunc(func(o *opts) {
+	return optionFunc(func(o *options) {
 		o.failureCodes = make(map[codes.Code]struct{}, len(cs))
 		for _, c := range cs {
 			o.failureCodes[c] = struct{}{}
@@ -55,7 +55,7 @@ func WithFailureCodes(cs ...codes.Code) Option {
 	})
 }
 
-func defaultOpts() *opts {
+func defaultOptions() *options {
 	failureCodes := map[codes.Code]struct{}{
 		codes.Unavailable:       {},
 		codes.DeadlineExceeded:  {},
@@ -63,7 +63,7 @@ func defaultOpts() *opts {
 		codes.Internal:          {},
 	}
 
-	return &opts{
+	return &options{
 		failureCodes: failureCodes,
 		settings:     breaker.DefaultSettings,
 	}

--- a/transport/grpc/breaker/registry.go
+++ b/transport/grpc/breaker/registry.go
@@ -8,7 +8,7 @@ import (
 )
 
 type registry struct {
-	opts     *opts
+	options  *options
 	breakers *sync.Map[string, *breaker.CircuitBreaker]
 }
 
@@ -17,11 +17,11 @@ func (r *registry) get(fullMethod string) *breaker.CircuitBreaker {
 		return cb
 	}
 
-	s := r.opts.settings
+	s := r.options.settings
 	s.Name = fullMethod
 
 	isSuccessful := s.IsSuccessful
-	failureCodes := r.opts.failureCodes
+	failureCodes := r.options.failureCodes
 	s.IsSuccessful = func(err error) bool {
 		if err == nil {
 			return true

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -27,10 +27,10 @@ import (
 // Most options are orthogonal and can be combined. Some options enable behavior by providing a non-nil
 // dependency (for example, retries are enabled when [WithClientRetry] provides a non-nil config).
 type ClientOption interface {
-	apply(opts *clientOpts)
+	apply(opts *clientOptions)
 }
 
-type clientOpts struct {
+type clientOptions struct {
 	gen              token.Generator
 	generator        id.Generator
 	breaker          *breaker.Config
@@ -50,9 +50,9 @@ type clientOpts struct {
 	compression      bool
 }
 
-type clientOptionFunc func(*clientOpts)
+type clientOptionFunc func(*clientOptions)
 
-func (f clientOptionFunc) apply(o *clientOpts) {
+func (f clientOptionFunc) apply(o *clientOptions) {
 	f(o)
 }
 
@@ -61,7 +61,7 @@ func (f clientOptionFunc) apply(o *clientOpts) {
 // This option appends a default call option that requests the "gzip" compressor. The server must also be
 // configured to accept gzip-compressed requests for this to have any effect.
 func WithClientCompression() ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.compression = true
 	})
 }
@@ -76,7 +76,7 @@ func WithClientCompression() ClientOption {
 // token per attempt. Streaming calls are not retried by the standard client chain and generate one token
 // when the stream is opened.
 func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.id = id
 		o.gen = gen
 	})
@@ -92,7 +92,7 @@ func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 // parent deadline. Streaming callers should use explicit context deadlines or
 // a custom stream interceptor.
 func WithClientTimeout(timeout time.Duration) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.timeout = timeout
 	})
 }
@@ -103,7 +103,7 @@ func WithClientTimeout(timeout time.Duration) ClientOption {
 //
 // If either value is unset (0), it defaults to the resolved client timeout (see [NewDialOptions]).
 func WithClientKeepalive(ping, timeout time.Duration) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.keepalivePing = ping
 		o.keepaliveTimeout = timeout
 	})
@@ -121,7 +121,7 @@ func WithClientKeepalive(ping, timeout time.Duration) ClientOption {
 //
 // If cfg is nil, retries are not enabled.
 func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.retry = cfg
 		o.retryPolicies = policies
 	})
@@ -132,7 +132,7 @@ func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
 // Circuit breakers are keyed per RPC full method name. Failure accounting is controlled by cfg.
 // Streaming callers should use a custom stream interceptor for stream-specific breaker behavior.
 func WithClientBreaker(cfg *breaker.Config) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.breaker = cfg
 	})
 }
@@ -143,7 +143,7 @@ func WithClientBreaker(cfg *breaker.Config) ClientOption {
 // empty config that relies on system roots and the target host name. Source strings may be resolved via the
 // package-registered filesystem (see the package [Register] function).
 func WithClientTLS(sec *tls.Config) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.security = sec
 	})
 }
@@ -157,7 +157,7 @@ func WithClientTLS(sec *tls.Config) ClientOption {
 // Pass all custom dial options for a client construction in one call. Repeating this option follows the
 // package's last-wins functional option convention and replaces earlier raw dial options.
 func WithClientDialOption(opts ...grpc.DialOption) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.opts = opts
 	})
 }
@@ -171,7 +171,7 @@ func WithClientDialOption(opts ...grpc.DialOption) ClientOption {
 // Pass all custom unary interceptors for a client construction in one call. Repeating this option follows
 // the package's last-wins functional option convention and replaces earlier custom unary interceptors.
 func WithClientUnaryInterceptors(unary ...grpc.UnaryClientInterceptor) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.unary = unary
 	})
 }
@@ -185,7 +185,7 @@ func WithClientUnaryInterceptors(unary ...grpc.UnaryClientInterceptor) ClientOpt
 // Pass all custom stream interceptors for a client construction in one call. Repeating this option follows
 // the package's last-wins functional option convention and replaces earlier custom stream interceptors.
 func WithClientStreamInterceptors(stream ...grpc.StreamClientInterceptor) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.stream = stream
 	})
 }
@@ -194,7 +194,7 @@ func WithClientStreamInterceptors(stream ...grpc.StreamClientInterceptor) Client
 //
 // When configured, both unary and stream client interceptors may emit logs about RPC outcomes.
 func WithClientLogger(logger *logger.Logger) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.logger = logger
 	})
 }
@@ -205,7 +205,7 @@ func WithClientLogger(logger *logger.Logger) ClientOption {
 //   - as the gRPC dial user agent ([grpc.WithUserAgent])
 //   - for metadata propagation via the [github.com/alexfalkowski/go-service/v2/net/grpc/meta] interceptors
 func WithClientUserAgent(userAgent env.UserAgent) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.userAgent = userAgent
 	})
 }
@@ -215,7 +215,7 @@ func WithClientUserAgent(userAgent env.UserAgent) ClientOption {
 // The generator is used to create a request id when one is not already present on the outgoing context
 // or outgoing metadata.
 func WithClientID(generator id.Generator) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.generator = generator
 	})
 }
@@ -225,7 +225,7 @@ func WithClientID(generator id.Generator) ClientOption {
 // When configured, unary client calls are rate-limited before being sent. Client streams are rate-limited
 // when opened and while sending or receiving messages. If limiter is nil, rate limiting is not enabled.
 func WithClientLimiter(limiter *limiter.Client) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.limiter = limiter
 	})
 }
@@ -363,7 +363,7 @@ func UnaryClientInterceptors(opts ...ClientOption) []grpc.UnaryClientInterceptor
 	return unary
 }
 
-func streamDialOption(opts *clientOpts) grpc.DialOption {
+func streamDialOption(opts *clientOptions) grpc.DialOption {
 	stream := []grpc.StreamClientInterceptor{}
 	stream = append(stream, meta.NewClient(opts.userAgent, opts.generator).StreamInterceptor())
 	stream = append(stream, opts.stream...)
@@ -385,8 +385,8 @@ func streamDialOption(opts *clientOpts) grpc.DialOption {
 	return grpc.WithChainStreamInterceptor(stream...)
 }
 
-func options(opts ...ClientOption) *clientOpts {
-	resolved := &clientOpts{}
+func options(opts ...ClientOption) *clientOptions {
+	resolved := &clientOptions{}
 	for _, o := range opts {
 		o.apply(resolved)
 	}

--- a/transport/http/breaker/breaker.go
+++ b/transport/http/breaker/breaker.go
@@ -61,14 +61,14 @@ type Settings = breaker.Settings
 //   - Your application logic continues to be driven by the HTTP response status/body, and
 //   - The breaker still "learns" that the upstream is unhealthy and may open accordingly.
 //
-// Defaults: HTTP status codes >= 500 or 429 are treated as failures (see `defaultOpts` and [WithFailureStatusFunc]).
+// Defaults: HTTP status codes >= 500 or 429 are treated as failures (see `defaultOptions` and [WithFailureStatusFunc]).
 func NewRoundTripper(hrt http.RoundTripper, options ...Option) *RoundTripper {
-	o := defaultOpts()
+	o := defaultOptions()
 	for _, option := range options {
 		option.apply(o)
 	}
 
-	return &RoundTripper{opts: o, RoundTripper: hrt, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}
+	return &RoundTripper{options: o, RoundTripper: hrt, breakers: sync.NewMap[string, *breaker.CircuitBreaker]()}
 }
 
 // RoundTripper wraps an underlying [http.RoundTripper] and applies circuit breaking.
@@ -80,7 +80,7 @@ func NewRoundTripper(hrt http.RoundTripper, options ...Option) *RoundTripper {
 // Use [NewRoundTripper] to construct instances with the desired settings and failure classification behavior.
 type RoundTripper struct {
 	http.RoundTripper
-	opts     *opts
+	options  *options
 	breakers *sync.Map[string, *breaker.CircuitBreaker]
 }
 
@@ -111,7 +111,7 @@ func (r *RoundTripper) roundTrip(req *http.Request) (*http.Response, error, bool
 			return nil, err
 		}
 
-		if r.opts.failureStatus(resp.StatusCode) {
+		if r.options.failureStatus(resp.StatusCode) {
 			return nil, responseError{resp: resp}
 		}
 
@@ -145,7 +145,7 @@ func (r *RoundTripper) get(req *http.Request) *breaker.CircuitBreaker {
 		return cb
 	}
 
-	settings := r.opts.settings
+	settings := r.options.settings
 	settings.Name = key
 	isSuccessful := settings.IsSuccessful
 	settings.IsSuccessful = func(err error) bool {

--- a/transport/http/breaker/options.go
+++ b/transport/http/breaker/options.go
@@ -10,17 +10,17 @@ import (
 // Options are applied in the order provided to [NewRoundTripper]. If multiple options configure
 // the same field, the last one wins.
 type Option interface {
-	apply(opts *opts)
+	apply(options *options)
 }
 
-type opts struct {
+type options struct {
 	settings      Settings
 	failureStatus FailureFunc
 }
 
-type optionFunc func(*opts)
+type optionFunc func(*options)
 
-func (f optionFunc) apply(o *opts) { f(o) }
+func (f optionFunc) apply(o *options) { f(o) }
 
 // FailureFunc classifies an HTTP response status code as a breaker failure.
 type FailureFunc func(code int) bool
@@ -36,7 +36,7 @@ type FailureFunc func(code int) bool
 // Note: because settings are copied, if your [Settings] contains function fields that close over
 // mutable state, ensure that state is safe for concurrent use.
 func WithSettings(s Settings) Option {
-	return optionFunc(func(o *opts) { o.settings = s })
+	return optionFunc(func(o *options) { o.settings = s })
 }
 
 // WithFailureStatusFunc configures the predicate that classifies an HTTP response status code as a failure
@@ -46,7 +46,7 @@ func WithSettings(s Settings) Option {
 // but the [RoundTripper] still returns the original *[http.Response] to the caller with a nil error.
 // This decouples breaker health tracking from application-level HTTP response handling.
 func WithFailureStatusFunc(f FailureFunc) Option {
-	return optionFunc(func(o *opts) {
+	return optionFunc(func(o *options) {
 		var failureStatus FailureFunc
 		if f == nil {
 			failureStatus = defaultFailureStatus
@@ -79,8 +79,8 @@ func WithFailureStatuses(statuses ...int) Option {
 	})
 }
 
-func defaultOpts() *opts {
-	return &opts{
+func defaultOptions() *options {
+	return &options{
 		failureStatus: defaultFailureStatus,
 		settings:      breaker.DefaultSettings,
 	}

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -25,10 +25,10 @@ import (
 // Most options are orthogonal and can be combined. Some options enable behavior by providing a non-nil
 // dependency (for example, retries are enabled when [WithClientRetry] provides a non-nil config).
 type ClientOption interface {
-	apply(opts *clientOpts)
+	apply(opts *clientOptions)
 }
 
-type clientOpts struct {
+type clientOptions struct {
 	gen           token.Generator
 	generator     id.Generator
 	roundTripper  http.RoundTripper
@@ -44,9 +44,9 @@ type clientOpts struct {
 	compression   bool
 }
 
-type clientOptionFunc func(*clientOpts)
+type clientOptionFunc func(*clientOptions)
 
-func (f clientOptionFunc) apply(o *clientOpts) {
+func (f clientOptionFunc) apply(o *clientOptions) {
 	f(o)
 }
 
@@ -57,7 +57,7 @@ func (f clientOptionFunc) apply(o *clientOpts) {
 //
 // This option uses [github.com/alexfalkowski/go-service/v2/net/http/compress] and wraps the underlying transport.
 func WithClientCompression() ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.compression = true
 	})
 }
@@ -72,7 +72,7 @@ func WithClientCompression() ClientOption {
 // Token-enabled clients use [http.SameOriginRedirect] so credentials are not forwarded to cross-origin
 // redirect targets. Cross-origin redirects are returned to the caller as [http.ErrUseLastResponse].
 func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.id = id
 		o.gen = gen
 	})
@@ -85,7 +85,7 @@ func WithClientTokenGenerator(id env.UserID, gen token.Generator) ClientOption {
 //
 // If unset or negative, a default timeout is applied (see `options()` defaults).
 func WithClientTimeout(timeout time.Duration) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.timeout = timeout
 	})
 }
@@ -98,7 +98,7 @@ func WithClientTimeout(timeout time.Duration) ClientOption {
 // If set, this round tripper is used as-is and the package will not perform default transport selection
 // based on TLS configuration (i.e. TLS config construction and `http.Transport(...)` selection are skipped).
 func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.roundTripper = rt
 	})
 }
@@ -115,7 +115,7 @@ func WithClientRoundTripper(rt http.RoundTripper) ClientOption {
 //
 // If cfg is nil, retries are not enabled.
 func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.retry = cfg
 		o.retryPolicies = policies
 	})
@@ -127,7 +127,7 @@ func WithClientRetry(cfg *retry.Config, policies ...retry.Policy) ClientOption {
 // (by method + host) so that failures are isolated by downstream destination.
 // Failure classification is controlled by cfg.
 func WithClientBreaker(cfg *breaker.Config) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.breaker = cfg
 	})
 }
@@ -136,7 +136,7 @@ func WithClientBreaker(cfg *breaker.Config) ClientOption {
 //
 // When configured, the composed RoundTripper logs request outcomes (duration and status classification).
 func WithClientLogger(logger *logger.Logger) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.logger = logger
 	})
 }
@@ -145,7 +145,7 @@ func WithClientLogger(logger *logger.Logger) ClientOption {
 //
 // The value is injected into outbound requests by the metadata RoundTripper ([github.com/alexfalkowski/go-service/v2/net/http/meta]).
 func WithClientUserAgent(userAgent env.UserAgent) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.userAgent = userAgent
 	})
 }
@@ -158,7 +158,7 @@ func WithClientUserAgent(userAgent env.UserAgent) ClientOption {
 // If TLS is enabled and no base round tripper is provided, TLS config is constructed using the package-
 // registered filesystem dependency (see [Register] in this package) to resolve TLS source strings.
 func WithClientTLS(sec *tls.Config) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.tls = sec
 	})
 }
@@ -168,7 +168,7 @@ func WithClientTLS(sec *tls.Config) ClientOption {
 // The generator is used to create a request id when one is not already present on the outgoing context
 // (as propagated by the meta package) and/or request headers.
 func WithClientID(generator id.Generator) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.generator = generator
 	})
 }
@@ -178,7 +178,7 @@ func WithClientID(generator id.Generator) ClientOption {
 // When configured, outbound requests are rate-limited before being sent. If limiter is nil, rate limiting
 // is not enabled.
 func WithClientLimiter(limiter *limiter.Client) ClientOption {
-	return clientOptionFunc(func(o *clientOpts) {
+	return clientOptionFunc(func(o *clientOptions) {
 		o.limiter = limiter
 	})
 }
@@ -277,7 +277,7 @@ func NewClient(opts ...ClientOption) (*http.Client, error) {
 	return client, nil
 }
 
-func roundTripper(resolved *clientOpts) (http.RoundTripper, error) {
+func roundTripper(resolved *clientOptions) (http.RoundTripper, error) {
 	hrt := resolved.roundTripper
 	if hrt != nil {
 		return hrt, nil
@@ -295,8 +295,8 @@ func roundTripper(resolved *clientOpts) (http.RoundTripper, error) {
 	return http.Transport(conf), nil
 }
 
-func options(opts ...ClientOption) *clientOpts {
-	resolved := &clientOpts{}
+func options(opts ...ClientOption) *clientOptions {
+	resolved := &clientOptions{}
 	for _, o := range opts {
 		o.apply(resolved)
 	}


### PR DESCRIPTION
## What

- Add shared decode options and apply `codec.WithDiscardUnknown` at HTTP request and response boundaries, while standalone codecs remain strict by default.
- Move the common codec contract into `encoding/codec`, update streaming decoder factories, and align internal option names.

## Why

- Lets independently deployed services exchange payloads that contain newly added fields without weakening direct codec validation.
- The public codec and stream decoder signatures intentionally change; downstream custom implementations must accept the new decode options, and direct protobuf JSON/text decoding is now strict unless callers opt in.

## Testing

- `make specs` - running; all changed encoding and HTTP packages reached so far have passed, and the full repository suite remains in progress.
- `make sec` - passed; govulncheck found no affected vulnerabilities and Trivy found no vulnerabilities or secrets.
- `make lint` - not passed because the locally updated linter reports an existing repository-wide `exhaustruct_v5` baseline; CI uses the previous linter version.

AI-assisted-by: [Codex](https://openai.com/codex/)
