### PR TITLE
feat(telemetry): standardize exported attribute naming

### DIFF
--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -51,22 +51,22 @@ func RestRequestNoContent(_ context.Context, _ *Request) (*Response, error) {
 	return nil, nil
 }
 
-// RestContent builds a greeting from the `name` query parameter and echoes camel-cased request metadata.
+// RestContent builds a greeting from the `name` query parameter and echoes snake_case request metadata.
 func RestContent(ctx context.Context) (*Response, error) {
 	req := meta.Request(ctx)
 	_ = meta.Response(ctx)
 	name := cmp.Or(req.URL.Query().Get("name"), "Bob")
 	s := "Hello " + name
 
-	return &Response{Meta: meta.CamelStrings(ctx, meta.NoPrefix), Greeting: s}, nil
+	return &Response{Meta: meta.Strings(ctx, meta.NoPrefix), Greeting: s}, nil
 }
 
-// RestRequestContent builds a greeting from the request body and echoes camel-cased request metadata.
+// RestRequestContent builds a greeting from the request body and echoes snake_case request metadata.
 func RestRequestContent(ctx context.Context, req *Request) (*Response, error) {
 	name := cmp.Or(req.Name, "Bob")
 	s := "Hello " + name
 
-	return &Response{Meta: meta.CamelStrings(ctx, meta.NoPrefix), Greeting: s}, nil
+	return &Response{Meta: meta.Strings(ctx, meta.NoPrefix), Greeting: s}, nil
 }
 
 // RestRequestProtobuf returns a protobuf greeting response for REST-to-protobuf content tests.

--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -35,7 +35,7 @@ func SuccessSayHello(ctx context.Context, r *Request) (*Response, error) {
 	name := cmp.Or(req.URL.Query().Get("name"), r.Name)
 	s := "Hello " + name
 
-	return &Response{Meta: meta.CamelStrings(ctx, meta.NoPrefix), Greeting: s}, nil
+	return &Response{Meta: meta.Strings(ctx, meta.NoPrefix), Greeting: s}, nil
 }
 
 // SuccessProtobufSayHello returns a protobuf greeting response for the supplied request name.

--- a/meta/attrs.go
+++ b/meta/attrs.go
@@ -9,7 +9,7 @@ const (
 	// RequestIDKey is the attribute key used for request IDs.
 	//
 	// This key is commonly used to correlate logs and traces for a single request across services.
-	RequestIDKey = "requestId"
+	RequestIDKey = "request_id"
 
 	// SystemKey is the attribute key used for the system name.
 	//
@@ -34,7 +34,7 @@ const (
 	// ServiceMethodKey is the attribute key used for transport service-method names.
 	//
 	// For example: an HTTP route path or a gRPC full method name.
-	ServiceMethodKey = "serviceMethod"
+	ServiceMethodKey = "service_method"
 
 	// CodeKey is the attribute key used for status codes.
 	//
@@ -49,22 +49,22 @@ const (
 	// UserAgentKey is the attribute key used for user agents.
 	//
 	// This value commonly originates from the HTTP User-Agent header.
-	UserAgentKey = "userAgent"
+	UserAgentKey = "user_agent"
 
 	// UserIDKey is the attribute key used for user IDs.
 	//
 	// This may represent an end user, an API key identity, or a service identity depending on context.
-	UserIDKey = "userId"
+	UserIDKey = "user_id"
 
 	// IPAddrKey is the attribute key used for IP addresses.
 	//
 	// This value is commonly derived from connection metadata or trusted forwarding headers.
-	IPAddrKey = "ipAddr"
+	IPAddrKey = "ip_addr"
 
 	// IPAddrKindKey is the attribute key used to describe how IPAddrKey was derived.
 	//
 	// This may be used to distinguish between direct peer IPs and values derived from proxy headers.
-	IPAddrKindKey = "ipAddrKind"
+	IPAddrKindKey = "ip_addr_kind"
 
 	// AuthorizationKey is the attribute key used for authorization values.
 	//
@@ -73,7 +73,7 @@ const (
 	AuthorizationKey = "authorization"
 
 	// GeolocationKey is the attribute key used for geolocation values.
-	GeolocationKey = "geoLocation"
+	GeolocationKey = "geo_location"
 )
 
 // WithRequestID creates a request ID pair for [WithAttributes].
@@ -144,7 +144,7 @@ func ServiceMethod(ctx context.Context) Value {
 // It combines the underlying [Value.Value] strings, so ignored transport/service-method values still
 // contribute to the combined value. The returned value is [Ignored] and formatted as
 // "<transport>:<service-method>", which keeps it available for in-process lookups such as limiter keys
-// while preventing it from being exported by [Strings], [SnakeStrings], or [CamelStrings].
+// while preventing it from being exported by [Strings].
 func TransportServiceMethod(ctx context.Context) Value {
 	return Ignored(strings.Concat(Transport(ctx).Value(), ":", ServiceMethod(ctx).Value()))
 }

--- a/meta/doc.go
+++ b/meta/doc.go
@@ -23,14 +23,12 @@
 // # Export helpers
 //
 // Stored attributes can be exported to plain string maps for logging and transport propagation using:
-//   - [Strings]: keys unchanged
-//   - [SnakeStrings]: keys converted to snake_case
-//   - [CamelStrings]: keys converted to lowerCamelCase
-//   - [Attributes]: lowerCamelCase keys with bounded values for telemetry sinks
+//   - [Strings]: keys unchanged (standard metadata keys use snake_case)
+//   - [Attributes]: snake_case keys with bounded values for telemetry sinks
 //
 // Export helpers skip attributes whose rendered string is empty. A prefix may be prepended to each exported key.
 //
 // Start with [WithAttributes], [NewPair], the typed With* pair helpers, and [Attribute] for arbitrary
 // attributes. Use [Value] constructors ([String], [Blank], [Ignored], [Redacted]) for controlling rendering,
-// and [Strings], [SnakeStrings], [CamelStrings], or [Attributes] for exporting attributes.
+// and [Strings] or [Attributes] for exporting attributes.
 package meta

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -41,24 +41,8 @@ func Attribute(ctx context.Context, key string) Value {
 
 // Map is a string key-value map of exported attributes.
 //
-// Export helpers return this type after rendering [Value] entries and applying key conversion and prefixing.
+// Export helpers return this type after rendering [Value] entries and applying optional key prefixes.
 type Map map[string]string
-
-// SnakeStrings returns all stored attributes as a string map with snake_cased keys.
-//
-// The prefix parameter is prepended to each exported key (if non-empty).
-// Attributes whose rendered value is empty are skipped.
-func SnakeStrings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix, strings.ToSnake)
-}
-
-// CamelStrings returns all stored attributes as a string map with lowerCamelCased keys.
-//
-// The prefix parameter is prepended to each exported key (if non-empty).
-// Attributes whose rendered value is empty are skipped.
-func CamelStrings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix, strings.ToLowerCamel)
-}
 
 // Limit bounds the length of an exported metadata value.
 //
@@ -72,12 +56,12 @@ func (l Limit) Bytes() int {
 	return int(l)
 }
 
-// Attributes returns context metadata as lowerCamelCase string attributes.
+// Attributes returns context metadata as snake_case string attributes.
 //
 // Attribute values are bounded by limit so one metadata value cannot dominate a
 // log record or telemetry payload. Metadata retained in ctx is not truncated.
 func Attributes(ctx context.Context, limit Limit) Map {
-	attrs := CamelStrings(ctx, NoPrefix)
+	attrs := Strings(ctx, NoPrefix)
 	for key, value := range attrs {
 		attrs[key] = truncate(value, limit)
 	}
@@ -90,11 +74,7 @@ func Attributes(ctx context.Context, limit Limit) Map {
 // The prefix parameter is prepended to each exported key (if non-empty).
 // Attributes whose rendered value is empty are skipped.
 func Strings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix, identity)
-}
-
-func identity(s string) string {
-	return s
+	return attributes(ctx).Strings(prefix)
 }
 
 func truncate(value string, limit Limit) string {

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -8,34 +8,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStringsFormatsVisibleAttributesWithCaseAndPrefix(t *testing.T) {
+func TestStringsFormatsVisibleAttributesWithPrefix(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
-		meta.NewPair("testId", meta.String("1")),
+		meta.NewPair("test_id", meta.String("1")),
 		meta.NewPair("see", meta.Ignored("secret")),
 		meta.NewPair("redacted", meta.Redacted("2")),
 	)
 
-	assertStrings(t, ctx, "snake", meta.Map{"test_id": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
-		return meta.SnakeStrings(ctx, meta.NoPrefix)
-	})
-	assertStrings(t, ctx, "camel", meta.Map{"testId": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
-		return meta.CamelStrings(ctx, meta.NoPrefix)
-	})
-	assertStrings(t, ctx, "none", meta.Map{"testId": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
+	assertStrings(t, ctx, "no prefix", meta.Map{"test_id": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
 		return meta.Strings(ctx, meta.NoPrefix)
 	})
-	assertStrings(t, ctx, "prefix", meta.Map{"test.testId": "1", "test.redacted": "*"}, func(ctx context.Context) meta.Map {
+	assertStrings(t, ctx, "prefix", meta.Map{"test.test_id": "1", "test.redacted": "*"}, func(ctx context.Context) meta.Map {
 		return meta.Strings(ctx, "test.")
 	})
 }
 
-func TestAttributesBoundsCamelCasedValues(t *testing.T) {
+func TestAttributesBoundsSnakeCasedValues(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
-		meta.NewPair("request-id", meta.String("abcd")),
+		meta.NewPair(meta.RequestIDKey, meta.String("abcd")),
 		meta.NewPair("secret", meta.Ignored("hidden")),
 	)
 
-	require.Equal(t, meta.Map{"requestId": "abc"}, meta.Attributes(ctx, meta.Limit(3)))
+	require.Equal(t, meta.Map{"request_id": "abc"}, meta.Attributes(ctx, meta.Limit(3)))
 }
 
 func TestWithAttributesReturnsSameContextWithoutPairs(t *testing.T) {
@@ -92,10 +86,10 @@ func TestWithAttributesKeepsParentContextIsolatedWithSinglePair(t *testing.T) {
 	parent := meta.WithAttributes(t.Context(), meta.WithRequestID(meta.String("parent")))
 	child := meta.WithAttributes(parent, meta.WithUserID(meta.String("child")))
 
-	require.Equal(t, meta.String("parent"), meta.Attribute(parent, "requestId"))
-	require.True(t, meta.Attribute(parent, "userId").IsEmpty())
-	require.Equal(t, meta.String("parent"), meta.Attribute(child, "requestId"))
-	require.Equal(t, meta.String("child"), meta.Attribute(child, "userId"))
+	require.Equal(t, meta.String("parent"), meta.Attribute(parent, "request_id"))
+	require.True(t, meta.Attribute(parent, "user_id").IsEmpty())
+	require.Equal(t, meta.String("parent"), meta.Attribute(child, "request_id"))
+	require.Equal(t, meta.String("child"), meta.Attribute(child, "user_id"))
 }
 
 func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
@@ -108,12 +102,12 @@ func TestWithAttributesKeepsParentContextIsolated(t *testing.T) {
 		meta.WithUserID(meta.String("user")),
 	)
 
-	require.Equal(t, meta.String("parent"), meta.Attribute(parent, "requestId"))
-	require.Equal(t, meta.String("test-agent"), meta.Attribute(parent, "userAgent"))
-	require.True(t, meta.Attribute(parent, "userId").IsEmpty())
-	require.Equal(t, meta.String("child"), meta.Attribute(child, "requestId"))
-	require.Equal(t, meta.String("test-agent"), meta.Attribute(child, "userAgent"))
-	require.Equal(t, meta.String("user"), meta.Attribute(child, "userId"))
+	require.Equal(t, meta.String("parent"), meta.Attribute(parent, "request_id"))
+	require.Equal(t, meta.String("test-agent"), meta.Attribute(parent, "user_agent"))
+	require.True(t, meta.Attribute(parent, "user_id").IsEmpty())
+	require.Equal(t, meta.String("child"), meta.Attribute(child, "request_id"))
+	require.Equal(t, meta.String("test-agent"), meta.Attribute(child, "user_agent"))
+	require.Equal(t, meta.String("user"), meta.Attribute(child, "user_id"))
 }
 
 func TestAccessorsReturnStoredAttributes(t *testing.T) {

--- a/meta/storage.go
+++ b/meta/storage.go
@@ -7,11 +7,6 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
-// Converter transforms an attribute key before it is exported.
-//
-// It is used by export helpers to normalize key casing (for example snake_case or lowerCamelCase).
-type Converter func(string) string
-
 // Storage stores meta values keyed by attribute name.
 //
 // Storage is the internal backing map used by this package to hold context-scoped attributes.
@@ -44,18 +39,18 @@ func (s Storage) Get(key string) Value {
 
 // Strings exports stored attributes as a string map.
 //
-// Each key is transformed using converter and then prefixed with prefix (if non-empty).
+// Each key is prefixed with prefix (if non-empty).
 // Each value is rendered using [Value.String].
 //
 // Export behavior:
 //   - Attributes whose rendered value is an empty string are skipped.
 //     (This includes [Blank] and [Ignored] values, and any [Value] whose rendered [Value.String] is empty.)
 //   - Keys are included only if they have a non-empty rendered value.
-func (s Storage) Strings(prefix string, converter Converter) Map {
+func (s Storage) Strings(prefix string) Map {
 	attributes := make(Map, len(s))
 	for key, value := range s {
 		if rendered := value.String(); !strings.IsEmpty(rendered) {
-			attributes[s.key(prefix, converter(key))] = rendered
+			attributes[s.key(prefix, key)] = rendered
 		}
 	}
 	return attributes

--- a/meta/value.go
+++ b/meta/value.go
@@ -20,8 +20,7 @@ const (
 // Ignored constructs a Value that preserves the underlying value in-context but renders as an empty string.
 //
 // This is useful when you want to keep the raw value available for in-process logic, but you do not want it
-// to be exported via [Strings], [SnakeStrings], or [CamelStrings] (for example into logs or
-// transport headers).
+// to be exported via [Strings] (for example into logs or transport headers).
 //
 // Note: export helpers skip attributes whose rendered string is empty, so [Ignored] values will not appear
 // in exported maps.

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -36,7 +36,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil
 	})
@@ -59,7 +59,7 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil
 	})
@@ -118,7 +118,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil, nil
 	}
@@ -169,7 +169,7 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil, nil
 	}
@@ -281,7 +281,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
 
 		return "ok", nil
 	})
@@ -356,7 +356,7 @@ func TestUnaryServerInterceptorStoresGeolocationAsIgnored(t *testing.T) {
 
 		require.Equal(t, "geo:47,11", geolocation.Value())
 		require.Empty(t, geolocation.String())
-		require.NotContains(t, meta.CamelStrings(ctx, meta.NoPrefix), meta.GeolocationKey)
+		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.GeolocationKey)
 
 		return "ok", nil
 	})
@@ -371,7 +371,7 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(_ any, stream grpc.ServerStream) error {
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(stream.Context()))
-		require.NotContains(t, meta.CamelStrings(stream.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(stream.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 
 		return nil
 	})

--- a/net/http/meta/doc.go
+++ b/net/http/meta/doc.go
@@ -4,7 +4,7 @@
 //
 //   - It exposes small convenience wrappers around the generic `meta` package for exporting
 //     context-scoped attributes as string maps suitable for logging and header propagation
-//     (for example CamelStrings).
+//     (for example Strings). Standard metadata keys use snake_case; arbitrary keys are preserved.
 //
 //   - It provides a small context-backed store for request-scoped HTTP objects used by go-service
 //     handlers and middleware, including:

--- a/net/http/meta/meta.go
+++ b/net/http/meta/meta.go
@@ -19,12 +19,12 @@ type Map = meta.Map
 // Pair is an alias for [meta.Pair].
 type Pair = meta.Pair
 
-// CamelStrings exports all stored meta attributes as a string map with lowerCamelCased keys.
+// Strings exports all stored meta attributes as a string map with unchanged keys.
 //
-// The prefix parameter is prepended to each exported key (if non-empty). Attributes whose rendered value is
-// empty are skipped.
-func CamelStrings(ctx context.Context, prefix string) Map {
-	return meta.CamelStrings(ctx, prefix)
+// Standard metadata keys use snake_case. The prefix parameter is prepended to each exported key (if non-empty).
+// Attributes whose rendered value is empty are skipped.
+func Strings(ctx context.Context, prefix string) Map {
+	return meta.Strings(ctx, prefix)
 }
 
 // Error converts err to a [meta.Value] using err.Error().
@@ -61,7 +61,6 @@ func Request(ctx context.Context) *http.Request {
 // It returns nil when WithRequestResponse has not been called.
 func Response(ctx context.Context) http.ResponseWriter {
 	requestResponse, _ := ctx.Value(requestResponseKey).(requestResponse)
-
 	return requestResponse.response
 }
 

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -181,7 +181,7 @@ func TestRoundTripperStoresServiceMethod(t *testing.T) {
 		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 			require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
-			require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+			require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 
 			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
 		}),
@@ -267,7 +267,7 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
 		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
-		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})
 }
 
@@ -284,7 +284,7 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("GET /users/{id}"), meta.ServiceMethod(req.Context()))
 		require.Equal(t, "GET /users/{id}", req.Pattern)
-		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
 	})
 }
 
@@ -313,6 +313,6 @@ func TestHandlerStoresGeolocationAsIgnored(t *testing.T) {
 
 		require.Equal(t, "geo:47,11", geolocation.Value())
 		require.Empty(t, geolocation.String())
-		require.NotContains(t, meta.CamelStrings(req.Context(), meta.NoPrefix), meta.GeolocationKey)
+		require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.GeolocationKey)
 	})
 }

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -129,7 +129,7 @@ type View struct {
 //
 // Render model:
 // Render wraps the provided model in a Template which includes exported meta attributes under [Template.Meta].
-// This allows templates to access request-scoped metadata (for example requestId) without controllers having
+// This allows templates to access request-scoped metadata (for example request_id) without controllers having
 // to explicitly thread those values through the model.
 //
 // Error handling:

--- a/telemetry/logger/meta.go
+++ b/telemetry/logger/meta.go
@@ -9,8 +9,8 @@ import (
 
 // Meta extracts context metadata and returns it as slog attributes.
 //
-// It reads metadata stored in the provided context (via the `meta` package) and converts
-// it to camel-cased string key/value attributes with no prefix.
+// It reads metadata stored in the provided context (via the `meta` package) as string key/value attributes with no
+// prefix. Standard metadata keys use snake_case; arbitrary keys are preserved.
 //
 // Metadata values are bounded by limit at a valid UTF-8 boundary.
 //

--- a/telemetry/tracer/meta.go
+++ b/telemetry/tracer/meta.go
@@ -9,10 +9,11 @@ import (
 
 // Meta extracts context metadata as OpenTelemetry span attributes.
 //
-// It reads the same exported metadata as the logger (via the meta package) and
-// converts it to camel-cased string key/value attributes with no prefix, so a
-// span carries the request/service context (request id, user id, ip, ...) used
-// to correlate it with logs. It returns no attributes when ctx carries none.
+// It reads the same exported metadata as the logger (via the meta package) as
+// string key/value attributes with no prefix, so a span carries the
+// request/service context (request_id, user_id, ip_addr, ...) used to correlate
+// it with logs. Standard metadata keys use snake_case; arbitrary keys are
+// preserved. It returns no attributes when ctx carries none.
 func Meta(ctx context.Context, limit meta.Limit) []attributes.KeyValue {
 	return attributes.Strings(meta.Attributes(ctx, limit))
 }

--- a/transport/http/events/events_test.go
+++ b/transport/http/events/events_test.go
@@ -216,7 +216,7 @@ func TestReceiveLogsPanickingProcessor(t *testing.T) {
 		require.Equal(t, "post", record.Attrs["method"].String())
 		require.Equal(t, int64(http.StatusInternalServerError), record.Attrs["code"].Int64())
 		require.NotEmpty(t, record.Attrs["duration"].String())
-		require.NotEmpty(t, record.Attrs["requestId"].String())
+		require.NotEmpty(t, record.Attrs["request_id"].String())
 	}
 
 	require.Equal(t, 1, panicLogs)

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -234,7 +234,7 @@ func requirePanicLog(t *testing.T, capture *test.CaptureHandler, panicMessage, s
 		require.Equal(t, "http", record.Attrs["system"].String())
 		require.Equal(t, service, record.Attrs["service"].String())
 		require.Equal(t, "get", record.Attrs["method"].String())
-		require.NotEmpty(t, record.Attrs["requestId"].String())
+		require.NotEmpty(t, record.Attrs["request_id"].String())
 
 		return
 	}


### PR DESCRIPTION
## What

- Standardize exported metadata keys as snake_case across string maps, log attributes, trace attributes, templates, and test fixtures.
- Remove the redundant SnakeStrings and CamelStrings helpers, the HTTP CamelStrings wrapper, and Storage.Strings key conversion so metadata exports use one unchanged-key path.
- Correct GoDocs to distinguish standard snake_case keys from arbitrary custom keys, which remain unchanged.

## Why

- This intentional breaking change gives observability consumers one predictable attribute convention instead of multiple case-specific export APIs.
- Migrate consumers by replacing meta.SnakeStrings, meta.CamelStrings, and net/http/meta.CamelStrings with Strings; call Storage.Strings with only its prefix; and update direct standard-key lookups, dashboards, log/span queries, and MVC templates from lowerCamelCase to snake_case. HTTP and gRPC wire headers remain request-id and user-agent.

## Testing

- `make package=meta specs`, `make package=net/grpc/meta specs`, `make package=net/http/meta specs`, `make package=net/http/mvc specs`, `make package=telemetry/logger specs`, `make package=telemetry/tracer specs`, `make package=transport/http/events specs`, and `make package=transport/http specs` - passed; covers metadata exports, telemetry attributes, HTTP/gRPC middleware, MVC rendering, and affected HTTP integration behavior.
- `make lint` - passed with 0 issues.
- Local validation is intentionally scoped to changed packages; CI additionally runs dependency, generated-output, security, full-spec, fuzz, benchmark, and coverage checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
