### PR TITLE
feat(meta): remove configurable export keys

### DIFF
--- a/internal/test/rest.go
+++ b/internal/test/rest.go
@@ -58,7 +58,7 @@ func RestContent(ctx context.Context) (*Response, error) {
 	name := cmp.Or(req.URL.Query().Get("name"), "Bob")
 	s := "Hello " + name
 
-	return &Response{Meta: meta.Strings(ctx, meta.NoPrefix), Greeting: s}, nil
+	return &Response{Meta: meta.Strings(ctx), Greeting: s}, nil
 }
 
 // RestRequestContent builds a greeting from the request body and echoes snake_case request metadata.
@@ -66,7 +66,7 @@ func RestRequestContent(ctx context.Context, req *Request) (*Response, error) {
 	name := cmp.Or(req.Name, "Bob")
 	s := "Hello " + name
 
-	return &Response{Meta: meta.Strings(ctx, meta.NoPrefix), Greeting: s}, nil
+	return &Response{Meta: meta.Strings(ctx), Greeting: s}, nil
 }
 
 // RestRequestProtobuf returns a protobuf greeting response for REST-to-protobuf content tests.

--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -35,7 +35,7 @@ func SuccessSayHello(ctx context.Context, r *Request) (*Response, error) {
 	name := cmp.Or(req.URL.Query().Get("name"), r.Name)
 	s := "Hello " + name
 
-	return &Response{Meta: meta.Strings(ctx, meta.NoPrefix), Greeting: s}, nil
+	return &Response{Meta: meta.Strings(ctx), Greeting: s}, nil
 }
 
 // SuccessProtobufSayHello returns a protobuf greeting response for the supplied request name.

--- a/meta/doc.go
+++ b/meta/doc.go
@@ -26,7 +26,7 @@
 //   - [Strings]: keys unchanged (standard metadata keys use snake_case)
 //   - [Attributes]: snake_case keys with bounded values for telemetry sinks
 //
-// Export helpers skip attributes whose rendered string is empty. A prefix may be prepended to each exported key.
+// Export helpers skip attributes whose rendered string is empty.
 //
 // Start with [WithAttributes], [NewPair], the typed With* pair helpers, and [Attribute] for arbitrary
 // attributes. Use [Value] constructors ([String], [Blank], [Ignored], [Redacted]) for controlling rendering,

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -5,11 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/strings"
 )
-
-// NoPrefix is a convenience constant for passing an empty prefix to export helpers.
-const NoPrefix = strings.Empty
 
 // contextKey is the package-private type used for metadata context storage.
 type contextKey struct{}
@@ -41,7 +37,7 @@ func Attribute(ctx context.Context, key string) Value {
 
 // Map is a string key-value map of exported attributes.
 //
-// Export helpers return this type after rendering [Value] entries and applying optional key prefixes.
+// Export helpers return this type after rendering [Value] entries.
 type Map map[string]string
 
 // Limit bounds the length of an exported metadata value.
@@ -61,7 +57,7 @@ func (l Limit) Bytes() int {
 // Attribute values are bounded by limit so one metadata value cannot dominate a
 // log record or telemetry payload. Metadata retained in ctx is not truncated.
 func Attributes(ctx context.Context, limit Limit) Map {
-	attrs := Strings(ctx, NoPrefix)
+	attrs := Strings(ctx)
 	for key, value := range attrs {
 		attrs[key] = truncate(value, limit)
 	}
@@ -71,10 +67,9 @@ func Attributes(ctx context.Context, limit Limit) Map {
 
 // Strings returns all stored attributes as a string map with keys unchanged.
 //
-// The prefix parameter is prepended to each exported key (if non-empty).
 // Attributes whose rendered value is empty are skipped.
-func Strings(ctx context.Context, prefix string) Map {
-	return attributes(ctx).Strings(prefix)
+func Strings(ctx context.Context) Map {
+	return attributes(ctx).Strings()
 }
 
 func truncate(value string, limit Limit) string {

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -8,19 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStringsFormatsVisibleAttributesWithPrefix(t *testing.T) {
+func TestStringsExportsVisibleAttributes(t *testing.T) {
 	ctx := meta.WithAttributes(t.Context(),
 		meta.NewPair("test_id", meta.String("1")),
 		meta.NewPair("see", meta.Ignored("secret")),
 		meta.NewPair("redacted", meta.Redacted("2")),
 	)
 
-	assertStrings(t, ctx, "no prefix", meta.Map{"test_id": "1", "redacted": "*"}, func(ctx context.Context) meta.Map {
-		return meta.Strings(ctx, meta.NoPrefix)
-	})
-	assertStrings(t, ctx, "prefix", meta.Map{"test.test_id": "1", "test.redacted": "*"}, func(ctx context.Context) meta.Map {
-		return meta.Strings(ctx, "test.")
-	})
+	require.Equal(t, meta.Map{"test_id": "1", "redacted": "*"}, meta.Strings(ctx))
 }
 
 func TestAttributesBoundsSnakeCasedValues(t *testing.T) {
@@ -152,12 +147,4 @@ func TestTransportServiceMethod(t *testing.T) {
 	)
 
 	require.Equal(t, meta.Ignored("http:GET /users/{id}"), meta.TransportServiceMethod(ctx))
-}
-
-func assertStrings(t *testing.T, ctx context.Context, name string, want meta.Map, export func(context.Context) meta.Map) {
-	t.Helper()
-
-	t.Run(name, func(t *testing.T) {
-		require.Equal(t, want, export(ctx))
-	})
 }

--- a/meta/storage.go
+++ b/meta/storage.go
@@ -39,18 +39,17 @@ func (s Storage) Get(key string) Value {
 
 // Strings exports stored attributes as a string map.
 //
-// Each key is prefixed with prefix (if non-empty).
 // Each value is rendered using [Value.String].
 //
 // Export behavior:
 //   - Attributes whose rendered value is an empty string are skipped.
 //     (This includes [Blank] and [Ignored] values, and any [Value] whose rendered [Value.String] is empty.)
 //   - Keys are included only if they have a non-empty rendered value.
-func (s Storage) Strings(prefix string) Map {
+func (s Storage) Strings() Map {
 	attributes := make(Map, len(s))
 	for key, value := range s {
 		if rendered := value.String(); !strings.IsEmpty(rendered) {
-			attributes[s.key(prefix, key)] = rendered
+			attributes[key] = rendered
 		}
 	}
 	return attributes
@@ -64,14 +63,6 @@ func (s Storage) Clone() Storage {
 	maps.Copy(cloned, s)
 
 	return cloned
-}
-
-func (s Storage) key(prefix, key string) string {
-	if strings.IsEmpty(prefix) {
-		return key
-	}
-
-	return prefix + key
 }
 
 func attributes(ctx context.Context) Storage {

--- a/net/grpc/meta/meta_test.go
+++ b/net/grpc/meta/meta_test.go
@@ -36,7 +36,7 @@ func TestUnaryClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx), meta.ServiceMethodKey)
 
 		return nil
 	})
@@ -59,7 +59,7 @@ func TestUnaryClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx), meta.ServiceMethodKey)
 
 		return nil
 	})
@@ -118,7 +118,7 @@ func TestStreamClientInterceptorReplacesOutgoingMetadata(t *testing.T) {
 		require.Equal(t, []string{"current-id"}, md.Get("request-id"))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx), meta.ServiceMethodKey)
 
 		return nil, nil
 	}
@@ -169,7 +169,7 @@ func TestStreamClientInterceptorIgnoresBlankOutgoingMetadata(t *testing.T) {
 		require.Equal(t, grpcmeta.String("generated-id"), meta.RequestID(ctx))
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx), meta.ServiceMethodKey)
 
 		return nil, nil
 	}
@@ -281,7 +281,7 @@ func TestUnaryServerInterceptorHandlesMissingPeer(t *testing.T) {
 		require.True(t, grpcmeta.IPAddr(ctx).IsEmpty())
 		require.Equal(t, meta.Ignored("grpc"), meta.Transport(ctx))
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayHello"), meta.ServiceMethod(ctx))
-		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(ctx), meta.ServiceMethodKey)
 
 		return "ok", nil
 	})
@@ -356,7 +356,7 @@ func TestUnaryServerInterceptorStoresGeolocationAsIgnored(t *testing.T) {
 
 		require.Equal(t, "geo:47,11", geolocation.Value())
 		require.Empty(t, geolocation.String())
-		require.NotContains(t, meta.Strings(ctx, meta.NoPrefix), meta.GeolocationKey)
+		require.NotContains(t, meta.Strings(ctx), meta.GeolocationKey)
 
 		return "ok", nil
 	})
@@ -371,7 +371,7 @@ func TestStreamServerInterceptorAppendDoesNotOverwriteRequestID(t *testing.T) {
 
 	err := interceptor(nil, stream, &grpc.StreamServerInfo{FullMethod: "/greet.v1.Greeter/SayStreamHello"}, func(_ any, stream grpc.ServerStream) error {
 		require.Equal(t, meta.Ignored("/greet.v1.Greeter/SayStreamHello"), meta.ServiceMethod(stream.Context()))
-		require.NotContains(t, meta.Strings(stream.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(stream.Context()), meta.ServiceMethodKey)
 
 		return nil
 	})

--- a/net/http/meta/meta.go
+++ b/net/http/meta/meta.go
@@ -10,9 +10,6 @@ const requestResponseKey = context.Key("request-response")
 
 const limiterKey = context.Key("limiter")
 
-// NoPrefix is an alias for [meta.NoPrefix].
-const NoPrefix = meta.NoPrefix
-
 // Map is an alias for [meta.Map].
 type Map = meta.Map
 
@@ -21,10 +18,9 @@ type Pair = meta.Pair
 
 // Strings exports all stored meta attributes as a string map with unchanged keys.
 //
-// Standard metadata keys use snake_case. The prefix parameter is prepended to each exported key (if non-empty).
-// Attributes whose rendered value is empty are skipped.
-func Strings(ctx context.Context, prefix string) Map {
-	return meta.Strings(ctx, prefix)
+// Standard metadata keys use snake_case. Attributes whose rendered value is empty are skipped.
+func Strings(ctx context.Context) Map {
+	return meta.Strings(ctx)
 }
 
 // Error converts err to a [meta.Value] using err.Error().

--- a/net/http/meta/meta_test.go
+++ b/net/http/meta/meta_test.go
@@ -181,7 +181,7 @@ func TestRoundTripperStoresServiceMethod(t *testing.T) {
 		test.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 			require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
-			require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+			require.NotContains(t, meta.Strings(req.Context()), meta.ServiceMethodKey)
 
 			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
 		}),
@@ -267,7 +267,7 @@ func TestHandlerStoresServiceMethodFromPath(t *testing.T) {
 	handler.ServeHTTP(res, req, func(_ http.ResponseWriter, req *http.Request) {
 		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("/users/123"), meta.ServiceMethod(req.Context()))
-		require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(req.Context()), meta.ServiceMethodKey)
 	})
 }
 
@@ -284,7 +284,7 @@ func TestHandlerStoresServiceMethodFromPattern(t *testing.T) {
 		require.Equal(t, meta.Ignored("http"), meta.Transport(req.Context()))
 		require.Equal(t, meta.Ignored("GET /users/{id}"), meta.ServiceMethod(req.Context()))
 		require.Equal(t, "GET /users/{id}", req.Pattern)
-		require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.ServiceMethodKey)
+		require.NotContains(t, meta.Strings(req.Context()), meta.ServiceMethodKey)
 	})
 }
 
@@ -313,6 +313,6 @@ func TestHandlerStoresGeolocationAsIgnored(t *testing.T) {
 
 		require.Equal(t, "geo:47,11", geolocation.Value())
 		require.Empty(t, geolocation.String())
-		require.NotContains(t, meta.Strings(req.Context(), meta.NoPrefix), meta.GeolocationKey)
+		require.NotContains(t, meta.Strings(req.Context()), meta.GeolocationKey)
 	})
 }

--- a/net/http/mvc/view.go
+++ b/net/http/mvc/view.go
@@ -159,7 +159,7 @@ func (v *View) render(ctx context.Context, writer io.Writer, model any) error {
 	}
 
 	template := &Template{
-		Meta:  meta.Strings(ctx, meta.NoPrefix),
+		Meta:  meta.Strings(ctx),
 		Model: model,
 	}
 


### PR DESCRIPTION
## What

- Remove prefix-based attribute export APIs so exported keys are always unchanged.
- Update HTTP, RPC, and MVC callers and fixtures for the simplified export surface.

## Why

- Standardize exported attribute names across consumers.
- Breaking: downstream callers must remove the prefix argument and `NoPrefix` constants; callers that require renamed keys must transform the exported map after calling `Strings`.

## Testing

- `make specs package=meta` - passed
- `make specs package=net/http/meta` - passed
- `make specs package=net/grpc/meta` - passed
- `make specs package=net/http/mvc` - passed
- `make specs package=transport/http` - passed
- `make lint` - passed
- CI will additionally run the full spec suite, security checks, fuzzes, benchmarks, generated-output freshness, and coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
