### PR TITLE
docs(transport): clarify http middleware order, cloudevents contracts, and grpc panic-recovery behavior

### DIFF
--- a/transport/grpc/recovery/recovery.go
+++ b/transport/grpc/recovery/recovery.go
@@ -7,8 +7,15 @@ import (
 
 // NewServer constructs a gRPC panic recovery interceptor server.
 //
-// handler converts a recovered panic value into the error returned to the RPC caller. If handler is nil, the
-// interceptor returns the upstream default panic error.
+// handler converts a recovered panic value into the error returned to the RPC caller and must be non-nil.
+// UnaryInterceptor and StreamInterceptor always call the upstream
+// [github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.WithRecoveryHandler] with handler,
+// which wraps handler in a non-nil callback regardless of whether handler itself is nil. If handler is nil, that
+// callback invokes a nil func value when a panic is recovered, which panics again with a nil pointer
+// dereference; that second panic happens outside the interceptor's own recover and propagates uncaught, so a
+// nil handler crashes the process on any recovered panic instead of returning a safe error. Return a
+// client-safe error from handler, for example via [github.com/alexfalkowski/go-service/v2/net/grpc/status.SafeError],
+// since gRPC renders an unwrapped handler error as the client-visible status message.
 func NewServer(handler func(any) error) *Server {
 	return &Server{handler: handler}
 }

--- a/transport/http/events/receiver.go
+++ b/transport/http/events/receiver.go
@@ -38,6 +38,10 @@ func NewReceiver(router *http.Router, hook *hooks.Webhook) *Receiver {
 // The handler is registered for HTTP POST requests as an unauthenticated transport route and dispatches each
 // decoded event to receiver.
 //
+// ctx is passed through for the underlying CloudEvents constructor and does not bound the registered handler:
+// it retains no construction-time context and serves every request with that request's own context. Cancel
+// the server, not ctx, to stop receiving.
+//
 // Middleware:
 // The receive handler is wrapped with the configured webhook hook handler, which typically verifies request
 // signatures before allowing events through. When a webhook hook is configured, the handler supports

--- a/transport/http/events/sender.go
+++ b/transport/http/events/sender.go
@@ -43,6 +43,11 @@ type Sender struct {
 }
 
 // Send transmits event using the configured CloudEvents HTTP encoding.
+//
+// ctx must carry the destination URL set via
+// [github.com/alexfalkowski/go-service/v2/net/http/events.ContextWithTarget]: Sender has no per-call target
+// parameter, so a ctx without a target makes Send fail immediately with a "not initialized" protocol error
+// rather than issuing a request.
 func (s *Sender) Send(ctx context.Context, event events.Event) events.Result {
 	if s.hook != nil {
 		ctx = hooks.WithWebhookID(ctx, s.hook.GenerateID())

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -105,6 +105,9 @@ type ServerParams struct {
 // The server is built using Negroni and composes middleware in this order inside that instrumentation wrapper
 // (first listed runs first):
 //   - metadata extraction/injection, route-pattern resolution, and response headers ([github.com/alexfalkowski/go-service/v2/net/http/meta])
+//   - the unary request timeout from `params.Config.GetTimeout()`; routes marked request- or
+//     response-streaming in `params.RoutePolicy` are exempt and keep their stream-specific lifecycle
+//     controls instead
 //   - optional logging ([github.com/alexfalkowski/go-service/v2/transport/http/telemetry/logger]) when `params.Logger` is non-nil
 //   - panic recovery that converts a downstream panic into a safe `500 Internal Server Error` response when the
 //     response has not already been committed

--- a/transport/http/telemetry/logger/doc.go
+++ b/transport/http/telemetry/logger/doc.go
@@ -1,7 +1,8 @@
 // Package logger provides HTTP logging middleware and wiring for go-service.
 //
 // This package integrates request/response logging into HTTP servers (handler middleware)
-// and HTTP clients (RoundTripper middleware). Ignorable paths bypass logging.
+// and HTTP clients (RoundTripper middleware). Registered operation paths (health/metrics/etc.)
+// bypass ordinary access logging on the server side but still log recovered panics.
 //
 // Start with [NewHandler] for server-side logging and [NewRoundTripper] for client-side logging.
 package logger


### PR DESCRIPTION
## What

- Document the HTTP transport server's middleware chain: the unary request timeout derived from `params.Config.GetTimeout()` runs right after metadata middleware, and request/response-streaming routes (per `params.RoutePolicy`) are exempt and keep their own stream lifecycle controls instead.
- Document `transport/http/events.Receiver.Register`'s `ctx` contract: it is only passed through to the underlying CloudEvents constructor, is not retained, and every request is served with its own request-scoped context — cancel the server, not `ctx`, to stop receiving.
- Document `transport/http/events.Sender.Send`'s `ctx` contract: the destination URL must be set on `ctx` via `events.ContextWithTarget` before calling `Send`, since `Sender` has no per-call target parameter; without it, `Send` fails immediately with a "not initialized" protocol error instead of issuing a request.
- Document `transport/http/telemetry/logger`'s package doc to match its existing per-type doc comments: registered operation paths (health/metrics/etc.) skip ordinary access logging but still log recovered panics.
- Correct and expand `transport/grpc/recovery.NewServer`'s `handler` doc. The previous text claimed a `nil` handler gracefully falls back to the upstream default `PanicError`. That's not what happens: `UnaryInterceptor`/`StreamInterceptor` always call the upstream `WithRecoveryHandler(handler)`, which installs a non-nil wrapper callback regardless of whether `handler` itself is nil, so a nil `handler` causes that wrapper to invoke a nil func value on a recovered panic — a second, uncaught nil-pointer-dereference panic that crashes the process instead of returning a safe error. The doc now states `handler` must be non-nil and describes the actual failure mode.

## Why

- These are all comment-only clarifications with no behavior change; supported DI wiring already always supplies a non-nil `recoveryHandler` (`transport/grpc/server.go`), so there's no code fix needed for the recovery case, only an accurate contract.
- The recovery.go correction matters because the previous doc actively misled a reader into believing `nil` was a safe, supported way to get default panic-error behavior, when it actually defeats the panic-recovery interceptor entirely on any real request panic. I verified this by reading the vendored `github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.4` recovery interceptor source and reproducing the crash with a standalone repro before writing the corrected text.
- The remaining clarifications close smaller but real gaps for callers integrating with this repo's HTTP transport and CloudEvents wiring: timeout-vs-streaming interaction, context lifetime for receivers, the target-URL precondition for senders, and which log lines survive on operation routes.

## Testing

- `go build ./...` - passed
- `gofmt -l` on all five changed files - no output (already formatted)
- `make golangci-lint package=transport/grpc/recovery` - passed, 0 issues
- `make golangci-lint package=transport/http/events` - passed, 0 issues
- `make golangci-lint package=transport/http` - passed, 0 issues
- `make golangci-lint package=transport/http/telemetry/logger` - passed, 0 issues
- `make specs package=transport/grpc/recovery` - passed (2 tests)
- `make specs package=transport/http/events` - passed (15 tests)
- `make specs package=transport/http` - passed (167 tests)
- `make specs package=transport/http/telemetry/logger` - passed (15 tests)
- Doc-only change with no behavior modification, so no new tests were added; the recovery.go nil-handler bug this PR documents is left as a known accepted-design gap (not fixed) since supported wiring never passes nil and the fix would be a behavior change outside this PR's scope.
- An independent review pass (separate agent instance, same repo state) found two low-severity wording issues in an earlier draft of this diff (an overstated failure description in the sender.go doc, and inconsistent doc-link syntax in recovery.go); both were fixed before this summary was written.
